### PR TITLE
feat(gax)!: stable paginator

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -42,9 +42,10 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-      - name: Test gax with features disabled
-        run: cargo test --package google-cloud-gax
-      - run: cargo test --workspace
+      - name: Test with features disabled
+        run: cargo test --workspace --no-default-features
+      - name: Test with features enabled
+        run: cargo test --workspace --all-features
   coverage:
     runs-on: ubuntu-24.04
     strategy:
@@ -99,9 +100,6 @@ jobs:
       - name: Display rustc version
         run: rustc --version
       - run: cargo doc --workspace
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-      - run: cargo doc --package google-cloud-gax
         env:
           RUSTDOCFLAGS: "-D warnings"
       - run: mdbook build guide

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Display rustc version
         run: rustc --version
       - name: Test with features disabled
-        run: cargo test --workspace --no-default-features
+        run: cargo test --workspace -p google-cloud-gax --no-default-features
       - name: Test with features enabled
         run: cargo test --workspace --all-features
   coverage:

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -42,10 +42,9 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-      - name: Test with features disabled
-        run: cargo test --workspace -p google-cloud-gax --no-default-features
-      - name: Test with features enabled
-        run: cargo test --workspace --all-features
+      - name: Test gax with features disabled
+        run: cargo test --package google-cloud-gax
+      - run: cargo test --workspace
   coverage:
     runs-on: ubuntu-24.04
     strategy:
@@ -100,6 +99,9 @@ jobs:
       - name: Display rustc version
         run: rustc --version
       - run: cargo doc --workspace
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+      - run: cargo doc --package google-cloud-gax
         env:
           RUSTDOCFLAGS: "-D warnings"
       - run: mdbook build guide

--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -166,7 +166,6 @@ impl wkt::message::Message for {{Codec.Name}} {
 {{/Codec.HasSyntheticFields}}
 {{#IsPageableResponse}}
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for {{Name}} {
     {{#PageableItem}}
     type PageItem = {{{Codec.PrimitiveFieldType}}};

--- a/generator/internal/rust/templates/crate/src/builders.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builders.rs.mustache
@@ -86,7 +86,7 @@ pub mod {{Codec.ModuleName}} {
         {{#IsPageable}}
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<{{OutputType.Codec.QualifiedName}}, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<{{OutputType.Codec.QualifiedName}}, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();

--- a/generator/internal/rust/templates/crate/src/builders.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builders.rs.mustache
@@ -86,7 +86,6 @@ pub mod {{Codec.ModuleName}} {
         {{#IsPageable}}
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<{{OutputType.Codec.QualifiedName}}, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {

--- a/generator/testdata/rust/openapi/golden/src/builders.rs
+++ b/generator/testdata/rust/openapi/golden/src/builders.rs
@@ -66,7 +66,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
@@ -184,7 +183,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
@@ -308,7 +306,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
@@ -898,7 +895,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
@@ -975,7 +971,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {

--- a/generator/testdata/rust/openapi/golden/src/builders.rs
+++ b/generator/testdata/rust/openapi/golden/src/builders.rs
@@ -66,7 +66,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();
@@ -183,7 +183,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();
@@ -306,7 +306,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();
@@ -895,7 +895,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();
@@ -971,7 +971,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -64,7 +64,6 @@ impl wkt::message::Message for ListLocationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLocationsResponse {
     type PageItem = crate::model::Location;
 
@@ -218,7 +217,6 @@ impl wkt::message::Message for ListSecretsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecretsResponse {
     type PageItem = crate::model::Secret;
 
@@ -1261,7 +1259,6 @@ impl wkt::message::Message for ListSecretVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecretVersionsResponse {
     type PageItem = crate::model::SecretVersion;
 

--- a/generator/testdata/rust/protobuf/golden/location/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builders.rs
@@ -66,7 +66,7 @@ pub mod locations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();

--- a/generator/testdata/rust/protobuf/golden/location/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builders.rs
@@ -66,7 +66,6 @@ pub mod locations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {

--- a/generator/testdata/rust/protobuf/golden/location/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/model.rs
@@ -126,7 +126,6 @@ impl wkt::message::Message for ListLocationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLocationsResponse {
     type PageItem = crate::model::Location;
 

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
@@ -66,7 +66,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();
@@ -371,7 +371,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();
@@ -816,7 +816,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(self) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error> {
+        pub async fn paginator(self) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let mut builder = self.clone();

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
@@ -66,7 +66,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
@@ -372,7 +371,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
@@ -818,7 +816,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(self) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -1530,7 +1530,6 @@ impl wkt::message::Message for ListSecretsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecretsResponse {
     type PageItem = crate::model::Secret;
 
@@ -1842,7 +1841,6 @@ impl wkt::message::Message for ListSecretVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecretVersionsResponse {
     type PageItem = crate::model::SecretVersion;
 

--- a/guide/samples/src/bin/getting_started.rs
+++ b/guide/samples/src/bin/getting_started.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut items = client
         .list_secrets(format!("projects/{project_id}"))
-        .stream()
+        .paginator()
         .await
         .items();
     while let Some(item) = items.next().await {

--- a/guide/samples/tests/initialize_client.rs
+++ b/guide/samples/tests/initialize_client.rs
@@ -31,7 +31,7 @@ pub async fn initialize_client(project_id: &str) -> Result {
     // ANCHOR: make-rpc
     let mut items = client
         .list_locations(format!("projects/{project_id}"))
-        .stream()
+        .paginator()
         .await;
     while let Some(page) = items.next().await {
         let page = page?;

--- a/src/auth/integration-tests/Cargo.toml
+++ b/src/auth/integration-tests/Cargo.toml
@@ -24,7 +24,7 @@ run-integration-tests = []
 
 [dependencies]
 auth          = { path = "../../../src/auth", package = "google-cloud-auth" }
-gax           = { path = "../../../src/gax", package = "google-cloud-gax" }
+gax           = { path = "../../../src/gax", package = "google-cloud-gax", features = ["unstable-stream"] }
 language      = { path = "../../../src/generated/cloud/language/v2", package = "google-cloud-language-v2" }
 scoped-env    = "2"
 secretmanager = { path = "../../../src/generated/cloud/secretmanager/v1", package = "google-cloud-secretmanager-v1" }

--- a/src/firestore/src/generated/model/mod.rs
+++ b/src/firestore/src/generated/model/mod.rs
@@ -1602,7 +1602,6 @@ impl wkt::message::Message for ListDocumentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDocumentsResponse {
     type PageItem = crate::model::Document;
 
@@ -3532,7 +3531,6 @@ impl wkt::message::Message for PartitionQueryResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for PartitionQueryResponse {
     type PageItem = crate::model::Cursor;
 

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -28,9 +28,9 @@ repository.workspace = true
 [dependencies]
 base64      = "0.22"
 bytes       = "1"
-futures     = { version = "0.3", optional = true }
+futures     = { version = "0.3"}
 http        = "1"
-pin-project = { version = "1", optional = true }
+pin-project = { version = "1"}
 rand        = "0.9"
 reqwest     = { version = "0.12", optional = true }
 serde       = "1"
@@ -61,4 +61,4 @@ built = "0.7"
 
 [features]
 unstable-sdk-client = ["dep:reqwest"]
-unstable-stream     = ["dep:futures", "dep:pin-project"]
+unstable-stream     = []

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -48,7 +48,7 @@ echo-server = { path = "echo-server" }
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
 axum        = "0.8"
-gax         = { path = ".", package = "google-cloud-gax", features = ["unstable-sdk-client", "unstable-stream"] }
+gax         = { path = ".", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 mockall     = "0.13"
 serde       = { version = "1", features = ["serde_derive"] }
 serial_test = "3"

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -28,9 +28,9 @@ repository.workspace = true
 [dependencies]
 base64      = "0.22"
 bytes       = "1"
-futures     = { version = "0.3"}
+futures     = { version = "0.3" }
 http        = "1"
-pin-project = { version = "1"}
+pin-project = { version = "1" }
 rand        = "0.9"
 reqwest     = { version = "0.12", optional = true }
 serde       = "1"

--- a/src/gax/echo-server/Cargo.toml
+++ b/src/gax/echo-server/Cargo.toml
@@ -23,5 +23,5 @@ publish           = false
 axum       = "0.8.1"
 serde_json = "1"
 tokio      = { version = "1.42", features = ["macros"] }
-gax        = { path = "..", package = "google-cloud-gax", features = ["unstable-sdk-client", "unstable-stream"] }
+gax        = { path = "..", package = "google-cloud-gax" }
 rpc        = { path = "../../generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -52,8 +52,6 @@ pub mod api_header;
 pub mod error;
 
 /// Defines some types and traits to convert and use List RPCs as a Stream.
-/// Async streams are not yet stable, so neither is the use of this feature.
-#[cfg(feature = "unstable-stream")]
 pub mod paginator;
 
 /// Defines traits and helpers for HTTP client implementations.

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 use futures::stream::unfold;
+use futures::{Stream, StreamExt};
 use pin_project::pin_project;
 use std::future::Future;
 use std::pin::Pin;
-
-#[cfg(feature = "unstable-stream")]
-use futures::{Stream, StreamExt};
 
 /// Describes a type that can be iterated over asyncly when used with [Paginator].
 pub trait PageableResponse {

--- a/src/generated/api/apikeys/v2/src/builders.rs
+++ b/src/generated/api/apikeys/v2/src/builders.rs
@@ -156,7 +156,7 @@ pub mod api_keys {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKeysResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);

--- a/src/generated/api/apikeys/v2/src/builders.rs
+++ b/src/generated/api/apikeys/v2/src/builders.rs
@@ -156,7 +156,6 @@ pub mod api_keys {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKeysResponse, gax::error::Error> {

--- a/src/generated/api/apikeys/v2/src/model.rs
+++ b/src/generated/api/apikeys/v2/src/model.rs
@@ -195,7 +195,6 @@ impl wkt::message::Message for ListKeysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListKeysResponse {
     type PageItem = crate::model::Key;
 

--- a/src/generated/api/servicemanagement/v1/src/builders.rs
+++ b/src/generated/api/servicemanagement/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod service_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -427,7 +426,6 @@ pub mod service_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServiceConfigsResponse, gax::error::Error>
@@ -710,7 +708,6 @@ pub mod service_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServiceRolloutsResponse, gax::error::Error>
@@ -1141,7 +1138,6 @@ pub mod service_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/api/servicemanagement/v1/src/builders.rs
+++ b/src/generated/api/servicemanagement/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod service_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -426,7 +426,7 @@ pub mod service_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServiceConfigsResponse, gax::error::Error>
         {
@@ -708,7 +708,7 @@ pub mod service_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServiceRolloutsResponse, gax::error::Error>
         {
@@ -1138,7 +1138,7 @@ pub mod service_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -1107,7 +1107,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::ManagedService;
 
@@ -1488,7 +1487,6 @@ impl wkt::message::Message for ListServiceConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServiceConfigsResponse {
     type PageItem = api::model::Service;
 
@@ -1792,7 +1790,6 @@ impl wkt::message::Message for ListServiceRolloutsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServiceRolloutsResponse {
     type PageItem = crate::model::Rollout;
 

--- a/src/generated/api/serviceusage/v1/src/builders.rs
+++ b/src/generated/api/serviceusage/v1/src/builders.rs
@@ -290,7 +290,7 @@ pub mod service_usage {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -517,7 +517,7 @@ pub mod service_usage {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/api/serviceusage/v1/src/builders.rs
+++ b/src/generated/api/serviceusage/v1/src/builders.rs
@@ -290,7 +290,6 @@ pub mod service_usage {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -518,7 +517,6 @@ pub mod service_usage {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/api/serviceusage/v1/src/model.rs
+++ b/src/generated/api/serviceusage/v1/src/model.rs
@@ -682,7 +682,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::Service;
 

--- a/src/generated/appengine/v1/src/builders.rs
+++ b/src/generated/appengine/v1/src/builders.rs
@@ -382,7 +382,7 @@ pub mod applications {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -525,7 +525,7 @@ pub mod services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -815,7 +815,7 @@ pub mod services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -958,7 +958,7 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
         {
@@ -1343,7 +1343,7 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1486,7 +1486,7 @@ pub mod instances {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -1758,7 +1758,7 @@ pub mod instances {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1904,7 +1904,7 @@ pub mod firewall {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIngressRulesResponse, gax::error::Error>
         {
@@ -2237,7 +2237,7 @@ pub mod firewall {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2383,7 +2383,7 @@ pub mod authorized_domains {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAuthorizedDomainsResponse, gax::error::Error>
         {
@@ -2453,7 +2453,7 @@ pub mod authorized_domains {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2601,7 +2601,7 @@ pub mod authorized_certificates {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAuthorizedCertificatesResponse,
@@ -2900,7 +2900,7 @@ pub mod authorized_certificates {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3046,7 +3046,7 @@ pub mod domain_mappings {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDomainMappingsResponse, gax::error::Error>
         {
@@ -3441,7 +3441,7 @@ pub mod domain_mappings {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/appengine/v1/src/builders.rs
+++ b/src/generated/appengine/v1/src/builders.rs
@@ -382,7 +382,6 @@ pub mod applications {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -526,7 +525,6 @@ pub mod services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -817,7 +815,6 @@ pub mod services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -961,7 +958,6 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
@@ -1347,7 +1343,6 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1491,7 +1486,6 @@ pub mod instances {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -1764,7 +1758,6 @@ pub mod instances {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1911,7 +1904,6 @@ pub mod firewall {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIngressRulesResponse, gax::error::Error>
@@ -2245,7 +2237,6 @@ pub mod firewall {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2392,7 +2383,6 @@ pub mod authorized_domains {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAuthorizedDomainsResponse, gax::error::Error>
@@ -2463,7 +2453,6 @@ pub mod authorized_domains {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2612,7 +2601,6 @@ pub mod authorized_certificates {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2912,7 +2900,6 @@ pub mod authorized_certificates {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3059,7 +3046,6 @@ pub mod domain_mappings {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDomainMappingsResponse, gax::error::Error>
@@ -3455,7 +3441,6 @@ pub mod domain_mappings {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -1274,7 +1274,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::Service;
 
@@ -1523,7 +1522,6 @@ impl wkt::message::Message for ListVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVersionsResponse {
     type PageItem = crate::model::Version;
 
@@ -1798,7 +1796,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 
@@ -2025,7 +2022,6 @@ impl wkt::message::Message for ListIngressRulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIngressRulesResponse {
     type PageItem = crate::model::FirewallRule;
 
@@ -2377,7 +2373,6 @@ impl wkt::message::Message for ListAuthorizedDomainsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAuthorizedDomainsResponse {
     type PageItem = crate::model::AuthorizedDomain;
 
@@ -2494,7 +2489,6 @@ impl wkt::message::Message for ListAuthorizedCertificatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAuthorizedCertificatesResponse {
     type PageItem = crate::model::AuthorizedCertificate;
 
@@ -2775,7 +2769,6 @@ impl wkt::message::Message for ListDomainMappingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDomainMappingsResponse {
     type PageItem = crate::model::DomainMapping;
 

--- a/src/generated/bigtable/admin/v2/src/builders.rs
+++ b/src/generated/bigtable/admin/v2/src/builders.rs
@@ -1045,7 +1045,6 @@ pub mod bigtable_instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAppProfilesResponse, gax::error::Error>
@@ -1428,7 +1427,6 @@ pub mod bigtable_instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHotTabletsResponse, gax::error::Error>
@@ -1514,7 +1512,6 @@ pub mod bigtable_instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1910,7 +1907,6 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTablesResponse, gax::error::Error>
@@ -2350,7 +2346,6 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAuthorizedViewsResponse, gax::error::Error>
@@ -2993,7 +2988,6 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSnapshotsResponse, gax::error::Error>
@@ -3331,7 +3325,6 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -3771,7 +3764,6 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/bigtable/admin/v2/src/builders.rs
+++ b/src/generated/bigtable/admin/v2/src/builders.rs
@@ -1045,7 +1045,7 @@ pub mod bigtable_instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAppProfilesResponse, gax::error::Error>
         {
@@ -1427,7 +1427,7 @@ pub mod bigtable_instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHotTabletsResponse, gax::error::Error>
         {
@@ -1512,7 +1512,7 @@ pub mod bigtable_instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1907,7 +1907,7 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTablesResponse, gax::error::Error>
         {
@@ -2346,7 +2346,7 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAuthorizedViewsResponse, gax::error::Error>
         {
@@ -2988,7 +2988,7 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSnapshotsResponse, gax::error::Error>
         {
@@ -3325,7 +3325,7 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -3764,7 +3764,7 @@ pub mod bigtable_table_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -1264,7 +1264,6 @@ impl wkt::message::Message for ListAppProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAppProfilesResponse {
     type PageItem = crate::model::AppProfile;
 
@@ -1530,7 +1529,6 @@ impl wkt::message::Message for ListHotTabletsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListHotTabletsResponse {
     type PageItem = crate::model::HotTablet;
 
@@ -2614,7 +2612,6 @@ impl wkt::message::Message for ListTablesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTablesResponse {
     type PageItem = crate::model::Table;
 
@@ -3697,7 +3694,6 @@ impl wkt::message::Message for ListSnapshotsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSnapshotsResponse {
     type PageItem = crate::model::Snapshot;
 
@@ -4322,7 +4318,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 
@@ -4733,7 +4728,6 @@ impl wkt::message::Message for ListAuthorizedViewsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAuthorizedViewsResponse {
     type PageItem = crate::model::AuthorizedView;
 

--- a/src/generated/cloud/accessapproval/v1/src/builders.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod access_approval {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApprovalRequestsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/accessapproval/v1/src/builders.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod access_approval {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApprovalRequestsResponse, gax::error::Error>

--- a/src/generated/cloud/accessapproval/v1/src/model.rs
+++ b/src/generated/cloud/accessapproval/v1/src/model.rs
@@ -1119,7 +1119,6 @@ impl wkt::message::Message for ListApprovalRequestsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListApprovalRequestsResponse {
     type PageItem = crate::model::ApprovalRequest;
 

--- a/src/generated/cloud/advisorynotifications/v1/src/builders.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/builders.rs
@@ -75,7 +75,6 @@ pub mod advisory_notifications_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNotificationsResponse, gax::error::Error>

--- a/src/generated/cloud/advisorynotifications/v1/src/builders.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/builders.rs
@@ -75,7 +75,7 @@ pub mod advisory_notifications_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNotificationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/advisorynotifications/v1/src/model.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/model.rs
@@ -615,7 +615,6 @@ impl wkt::message::Message for ListNotificationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNotificationsResponse {
     type PageItem = crate::model::Notification;
 

--- a/src/generated/cloud/aiplatform/v1/src/builders.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builders.rs
@@ -257,7 +257,7 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatasetsResponse, gax::error::Error>
         {
@@ -886,7 +886,7 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatasetVersionsResponse, gax::error::Error>
         {
@@ -1058,7 +1058,7 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataItemsResponse, gax::error::Error>
         {
@@ -1143,7 +1143,7 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchDataItemsResponse, gax::error::Error>
         {
@@ -1278,7 +1278,7 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSavedQueriesResponse, gax::error::Error>
         {
@@ -1492,7 +1492,7 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAnnotationsResponse, gax::error::Error>
         {
@@ -1580,7 +1580,7 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1861,7 +1861,7 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2310,7 +2310,7 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListDeploymentResourcePoolsResponse,
@@ -2572,7 +2572,7 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::QueryDeployedModelsResponse, gax::error::Error>
         {
@@ -2644,7 +2644,7 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2935,7 +2935,7 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3362,7 +3362,7 @@ pub mod endpoint_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEndpointsResponse, gax::error::Error>
         {
@@ -3981,7 +3981,7 @@ pub mod endpoint_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -4262,7 +4262,7 @@ pub mod endpoint_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4601,7 +4601,7 @@ pub mod evaluation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -4882,7 +4882,7 @@ pub mod evaluation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5326,7 +5326,7 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListFeatureOnlineStoresResponse,
@@ -5757,7 +5757,7 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeatureViewsResponse, gax::error::Error>
         {
@@ -6110,7 +6110,7 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeatureViewSyncsResponse, gax::error::Error>
         {
@@ -6194,7 +6194,7 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -6485,7 +6485,7 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -6898,7 +6898,7 @@ pub mod feature_online_store_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -7179,7 +7179,7 @@ pub mod feature_online_store_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -7606,7 +7606,7 @@ pub mod feature_registry_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeatureGroupsResponse, gax::error::Error>
         {
@@ -8103,7 +8103,7 @@ pub mod feature_registry_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeaturesResponse, gax::error::Error>
         {
@@ -8365,7 +8365,7 @@ pub mod feature_registry_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -8646,7 +8646,7 @@ pub mod feature_registry_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -9052,7 +9052,7 @@ pub mod featurestore_online_serving_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -9343,7 +9343,7 @@ pub mod featurestore_online_serving_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -9778,7 +9778,7 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeaturestoresResponse, gax::error::Error>
         {
@@ -10188,7 +10188,7 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntityTypesResponse, gax::error::Error>
         {
@@ -10648,7 +10648,7 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeaturesResponse, gax::error::Error>
         {
@@ -11377,7 +11377,7 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchFeaturesResponse, gax::error::Error>
         {
@@ -11453,7 +11453,7 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -11734,7 +11734,7 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -12215,7 +12215,7 @@ pub mod gen_ai_cache_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCachedContentsResponse, gax::error::Error>
         {
@@ -12285,7 +12285,7 @@ pub mod gen_ai_cache_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -12566,7 +12566,7 @@ pub mod gen_ai_cache_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -12938,7 +12938,7 @@ pub mod gen_ai_tuning_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTuningJobsResponse, gax::error::Error>
         {
@@ -13175,7 +13175,7 @@ pub mod gen_ai_tuning_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -13456,7 +13456,7 @@ pub mod gen_ai_tuning_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -13880,7 +13880,7 @@ pub mod index_endpoint_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIndexEndpointsResponse, gax::error::Error>
         {
@@ -14376,7 +14376,7 @@ pub mod index_endpoint_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -14657,7 +14657,7 @@ pub mod index_endpoint_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -15068,7 +15068,7 @@ pub mod index_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIndexesResponse, gax::error::Error>
         {
@@ -15437,7 +15437,7 @@ pub mod index_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -15718,7 +15718,7 @@ pub mod index_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -16090,7 +16090,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomJobsResponse, gax::error::Error>
         {
@@ -16388,7 +16388,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataLabelingJobsResponse, gax::error::Error>
         {
@@ -16704,7 +16704,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListHyperparameterTuningJobsResponse,
@@ -17003,7 +17003,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNasJobsResponse, gax::error::Error>
         {
@@ -17246,7 +17246,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNasTrialDetailsResponse, gax::error::Error>
         {
@@ -17419,7 +17419,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListBatchPredictionJobsResponse,
@@ -17693,7 +17693,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchModelDeploymentMonitoringStatsAnomaliesResponse,
@@ -17854,7 +17854,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListModelDeploymentMonitoringJobsResponse,
@@ -18214,7 +18214,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -18495,7 +18495,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -18948,7 +18948,7 @@ pub mod llm_utility_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -19229,7 +19229,7 @@ pub mod llm_utility_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -19638,7 +19638,7 @@ pub mod match_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -19919,7 +19919,7 @@ pub mod match_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -20349,7 +20349,7 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMetadataStoresResponse, gax::error::Error>
         {
@@ -20602,7 +20602,7 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListArtifactsResponse, gax::error::Error>
         {
@@ -21013,7 +21013,7 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListContextsResponse, gax::error::Error>
         {
@@ -21654,7 +21654,7 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExecutionsResponse, gax::error::Error>
         {
@@ -22175,7 +22175,7 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMetadataSchemasResponse, gax::error::Error>
         {
@@ -22309,7 +22309,7 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -22590,7 +22590,7 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -22876,7 +22876,7 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchMigratableResourcesResponse,
@@ -23052,7 +23052,7 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -23333,7 +23333,7 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -23685,7 +23685,7 @@ pub mod model_garden_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -23966,7 +23966,7 @@ pub mod model_garden_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -24399,7 +24399,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelsResponse, gax::error::Error>
         {
@@ -24487,7 +24487,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelVersionsResponse, gax::error::Error>
         {
@@ -24577,7 +24577,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListModelVersionCheckpointsResponse,
@@ -25424,7 +25424,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelEvaluationsResponse, gax::error::Error>
         {
@@ -25554,7 +25554,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListModelEvaluationSlicesResponse,
@@ -25638,7 +25638,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -25919,7 +25919,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -26360,7 +26360,7 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListNotebookRuntimeTemplatesResponse,
@@ -26743,7 +26743,7 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNotebookRuntimesResponse, gax::error::Error>
         {
@@ -27331,7 +27331,7 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListNotebookExecutionJobsResponse,
@@ -27502,7 +27502,7 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -27783,7 +27783,7 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -28219,7 +28219,7 @@ pub mod persistent_resource_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListPersistentResourcesResponse,
@@ -28564,7 +28564,7 @@ pub mod persistent_resource_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -28845,7 +28845,7 @@ pub mod persistent_resource_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -29228,7 +29228,7 @@ pub mod pipeline_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTrainingPipelinesResponse, gax::error::Error>
         {
@@ -29533,7 +29533,7 @@ pub mod pipeline_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPipelineJobsResponse, gax::error::Error>
         {
@@ -29944,7 +29944,7 @@ pub mod pipeline_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -30225,7 +30225,7 @@ pub mod pipeline_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -30925,7 +30925,7 @@ pub mod prediction_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -31206,7 +31206,7 @@ pub mod prediction_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -31552,7 +31552,7 @@ pub mod reasoning_engine_execution_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -31843,7 +31843,7 @@ pub mod reasoning_engine_execution_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -32275,7 +32275,7 @@ pub mod reasoning_engine_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReasoningEnginesResponse, gax::error::Error>
         {
@@ -32529,7 +32529,7 @@ pub mod reasoning_engine_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -32810,7 +32810,7 @@ pub mod reasoning_engine_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -33258,7 +33258,7 @@ pub mod schedule_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSchedulesResponse, gax::error::Error>
         {
@@ -33481,7 +33481,7 @@ pub mod schedule_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -33762,7 +33762,7 @@ pub mod schedule_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -34186,7 +34186,7 @@ pub mod specialist_pool_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSpecialistPoolsResponse, gax::error::Error>
         {
@@ -34446,7 +34446,7 @@ pub mod specialist_pool_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -34727,7 +34727,7 @@ pub mod specialist_pool_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -35243,7 +35243,7 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTensorboardsResponse, gax::error::Error>
         {
@@ -35669,7 +35669,7 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListTensorboardExperimentsResponse,
@@ -36056,7 +36056,7 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTensorboardRunsResponse, gax::error::Error>
         {
@@ -36454,7 +36454,7 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListTensorboardTimeSeriesResponse,
@@ -36858,7 +36858,7 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ExportTensorboardTimeSeriesDataResponse,
@@ -36942,7 +36942,7 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -37223,7 +37223,7 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -37721,7 +37721,7 @@ pub mod vertex_rag_data_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRagCorporaResponse, gax::error::Error>
         {
@@ -38067,7 +38067,7 @@ pub mod vertex_rag_data_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRagFilesResponse, gax::error::Error>
         {
@@ -38213,7 +38213,7 @@ pub mod vertex_rag_data_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -38494,7 +38494,7 @@ pub mod vertex_rag_data_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -38991,7 +38991,7 @@ pub mod vertex_rag_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -39272,7 +39272,7 @@ pub mod vertex_rag_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -39644,7 +39644,7 @@ pub mod vizier_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStudiesResponse, gax::error::Error>
         {
@@ -39995,7 +39995,7 @@ pub mod vizier_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTrialsResponse, gax::error::Error>
         {
@@ -40395,7 +40395,7 @@ pub mod vizier_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -40676,7 +40676,7 @@ pub mod vizier_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/aiplatform/v1/src/builders.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builders.rs
@@ -257,7 +257,6 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatasetsResponse, gax::error::Error>
@@ -887,7 +886,6 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatasetVersionsResponse, gax::error::Error>
@@ -1060,7 +1058,6 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataItemsResponse, gax::error::Error>
@@ -1146,7 +1143,6 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchDataItemsResponse, gax::error::Error>
@@ -1282,7 +1278,6 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSavedQueriesResponse, gax::error::Error>
@@ -1497,7 +1492,6 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAnnotationsResponse, gax::error::Error>
@@ -1586,7 +1580,6 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1868,7 +1861,6 @@ pub mod dataset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2318,7 +2310,6 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2581,7 +2572,6 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::QueryDeployedModelsResponse, gax::error::Error>
@@ -2654,7 +2644,6 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2946,7 +2935,6 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3374,7 +3362,6 @@ pub mod endpoint_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEndpointsResponse, gax::error::Error>
@@ -3994,7 +3981,6 @@ pub mod endpoint_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -4276,7 +4262,6 @@ pub mod endpoint_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4616,7 +4601,6 @@ pub mod evaluation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -4898,7 +4882,6 @@ pub mod evaluation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5343,7 +5326,6 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -5775,7 +5757,6 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeatureViewsResponse, gax::error::Error>
@@ -6129,7 +6110,6 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeatureViewSyncsResponse, gax::error::Error>
@@ -6214,7 +6194,6 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -6506,7 +6485,6 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -6920,7 +6898,6 @@ pub mod feature_online_store_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -7202,7 +7179,6 @@ pub mod feature_online_store_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -7630,7 +7606,6 @@ pub mod feature_registry_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeatureGroupsResponse, gax::error::Error>
@@ -8128,7 +8103,6 @@ pub mod feature_registry_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeaturesResponse, gax::error::Error>
@@ -8391,7 +8365,6 @@ pub mod feature_registry_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -8673,7 +8646,6 @@ pub mod feature_registry_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -9080,7 +9052,6 @@ pub mod featurestore_online_serving_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -9372,7 +9343,6 @@ pub mod featurestore_online_serving_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -9808,7 +9778,6 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeaturestoresResponse, gax::error::Error>
@@ -10219,7 +10188,6 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntityTypesResponse, gax::error::Error>
@@ -10680,7 +10648,6 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeaturesResponse, gax::error::Error>
@@ -11410,7 +11377,6 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchFeaturesResponse, gax::error::Error>
@@ -11487,7 +11453,6 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -11769,7 +11734,6 @@ pub mod featurestore_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -12251,7 +12215,6 @@ pub mod gen_ai_cache_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCachedContentsResponse, gax::error::Error>
@@ -12322,7 +12285,6 @@ pub mod gen_ai_cache_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -12604,7 +12566,6 @@ pub mod gen_ai_cache_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -12977,7 +12938,6 @@ pub mod gen_ai_tuning_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTuningJobsResponse, gax::error::Error>
@@ -13215,7 +13175,6 @@ pub mod gen_ai_tuning_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -13497,7 +13456,6 @@ pub mod gen_ai_tuning_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -13922,7 +13880,6 @@ pub mod index_endpoint_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIndexEndpointsResponse, gax::error::Error>
@@ -14419,7 +14376,6 @@ pub mod index_endpoint_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -14701,7 +14657,6 @@ pub mod index_endpoint_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -15113,7 +15068,6 @@ pub mod index_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIndexesResponse, gax::error::Error>
@@ -15483,7 +15437,6 @@ pub mod index_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -15765,7 +15718,6 @@ pub mod index_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -16138,7 +16090,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomJobsResponse, gax::error::Error>
@@ -16437,7 +16388,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataLabelingJobsResponse, gax::error::Error>
@@ -16754,7 +16704,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -17054,7 +17003,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNasJobsResponse, gax::error::Error>
@@ -17298,7 +17246,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNasTrialDetailsResponse, gax::error::Error>
@@ -17472,7 +17419,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -17747,7 +17693,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -17909,7 +17854,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -18270,7 +18214,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -18552,7 +18495,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -19006,7 +18948,6 @@ pub mod llm_utility_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -19288,7 +19229,6 @@ pub mod llm_utility_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -19698,7 +19638,6 @@ pub mod match_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -19980,7 +19919,6 @@ pub mod match_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -20411,7 +20349,6 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMetadataStoresResponse, gax::error::Error>
@@ -20665,7 +20602,6 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListArtifactsResponse, gax::error::Error>
@@ -21077,7 +21013,6 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListContextsResponse, gax::error::Error>
@@ -21719,7 +21654,6 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExecutionsResponse, gax::error::Error>
@@ -22241,7 +22175,6 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMetadataSchemasResponse, gax::error::Error>
@@ -22376,7 +22309,6 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -22658,7 +22590,6 @@ pub mod metadata_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -22945,7 +22876,6 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -23122,7 +23052,6 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -23404,7 +23333,6 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -23757,7 +23685,6 @@ pub mod model_garden_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -24039,7 +23966,6 @@ pub mod model_garden_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -24473,7 +24399,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelsResponse, gax::error::Error>
@@ -24562,7 +24487,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelVersionsResponse, gax::error::Error>
@@ -24653,7 +24577,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -25501,7 +25424,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelEvaluationsResponse, gax::error::Error>
@@ -25632,7 +25554,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -25717,7 +25638,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -25999,7 +25919,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -26441,7 +26360,6 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -26825,7 +26743,6 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNotebookRuntimesResponse, gax::error::Error>
@@ -27414,7 +27331,6 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -27586,7 +27502,6 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -27868,7 +27783,6 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -28305,7 +28219,6 @@ pub mod persistent_resource_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -28651,7 +28564,6 @@ pub mod persistent_resource_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -28933,7 +28845,6 @@ pub mod persistent_resource_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -29317,7 +29228,6 @@ pub mod pipeline_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTrainingPipelinesResponse, gax::error::Error>
@@ -29623,7 +29533,6 @@ pub mod pipeline_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPipelineJobsResponse, gax::error::Error>
@@ -30035,7 +29944,6 @@ pub mod pipeline_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -30317,7 +30225,6 @@ pub mod pipeline_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -31018,7 +30925,6 @@ pub mod prediction_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -31300,7 +31206,6 @@ pub mod prediction_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -31647,7 +31552,6 @@ pub mod reasoning_engine_execution_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -31939,7 +31843,6 @@ pub mod reasoning_engine_execution_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -32372,7 +32275,6 @@ pub mod reasoning_engine_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReasoningEnginesResponse, gax::error::Error>
@@ -32627,7 +32529,6 @@ pub mod reasoning_engine_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -32909,7 +32810,6 @@ pub mod reasoning_engine_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -33358,7 +33258,6 @@ pub mod schedule_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSchedulesResponse, gax::error::Error>
@@ -33582,7 +33481,6 @@ pub mod schedule_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -33864,7 +33762,6 @@ pub mod schedule_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -34289,7 +34186,6 @@ pub mod specialist_pool_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSpecialistPoolsResponse, gax::error::Error>
@@ -34550,7 +34446,6 @@ pub mod specialist_pool_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -34832,7 +34727,6 @@ pub mod specialist_pool_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -35349,7 +35243,6 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTensorboardsResponse, gax::error::Error>
@@ -35776,7 +35669,6 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -36164,7 +36056,6 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTensorboardRunsResponse, gax::error::Error>
@@ -36563,7 +36454,6 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -36968,7 +36858,6 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -37053,7 +36942,6 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -37335,7 +37223,6 @@ pub mod tensorboard_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -37834,7 +37721,6 @@ pub mod vertex_rag_data_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRagCorporaResponse, gax::error::Error>
@@ -38181,7 +38067,6 @@ pub mod vertex_rag_data_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRagFilesResponse, gax::error::Error>
@@ -38328,7 +38213,6 @@ pub mod vertex_rag_data_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -38610,7 +38494,6 @@ pub mod vertex_rag_data_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -39108,7 +38991,6 @@ pub mod vertex_rag_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -39390,7 +39272,6 @@ pub mod vertex_rag_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -39763,7 +39644,6 @@ pub mod vizier_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStudiesResponse, gax::error::Error>
@@ -40115,7 +39995,6 @@ pub mod vizier_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTrialsResponse, gax::error::Error>
@@ -40516,7 +40395,6 @@ pub mod vizier_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -40798,7 +40676,6 @@ pub mod vizier_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/aiplatform/v1/src/model.rs
+++ b/src/generated/cloud/aiplatform/v1/src/model.rs
@@ -7868,7 +7868,6 @@ impl wkt::message::Message for ListDatasetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatasetsResponse {
     type PageItem = crate::model::Dataset;
 
@@ -8485,7 +8484,6 @@ impl wkt::message::Message for ListDatasetVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatasetVersionsResponse {
     type PageItem = crate::model::DatasetVersion;
 
@@ -8703,7 +8701,6 @@ impl wkt::message::Message for ListDataItemsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDataItemsResponse {
     type PageItem = crate::model::DataItem;
 
@@ -9097,7 +9094,6 @@ impl wkt::message::Message for SearchDataItemsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchDataItemsResponse {
     type PageItem = crate::model::DataItemView;
 
@@ -9307,7 +9303,6 @@ impl wkt::message::Message for ListSavedQueriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSavedQueriesResponse {
     type PageItem = crate::model::SavedQuery;
 
@@ -9535,7 +9530,6 @@ impl wkt::message::Message for ListAnnotationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAnnotationsResponse {
     type PageItem = crate::model::Annotation;
 
@@ -10130,7 +10124,6 @@ impl wkt::message::Message for ListDeploymentResourcePoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeploymentResourcePoolsResponse {
     type PageItem = crate::model::DeploymentResourcePool;
 
@@ -10399,7 +10392,6 @@ impl wkt::message::Message for QueryDeployedModelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for QueryDeployedModelsResponse {
     type PageItem = crate::model::DeployedModel;
 
@@ -11956,7 +11948,6 @@ impl wkt::message::Message for ListEndpointsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEndpointsResponse {
     type PageItem = crate::model::Endpoint;
 
@@ -25212,7 +25203,6 @@ impl wkt::message::Message for ListFeatureOnlineStoresResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFeatureOnlineStoresResponse {
     type PageItem = crate::model::FeatureOnlineStore;
 
@@ -25609,7 +25599,6 @@ impl wkt::message::Message for ListFeatureViewsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFeatureViewsResponse {
     type PageItem = crate::model::FeatureView;
 
@@ -26116,7 +26105,6 @@ impl wkt::message::Message for ListFeatureViewSyncsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFeatureViewSyncsResponse {
     type PageItem = crate::model::FeatureViewSync;
 
@@ -27617,7 +27605,6 @@ impl wkt::message::Message for ListFeatureGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFeatureGroupsResponse {
     type PageItem = crate::model::FeatureGroup;
 
@@ -31305,7 +31292,6 @@ impl wkt::message::Message for ListFeaturestoresResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFeaturestoresResponse {
     type PageItem = crate::model::Featurestore;
 
@@ -32994,7 +32980,6 @@ impl wkt::message::Message for ListEntityTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEntityTypesResponse {
     type PageItem = crate::model::EntityType;
 
@@ -33526,7 +33511,6 @@ impl wkt::message::Message for ListFeaturesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFeaturesResponse {
     type PageItem = crate::model::Feature;
 
@@ -33731,7 +33715,6 @@ impl wkt::message::Message for SearchFeaturesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchFeaturesResponse {
     type PageItem = crate::model::Feature;
 
@@ -35086,7 +35069,6 @@ impl wkt::message::Message for ListCachedContentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCachedContentsResponse {
     type PageItem = crate::model::CachedContent;
 
@@ -35297,7 +35279,6 @@ impl wkt::message::Message for ListTuningJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTuningJobsResponse {
     type PageItem = crate::model::TuningJob;
 
@@ -37546,7 +37527,6 @@ impl wkt::message::Message for ListIndexEndpointsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIndexEndpointsResponse {
     type PageItem = crate::model::IndexEndpoint;
 
@@ -38302,7 +38282,6 @@ impl wkt::message::Message for ListIndexesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIndexesResponse {
     type PageItem = crate::model::Index;
 
@@ -40296,7 +40275,6 @@ impl wkt::message::Message for ListCustomJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCustomJobsResponse {
     type PageItem = crate::model::CustomJob;
 
@@ -40616,7 +40594,6 @@ impl wkt::message::Message for ListDataLabelingJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDataLabelingJobsResponse {
     type PageItem = crate::model::DataLabelingJob;
 
@@ -40939,7 +40916,6 @@ impl wkt::message::Message for ListHyperparameterTuningJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListHyperparameterTuningJobsResponse {
     type PageItem = crate::model::HyperparameterTuningJob;
 
@@ -41258,7 +41234,6 @@ impl wkt::message::Message for ListNasJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNasJobsResponse {
     type PageItem = crate::model::NasJob;
 
@@ -41486,7 +41461,6 @@ impl wkt::message::Message for ListNasTrialDetailsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNasTrialDetailsResponse {
     type PageItem = crate::model::NasTrialDetail;
 
@@ -41736,7 +41710,6 @@ impl wkt::message::Message for ListBatchPredictionJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBatchPredictionJobsResponse {
     type PageItem = crate::model::BatchPredictionJob;
 
@@ -42115,7 +42088,6 @@ impl wkt::message::Message for SearchModelDeploymentMonitoringStatsAnomaliesResp
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchModelDeploymentMonitoringStatsAnomaliesResponse {
     type PageItem = crate::model::ModelMonitoringStatsAnomalies;
 
@@ -42304,7 +42276,6 @@ impl wkt::message::Message for ListModelDeploymentMonitoringJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelDeploymentMonitoringJobsResponse {
     type PageItem = crate::model::ModelDeploymentMonitoringJob;
 
@@ -44332,7 +44303,6 @@ impl wkt::message::Message for ListMetadataStoresResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMetadataStoresResponse {
     type PageItem = crate::model::MetadataStore;
 
@@ -44692,7 +44662,6 @@ impl wkt::message::Message for ListArtifactsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListArtifactsResponse {
     type PageItem = crate::model::Artifact;
 
@@ -45233,7 +45202,6 @@ impl wkt::message::Message for ListContextsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListContextsResponse {
     type PageItem = crate::model::Context;
 
@@ -46052,7 +46020,6 @@ impl wkt::message::Message for ListExecutionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExecutionsResponse {
     type PageItem = crate::model::Execution;
 
@@ -46655,7 +46622,6 @@ impl wkt::message::Message for ListMetadataSchemasResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMetadataSchemasResponse {
     type PageItem = crate::model::MetadataSchema;
 
@@ -47530,7 +47496,6 @@ impl wkt::message::Message for SearchMigratableResourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchMigratableResourcesResponse {
     type PageItem = crate::model::MigratableResource;
 
@@ -54199,7 +54164,6 @@ impl wkt::message::Message for ListModelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelsResponse {
     type PageItem = crate::model::Model;
 
@@ -54375,7 +54339,6 @@ impl wkt::message::Message for ListModelVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelVersionsResponse {
     type PageItem = crate::model::Model;
 
@@ -54555,7 +54518,6 @@ impl wkt::message::Message for ListModelVersionCheckpointsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelVersionCheckpointsResponse {
     type PageItem = crate::model::ModelVersionCheckpoint;
 
@@ -55766,7 +55728,6 @@ impl wkt::message::Message for ListModelEvaluationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelEvaluationsResponse {
     type PageItem = crate::model::ModelEvaluation;
 
@@ -55951,7 +55912,6 @@ impl wkt::message::Message for ListModelEvaluationSlicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelEvaluationSlicesResponse {
     type PageItem = crate::model::ModelEvaluationSlice;
 
@@ -59228,7 +59188,6 @@ impl wkt::message::Message for ListNotebookRuntimeTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNotebookRuntimeTemplatesResponse {
     type PageItem = crate::model::NotebookRuntimeTemplate;
 
@@ -59685,7 +59644,6 @@ impl wkt::message::Message for ListNotebookRuntimesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNotebookRuntimesResponse {
     type PageItem = crate::model::NotebookRuntime;
 
@@ -60351,7 +60309,6 @@ impl wkt::message::Message for ListNotebookExecutionJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNotebookExecutionJobsResponse {
     type PageItem = crate::model::NotebookExecutionJob;
 
@@ -62119,7 +62076,6 @@ impl wkt::message::Message for ListPersistentResourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPersistentResourcesResponse {
     type PageItem = crate::model::PersistentResource;
 
@@ -63843,7 +63799,6 @@ impl wkt::message::Message for ListTrainingPipelinesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTrainingPipelinesResponse {
     type PageItem = crate::model::TrainingPipeline;
 
@@ -64211,7 +64166,6 @@ impl wkt::message::Message for ListPipelineJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPipelineJobsResponse {
     type PageItem = crate::model::PipelineJob;
 
@@ -68458,7 +68412,6 @@ impl wkt::message::Message for ListReasoningEnginesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReasoningEnginesResponse {
     type PageItem = crate::model::ReasoningEngine;
 
@@ -69547,7 +69500,6 @@ impl wkt::message::Message for ListSchedulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSchedulesResponse {
     type PageItem = crate::model::Schedule;
 
@@ -70227,7 +70179,6 @@ impl wkt::message::Message for ListSpecialistPoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSpecialistPoolsResponse {
     type PageItem = crate::model::SpecialistPool;
 
@@ -73964,7 +73915,6 @@ impl wkt::message::Message for ListTensorboardsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTensorboardsResponse {
     type PageItem = crate::model::Tensorboard;
 
@@ -74538,7 +74488,6 @@ impl wkt::message::Message for ListTensorboardExperimentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTensorboardExperimentsResponse {
     type PageItem = crate::model::TensorboardExperiment;
 
@@ -75062,7 +75011,6 @@ impl wkt::message::Message for ListTensorboardRunsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTensorboardRunsResponse {
     type PageItem = crate::model::TensorboardRun;
 
@@ -75506,7 +75454,6 @@ impl wkt::message::Message for ListTensorboardTimeSeriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTensorboardTimeSeriesResponse {
     type PageItem = crate::model::TensorboardTimeSeries;
 
@@ -76089,7 +76036,6 @@ impl wkt::message::Message for ExportTensorboardTimeSeriesDataResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ExportTensorboardTimeSeriesDataResponse {
     type PageItem = crate::model::TimeSeriesDataPoint;
 
@@ -82898,7 +82844,6 @@ impl wkt::message::Message for ListRagCorporaResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRagCorporaResponse {
     type PageItem = crate::model::RagCorpus;
 
@@ -83477,7 +83422,6 @@ impl wkt::message::Message for ListRagFilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRagFilesResponse {
     type PageItem = crate::model::RagFile;
 
@@ -84893,7 +84837,6 @@ impl wkt::message::Message for ListStudiesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListStudiesResponse {
     type PageItem = crate::model::Study;
 
@@ -85395,7 +85338,6 @@ impl wkt::message::Message for ListTrialsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTrialsResponse {
     type PageItem = crate::model::Trial;
 

--- a/src/generated/cloud/alloydb/v1/src/builders.rs
+++ b/src/generated/cloud/alloydb/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
@@ -919,7 +918,6 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -1932,7 +1930,6 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -2365,7 +2362,6 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2558,7 +2554,6 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListUsersResponse, gax::error::Error> {
@@ -2864,7 +2859,6 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatabasesResponse, gax::error::Error>
@@ -2941,7 +2935,6 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3059,7 +3052,6 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/alloydb/v1/src/builders.rs
+++ b/src/generated/cloud/alloydb/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
         {
@@ -918,7 +918,7 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -1930,7 +1930,7 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -2362,7 +2362,7 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListSupportedDatabaseFlagsResponse,
@@ -2554,7 +2554,7 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListUsersResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -2859,7 +2859,7 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatabasesResponse, gax::error::Error>
         {
@@ -2935,7 +2935,7 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3052,7 +3052,7 @@ pub mod alloy_db_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -4717,7 +4717,6 @@ impl wkt::message::Message for ListClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClustersResponse {
     type PageItem = crate::model::Cluster;
 
@@ -5573,7 +5572,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 
@@ -7058,7 +7056,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 
@@ -7449,7 +7446,6 @@ impl wkt::message::Message for ListSupportedDatabaseFlagsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSupportedDatabaseFlagsResponse {
     type PageItem = crate::model::SupportedDatabaseFlag;
 
@@ -7943,7 +7939,6 @@ impl wkt::message::Message for ListUsersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUsersResponse {
     type PageItem = crate::model::User;
 
@@ -8331,7 +8326,6 @@ impl wkt::message::Message for ListDatabasesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatabasesResponse {
     type PageItem = crate::model::Database;
 

--- a/src/generated/cloud/apigateway/v1/src/builders.rs
+++ b/src/generated/cloud/apigateway/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod api_gateway_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGatewaysResponse, gax::error::Error>
@@ -448,7 +447,6 @@ pub mod api_gateway_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApisResponse, gax::error::Error> {
@@ -819,7 +817,6 @@ pub mod api_gateway_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApiConfigsResponse, gax::error::Error>
@@ -1213,7 +1210,6 @@ pub mod api_gateway_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/apigateway/v1/src/builders.rs
+++ b/src/generated/cloud/apigateway/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod api_gateway_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGatewaysResponse, gax::error::Error>
         {
@@ -447,7 +447,7 @@ pub mod api_gateway_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApisResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -817,7 +817,7 @@ pub mod api_gateway_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApiConfigsResponse, gax::error::Error>
         {
@@ -1210,7 +1210,7 @@ pub mod api_gateway_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/apigateway/v1/src/model.rs
+++ b/src/generated/cloud/apigateway/v1/src/model.rs
@@ -947,7 +947,6 @@ impl wkt::message::Message for ListGatewaysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGatewaysResponse {
     type PageItem = crate::model::Gateway;
 
@@ -1251,7 +1250,6 @@ impl wkt::message::Message for ListApisResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListApisResponse {
     type PageItem = crate::model::Api;
 
@@ -1555,7 +1553,6 @@ impl wkt::message::Message for ListApiConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListApiConfigsResponse {
     type PageItem = crate::model::ApiConfig;
 

--- a/src/generated/cloud/apigeeconnect/v1/src/builders.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod connection_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>

--- a/src/generated/cloud/apigeeconnect/v1/src/builders.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod connection_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -131,7 +131,6 @@ impl wkt::message::Message for ListConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectionsResponse {
     type PageItem = crate::model::Connection;
 

--- a/src/generated/cloud/apihub/v1/src/builders.rs
+++ b/src/generated/cloud/apihub/v1/src/builders.rs
@@ -160,7 +160,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApisResponse, gax::error::Error> {
@@ -427,7 +426,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
@@ -736,7 +734,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSpecsResponse, gax::error::Error> {
@@ -944,7 +941,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApiOperationsResponse, gax::error::Error>
@@ -1159,7 +1155,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
@@ -1524,7 +1519,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttributesResponse, gax::error::Error>
@@ -1598,7 +1592,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchResourcesResponse, gax::error::Error>
@@ -1881,7 +1874,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExternalApisResponse, gax::error::Error>
@@ -1952,7 +1944,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2070,7 +2061,6 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2505,7 +2495,6 @@ pub mod api_hub_dependencies {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDependenciesResponse, gax::error::Error>
@@ -2582,7 +2571,6 @@ pub mod api_hub_dependencies {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2700,7 +2688,6 @@ pub mod api_hub_dependencies {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3057,7 +3044,6 @@ pub mod host_project_registration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -3144,7 +3130,6 @@ pub mod host_project_registration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3266,7 +3251,6 @@ pub mod host_project_registration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3689,7 +3673,6 @@ pub mod linting_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3807,7 +3790,6 @@ pub mod linting_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4165,7 +4147,6 @@ pub mod api_hub_plugin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -4283,7 +4264,6 @@ pub mod api_hub_plugin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4704,7 +4684,6 @@ pub mod provisioning {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -4822,7 +4801,6 @@ pub mod provisioning {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5179,7 +5157,6 @@ pub mod runtime_project_attachment_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -5362,7 +5339,6 @@ pub mod runtime_project_attachment_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -5484,7 +5460,6 @@ pub mod runtime_project_attachment_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/apihub/v1/src/builders.rs
+++ b/src/generated/cloud/apihub/v1/src/builders.rs
@@ -160,7 +160,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApisResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -426,7 +426,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
         {
@@ -734,7 +734,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSpecsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -941,7 +941,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApiOperationsResponse, gax::error::Error>
         {
@@ -1155,7 +1155,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
         {
@@ -1519,7 +1519,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttributesResponse, gax::error::Error>
         {
@@ -1592,7 +1592,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchResourcesResponse, gax::error::Error>
         {
@@ -1874,7 +1874,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExternalApisResponse, gax::error::Error>
         {
@@ -1944,7 +1944,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2061,7 +2061,7 @@ pub mod api_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2495,7 +2495,7 @@ pub mod api_hub_dependencies {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDependenciesResponse, gax::error::Error>
         {
@@ -2571,7 +2571,7 @@ pub mod api_hub_dependencies {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2688,7 +2688,7 @@ pub mod api_hub_dependencies {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3044,7 +3044,7 @@ pub mod host_project_registration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListHostProjectRegistrationsResponse,
@@ -3130,7 +3130,7 @@ pub mod host_project_registration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3251,7 +3251,7 @@ pub mod host_project_registration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3673,7 +3673,7 @@ pub mod linting_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3790,7 +3790,7 @@ pub mod linting_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4147,7 +4147,7 @@ pub mod api_hub_plugin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -4264,7 +4264,7 @@ pub mod api_hub_plugin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4684,7 +4684,7 @@ pub mod provisioning {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -4801,7 +4801,7 @@ pub mod provisioning {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5157,7 +5157,7 @@ pub mod runtime_project_attachment_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListRuntimeProjectAttachmentsResponse,
@@ -5339,7 +5339,7 @@ pub mod runtime_project_attachment_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -5460,7 +5460,7 @@ pub mod runtime_project_attachment_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/apihub/v1/src/model.rs
+++ b/src/generated/cloud/apihub/v1/src/model.rs
@@ -405,7 +405,6 @@ impl wkt::message::Message for ListApisResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListApisResponse {
     type PageItem = crate::model::Api;
 
@@ -787,7 +786,6 @@ impl wkt::message::Message for ListVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVersionsResponse {
     type PageItem = crate::model::Version;
 
@@ -1147,7 +1145,6 @@ impl wkt::message::Message for ListSpecsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSpecsResponse {
     type PageItem = crate::model::Spec;
 
@@ -1389,7 +1386,6 @@ impl wkt::message::Message for ListApiOperationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListApiOperationsResponse {
     type PageItem = crate::model::ApiOperation;
 
@@ -1794,7 +1790,6 @@ impl wkt::message::Message for ListDeploymentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeploymentsResponse {
     type PageItem = crate::model::Deployment;
 
@@ -2151,7 +2146,6 @@ impl wkt::message::Message for ListAttributesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAttributesResponse {
     type PageItem = crate::model::Attribute;
 
@@ -2582,7 +2576,6 @@ impl wkt::message::Message for SearchResourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchResourcesResponse {
     type PageItem = crate::model::SearchResult;
 
@@ -2930,7 +2923,6 @@ impl wkt::message::Message for ListDependenciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDependenciesResponse {
     type PageItem = crate::model::Dependency;
 
@@ -3242,7 +3234,6 @@ impl wkt::message::Message for ListExternalApisResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExternalApisResponse {
     type PageItem = crate::model::ExternalApi;
 
@@ -7490,7 +7481,6 @@ impl wkt::message::Message for ListHostProjectRegistrationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListHostProjectRegistrationsResponse {
     type PageItem = crate::model::HostProjectRegistration;
 
@@ -8468,7 +8458,6 @@ impl wkt::message::Message for ListRuntimeProjectAttachmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRuntimeProjectAttachmentsResponse {
     type PageItem = crate::model::RuntimeProjectAttachment;
 

--- a/src/generated/cloud/apphub/v1/src/builders.rs
+++ b/src/generated/cloud/apphub/v1/src/builders.rs
@@ -119,7 +119,7 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListServiceProjectAttachmentsResponse,
@@ -495,7 +495,7 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListDiscoveredServicesResponse,
@@ -672,7 +672,7 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -1074,7 +1074,7 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListDiscoveredWorkloadsResponse,
@@ -1251,7 +1251,7 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkloadsResponse, gax::error::Error>
         {
@@ -1653,7 +1653,7 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApplicationsResponse, gax::error::Error>
         {
@@ -2064,7 +2064,7 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2345,7 +2345,7 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/apphub/v1/src/builders.rs
+++ b/src/generated/cloud/apphub/v1/src/builders.rs
@@ -119,7 +119,6 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -496,7 +495,6 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -674,7 +672,6 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -1077,7 +1074,6 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1255,7 +1251,6 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkloadsResponse, gax::error::Error>
@@ -1658,7 +1653,6 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListApplicationsResponse, gax::error::Error>
@@ -2070,7 +2064,6 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2352,7 +2345,6 @@ pub mod app_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/apphub/v1/src/model.rs
+++ b/src/generated/cloud/apphub/v1/src/model.rs
@@ -228,7 +228,6 @@ impl wkt::message::Message for ListServiceProjectAttachmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServiceProjectAttachmentsResponse {
     type PageItem = crate::model::ServiceProjectAttachment;
 
@@ -588,7 +587,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::Service;
 
@@ -730,7 +728,6 @@ impl wkt::message::Message for ListDiscoveredServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDiscoveredServicesResponse {
     type PageItem = crate::model::DiscoveredService;
 
@@ -1217,7 +1214,6 @@ impl wkt::message::Message for ListApplicationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListApplicationsResponse {
     type PageItem = crate::model::Application;
 
@@ -1601,7 +1597,6 @@ impl wkt::message::Message for ListWorkloadsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkloadsResponse {
     type PageItem = crate::model::Workload;
 
@@ -1743,7 +1738,6 @@ impl wkt::message::Message for ListDiscoveredWorkloadsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDiscoveredWorkloadsResponse {
     type PageItem = crate::model::DiscoveredWorkload;
 

--- a/src/generated/cloud/asset/v1/src/builders.rs
+++ b/src/generated/cloud/asset/v1/src/builders.rs
@@ -193,7 +193,6 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAssetsResponse, gax::error::Error>
@@ -605,7 +604,6 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAllResourcesResponse, gax::error::Error>
@@ -705,7 +703,6 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAllIamPoliciesResponse, gax::error::Error>
@@ -1218,7 +1215,6 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSavedQueriesResponse, gax::error::Error>
@@ -1452,7 +1448,6 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::AnalyzeOrgPoliciesResponse, gax::error::Error>
@@ -1539,7 +1534,6 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1626,7 +1620,6 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/cloud/asset/v1/src/builders.rs
+++ b/src/generated/cloud/asset/v1/src/builders.rs
@@ -193,7 +193,7 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAssetsResponse, gax::error::Error>
         {
@@ -604,7 +604,7 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAllResourcesResponse, gax::error::Error>
         {
@@ -703,7 +703,7 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAllIamPoliciesResponse, gax::error::Error>
         {
@@ -1215,7 +1215,7 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSavedQueriesResponse, gax::error::Error>
         {
@@ -1448,7 +1448,7 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::AnalyzeOrgPoliciesResponse, gax::error::Error>
         {
@@ -1534,7 +1534,7 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::AnalyzeOrgPolicyGovernedContainersResponse,
@@ -1620,7 +1620,7 @@ pub mod asset_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::AnalyzeOrgPolicyGovernedAssetsResponse,

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -488,7 +488,6 @@ impl wkt::message::Message for ListAssetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAssetsResponse {
     type PageItem = crate::model::Asset;
 
@@ -2036,7 +2035,6 @@ impl wkt::message::Message for SearchAllResourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchAllResourcesResponse {
     type PageItem = crate::model::ResourceSearchResult;
 
@@ -2264,7 +2262,6 @@ impl wkt::message::Message for SearchAllIamPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchAllIamPoliciesResponse {
     type PageItem = crate::model::IamPolicySearchResult;
 
@@ -3909,7 +3906,6 @@ impl wkt::message::Message for ListSavedQueriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSavedQueriesResponse {
     type PageItem = crate::model::SavedQuery;
 
@@ -6632,7 +6628,6 @@ impl wkt::message::Message for AnalyzeOrgPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for AnalyzeOrgPoliciesResponse {
     type PageItem = crate::model::analyze_org_policies_response::OrgPolicyResult;
 
@@ -6918,7 +6913,6 @@ impl wkt::message::Message for AnalyzeOrgPolicyGovernedContainersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for AnalyzeOrgPolicyGovernedContainersResponse {
     type PageItem =
         crate::model::analyze_org_policy_governed_containers_response::GovernedContainer;
@@ -7272,7 +7266,6 @@ impl wkt::message::Message for AnalyzeOrgPolicyGovernedAssetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for AnalyzeOrgPolicyGovernedAssetsResponse {
     type PageItem = crate::model::analyze_org_policy_governed_assets_response::GovernedAsset;
 

--- a/src/generated/cloud/assuredworkloads/v1/src/builders.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builders.rs
@@ -363,7 +363,7 @@ pub mod assured_workloads_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkloadsResponse, gax::error::Error>
         {
@@ -439,7 +439,7 @@ pub mod assured_workloads_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/assuredworkloads/v1/src/builders.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builders.rs
@@ -363,7 +363,6 @@ pub mod assured_workloads_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkloadsResponse, gax::error::Error>
@@ -440,7 +439,6 @@ pub mod assured_workloads_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -316,7 +316,6 @@ impl wkt::message::Message for ListWorkloadsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkloadsResponse {
     type PageItem = crate::model::Workload;
 
@@ -1717,7 +1716,6 @@ impl wkt::message::Message for ListViolationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListViolationsResponse {
     type PageItem = crate::model::Violation;
 

--- a/src/generated/cloud/backupdr/v1/src/builders.rs
+++ b/src/generated/cloud/backupdr/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListManagementServersResponse, gax::error::Error>
         {
@@ -503,7 +503,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupVaultsResponse, gax::error::Error>
         {
@@ -593,7 +593,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::FetchUsableBackupVaultsResponse,
@@ -948,7 +948,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataSourcesResponse, gax::error::Error>
         {
@@ -1174,7 +1174,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -1740,7 +1740,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupPlansResponse, gax::error::Error>
         {
@@ -2068,7 +2068,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListBackupPlanAssociationsResponse,
@@ -2424,7 +2424,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2705,7 +2705,7 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/backupdr/v1/src/builders.rs
+++ b/src/generated/cloud/backupdr/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListManagementServersResponse, gax::error::Error>
@@ -504,7 +503,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupVaultsResponse, gax::error::Error>
@@ -595,7 +593,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -951,7 +948,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataSourcesResponse, gax::error::Error>
@@ -1178,7 +1174,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -1745,7 +1740,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupPlansResponse, gax::error::Error>
@@ -2074,7 +2068,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2431,7 +2424,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2713,7 +2705,6 @@ pub mod backup_dr {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -805,7 +805,6 @@ impl wkt::message::Message for ListManagementServersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListManagementServersResponse {
     type PageItem = crate::model::ManagementServer;
 
@@ -2230,7 +2229,6 @@ impl wkt::message::Message for ListBackupPlansResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupPlansResponse {
     type PageItem = crate::model::BackupPlan;
 
@@ -2891,7 +2889,6 @@ impl wkt::message::Message for ListBackupPlanAssociationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupPlanAssociationsResponse {
     type PageItem = crate::model::BackupPlanAssociation;
 
@@ -5481,7 +5478,6 @@ impl wkt::message::Message for ListBackupVaultsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupVaultsResponse {
     type PageItem = crate::model::BackupVault;
 
@@ -5634,7 +5630,6 @@ impl wkt::message::Message for FetchUsableBackupVaultsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for FetchUsableBackupVaultsResponse {
     type PageItem = crate::model::BackupVault;
 
@@ -6023,7 +6018,6 @@ impl wkt::message::Message for ListDataSourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDataSourcesResponse {
     type PageItem = crate::model::DataSource;
 
@@ -6296,7 +6290,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 

--- a/src/generated/cloud/baremetalsolution/v2/src/builders.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builders.rs
@@ -68,7 +68,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -833,7 +833,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSSHKeysResponse, gax::error::Error>
         {
@@ -997,7 +997,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumesResponse, gax::error::Error>
         {
@@ -1408,7 +1408,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNetworksResponse, gax::error::Error>
         {
@@ -1883,7 +1883,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumeSnapshotsResponse, gax::error::Error>
         {
@@ -1989,7 +1989,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLunsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -2172,7 +2172,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNfsSharesResponse, gax::error::Error>
         {
@@ -2550,7 +2550,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListProvisioningQuotasResponse,
@@ -2902,7 +2902,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOSImagesResponse, gax::error::Error>
         {
@@ -2972,7 +2972,7 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/baremetalsolution/v2/src/builders.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builders.rs
@@ -68,7 +68,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -834,7 +833,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSSHKeysResponse, gax::error::Error>
@@ -999,7 +997,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumesResponse, gax::error::Error>
@@ -1411,7 +1408,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNetworksResponse, gax::error::Error>
@@ -1887,7 +1883,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumeSnapshotsResponse, gax::error::Error>
@@ -1994,7 +1989,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLunsResponse, gax::error::Error> {
@@ -2178,7 +2172,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNfsSharesResponse, gax::error::Error>
@@ -2557,7 +2550,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2910,7 +2902,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOSImagesResponse, gax::error::Error>
@@ -2981,7 +2972,6 @@ pub mod bare_metal_solution {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -655,7 +655,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 
@@ -1700,7 +1699,6 @@ impl wkt::message::Message for ListLunsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLunsResponse {
     type PageItem = crate::model::Lun;
 
@@ -2676,7 +2674,6 @@ impl wkt::message::Message for ListNetworksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNetworksResponse {
     type PageItem = crate::model::Network;
 
@@ -3523,7 +3520,6 @@ impl wkt::message::Message for ListNfsSharesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNfsSharesResponse {
     type PageItem = crate::model::NfsShare;
 
@@ -3875,7 +3871,6 @@ impl wkt::message::Message for ListOSImagesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOSImagesResponse {
     type PageItem = crate::model::OSImage;
 
@@ -4650,7 +4645,6 @@ impl wkt::message::Message for ListProvisioningQuotasResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProvisioningQuotasResponse {
     type PageItem = crate::model::ProvisioningQuota;
 
@@ -6230,7 +6224,6 @@ impl wkt::message::Message for ListSSHKeysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSSHKeysResponse {
     type PageItem = crate::model::SSHKey;
 
@@ -7169,7 +7162,6 @@ impl wkt::message::Message for ListVolumesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVolumesResponse {
     type PageItem = crate::model::Volume;
 
@@ -7628,7 +7620,6 @@ impl wkt::message::Message for ListVolumeSnapshotsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVolumeSnapshotsResponse {
     type PageItem = crate::model::VolumeSnapshot;
 

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod app_connections_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAppConnectionsResponse, gax::error::Error>
@@ -519,7 +518,6 @@ pub mod app_connections_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ResolveAppConnectionsResponse, gax::error::Error>
@@ -596,7 +594,6 @@ pub mod app_connections_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -878,7 +875,6 @@ pub mod app_connections_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod app_connections_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAppConnectionsResponse, gax::error::Error>
         {
@@ -518,7 +518,7 @@ pub mod app_connections_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ResolveAppConnectionsResponse, gax::error::Error>
         {
@@ -594,7 +594,7 @@ pub mod app_connections_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -875,7 +875,7 @@ pub mod app_connections_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
@@ -171,7 +171,6 @@ impl wkt::message::Message for ListAppConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAppConnectionsResponse {
     type PageItem = crate::model::AppConnection;
 
@@ -597,7 +596,6 @@ impl wkt::message::Message for ResolveAppConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ResolveAppConnectionsResponse {
     type PageItem = crate::model::resolve_app_connections_response::AppConnectionDetails;
 

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod app_connectors_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAppConnectorsResponse, gax::error::Error>
         {
@@ -612,7 +612,7 @@ pub mod app_connectors_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -893,7 +893,7 @@ pub mod app_connectors_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod app_connectors_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAppConnectorsResponse, gax::error::Error>
@@ -613,7 +612,6 @@ pub mod app_connectors_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -895,7 +893,6 @@ pub mod app_connectors_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -405,7 +405,6 @@ impl wkt::message::Message for ListAppConnectorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAppConnectorsResponse {
     type PageItem = crate::model::AppConnector;
 

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod app_gateways_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAppGatewaysResponse, gax::error::Error>
@@ -395,7 +394,6 @@ pub mod app_gateways_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -677,7 +675,6 @@ pub mod app_gateways_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod app_gateways_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAppGatewaysResponse, gax::error::Error>
         {
@@ -394,7 +394,7 @@ pub mod app_gateways_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -675,7 +675,7 @@ pub mod app_gateways_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
@@ -171,7 +171,6 @@ impl wkt::message::Message for ListAppGatewaysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAppGatewaysResponse {
     type PageItem = crate::model::AppGateway;
 

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builders.rs
@@ -77,7 +77,6 @@ pub mod client_connector_services_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -557,7 +556,6 @@ pub mod client_connector_services_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -849,7 +847,6 @@ pub mod client_connector_services_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builders.rs
@@ -77,7 +77,7 @@ pub mod client_connector_services_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListClientConnectorServicesResponse,
@@ -556,7 +556,7 @@ pub mod client_connector_services_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -847,7 +847,7 @@ pub mod client_connector_services_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
@@ -733,7 +733,6 @@ impl wkt::message::Message for ListClientConnectorServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClientConnectorServicesResponse {
     type PageItem = crate::model::ClientConnectorService;
 

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod client_gateways_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClientGatewaysResponse, gax::error::Error>
@@ -404,7 +403,6 @@ pub mod client_gateways_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -686,7 +684,6 @@ pub mod client_gateways_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod client_gateways_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClientGatewaysResponse, gax::error::Error>
         {
@@ -403,7 +403,7 @@ pub mod client_gateways_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -684,7 +684,7 @@ pub mod client_gateways_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
@@ -337,7 +337,6 @@ impl wkt::message::Message for ListClientGatewaysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClientGatewaysResponse {
     type PageItem = crate::model::ClientGateway;
 

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataExchangesResponse, gax::error::Error>
@@ -142,7 +141,6 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOrgDataExchangesResponse, gax::error::Error>
@@ -410,7 +408,6 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListListingsResponse, gax::error::Error>
@@ -956,7 +953,6 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSubscriptionsResponse, gax::error::Error>
@@ -1035,7 +1031,6 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataExchangesResponse, gax::error::Error>
         {
@@ -141,7 +141,7 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOrgDataExchangesResponse, gax::error::Error>
         {
@@ -408,7 +408,7 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListListingsResponse, gax::error::Error>
         {
@@ -953,7 +953,7 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSubscriptionsResponse, gax::error::Error>
         {
@@ -1031,7 +1031,7 @@ pub mod analytics_hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListSharedResourceSubscriptionsResponse,

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -1741,7 +1741,6 @@ impl wkt::message::Message for ListDataExchangesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDataExchangesResponse {
     type PageItem = crate::model::DataExchange;
 
@@ -1851,7 +1850,6 @@ impl wkt::message::Message for ListOrgDataExchangesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOrgDataExchangesResponse {
     type PageItem = crate::model::DataExchange;
 
@@ -2130,7 +2128,6 @@ impl wkt::message::Message for ListListingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListListingsResponse {
     type PageItem = crate::model::Listing;
 
@@ -2745,7 +2742,6 @@ impl wkt::message::Message for ListSubscriptionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSubscriptionsResponse {
     type PageItem = crate::model::Subscription;
 
@@ -2863,7 +2859,6 @@ impl wkt::message::Message for ListSharedResourceSubscriptionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSharedResourceSubscriptionsResponse {
     type PageItem = crate::model::Subscription;
 

--- a/src/generated/cloud/bigquery/connection/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/builders.rs
@@ -168,7 +168,7 @@ pub mod connection_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/bigquery/connection/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/builders.rs
@@ -168,7 +168,6 @@ pub mod connection_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -218,7 +218,6 @@ impl wkt::message::Message for ListConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectionsResponse {
     type PageItem = crate::model::Connection;
 

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/builders.rs
@@ -315,7 +315,6 @@ pub mod data_policy_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataPoliciesResponse, gax::error::Error>

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/builders.rs
@@ -315,7 +315,7 @@ pub mod data_policy_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataPoliciesResponse, gax::error::Error>
         {

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
@@ -344,7 +344,6 @@ impl wkt::message::Message for ListDataPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDataPoliciesResponse {
     type PageItem = crate::model::DataPolicy;
 

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builders.rs
@@ -109,7 +109,6 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataSourcesResponse, gax::error::Error>
@@ -413,7 +412,6 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTransferConfigsResponse, gax::error::Error>
@@ -694,7 +692,6 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTransferRunsResponse, gax::error::Error>
@@ -785,7 +782,6 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTransferLogsResponse, gax::error::Error>
@@ -1018,7 +1014,6 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builders.rs
@@ -109,7 +109,7 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataSourcesResponse, gax::error::Error>
         {
@@ -412,7 +412,7 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTransferConfigsResponse, gax::error::Error>
         {
@@ -692,7 +692,7 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTransferRunsResponse, gax::error::Error>
         {
@@ -782,7 +782,7 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTransferLogsResponse, gax::error::Error>
         {
@@ -1014,7 +1014,7 @@ pub mod data_transfer_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -832,7 +832,6 @@ impl wkt::message::Message for ListDataSourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDataSourcesResponse {
     type PageItem = crate::model::DataSource;
 
@@ -1341,7 +1340,6 @@ impl wkt::message::Message for ListTransferConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTransferConfigsResponse {
     type PageItem = crate::model::TransferConfig;
 
@@ -1545,7 +1543,6 @@ impl wkt::message::Message for ListTransferRunsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTransferRunsResponse {
     type PageItem = crate::model::TransferRun;
 
@@ -1675,7 +1672,6 @@ impl wkt::message::Message for ListTransferLogsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTransferLogsResponse {
     type PageItem = crate::model::TransferMessage;
 

--- a/src/generated/cloud/bigquery/migration/v2/src/builders.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/builders.rs
@@ -178,7 +178,6 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -397,7 +396,6 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMigrationSubtasksResponse, gax::error::Error>

--- a/src/generated/cloud/bigquery/migration/v2/src/builders.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/builders.rs
@@ -178,7 +178,7 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListMigrationWorkflowsResponse,
@@ -396,7 +396,7 @@ pub mod migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMigrationSubtasksResponse, gax::error::Error>
         {

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -1638,7 +1638,6 @@ impl wkt::message::Message for ListMigrationWorkflowsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMigrationWorkflowsResponse {
     type PageItem = crate::model::MigrationWorkflow;
 
@@ -1878,7 +1877,6 @@ impl wkt::message::Message for ListMigrationSubtasksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMigrationSubtasksResponse {
     type PageItem = crate::model::MigrationSubtask;
 

--- a/src/generated/cloud/bigquery/reservation/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/builders.rs
@@ -130,7 +130,6 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReservationsResponse, gax::error::Error>
@@ -457,7 +456,6 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -851,7 +849,6 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAssignmentsResponse, gax::error::Error>
@@ -966,7 +963,6 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAssignmentsResponse, gax::error::Error>
@@ -1043,7 +1039,6 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAllAssignmentsResponse, gax::error::Error>

--- a/src/generated/cloud/bigquery/reservation/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/builders.rs
@@ -130,7 +130,7 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReservationsResponse, gax::error::Error>
         {
@@ -456,7 +456,7 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListCapacityCommitmentsResponse,
@@ -849,7 +849,7 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAssignmentsResponse, gax::error::Error>
         {
@@ -963,7 +963,7 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAssignmentsResponse, gax::error::Error>
         {
@@ -1039,7 +1039,7 @@ pub mod reservation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAllAssignmentsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -885,7 +885,6 @@ impl wkt::message::Message for ListReservationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReservationsResponse {
     type PageItem = crate::model::Reservation;
 
@@ -1222,7 +1221,6 @@ impl wkt::message::Message for ListCapacityCommitmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCapacityCommitmentsResponse {
     type PageItem = crate::model::CapacityCommitment;
 
@@ -1900,7 +1898,6 @@ impl wkt::message::Message for ListAssignmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAssignmentsResponse {
     type PageItem = crate::model::Assignment;
 
@@ -2138,7 +2135,6 @@ impl wkt::message::Message for SearchAssignmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchAssignmentsResponse {
     type PageItem = crate::model::Assignment;
 
@@ -2199,7 +2195,6 @@ impl wkt::message::Message for SearchAllAssignmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchAllAssignmentsResponse {
     type PageItem = crate::model::Assignment;
 

--- a/src/generated/cloud/billing/v1/src/builders.rs
+++ b/src/generated/cloud/billing/v1/src/builders.rs
@@ -115,7 +115,6 @@ pub mod cloud_billing {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBillingAccountsResponse, gax::error::Error>
@@ -307,7 +306,6 @@ pub mod cloud_billing {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -718,7 +716,6 @@ pub mod cloud_catalog {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -780,7 +777,6 @@ pub mod cloud_catalog {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSkusResponse, gax::error::Error> {

--- a/src/generated/cloud/billing/v1/src/builders.rs
+++ b/src/generated/cloud/billing/v1/src/builders.rs
@@ -115,7 +115,7 @@ pub mod cloud_billing {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBillingAccountsResponse, gax::error::Error>
         {
@@ -306,7 +306,7 @@ pub mod cloud_billing {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListProjectBillingInfoResponse,
@@ -716,7 +716,7 @@ pub mod cloud_catalog {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -777,7 +777,7 @@ pub mod cloud_catalog {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSkusResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);

--- a/src/generated/cloud/billing/v1/src/model.rs
+++ b/src/generated/cloud/billing/v1/src/model.rs
@@ -362,7 +362,6 @@ impl wkt::message::Message for ListBillingAccountsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBillingAccountsResponse {
     type PageItem = crate::model::BillingAccount;
 
@@ -583,7 +582,6 @@ impl wkt::message::Message for ListProjectBillingInfoResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProjectBillingInfoResponse {
     type PageItem = crate::model::ProjectBillingInfo;
 
@@ -1626,7 +1624,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::Service;
 
@@ -1784,7 +1781,6 @@ impl wkt::message::Message for ListSkusResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSkusResponse {
     type PageItem = crate::model::Sku;
 

--- a/src/generated/cloud/binaryauthorization/v1/src/builders.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/builders.rs
@@ -308,7 +308,6 @@ pub mod binauthz_management_service_v_1 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttestorsResponse, gax::error::Error>

--- a/src/generated/cloud/binaryauthorization/v1/src/builders.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/builders.rs
@@ -308,7 +308,7 @@ pub mod binauthz_management_service_v_1 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttestorsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/binaryauthorization/v1/src/model.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/model.rs
@@ -1374,7 +1374,6 @@ impl wkt::message::Message for ListAttestorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAttestorsResponse {
     type PageItem = crate::model::Attestor;
 

--- a/src/generated/cloud/certificatemanager/v1/src/builders.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCertificatesResponse, gax::error::Error>
@@ -465,7 +464,6 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCertificateMapsResponse, gax::error::Error>
@@ -866,7 +864,6 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1277,7 +1274,6 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDnsAuthorizationsResponse, gax::error::Error>
@@ -1682,7 +1678,6 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2001,7 +1996,6 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTrustConfigsResponse, gax::error::Error>
@@ -2401,7 +2395,6 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2519,7 +2512,6 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/certificatemanager/v1/src/builders.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCertificatesResponse, gax::error::Error>
         {
@@ -464,7 +464,7 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCertificateMapsResponse, gax::error::Error>
         {
@@ -864,7 +864,7 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListCertificateMapEntriesResponse,
@@ -1274,7 +1274,7 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDnsAuthorizationsResponse, gax::error::Error>
         {
@@ -1678,7 +1678,7 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListCertificateIssuanceConfigsResponse,
@@ -1996,7 +1996,7 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTrustConfigsResponse, gax::error::Error>
         {
@@ -2395,7 +2395,7 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2512,7 +2512,7 @@ pub mod certificate_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/certificatemanager/v1/src/model.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/model.rs
@@ -167,7 +167,6 @@ impl wkt::message::Message for ListCertificateIssuanceConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCertificateIssuanceConfigsResponse {
     type PageItem = crate::model::CertificateIssuanceConfig;
 
@@ -749,7 +748,6 @@ impl wkt::message::Message for ListCertificatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCertificatesResponse {
     type PageItem = crate::model::Certificate;
 
@@ -1060,7 +1058,6 @@ impl wkt::message::Message for ListCertificateMapsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCertificateMapsResponse {
     type PageItem = crate::model::CertificateMap;
 
@@ -1379,7 +1376,6 @@ impl wkt::message::Message for ListCertificateMapEntriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCertificateMapEntriesResponse {
     type PageItem = crate::model::CertificateMapEntry;
 
@@ -1693,7 +1689,6 @@ impl wkt::message::Message for ListDnsAuthorizationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDnsAuthorizationsResponse {
     type PageItem = crate::model::DnsAuthorization;
 
@@ -3734,7 +3729,6 @@ impl wkt::message::Message for ListTrustConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTrustConfigsResponse {
     type PageItem = crate::model::TrustConfig;
 

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/builders.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/builders.rs
@@ -109,7 +109,7 @@ pub mod cloud_controls_partner_core {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkloadsResponse, gax::error::Error>
         {
@@ -229,7 +229,7 @@ pub mod cloud_controls_partner_core {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomersResponse, gax::error::Error>
         {
@@ -401,7 +401,7 @@ pub mod cloud_controls_partner_core {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAccessApprovalRequestsResponse,
@@ -553,7 +553,7 @@ pub mod cloud_controls_partner_monitoring {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListViolationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/builders.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/builders.rs
@@ -109,7 +109,6 @@ pub mod cloud_controls_partner_core {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkloadsResponse, gax::error::Error>
@@ -230,7 +229,6 @@ pub mod cloud_controls_partner_core {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomersResponse, gax::error::Error>
@@ -403,7 +401,6 @@ pub mod cloud_controls_partner_core {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -556,7 +553,6 @@ pub mod cloud_controls_partner_monitoring {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListViolationsResponse, gax::error::Error>

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
@@ -238,7 +238,6 @@ impl wkt::message::Message for ListAccessApprovalRequestsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAccessApprovalRequestsResponse {
     type PageItem = crate::model::AccessApprovalRequest;
 
@@ -854,7 +853,6 @@ impl wkt::message::Message for ListWorkloadsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkloadsResponse {
     type PageItem = crate::model::Workload;
 
@@ -1260,7 +1258,6 @@ impl wkt::message::Message for ListCustomersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCustomersResponse {
     type PageItem = crate::model::Customer;
 
@@ -2914,7 +2911,6 @@ impl wkt::message::Message for ListViolationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListViolationsResponse {
     type PageItem = crate::model::Violation;
 

--- a/src/generated/cloud/clouddms/v1/src/builders.rs
+++ b/src/generated/cloud/clouddms/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMigrationJobsResponse, gax::error::Error>
@@ -1146,7 +1145,6 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1763,7 +1761,6 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1981,7 +1978,6 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2481,7 +2477,6 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMappingRulesResponse, gax::error::Error>
@@ -3199,7 +3194,6 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -3477,7 +3471,6 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3759,7 +3752,6 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/clouddms/v1/src/builders.rs
+++ b/src/generated/cloud/clouddms/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMigrationJobsResponse, gax::error::Error>
         {
@@ -1145,7 +1145,7 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListConnectionProfilesResponse,
@@ -1761,7 +1761,7 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListPrivateConnectionsResponse,
@@ -1978,7 +1978,7 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListConversionWorkspacesResponse,
@@ -2477,7 +2477,7 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMappingRulesResponse, gax::error::Error>
         {
@@ -3194,7 +3194,7 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::DescribeDatabaseEntitiesResponse,
@@ -3471,7 +3471,7 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3752,7 +3752,7 @@ pub mod data_migration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -178,7 +178,6 @@ impl wkt::message::Message for ListMigrationJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMigrationJobsResponse {
     type PageItem = crate::model::MigrationJob;
 
@@ -1140,7 +1139,6 @@ impl wkt::message::Message for ListConnectionProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectionProfilesResponse {
     type PageItem = crate::model::ConnectionProfile;
 
@@ -1642,7 +1640,6 @@ impl wkt::message::Message for ListPrivateConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPrivateConnectionsResponse {
     type PageItem = crate::model::PrivateConnection;
 
@@ -1962,7 +1959,6 @@ impl wkt::message::Message for ListConversionWorkspacesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConversionWorkspacesResponse {
     type PageItem = crate::model::ConversionWorkspace;
 
@@ -2492,7 +2488,6 @@ impl wkt::message::Message for ListMappingRulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMappingRulesResponse {
     type PageItem = crate::model::MappingRule;
 
@@ -3093,7 +3088,6 @@ impl wkt::message::Message for DescribeDatabaseEntitiesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for DescribeDatabaseEntitiesResponse {
     type PageItem = crate::model::DatabaseEntity;
 

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builders.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builders.rs
@@ -270,7 +270,6 @@ pub mod license_management_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -560,7 +559,6 @@ pub mod consumer_procurement_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOrdersResponse, gax::error::Error>

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builders.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builders.rs
@@ -270,7 +270,7 @@ pub mod license_management_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::EnumerateLicensedUsersResponse,
@@ -559,7 +559,7 @@ pub mod consumer_procurement_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOrdersResponse, gax::error::Error>
         {

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -651,7 +651,6 @@ impl wkt::message::Message for EnumerateLicensedUsersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for EnumerateLicensedUsersResponse {
     type PageItem = crate::model::LicensedUser;
 
@@ -1562,7 +1561,6 @@ impl wkt::message::Message for ListOrdersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOrdersResponse {
     type PageItem = crate::model::Order;
 

--- a/src/generated/cloud/confidentialcomputing/v1/src/builders.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builders.rs
@@ -220,7 +220,6 @@ pub mod confidential_computing {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/confidentialcomputing/v1/src/builders.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builders.rs
@@ -220,7 +220,7 @@ pub mod confidential_computing {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/config/v1/src/builders.rs
+++ b/src/generated/cloud/config/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
         {
@@ -494,7 +494,7 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRevisionsResponse, gax::error::Error>
         {
@@ -655,7 +655,7 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListResourcesResponse, gax::error::Error>
         {
@@ -1280,7 +1280,7 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPreviewsResponse, gax::error::Error>
         {
@@ -1490,7 +1490,7 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTerraformVersionsResponse, gax::error::Error>
         {
@@ -1616,7 +1616,7 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1897,7 +1897,7 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/config/v1/src/builders.rs
+++ b/src/generated/cloud/config/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
@@ -495,7 +494,6 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRevisionsResponse, gax::error::Error>
@@ -657,7 +655,6 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListResourcesResponse, gax::error::Error>
@@ -1283,7 +1280,6 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPreviewsResponse, gax::error::Error>
@@ -1494,7 +1490,6 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTerraformVersionsResponse, gax::error::Error>
@@ -1621,7 +1616,6 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1903,7 +1897,6 @@ pub mod config {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -1086,7 +1086,6 @@ impl wkt::message::Message for ListDeploymentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeploymentsResponse {
     type PageItem = crate::model::Deployment;
 
@@ -1286,7 +1285,6 @@ impl wkt::message::Message for ListRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRevisionsResponse {
     type PageItem = crate::model::Revision;
 
@@ -3162,7 +3160,6 @@ impl wkt::message::Message for ListResourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListResourcesResponse {
     type PageItem = crate::model::Resource;
 
@@ -4610,7 +4607,6 @@ impl wkt::message::Message for ListPreviewsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPreviewsResponse {
     type PageItem = crate::model::Preview;
 
@@ -4953,7 +4949,6 @@ impl wkt::message::Message for ListTerraformVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTerraformVersionsResponse {
     type PageItem = crate::model::TerraformVersion;
 

--- a/src/generated/cloud/connectors/v1/src/builders.rs
+++ b/src/generated/cloud/connectors/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
@@ -471,7 +470,6 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProvidersResponse, gax::error::Error>
@@ -580,7 +578,6 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectorsResponse, gax::error::Error>
@@ -692,7 +689,6 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectorVersionsResponse, gax::error::Error>
@@ -954,7 +950,6 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1035,7 +1030,6 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1202,7 +1196,6 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1484,7 +1477,6 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/connectors/v1/src/builders.rs
+++ b/src/generated/cloud/connectors/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
         {
@@ -470,7 +470,7 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProvidersResponse, gax::error::Error>
         {
@@ -578,7 +578,7 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectorsResponse, gax::error::Error>
         {
@@ -689,7 +689,7 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectorVersionsResponse, gax::error::Error>
         {
@@ -950,7 +950,7 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListRuntimeEntitySchemasResponse,
@@ -1030,7 +1030,7 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListRuntimeActionSchemasResponse,
@@ -1196,7 +1196,7 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1477,7 +1477,7 @@ pub mod connectors {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -2501,7 +2501,6 @@ impl wkt::message::Message for ListConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectionsResponse {
     type PageItem = crate::model::Connection;
 
@@ -2875,7 +2874,6 @@ impl wkt::message::Message for ListRuntimeEntitySchemasResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRuntimeEntitySchemasResponse {
     type PageItem = crate::model::RuntimeEntitySchema;
 
@@ -3000,7 +2998,6 @@ impl wkt::message::Message for ListRuntimeActionSchemasResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRuntimeActionSchemasResponse {
     type PageItem = crate::model::RuntimeActionSchema;
 
@@ -3437,7 +3434,6 @@ impl wkt::message::Message for ListConnectorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectorsResponse {
     type PageItem = crate::model::Connector;
 
@@ -3829,7 +3825,6 @@ impl wkt::message::Message for ListConnectorVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectorVersionsResponse {
     type PageItem = crate::model::ConnectorVersion;
 
@@ -4623,7 +4618,6 @@ impl wkt::message::Message for ListProvidersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProvidersResponse {
     type PageItem = crate::model::Provider;
 

--- a/src/generated/cloud/contactcenterinsights/v1/src/builders.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builders.rs
@@ -351,7 +351,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConversationsResponse, gax::error::Error>
@@ -619,7 +618,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAnalysesResponse, gax::error::Error>
@@ -2225,7 +2223,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPhraseMatchersResponse, gax::error::Error>
@@ -2637,7 +2634,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAnalysisRulesResponse, gax::error::Error>
@@ -3029,7 +3025,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListViewsResponse, gax::error::Error> {
@@ -3506,7 +3501,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQaQuestionsResponse, gax::error::Error>
@@ -3783,7 +3777,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQaScorecardsResponse, gax::error::Error>
@@ -4208,7 +4201,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -4346,7 +4338,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeedbackLabelsResponse, gax::error::Error>
@@ -4567,7 +4558,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAllFeedbackLabelsResponse, gax::error::Error>
@@ -4890,7 +4880,6 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/contactcenterinsights/v1/src/builders.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builders.rs
@@ -351,7 +351,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConversationsResponse, gax::error::Error>
         {
@@ -618,7 +618,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAnalysesResponse, gax::error::Error>
         {
@@ -2223,7 +2223,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPhraseMatchersResponse, gax::error::Error>
         {
@@ -2634,7 +2634,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAnalysisRulesResponse, gax::error::Error>
         {
@@ -3025,7 +3025,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListViewsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -3501,7 +3501,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQaQuestionsResponse, gax::error::Error>
         {
@@ -3777,7 +3777,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQaScorecardsResponse, gax::error::Error>
         {
@@ -4201,7 +4201,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListQaScorecardRevisionsResponse,
@@ -4338,7 +4338,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeedbackLabelsResponse, gax::error::Error>
         {
@@ -4558,7 +4558,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAllFeedbackLabelsResponse, gax::error::Error>
         {
@@ -4880,7 +4880,7 @@ pub mod contact_center_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -770,7 +770,6 @@ impl wkt::message::Message for ListConversationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConversationsResponse {
     type PageItem = crate::model::Conversation;
 
@@ -1713,7 +1712,6 @@ impl wkt::message::Message for ListAnalysesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAnalysesResponse {
     type PageItem = crate::model::Analysis;
 
@@ -3834,7 +3832,6 @@ impl wkt::message::Message for ListPhraseMatchersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPhraseMatchersResponse {
     type PageItem = crate::model::PhraseMatcher;
 
@@ -4279,7 +4276,6 @@ impl wkt::message::Message for ListAnalysisRulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAnalysisRulesResponse {
     type PageItem = crate::model::AnalysisRule;
 
@@ -4625,7 +4621,6 @@ impl wkt::message::Message for ListViewsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListViewsResponse {
     type PageItem = crate::model::View;
 
@@ -6171,7 +6166,6 @@ impl wkt::message::Message for ListQaQuestionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListQaQuestionsResponse {
     type PageItem = crate::model::QaQuestion;
 
@@ -7055,7 +7049,6 @@ impl wkt::message::Message for ListQaScorecardsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListQaScorecardsResponse {
     type PageItem = crate::model::QaScorecard;
 
@@ -7180,7 +7173,6 @@ impl wkt::message::Message for ListQaScorecardRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListQaScorecardRevisionsResponse {
     type PageItem = crate::model::QaScorecardRevision;
 
@@ -7372,7 +7364,6 @@ impl wkt::message::Message for ListFeedbackLabelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFeedbackLabelsResponse {
     type PageItem = crate::model::FeedbackLabel;
 
@@ -7610,7 +7601,6 @@ impl wkt::message::Message for ListAllFeedbackLabelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAllFeedbackLabelsResponse {
     type PageItem = crate::model::FeedbackLabel;
 

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builders.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builders.rs
@@ -282,7 +282,7 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProcessesResponse, gax::error::Error>
         {
@@ -579,7 +579,7 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRunsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -830,7 +830,7 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLineageEventsResponse, gax::error::Error>
         {
@@ -947,7 +947,7 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchLinksResponse, gax::error::Error>
         {
@@ -1028,7 +1028,7 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::BatchSearchLinkProcessesResponse,
@@ -1111,7 +1111,7 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builders.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builders.rs
@@ -282,7 +282,6 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProcessesResponse, gax::error::Error>
@@ -580,7 +579,6 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRunsResponse, gax::error::Error> {
@@ -832,7 +830,6 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLineageEventsResponse, gax::error::Error>
@@ -950,7 +947,6 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchLinksResponse, gax::error::Error>
@@ -1032,7 +1028,6 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1116,7 +1111,6 @@ pub mod lineage {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
@@ -1028,7 +1028,6 @@ impl wkt::message::Message for ListProcessesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProcessesResponse {
     type PageItem = crate::model::Process;
 
@@ -1329,7 +1328,6 @@ impl wkt::message::Message for ListRunsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRunsResponse {
     type PageItem = crate::model::Run;
 
@@ -1573,7 +1571,6 @@ impl wkt::message::Message for ListLineageEventsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLineageEventsResponse {
     type PageItem = crate::model::LineageEvent;
 
@@ -1825,7 +1822,6 @@ impl wkt::message::Message for SearchLinksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchLinksResponse {
     type PageItem = crate::model::Link;
 
@@ -2050,7 +2046,6 @@ impl wkt::message::Message for BatchSearchLinkProcessesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for BatchSearchLinkProcessesResponse {
     type PageItem = crate::model::ProcessLinks;
 

--- a/src/generated/cloud/datacatalog/v1/src/builders.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchCatalogResponse, gax::error::Error>
         {
@@ -370,7 +370,7 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntryGroupsResponse, gax::error::Error>
         {
@@ -684,7 +684,7 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntriesResponse, gax::error::Error>
         {
@@ -1487,7 +1487,7 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -2143,7 +2143,7 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2518,7 +2518,7 @@ pub mod policy_tag_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTaxonomiesResponse, gax::error::Error>
         {
@@ -2776,7 +2776,7 @@ pub mod policy_tag_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPolicyTagsResponse, gax::error::Error>
         {
@@ -3051,7 +3051,7 @@ pub mod policy_tag_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3466,7 +3466,7 @@ pub mod policy_tag_manager_serialization {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/datacatalog/v1/src/builders.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchCatalogResponse, gax::error::Error>
@@ -371,7 +370,6 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntryGroupsResponse, gax::error::Error>
@@ -686,7 +684,6 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntriesResponse, gax::error::Error>
@@ -1490,7 +1487,6 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagsResponse, gax::error::Error> {
@@ -2147,7 +2143,6 @@ pub mod data_catalog {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2523,7 +2518,6 @@ pub mod policy_tag_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTaxonomiesResponse, gax::error::Error>
@@ -2782,7 +2776,6 @@ pub mod policy_tag_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPolicyTagsResponse, gax::error::Error>
@@ -3058,7 +3051,6 @@ pub mod policy_tag_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3474,7 +3466,6 @@ pub mod policy_tag_manager_serialization {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -956,7 +956,6 @@ impl wkt::message::Message for SearchCatalogResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchCatalogResponse {
     type PageItem = crate::model::SearchCatalogResult;
 
@@ -1275,7 +1274,6 @@ impl wkt::message::Message for ListEntryGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEntryGroupsResponse {
     type PageItem = crate::model::EntryGroup;
 
@@ -5322,7 +5320,6 @@ impl wkt::message::Message for ListTagsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTagsResponse {
     type PageItem = crate::model::Tag;
 
@@ -5712,7 +5709,6 @@ impl wkt::message::Message for ListEntriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEntriesResponse {
     type PageItem = crate::model::Entry;
 
@@ -8011,7 +8007,6 @@ impl wkt::message::Message for ListTaxonomiesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTaxonomiesResponse {
     type PageItem = crate::model::Taxonomy;
 
@@ -8293,7 +8288,6 @@ impl wkt::message::Message for ListPolicyTagsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPolicyTagsResponse {
     type PageItem = crate::model::PolicyTag;
 

--- a/src/generated/cloud/datafusion/v1/src/builders.rs
+++ b/src/generated/cloud/datafusion/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod data_fusion {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAvailableVersionsResponse, gax::error::Error>
@@ -145,7 +144,6 @@ pub mod data_fusion {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -609,7 +607,6 @@ pub mod data_fusion {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/datafusion/v1/src/builders.rs
+++ b/src/generated/cloud/datafusion/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod data_fusion {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAvailableVersionsResponse, gax::error::Error>
         {
@@ -144,7 +144,7 @@ pub mod data_fusion {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -607,7 +607,7 @@ pub mod data_fusion {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/datafusion/v1/src/model.rs
+++ b/src/generated/cloud/datafusion/v1/src/model.rs
@@ -1148,7 +1148,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 
@@ -1267,7 +1266,6 @@ impl wkt::message::Message for ListAvailableVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAvailableVersionsResponse {
     type PageItem = crate::model::Version;
 

--- a/src/generated/cloud/dataproc/v1/src/builders.rs
+++ b/src/generated/cloud/dataproc/v1/src/builders.rs
@@ -221,7 +221,6 @@ pub mod autoscaling_policy_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -504,7 +503,6 @@ pub mod autoscaling_policy_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -877,7 +875,6 @@ pub mod batch_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBatchesResponse, gax::error::Error>
@@ -1165,7 +1162,6 @@ pub mod batch_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1995,7 +1991,6 @@ pub mod cluster_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
@@ -2384,7 +2379,6 @@ pub mod cluster_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2820,7 +2814,6 @@ pub mod job_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
@@ -3255,7 +3248,6 @@ pub mod job_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3897,7 +3889,6 @@ pub mod node_group_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4276,7 +4267,6 @@ pub mod session_template_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSessionTemplatesResponse, gax::error::Error>
@@ -4561,7 +4551,6 @@ pub mod session_template_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4935,7 +4924,6 @@ pub mod session_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSessionsResponse, gax::error::Error>
@@ -5351,7 +5339,6 @@ pub mod session_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5936,7 +5923,6 @@ pub mod workflow_template_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkflowTemplatesResponse, gax::error::Error>
@@ -6221,7 +6207,6 @@ pub mod workflow_template_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/dataproc/v1/src/builders.rs
+++ b/src/generated/cloud/dataproc/v1/src/builders.rs
@@ -221,7 +221,7 @@ pub mod autoscaling_policy_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAutoscalingPoliciesResponse,
@@ -503,7 +503,7 @@ pub mod autoscaling_policy_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -875,7 +875,7 @@ pub mod batch_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBatchesResponse, gax::error::Error>
         {
@@ -1162,7 +1162,7 @@ pub mod batch_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1991,7 +1991,7 @@ pub mod cluster_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
         {
@@ -2379,7 +2379,7 @@ pub mod cluster_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2814,7 +2814,7 @@ pub mod job_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -3248,7 +3248,7 @@ pub mod job_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3889,7 +3889,7 @@ pub mod node_group_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4267,7 +4267,7 @@ pub mod session_template_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSessionTemplatesResponse, gax::error::Error>
         {
@@ -4551,7 +4551,7 @@ pub mod session_template_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4924,7 +4924,7 @@ pub mod session_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSessionsResponse, gax::error::Error>
         {
@@ -5339,7 +5339,7 @@ pub mod session_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5923,7 +5923,7 @@ pub mod workflow_template_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkflowTemplatesResponse, gax::error::Error>
         {
@@ -6207,7 +6207,7 @@ pub mod workflow_template_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -745,7 +745,6 @@ impl wkt::message::Message for ListAutoscalingPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAutoscalingPoliciesResponse {
     type PageItem = crate::model::AutoscalingPolicy;
 
@@ -1014,7 +1013,6 @@ impl wkt::message::Message for ListBatchesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBatchesResponse {
     type PageItem = crate::model::Batch;
 
@@ -6117,7 +6115,6 @@ impl wkt::message::Message for ListClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClustersResponse {
     type PageItem = crate::model::Cluster;
 
@@ -10029,7 +10026,6 @@ impl wkt::message::Message for ListJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListJobsResponse {
     type PageItem = crate::model::Job;
 
@@ -11397,7 +11393,6 @@ impl wkt::message::Message for ListSessionTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSessionTemplatesResponse {
     type PageItem = crate::model::SessionTemplate;
 
@@ -11900,7 +11895,6 @@ impl wkt::message::Message for ListSessionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSessionsResponse {
     type PageItem = crate::model::Session;
 
@@ -16436,7 +16430,6 @@ impl wkt::message::Message for ListWorkflowTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkflowTemplatesResponse {
     type PageItem = crate::model::WorkflowTemplate;
 

--- a/src/generated/cloud/datastream/v1/src/builders.rs
+++ b/src/generated/cloud/datastream/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListConnectionProfilesResponse,
@@ -599,7 +599,7 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStreamsResponse, gax::error::Error>
         {
@@ -1212,7 +1212,7 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStreamObjectsResponse, gax::error::Error>
         {
@@ -1578,7 +1578,7 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListPrivateConnectionsResponse,
@@ -1892,7 +1892,7 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRoutesResponse, gax::error::Error>
         {
@@ -2056,7 +2056,7 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2173,7 +2173,7 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/datastream/v1/src/builders.rs
+++ b/src/generated/cloud/datastream/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -600,7 +599,6 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStreamsResponse, gax::error::Error>
@@ -1214,7 +1212,6 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStreamObjectsResponse, gax::error::Error>
@@ -1581,7 +1578,6 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1896,7 +1892,6 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRoutesResponse, gax::error::Error>
@@ -2061,7 +2056,6 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2179,7 +2173,6 @@ pub mod datastream {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -812,7 +812,6 @@ impl wkt::message::Message for ListConnectionProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectionProfilesResponse {
     type PageItem = crate::model::ConnectionProfile;
 
@@ -1229,7 +1228,6 @@ impl wkt::message::Message for ListStreamsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListStreamsResponse {
     type PageItem = crate::model::Stream;
 
@@ -1857,7 +1855,6 @@ impl wkt::message::Message for ListStreamObjectsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListStreamObjectsResponse {
     type PageItem = crate::model::StreamObject;
 
@@ -2212,7 +2209,6 @@ impl wkt::message::Message for ListPrivateConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPrivateConnectionsResponse {
     type PageItem = crate::model::PrivateConnection;
 
@@ -2525,7 +2521,6 @@ impl wkt::message::Message for ListRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRoutesResponse {
     type PageItem = crate::model::Route;
 

--- a/src/generated/cloud/deploy/v1/src/builders.rs
+++ b/src/generated/cloud/deploy/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeliveryPipelinesResponse, gax::error::Error>
         {
@@ -530,7 +530,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTargetsResponse, gax::error::Error>
         {
@@ -1059,7 +1059,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomTargetTypesResponse, gax::error::Error>
         {
@@ -1512,7 +1512,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReleasesResponse, gax::error::Error>
         {
@@ -2116,7 +2116,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeployPoliciesResponse, gax::error::Error>
         {
@@ -2404,7 +2404,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRolloutsResponse, gax::error::Error>
         {
@@ -2774,7 +2774,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobRunsResponse, gax::error::Error>
         {
@@ -3352,7 +3352,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAutomationsResponse, gax::error::Error>
         {
@@ -3478,7 +3478,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAutomationRunsResponse, gax::error::Error>
         {
@@ -3604,7 +3604,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3885,7 +3885,7 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/deploy/v1/src/builders.rs
+++ b/src/generated/cloud/deploy/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeliveryPipelinesResponse, gax::error::Error>
@@ -531,7 +530,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTargetsResponse, gax::error::Error>
@@ -1061,7 +1059,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomTargetTypesResponse, gax::error::Error>
@@ -1515,7 +1512,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReleasesResponse, gax::error::Error>
@@ -2120,7 +2116,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeployPoliciesResponse, gax::error::Error>
@@ -2409,7 +2404,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRolloutsResponse, gax::error::Error>
@@ -2780,7 +2774,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobRunsResponse, gax::error::Error>
@@ -3359,7 +3352,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAutomationsResponse, gax::error::Error>
@@ -3486,7 +3478,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAutomationRunsResponse, gax::error::Error>
@@ -3613,7 +3604,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3895,7 +3885,6 @@ pub mod cloud_deploy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -2059,7 +2059,6 @@ impl wkt::message::Message for ListDeliveryPipelinesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeliveryPipelinesResponse {
     type PageItem = crate::model::DeliveryPipeline;
 
@@ -3732,7 +3731,6 @@ impl wkt::message::Message for ListTargetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTargetsResponse {
     type PageItem = crate::model::Target;
 
@@ -4759,7 +4757,6 @@ impl wkt::message::Message for ListCustomTargetTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCustomTargetTypesResponse {
     type PageItem = crate::model::CustomTargetType;
 
@@ -7261,7 +7258,6 @@ impl wkt::message::Message for ListDeployPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeployPoliciesResponse {
     type PageItem = crate::model::DeployPolicy;
 
@@ -7781,7 +7777,6 @@ impl wkt::message::Message for ListReleasesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReleasesResponse {
     type PageItem = crate::model::Release;
 
@@ -9818,7 +9813,6 @@ impl wkt::message::Message for ListRolloutsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRolloutsResponse {
     type PageItem = crate::model::Rollout;
 
@@ -11779,7 +11773,6 @@ impl wkt::message::Message for ListJobRunsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListJobRunsResponse {
     type PageItem = crate::model::JobRun;
 
@@ -13659,7 +13652,6 @@ impl wkt::message::Message for ListAutomationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAutomationsResponse {
     type PageItem = crate::model::Automation;
 
@@ -14835,7 +14827,6 @@ impl wkt::message::Message for ListAutomationRunsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAutomationRunsResponse {
     type PageItem = crate::model::AutomationRun;
 

--- a/src/generated/cloud/developerconnect/v1/src/builders.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
         {
@@ -722,7 +722,7 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListGitRepositoryLinksResponse,
@@ -937,7 +937,7 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::FetchLinkableGitRepositoriesResponse,
@@ -1117,7 +1117,7 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1234,7 +1234,7 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/developerconnect/v1/src/builders.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
@@ -723,7 +722,6 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -939,7 +937,6 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1120,7 +1117,6 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1238,7 +1234,6 @@ pub mod developer_connect {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -1254,7 +1254,6 @@ impl wkt::message::Message for ListConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectionsResponse {
     type PageItem = crate::model::Connection;
 
@@ -2093,7 +2092,6 @@ impl wkt::message::Message for ListGitRepositoryLinksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGitRepositoryLinksResponse {
     type PageItem = crate::model::GitRepositoryLink;
 
@@ -2402,7 +2400,6 @@ impl wkt::message::Message for FetchLinkableGitRepositoriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for FetchLinkableGitRepositoriesResponse {
     type PageItem = crate::model::LinkableGitRepository;
 

--- a/src/generated/cloud/dialogflow/cx/v3/src/builders.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builders.rs
@@ -68,7 +68,6 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAgentsResponse, gax::error::Error>
@@ -741,7 +740,6 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -859,7 +857,6 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1047,7 +1044,6 @@ pub mod changelogs {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListChangelogsResponse, gax::error::Error>
@@ -1165,7 +1161,6 @@ pub mod changelogs {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1283,7 +1278,6 @@ pub mod changelogs {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1471,7 +1465,6 @@ pub mod deployments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
@@ -1583,7 +1576,6 @@ pub mod deployments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1701,7 +1693,6 @@ pub mod deployments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2107,7 +2098,6 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntityTypesResponse, gax::error::Error>
@@ -2421,7 +2411,6 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2539,7 +2528,6 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2730,7 +2718,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnvironmentsResponse, gax::error::Error>
@@ -3067,7 +3054,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -3229,7 +3215,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -3388,7 +3373,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3506,7 +3490,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3694,7 +3677,6 @@ pub mod experiments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExperimentsResponse, gax::error::Error>
@@ -4041,7 +4023,6 @@ pub mod experiments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -4159,7 +4140,6 @@ pub mod experiments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4447,7 +4427,6 @@ pub mod flows {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFlowsResponse, gax::error::Error> {
@@ -4994,7 +4973,6 @@ pub mod flows {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -5112,7 +5090,6 @@ pub mod flows {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5300,7 +5277,6 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGeneratorsResponse, gax::error::Error>
@@ -5586,7 +5562,6 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -5704,7 +5679,6 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5892,7 +5866,6 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIntentsResponse, gax::error::Error>
@@ -6391,7 +6364,6 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -6509,7 +6481,6 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -6697,7 +6668,6 @@ pub mod pages {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPagesResponse, gax::error::Error> {
@@ -6976,7 +6946,6 @@ pub mod pages {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -7094,7 +7063,6 @@ pub mod pages {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -7442,7 +7410,6 @@ pub mod security_settings_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecuritySettingsResponse, gax::error::Error>
@@ -7557,7 +7524,6 @@ pub mod security_settings_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -7675,7 +7641,6 @@ pub mod security_settings_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -8135,7 +8100,6 @@ pub mod sessions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -8253,7 +8217,6 @@ pub mod sessions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -8444,7 +8407,6 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -8724,7 +8686,6 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -8842,7 +8803,6 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -9030,7 +8990,6 @@ pub mod test_cases {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTestCasesResponse, gax::error::Error>
@@ -9753,7 +9712,6 @@ pub mod test_cases {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTestCaseResultsResponse, gax::error::Error>
@@ -9874,7 +9832,6 @@ pub mod test_cases {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -9992,7 +9949,6 @@ pub mod test_cases {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -10185,7 +10141,6 @@ pub mod transition_route_groups {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -10497,7 +10452,6 @@ pub mod transition_route_groups {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -10615,7 +10569,6 @@ pub mod transition_route_groups {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -10803,7 +10756,6 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
@@ -11233,7 +11185,6 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -11351,7 +11302,6 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -11539,7 +11489,6 @@ pub mod webhooks {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWebhooksResponse, gax::error::Error>
@@ -11801,7 +11750,6 @@ pub mod webhooks {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -11919,7 +11867,6 @@ pub mod webhooks {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/dialogflow/cx/v3/src/builders.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builders.rs
@@ -68,7 +68,7 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAgentsResponse, gax::error::Error>
         {
@@ -740,7 +740,7 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -857,7 +857,7 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1044,7 +1044,7 @@ pub mod changelogs {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListChangelogsResponse, gax::error::Error>
         {
@@ -1161,7 +1161,7 @@ pub mod changelogs {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1278,7 +1278,7 @@ pub mod changelogs {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1465,7 +1465,7 @@ pub mod deployments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
         {
@@ -1576,7 +1576,7 @@ pub mod deployments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1693,7 +1693,7 @@ pub mod deployments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2098,7 +2098,7 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntityTypesResponse, gax::error::Error>
         {
@@ -2411,7 +2411,7 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2528,7 +2528,7 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2718,7 +2718,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnvironmentsResponse, gax::error::Error>
         {
@@ -3054,7 +3054,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::LookupEnvironmentHistoryResponse,
@@ -3215,7 +3215,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListContinuousTestResultsResponse,
@@ -3373,7 +3373,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3490,7 +3490,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3677,7 +3677,7 @@ pub mod experiments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExperimentsResponse, gax::error::Error>
         {
@@ -4023,7 +4023,7 @@ pub mod experiments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -4140,7 +4140,7 @@ pub mod experiments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4427,7 +4427,7 @@ pub mod flows {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFlowsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -4973,7 +4973,7 @@ pub mod flows {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -5090,7 +5090,7 @@ pub mod flows {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5277,7 +5277,7 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGeneratorsResponse, gax::error::Error>
         {
@@ -5562,7 +5562,7 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -5679,7 +5679,7 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5866,7 +5866,7 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIntentsResponse, gax::error::Error>
         {
@@ -6364,7 +6364,7 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -6481,7 +6481,7 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -6668,7 +6668,7 @@ pub mod pages {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPagesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -6946,7 +6946,7 @@ pub mod pages {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -7063,7 +7063,7 @@ pub mod pages {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -7410,7 +7410,7 @@ pub mod security_settings_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecuritySettingsResponse, gax::error::Error>
         {
@@ -7524,7 +7524,7 @@ pub mod security_settings_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -7641,7 +7641,7 @@ pub mod security_settings_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -8100,7 +8100,7 @@ pub mod sessions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -8217,7 +8217,7 @@ pub mod sessions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -8407,7 +8407,7 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListSessionEntityTypesResponse,
@@ -8686,7 +8686,7 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -8803,7 +8803,7 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -8990,7 +8990,7 @@ pub mod test_cases {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTestCasesResponse, gax::error::Error>
         {
@@ -9712,7 +9712,7 @@ pub mod test_cases {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTestCaseResultsResponse, gax::error::Error>
         {
@@ -9832,7 +9832,7 @@ pub mod test_cases {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -9949,7 +9949,7 @@ pub mod test_cases {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -10141,7 +10141,7 @@ pub mod transition_route_groups {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListTransitionRouteGroupsResponse,
@@ -10452,7 +10452,7 @@ pub mod transition_route_groups {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -10569,7 +10569,7 @@ pub mod transition_route_groups {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -10756,7 +10756,7 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
         {
@@ -11185,7 +11185,7 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -11302,7 +11302,7 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -11489,7 +11489,7 @@ pub mod webhooks {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWebhooksResponse, gax::error::Error>
         {
@@ -11750,7 +11750,7 @@ pub mod webhooks {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -11867,7 +11867,7 @@ pub mod webhooks {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -1209,7 +1209,6 @@ impl wkt::message::Message for ListAgentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAgentsResponse {
     type PageItem = crate::model::Agent;
 
@@ -2933,7 +2932,6 @@ impl wkt::message::Message for ListChangelogsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListChangelogsResponse {
     type PageItem = crate::model::Changelog;
 
@@ -4295,7 +4293,6 @@ impl wkt::message::Message for ListDeploymentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeploymentsResponse {
     type PageItem = crate::model::Deployment;
 
@@ -5630,7 +5627,6 @@ impl wkt::message::Message for ListEntityTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEntityTypesResponse {
     type PageItem = crate::model::EntityType;
 
@@ -6261,7 +6257,6 @@ impl wkt::message::Message for ListEnvironmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEnvironmentsResponse {
     type PageItem = crate::model::Environment;
 
@@ -6554,7 +6549,6 @@ impl wkt::message::Message for LookupEnvironmentHistoryResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for LookupEnvironmentHistoryResponse {
     type PageItem = crate::model::Environment;
 
@@ -6913,7 +6907,6 @@ impl wkt::message::Message for ListContinuousTestResultsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListContinuousTestResultsResponse {
     type PageItem = crate::model::ContinuousTestResult;
 
@@ -8399,7 +8392,6 @@ impl wkt::message::Message for ListExperimentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExperimentsResponse {
     type PageItem = crate::model::Experiment;
 
@@ -9377,7 +9369,6 @@ impl wkt::message::Message for ListFlowsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFlowsResponse {
     type PageItem = crate::model::Flow;
 
@@ -11279,7 +11270,6 @@ impl wkt::message::Message for ListGeneratorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGeneratorsResponse {
     type PageItem = crate::model::Generator;
 
@@ -12065,7 +12055,6 @@ impl wkt::message::Message for ListIntentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIntentsResponse {
     type PageItem = crate::model::Intent;
 
@@ -14026,7 +14015,6 @@ impl wkt::message::Message for ListPagesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPagesResponse {
     type PageItem = crate::model::Page;
 
@@ -15878,7 +15866,6 @@ impl wkt::message::Message for ListSecuritySettingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecuritySettingsResponse {
     type PageItem = crate::model::SecuritySettings;
 
@@ -20724,7 +20711,6 @@ impl wkt::message::Message for ListSessionEntityTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSessionEntityTypesResponse {
     type PageItem = crate::model::SessionEntityType;
 
@@ -22640,7 +22626,6 @@ impl wkt::message::Message for ListTestCasesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTestCasesResponse {
     type PageItem = crate::model::TestCase;
 
@@ -23842,7 +23827,6 @@ impl wkt::message::Message for ListTestCaseResultsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTestCaseResultsResponse {
     type PageItem = crate::model::TestCaseResult;
 
@@ -24085,7 +24069,6 @@ impl wkt::message::Message for ListTransitionRouteGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTransitionRouteGroupsResponse {
     type PageItem = crate::model::TransitionRouteGroup;
 
@@ -24970,7 +24953,6 @@ impl wkt::message::Message for ListVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVersionsResponse {
     type PageItem = crate::model::Version;
 
@@ -26137,7 +26119,6 @@ impl wkt::message::Message for ListWebhooksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWebhooksResponse {
     type PageItem = crate::model::Webhook;
 

--- a/src/generated/cloud/dialogflow/v2/src/builders.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builders.rs
@@ -203,7 +203,7 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAgentsResponse, gax::error::Error>
         {
@@ -651,7 +651,7 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -768,7 +768,7 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -958,7 +958,7 @@ pub mod answer_records {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAnswerRecordsResponse, gax::error::Error>
         {
@@ -1090,7 +1090,7 @@ pub mod answer_records {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1207,7 +1207,7 @@ pub mod answer_records {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1394,7 +1394,7 @@ pub mod contexts {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListContextsResponse, gax::error::Error>
         {
@@ -1693,7 +1693,7 @@ pub mod contexts {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1810,7 +1810,7 @@ pub mod contexts {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2059,7 +2059,7 @@ pub mod conversations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConversationsResponse, gax::error::Error>
         {
@@ -2275,7 +2275,7 @@ pub mod conversations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMessagesResponse, gax::error::Error>
         {
@@ -2759,7 +2759,7 @@ pub mod conversations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2876,7 +2876,7 @@ pub mod conversations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3212,7 +3212,7 @@ pub mod conversation_datasets {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListConversationDatasetsResponse,
@@ -3467,7 +3467,7 @@ pub mod conversation_datasets {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3584,7 +3584,7 @@ pub mod conversation_datasets {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3918,7 +3918,7 @@ pub mod conversation_models {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListConversationModelsResponse,
@@ -4295,7 +4295,7 @@ pub mod conversation_models {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListConversationModelEvaluationsResponse,
@@ -4467,7 +4467,7 @@ pub mod conversation_models {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -4584,7 +4584,7 @@ pub mod conversation_models {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4776,7 +4776,7 @@ pub mod conversation_profiles {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListConversationProfilesResponse,
@@ -5275,7 +5275,7 @@ pub mod conversation_profiles {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -5392,7 +5392,7 @@ pub mod conversation_profiles {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5579,7 +5579,7 @@ pub mod documents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDocumentsResponse, gax::error::Error>
         {
@@ -6269,7 +6269,7 @@ pub mod documents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -6386,7 +6386,7 @@ pub mod documents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -6712,7 +6712,7 @@ pub mod encryption_spec_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -6829,7 +6829,7 @@ pub mod encryption_spec_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -7016,7 +7016,7 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntityTypesResponse, gax::error::Error>
         {
@@ -7799,7 +7799,7 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -7916,7 +7916,7 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -8106,7 +8106,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnvironmentsResponse, gax::error::Error>
         {
@@ -8382,7 +8382,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::EnvironmentHistory, gax::error::Error>
         {
@@ -8452,7 +8452,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -8569,7 +8569,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -8856,7 +8856,7 @@ pub mod fulfillments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -8973,7 +8973,7 @@ pub mod fulfillments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -9257,7 +9257,7 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGeneratorsResponse, gax::error::Error>
         {
@@ -9421,7 +9421,7 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -9538,7 +9538,7 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -9725,7 +9725,7 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIntentsResponse, gax::error::Error>
         {
@@ -10231,7 +10231,7 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -10348,7 +10348,7 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -10538,7 +10538,7 @@ pub mod knowledge_bases {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKnowledgeBasesResponse, gax::error::Error>
         {
@@ -10817,7 +10817,7 @@ pub mod knowledge_bases {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -10934,7 +10934,7 @@ pub mod knowledge_bases {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -11218,7 +11218,7 @@ pub mod participants {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListParticipantsResponse, gax::error::Error>
         {
@@ -11698,7 +11698,7 @@ pub mod participants {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -11815,7 +11815,7 @@ pub mod participants {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -12090,7 +12090,7 @@ pub mod sessions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -12207,7 +12207,7 @@ pub mod sessions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -12397,7 +12397,7 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListSessionEntityTypesResponse,
@@ -12676,7 +12676,7 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -12793,7 +12793,7 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -12980,7 +12980,7 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
         {
@@ -13235,7 +13235,7 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -13352,7 +13352,7 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/dialogflow/v2/src/builders.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builders.rs
@@ -203,7 +203,6 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchAgentsResponse, gax::error::Error>
@@ -652,7 +651,6 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -770,7 +768,6 @@ pub mod agents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -961,7 +958,6 @@ pub mod answer_records {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAnswerRecordsResponse, gax::error::Error>
@@ -1094,7 +1090,6 @@ pub mod answer_records {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1212,7 +1207,6 @@ pub mod answer_records {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1400,7 +1394,6 @@ pub mod contexts {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListContextsResponse, gax::error::Error>
@@ -1700,7 +1693,6 @@ pub mod contexts {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1818,7 +1810,6 @@ pub mod contexts {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2068,7 +2059,6 @@ pub mod conversations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConversationsResponse, gax::error::Error>
@@ -2285,7 +2275,6 @@ pub mod conversations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMessagesResponse, gax::error::Error>
@@ -2770,7 +2759,6 @@ pub mod conversations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2888,7 +2876,6 @@ pub mod conversations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3225,7 +3212,6 @@ pub mod conversation_datasets {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -3481,7 +3467,6 @@ pub mod conversation_datasets {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3599,7 +3584,6 @@ pub mod conversation_datasets {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3934,7 +3918,6 @@ pub mod conversation_models {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -4312,7 +4295,6 @@ pub mod conversation_models {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -4485,7 +4467,6 @@ pub mod conversation_models {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -4603,7 +4584,6 @@ pub mod conversation_models {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4796,7 +4776,6 @@ pub mod conversation_profiles {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -5296,7 +5275,6 @@ pub mod conversation_profiles {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -5414,7 +5392,6 @@ pub mod conversation_profiles {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5602,7 +5579,6 @@ pub mod documents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDocumentsResponse, gax::error::Error>
@@ -6293,7 +6269,6 @@ pub mod documents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -6411,7 +6386,6 @@ pub mod documents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -6738,7 +6712,6 @@ pub mod encryption_spec_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -6856,7 +6829,6 @@ pub mod encryption_spec_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -7044,7 +7016,6 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntityTypesResponse, gax::error::Error>
@@ -7828,7 +7799,6 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -7946,7 +7916,6 @@ pub mod entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -8137,7 +8106,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnvironmentsResponse, gax::error::Error>
@@ -8414,7 +8382,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::EnvironmentHistory, gax::error::Error>
@@ -8485,7 +8452,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -8603,7 +8569,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -8891,7 +8856,6 @@ pub mod fulfillments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -9009,7 +8973,6 @@ pub mod fulfillments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -9294,7 +9257,6 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGeneratorsResponse, gax::error::Error>
@@ -9459,7 +9421,6 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -9577,7 +9538,6 @@ pub mod generators {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -9765,7 +9725,6 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIntentsResponse, gax::error::Error>
@@ -10272,7 +10231,6 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -10390,7 +10348,6 @@ pub mod intents {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -10581,7 +10538,6 @@ pub mod knowledge_bases {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKnowledgeBasesResponse, gax::error::Error>
@@ -10861,7 +10817,6 @@ pub mod knowledge_bases {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -10979,7 +10934,6 @@ pub mod knowledge_bases {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -11264,7 +11218,6 @@ pub mod participants {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListParticipantsResponse, gax::error::Error>
@@ -11745,7 +11698,6 @@ pub mod participants {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -11863,7 +11815,6 @@ pub mod participants {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -12139,7 +12090,6 @@ pub mod sessions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -12257,7 +12207,6 @@ pub mod sessions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -12448,7 +12397,6 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -12728,7 +12676,6 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -12846,7 +12793,6 @@ pub mod session_entity_types {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -13034,7 +12980,6 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
@@ -13290,7 +13235,6 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -13408,7 +13352,6 @@ pub mod versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -620,7 +620,6 @@ impl wkt::message::Message for SearchAgentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchAgentsResponse {
     type PageItem = crate::model::Agent;
 
@@ -1393,7 +1392,6 @@ impl wkt::message::Message for ListAnswerRecordsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAnswerRecordsResponse {
     type PageItem = crate::model::AnswerRecord;
 
@@ -3276,7 +3274,6 @@ impl wkt::message::Message for ListContextsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListContextsResponse {
     type PageItem = crate::model::Context;
 
@@ -4424,7 +4421,6 @@ impl wkt::message::Message for ListConversationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConversationsResponse {
     type PageItem = crate::model::Conversation;
 
@@ -4626,7 +4622,6 @@ impl wkt::message::Message for ListMessagesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMessagesResponse {
     type PageItem = crate::model::Message;
 
@@ -7070,7 +7065,6 @@ impl wkt::message::Message for ListConversationDatasetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConversationDatasetsResponse {
     type PageItem = crate::model::ConversationDataset;
 
@@ -8734,7 +8728,6 @@ impl wkt::message::Message for ListConversationModelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConversationModelsResponse {
     type PageItem = crate::model::ConversationModel;
 
@@ -8981,7 +8974,6 @@ impl wkt::message::Message for ListConversationModelEvaluationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConversationModelEvaluationsResponse {
     type PageItem = crate::model::ConversationModelEvaluation;
 
@@ -9875,7 +9867,6 @@ impl wkt::message::Message for ListConversationProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConversationProfilesResponse {
     type PageItem = crate::model::ConversationProfile;
 
@@ -12652,7 +12643,6 @@ impl wkt::message::Message for ListDocumentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDocumentsResponse {
     type PageItem = crate::model::Document;
 
@@ -14062,7 +14052,6 @@ impl wkt::message::Message for ListEntityTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEntityTypesResponse {
     type PageItem = crate::model::EntityType;
 
@@ -15152,7 +15141,6 @@ impl wkt::message::Message for ListEnvironmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEnvironmentsResponse {
     type PageItem = crate::model::Environment;
 
@@ -15494,7 +15482,6 @@ impl wkt::message::Message for EnvironmentHistory {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for EnvironmentHistory {
     type PageItem = crate::model::environment_history::Entry;
 
@@ -16230,7 +16217,6 @@ impl wkt::message::Message for ListGeneratorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGeneratorsResponse {
     type PageItem = crate::model::Generator;
 
@@ -20940,7 +20926,6 @@ impl wkt::message::Message for ListIntentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIntentsResponse {
     type PageItem = crate::model::Intent;
 
@@ -21676,7 +21661,6 @@ impl wkt::message::Message for ListKnowledgeBasesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListKnowledgeBasesResponse {
     type PageItem = crate::model::KnowledgeBase;
 
@@ -22403,7 +22387,6 @@ impl wkt::message::Message for ListParticipantsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListParticipantsResponse {
     type PageItem = crate::model::Participant;
 
@@ -27979,7 +27962,6 @@ impl wkt::message::Message for ListSessionEntityTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSessionEntityTypesResponse {
     type PageItem = crate::model::SessionEntityType;
 
@@ -28619,7 +28601,6 @@ impl wkt::message::Message for ListVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVersionsResponse {
     type PageItem = crate::model::Version;
 

--- a/src/generated/cloud/discoveryengine/v1/src/builders.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builders.rs
@@ -523,7 +523,7 @@ pub mod completion_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -901,7 +901,7 @@ pub mod control_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListControlsResponse, gax::error::Error>
         {
@@ -977,7 +977,7 @@ pub mod control_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1490,7 +1490,7 @@ pub mod conversational_search_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConversationsResponse, gax::error::Error>
         {
@@ -1943,7 +1943,7 @@ pub mod conversational_search_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSessionsResponse, gax::error::Error>
         {
@@ -2027,7 +2027,7 @@ pub mod conversational_search_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2366,7 +2366,7 @@ pub mod data_store_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataStoresResponse, gax::error::Error>
         {
@@ -2571,7 +2571,7 @@ pub mod data_store_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2799,7 +2799,7 @@ pub mod document_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDocumentsResponse, gax::error::Error>
         {
@@ -3326,7 +3326,7 @@ pub mod document_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3777,7 +3777,7 @@ pub mod engine_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnginesResponse, gax::error::Error>
         {
@@ -3853,7 +3853,7 @@ pub mod engine_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4230,7 +4230,7 @@ pub mod grounded_generation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4515,7 +4515,7 @@ pub mod project_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4790,7 +4790,7 @@ pub mod rank_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5070,7 +5070,7 @@ pub mod recommendation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5298,7 +5298,7 @@ pub mod schema_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSchemasResponse, gax::error::Error>
         {
@@ -5626,7 +5626,7 @@ pub mod schema_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5811,7 +5811,7 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -6073,7 +6073,7 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -6338,7 +6338,7 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -6691,7 +6691,7 @@ pub mod search_tuning_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -7320,7 +7320,7 @@ pub mod site_search_engine_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTargetSitesResponse, gax::error::Error>
         {
@@ -7756,7 +7756,7 @@ pub mod site_search_engine_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::FetchDomainVerificationStatusResponse,
@@ -7828,7 +7828,7 @@ pub mod site_search_engine_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -8335,7 +8335,7 @@ pub mod user_event_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/discoveryengine/v1/src/builders.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builders.rs
@@ -523,7 +523,6 @@ pub mod completion_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -902,7 +901,6 @@ pub mod control_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListControlsResponse, gax::error::Error>
@@ -979,7 +977,6 @@ pub mod control_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1493,7 +1490,6 @@ pub mod conversational_search_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConversationsResponse, gax::error::Error>
@@ -1947,7 +1943,6 @@ pub mod conversational_search_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSessionsResponse, gax::error::Error>
@@ -2032,7 +2027,6 @@ pub mod conversational_search_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2372,7 +2366,6 @@ pub mod data_store_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataStoresResponse, gax::error::Error>
@@ -2578,7 +2571,6 @@ pub mod data_store_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2807,7 +2799,6 @@ pub mod document_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDocumentsResponse, gax::error::Error>
@@ -3335,7 +3326,6 @@ pub mod document_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3787,7 +3777,6 @@ pub mod engine_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnginesResponse, gax::error::Error>
@@ -3864,7 +3853,6 @@ pub mod engine_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4242,7 +4230,6 @@ pub mod grounded_generation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4528,7 +4515,6 @@ pub mod project_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4804,7 +4790,6 @@ pub mod rank_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5085,7 +5070,6 @@ pub mod recommendation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5314,7 +5298,6 @@ pub mod schema_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSchemasResponse, gax::error::Error>
@@ -5643,7 +5626,6 @@ pub mod schema_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5829,7 +5811,6 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchResponse, gax::error::Error> {
@@ -6092,7 +6073,6 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchResponse, gax::error::Error> {
@@ -6358,7 +6338,6 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -6712,7 +6691,6 @@ pub mod search_tuning_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -7342,7 +7320,6 @@ pub mod site_search_engine_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTargetSitesResponse, gax::error::Error>
@@ -7779,7 +7756,6 @@ pub mod site_search_engine_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -7852,7 +7828,6 @@ pub mod site_search_engine_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -8360,7 +8335,6 @@ pub mod user_event_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -3739,7 +3739,6 @@ impl wkt::message::Message for ListControlsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListControlsResponse {
     type PageItem = crate::model::Control;
 
@@ -4686,7 +4685,6 @@ impl wkt::message::Message for ListConversationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConversationsResponse {
     type PageItem = crate::model::Conversation;
 
@@ -6587,7 +6585,6 @@ impl wkt::message::Message for ListSessionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSessionsResponse {
     type PageItem = crate::model::Session;
 
@@ -7701,7 +7698,6 @@ impl wkt::message::Message for ListDataStoresResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDataStoresResponse {
     type PageItem = crate::model::DataStore;
 
@@ -8981,7 +8977,6 @@ impl wkt::message::Message for ListDocumentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDocumentsResponse {
     type PageItem = crate::model::Document;
 
@@ -10802,7 +10797,6 @@ impl wkt::message::Message for ListEnginesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEnginesResponse {
     type PageItem = crate::model::Engine;
 
@@ -17709,7 +17703,6 @@ impl wkt::message::Message for ListSchemasResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSchemasResponse {
     type PageItem = crate::model::Schema;
 
@@ -20648,7 +20641,6 @@ impl wkt::message::Message for SearchResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchResponse {
     type PageItem = crate::model::search_response::Facet;
 
@@ -23462,7 +23454,6 @@ impl wkt::message::Message for ListTargetSitesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTargetSitesResponse {
     type PageItem = crate::model::TargetSite;
 
@@ -24430,7 +24421,6 @@ impl wkt::message::Message for FetchDomainVerificationStatusResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for FetchDomainVerificationStatusResponse {
     type PageItem = crate::model::TargetSite;
 

--- a/src/generated/cloud/documentai/v1/src/builders.rs
+++ b/src/generated/cloud/documentai/v1/src/builders.rs
@@ -336,7 +336,7 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProcessorTypesResponse, gax::error::Error>
         {
@@ -447,7 +447,7 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProcessorsResponse, gax::error::Error>
         {
@@ -737,7 +737,7 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProcessorVersionsResponse, gax::error::Error>
         {
@@ -1710,7 +1710,7 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEvaluationsResponse, gax::error::Error>
         {
@@ -1780,7 +1780,7 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1897,7 +1897,7 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/documentai/v1/src/builders.rs
+++ b/src/generated/cloud/documentai/v1/src/builders.rs
@@ -336,7 +336,6 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProcessorTypesResponse, gax::error::Error>
@@ -448,7 +447,6 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProcessorsResponse, gax::error::Error>
@@ -739,7 +737,6 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProcessorVersionsResponse, gax::error::Error>
@@ -1713,7 +1710,6 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEvaluationsResponse, gax::error::Error>
@@ -1784,7 +1780,6 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1902,7 +1897,6 @@ pub mod document_processor_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -6827,7 +6827,6 @@ impl wkt::message::Message for ListProcessorTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProcessorTypesResponse {
     type PageItem = crate::model::ProcessorType;
 
@@ -6940,7 +6939,6 @@ impl wkt::message::Message for ListProcessorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProcessorsResponse {
     type PageItem = crate::model::Processor;
 
@@ -7153,7 +7151,6 @@ impl wkt::message::Message for ListProcessorVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProcessorVersionsResponse {
     type PageItem = crate::model::ProcessorVersion;
 
@@ -9070,7 +9067,6 @@ impl wkt::message::Message for ListEvaluationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEvaluationsResponse {
     type PageItem = crate::model::Evaluation;
 

--- a/src/generated/cloud/domains/v1/src/builders.rs
+++ b/src/generated/cloud/domains/v1/src/builders.rs
@@ -472,7 +472,6 @@ pub mod domains {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRegistrationsResponse, gax::error::Error>
@@ -1264,7 +1263,6 @@ pub mod domains {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/domains/v1/src/builders.rs
+++ b/src/generated/cloud/domains/v1/src/builders.rs
@@ -472,7 +472,7 @@ pub mod domains {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRegistrationsResponse, gax::error::Error>
         {
@@ -1263,7 +1263,7 @@ pub mod domains {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/domains/v1/src/model.rs
+++ b/src/generated/cloud/domains/v1/src/model.rs
@@ -1897,7 +1897,6 @@ impl wkt::message::Message for ListRegistrationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRegistrationsResponse {
     type PageItem = crate::model::Registration;
 

--- a/src/generated/cloud/edgecontainer/v1/src/builders.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
@@ -655,7 +654,6 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNodePoolsResponse, gax::error::Error>
@@ -1055,7 +1053,6 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMachinesResponse, gax::error::Error>
@@ -1179,7 +1176,6 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVpnConnectionsResponse, gax::error::Error>
@@ -1536,7 +1532,6 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1654,7 +1649,6 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/edgecontainer/v1/src/builders.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
         {
@@ -654,7 +654,7 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNodePoolsResponse, gax::error::Error>
         {
@@ -1053,7 +1053,7 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMachinesResponse, gax::error::Error>
         {
@@ -1176,7 +1176,7 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVpnConnectionsResponse, gax::error::Error>
         {
@@ -1532,7 +1532,7 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1649,7 +1649,7 @@ pub mod edge_container {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -3505,7 +3505,6 @@ impl wkt::message::Message for ListClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClustersResponse {
     type PageItem = crate::model::Cluster;
 
@@ -4128,7 +4127,6 @@ impl wkt::message::Message for ListNodePoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNodePoolsResponse {
     type PageItem = crate::model::NodePool;
 
@@ -4463,7 +4461,6 @@ impl wkt::message::Message for ListMachinesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMachinesResponse {
     type PageItem = crate::model::Machine;
 
@@ -4633,7 +4630,6 @@ impl wkt::message::Message for ListVpnConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVpnConnectionsResponse {
     type PageItem = crate::model::VpnConnection;
 

--- a/src/generated/cloud/edgenetwork/v1/src/builders.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builders.rs
@@ -109,7 +109,6 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListZonesResponse, gax::error::Error> {
@@ -229,7 +228,6 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNetworksResponse, gax::error::Error>
@@ -572,7 +570,6 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSubnetsResponse, gax::error::Error>
@@ -973,7 +970,6 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInterconnectsResponse, gax::error::Error>
@@ -1143,7 +1139,6 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1471,7 +1466,6 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRoutersResponse, gax::error::Error>
@@ -1913,7 +1907,6 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2031,7 +2024,6 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/edgenetwork/v1/src/builders.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builders.rs
@@ -109,7 +109,7 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListZonesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -228,7 +228,7 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNetworksResponse, gax::error::Error>
         {
@@ -570,7 +570,7 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSubnetsResponse, gax::error::Error>
         {
@@ -970,7 +970,7 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInterconnectsResponse, gax::error::Error>
         {
@@ -1139,7 +1139,7 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListInterconnectAttachmentsResponse,
@@ -1466,7 +1466,7 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRoutersResponse, gax::error::Error>
         {
@@ -1907,7 +1907,7 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2024,7 +2024,7 @@ pub mod edge_network {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -2192,7 +2192,6 @@ impl wkt::message::Message for ListZonesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListZonesResponse {
     type PageItem = crate::model::Zone;
 
@@ -2363,7 +2362,6 @@ impl wkt::message::Message for ListNetworksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNetworksResponse {
     type PageItem = crate::model::Network;
 
@@ -2660,7 +2658,6 @@ impl wkt::message::Message for ListSubnetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSubnetsResponse {
     type PageItem = crate::model::Subnet;
 
@@ -3028,7 +3025,6 @@ impl wkt::message::Message for ListInterconnectsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInterconnectsResponse {
     type PageItem = crate::model::Interconnect;
 
@@ -3198,7 +3194,6 @@ impl wkt::message::Message for ListInterconnectAttachmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInterconnectAttachmentsResponse {
     type PageItem = crate::model::InterconnectAttachment;
 
@@ -3500,7 +3495,6 @@ impl wkt::message::Message for ListRoutersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRoutersResponse {
     type PageItem = crate::model::Router;
 

--- a/src/generated/cloud/essentialcontacts/v1/src/builders.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builders.rs
@@ -171,7 +171,6 @@ pub mod essential_contacts_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListContactsResponse, gax::error::Error>
@@ -321,7 +320,6 @@ pub mod essential_contacts_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ComputeContactsResponse, gax::error::Error>

--- a/src/generated/cloud/essentialcontacts/v1/src/builders.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builders.rs
@@ -171,7 +171,7 @@ pub mod essential_contacts_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListContactsResponse, gax::error::Error>
         {
@@ -320,7 +320,7 @@ pub mod essential_contacts_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ComputeContactsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/essentialcontacts/v1/src/model.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/model.rs
@@ -230,7 +230,6 @@ impl wkt::message::Message for ListContactsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListContactsResponse {
     type PageItem = crate::model::Contact;
 
@@ -522,7 +521,6 @@ impl wkt::message::Message for ComputeContactsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ComputeContactsResponse {
     type PageItem = crate::model::Contact;
 

--- a/src/generated/cloud/eventarc/v1/src/builders.rs
+++ b/src/generated/cloud/eventarc/v1/src/builders.rs
@@ -109,7 +109,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTriggersResponse, gax::error::Error>
@@ -527,7 +526,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListChannelsResponse, gax::error::Error>
@@ -921,7 +919,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProvidersResponse, gax::error::Error>
@@ -1048,7 +1045,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1453,7 +1449,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMessageBusesResponse, gax::error::Error>
@@ -1941,7 +1936,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnrollmentsResponse, gax::error::Error>
@@ -2371,7 +2365,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPipelinesResponse, gax::error::Error>
@@ -2798,7 +2791,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGoogleApiSourcesResponse, gax::error::Error>
@@ -3197,7 +3189,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3479,7 +3470,6 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/eventarc/v1/src/builders.rs
+++ b/src/generated/cloud/eventarc/v1/src/builders.rs
@@ -109,7 +109,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTriggersResponse, gax::error::Error>
         {
@@ -526,7 +526,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListChannelsResponse, gax::error::Error>
         {
@@ -919,7 +919,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProvidersResponse, gax::error::Error>
         {
@@ -1045,7 +1045,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListChannelConnectionsResponse,
@@ -1449,7 +1449,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMessageBusesResponse, gax::error::Error>
         {
@@ -1936,7 +1936,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnrollmentsResponse, gax::error::Error>
         {
@@ -2365,7 +2365,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPipelinesResponse, gax::error::Error>
         {
@@ -2791,7 +2791,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGoogleApiSourcesResponse, gax::error::Error>
         {
@@ -3189,7 +3189,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3470,7 +3470,7 @@ pub mod eventarc {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -909,7 +909,6 @@ impl wkt::message::Message for ListTriggersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTriggersResponse {
     type PageItem = crate::model::Trigger;
 
@@ -1267,7 +1266,6 @@ impl wkt::message::Message for ListChannelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListChannelsResponse {
     type PageItem = crate::model::Channel;
 
@@ -1602,7 +1600,6 @@ impl wkt::message::Message for ListProvidersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProvidersResponse {
     type PageItem = crate::model::Provider;
 
@@ -1760,7 +1757,6 @@ impl wkt::message::Message for ListChannelConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListChannelConnectionsResponse {
     type PageItem = crate::model::ChannelConnection;
 
@@ -2104,7 +2100,6 @@ impl wkt::message::Message for ListMessageBusesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMessageBusesResponse {
     type PageItem = crate::model::MessageBus;
 
@@ -2588,7 +2583,6 @@ impl wkt::message::Message for ListEnrollmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEnrollmentsResponse {
     type PageItem = crate::model::Enrollment;
 
@@ -2958,7 +2952,6 @@ impl wkt::message::Message for ListPipelinesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPipelinesResponse {
     type PageItem = crate::model::Pipeline;
 
@@ -3327,7 +3320,6 @@ impl wkt::message::Message for ListGoogleApiSourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGoogleApiSourcesResponse {
     type PageItem = crate::model::GoogleApiSource;
 

--- a/src/generated/cloud/filestore/v1/src/builders.rs
+++ b/src/generated/cloud/filestore/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -640,7 +640,7 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSnapshotsResponse, gax::error::Error>
         {
@@ -1031,7 +1031,7 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -1505,7 +1505,7 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1622,7 +1622,7 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/filestore/v1/src/builders.rs
+++ b/src/generated/cloud/filestore/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -641,7 +640,6 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSnapshotsResponse, gax::error::Error>
@@ -1033,7 +1031,6 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -1508,7 +1505,6 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1626,7 +1622,6 @@ pub mod cloud_filestore_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -2276,7 +2276,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 
@@ -2777,7 +2776,6 @@ impl wkt::message::Message for ListSnapshotsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSnapshotsResponse {
     type PageItem = crate::model::Snapshot;
 
@@ -3445,7 +3443,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 

--- a/src/generated/cloud/financialservices/v1/src/builders.rs
+++ b/src/generated/cloud/financialservices/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -692,7 +692,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatasetsResponse, gax::error::Error>
         {
@@ -1089,7 +1089,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelsResponse, gax::error::Error>
         {
@@ -1585,7 +1585,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEngineConfigsResponse, gax::error::Error>
         {
@@ -2140,7 +2140,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEngineVersionsResponse, gax::error::Error>
         {
@@ -2222,7 +2222,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPredictionResultsResponse, gax::error::Error>
         {
@@ -2742,7 +2742,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBacktestResultsResponse, gax::error::Error>
         {
@@ -3258,7 +3258,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3375,7 +3375,7 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/financialservices/v1/src/builders.rs
+++ b/src/generated/cloud/financialservices/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -693,7 +692,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatasetsResponse, gax::error::Error>
@@ -1091,7 +1089,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelsResponse, gax::error::Error>
@@ -1588,7 +1585,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEngineConfigsResponse, gax::error::Error>
@@ -2144,7 +2140,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEngineVersionsResponse, gax::error::Error>
@@ -2227,7 +2222,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPredictionResultsResponse, gax::error::Error>
@@ -2748,7 +2742,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBacktestResultsResponse, gax::error::Error>
@@ -3265,7 +3258,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3383,7 +3375,6 @@ pub mod aml {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/financialservices/v1/src/model.rs
+++ b/src/generated/cloud/financialservices/v1/src/model.rs
@@ -444,7 +444,6 @@ impl wkt::message::Message for ListBacktestResultsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBacktestResultsResponse {
     type PageItem = crate::model::BacktestResult;
 
@@ -1208,7 +1207,6 @@ impl wkt::message::Message for ListDatasetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatasetsResponse {
     type PageItem = crate::model::Dataset;
 
@@ -2032,7 +2030,6 @@ impl wkt::message::Message for ListEngineConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEngineConfigsResponse {
     type PageItem = crate::model::EngineConfig;
 
@@ -2638,7 +2635,6 @@ impl wkt::message::Message for ListEngineVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEngineVersionsResponse {
     type PageItem = crate::model::EngineVersion;
 
@@ -2989,7 +2985,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 
@@ -3899,7 +3894,6 @@ impl wkt::message::Message for ListModelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelsResponse {
     type PageItem = crate::model::Model;
 
@@ -4630,7 +4624,6 @@ impl wkt::message::Message for ListPredictionResultsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPredictionResultsResponse {
     type PageItem = crate::model::PredictionResult;
 

--- a/src/generated/cloud/functions/v2/src/builders.rs
+++ b/src/generated/cloud/functions/v2/src/builders.rs
@@ -115,7 +115,7 @@ pub mod function_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFunctionsResponse, gax::error::Error>
         {
@@ -605,7 +605,7 @@ pub mod function_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -845,7 +845,7 @@ pub mod function_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/functions/v2/src/builders.rs
+++ b/src/generated/cloud/functions/v2/src/builders.rs
@@ -115,7 +115,6 @@ pub mod function_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFunctionsResponse, gax::error::Error>
@@ -606,7 +605,6 @@ pub mod function_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -847,7 +845,6 @@ pub mod function_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -2352,7 +2352,6 @@ impl wkt::message::Message for ListFunctionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFunctionsResponse {
     type PageItem = crate::model::Function;
 

--- a/src/generated/cloud/gkebackup/v1/src/builders.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builders.rs
@@ -165,7 +165,6 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupPlansResponse, gax::error::Error>
@@ -558,7 +557,6 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -860,7 +858,6 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumeBackupsResponse, gax::error::Error>
@@ -1081,7 +1078,6 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRestorePlansResponse, gax::error::Error>
@@ -1480,7 +1476,6 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRestoresResponse, gax::error::Error>
@@ -1782,7 +1777,6 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumeRestoresResponse, gax::error::Error>
@@ -1955,7 +1949,6 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2237,7 +2230,6 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/gkebackup/v1/src/builders.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builders.rs
@@ -165,7 +165,7 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupPlansResponse, gax::error::Error>
         {
@@ -557,7 +557,7 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -858,7 +858,7 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumeBackupsResponse, gax::error::Error>
         {
@@ -1078,7 +1078,7 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRestorePlansResponse, gax::error::Error>
         {
@@ -1476,7 +1476,7 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRestoresResponse, gax::error::Error>
         {
@@ -1777,7 +1777,7 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumeRestoresResponse, gax::error::Error>
         {
@@ -1949,7 +1949,7 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2230,7 +2230,7 @@ pub mod backup_for_gke {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -2280,7 +2280,6 @@ impl wkt::message::Message for ListBackupPlansResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupPlansResponse {
     type PageItem = crate::model::BackupPlan;
 
@@ -2613,7 +2612,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 
@@ -2897,7 +2895,6 @@ impl wkt::message::Message for ListVolumeBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVolumeBackupsResponse {
     type PageItem = crate::model::VolumeBackup;
 
@@ -3150,7 +3147,6 @@ impl wkt::message::Message for ListRestorePlansResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRestorePlansResponse {
     type PageItem = crate::model::RestorePlan;
 
@@ -3510,7 +3506,6 @@ impl wkt::message::Message for ListRestoresResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRestoresResponse {
     type PageItem = crate::model::Restore;
 
@@ -3794,7 +3789,6 @@ impl wkt::message::Message for ListVolumeRestoresResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVolumeRestoresResponse {
     type PageItem = crate::model::VolumeRestore;
 

--- a/src/generated/cloud/gkehub/v1/src/builders.rs
+++ b/src/generated/cloud/gkehub/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod gke_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMembershipsResponse, gax::error::Error>
         {
@@ -147,7 +147,7 @@ pub mod gke_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeaturesResponse, gax::error::Error>
         {
@@ -982,7 +982,7 @@ pub mod gke_hub {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/gkehub/v1/src/builders.rs
+++ b/src/generated/cloud/gkehub/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod gke_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMembershipsResponse, gax::error::Error>
@@ -148,7 +147,6 @@ pub mod gke_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFeaturesResponse, gax::error::Error>
@@ -984,7 +982,6 @@ pub mod gke_hub {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -1861,7 +1861,6 @@ impl wkt::message::Message for ListMembershipsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMembershipsResponse {
     type PageItem = crate::model::Membership;
 
@@ -2499,7 +2498,6 @@ impl wkt::message::Message for ListFeaturesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFeaturesResponse {
     type PageItem = crate::model::Feature;
 

--- a/src/generated/cloud/gkemulticloud/v1/src/builders.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builders.rs
@@ -436,7 +436,6 @@ pub mod attached_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttachedClustersResponse, gax::error::Error>
@@ -821,7 +820,6 @@ pub mod attached_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1297,7 +1295,6 @@ pub mod aws_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAwsClustersResponse, gax::error::Error>
@@ -1949,7 +1946,6 @@ pub mod aws_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAwsNodePoolsResponse, gax::error::Error>
@@ -2255,7 +2251,6 @@ pub mod aws_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2634,7 +2629,6 @@ pub mod azure_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAzureClientsResponse, gax::error::Error>
@@ -3040,7 +3034,6 @@ pub mod azure_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAzureClustersResponse, gax::error::Error>
@@ -3609,7 +3602,6 @@ pub mod azure_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAzureNodePoolsResponse, gax::error::Error>
@@ -3915,7 +3907,6 @@ pub mod azure_clusters {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/gkemulticloud/v1/src/builders.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builders.rs
@@ -436,7 +436,7 @@ pub mod attached_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttachedClustersResponse, gax::error::Error>
         {
@@ -820,7 +820,7 @@ pub mod attached_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1295,7 +1295,7 @@ pub mod aws_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAwsClustersResponse, gax::error::Error>
         {
@@ -1946,7 +1946,7 @@ pub mod aws_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAwsNodePoolsResponse, gax::error::Error>
         {
@@ -2251,7 +2251,7 @@ pub mod aws_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2629,7 +2629,7 @@ pub mod azure_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAzureClientsResponse, gax::error::Error>
         {
@@ -3034,7 +3034,7 @@ pub mod azure_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAzureClustersResponse, gax::error::Error>
         {
@@ -3602,7 +3602,7 @@ pub mod azure_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAzureNodePoolsResponse, gax::error::Error>
         {
@@ -3907,7 +3907,7 @@ pub mod azure_clusters {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -1408,7 +1408,6 @@ impl wkt::message::Message for ListAttachedClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAttachedClustersResponse {
     type PageItem = crate::model::AttachedCluster;
 
@@ -4526,7 +4525,6 @@ impl wkt::message::Message for ListAwsClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAwsClustersResponse {
     type PageItem = crate::model::AwsCluster;
 
@@ -5023,7 +5021,6 @@ impl wkt::message::Message for ListAwsNodePoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAwsNodePoolsResponse {
     type PageItem = crate::model::AwsNodePool;
 
@@ -8117,7 +8114,6 @@ impl wkt::message::Message for ListAzureClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAzureClustersResponse {
     type PageItem = crate::model::AzureCluster;
 
@@ -8543,7 +8539,6 @@ impl wkt::message::Message for ListAzureNodePoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAzureNodePoolsResponse {
     type PageItem = crate::model::AzureNodePool;
 
@@ -9000,7 +8995,6 @@ impl wkt::message::Message for ListAzureClientsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAzureClientsResponse {
     type PageItem = crate::model::AzureClient;
 

--- a/src/generated/cloud/gsuiteaddons/v1/src/builders.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/builders.rs
@@ -259,7 +259,6 @@ pub mod g_suite_add_ons {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>

--- a/src/generated/cloud/gsuiteaddons/v1/src/builders.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/builders.rs
@@ -259,7 +259,7 @@ pub mod g_suite_add_ons {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/gsuiteaddons/v1/src/model.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/model.rs
@@ -343,7 +343,6 @@ impl wkt::message::Message for ListDeploymentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeploymentsResponse {
     type PageItem = crate::model::Deployment;
 

--- a/src/generated/cloud/iap/v1/src/builders.rs
+++ b/src/generated/cloud/iap/v1/src/builders.rs
@@ -346,7 +346,7 @@ pub mod identity_aware_proxy_admin_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTunnelDestGroupsResponse, gax::error::Error>
         {
@@ -860,7 +860,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListIdentityAwareProxyClientsResponse,

--- a/src/generated/cloud/iap/v1/src/builders.rs
+++ b/src/generated/cloud/iap/v1/src/builders.rs
@@ -346,7 +346,6 @@ pub mod identity_aware_proxy_admin_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTunnelDestGroupsResponse, gax::error::Error>
@@ -861,7 +860,6 @@ pub mod identity_aware_proxy_o_auth_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/cloud/iap/v1/src/model.rs
+++ b/src/generated/cloud/iap/v1/src/model.rs
@@ -134,7 +134,6 @@ impl wkt::message::Message for ListTunnelDestGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTunnelDestGroupsResponse {
     type PageItem = crate::model::TunnelDestGroup;
 
@@ -1585,7 +1584,6 @@ impl wkt::message::Message for ListIdentityAwareProxyClientsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIdentityAwareProxyClientsResponse {
     type PageItem = crate::model::IdentityAwareProxyClient;
 

--- a/src/generated/cloud/ids/v1/src/builders.rs
+++ b/src/generated/cloud/ids/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod ids {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEndpointsResponse, gax::error::Error>
         {
@@ -373,7 +373,7 @@ pub mod ids {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/ids/v1/src/builders.rs
+++ b/src/generated/cloud/ids/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod ids {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEndpointsResponse, gax::error::Error>
@@ -374,7 +373,6 @@ pub mod ids {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/ids/v1/src/model.rs
+++ b/src/generated/cloud/ids/v1/src/model.rs
@@ -450,7 +450,6 @@ impl wkt::message::Message for ListEndpointsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEndpointsResponse {
     type PageItem = crate::model::Endpoint;
 

--- a/src/generated/cloud/kms/inventory/v1/src/builders.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod key_dashboard_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCryptoKeysResponse, gax::error::Error>
@@ -213,7 +212,6 @@ pub mod key_tracking_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/cloud/kms/inventory/v1/src/builders.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod key_dashboard_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCryptoKeysResponse, gax::error::Error>
         {
@@ -212,7 +212,7 @@ pub mod key_tracking_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchProtectedResourcesResponse,

--- a/src/generated/cloud/kms/inventory/v1/src/model.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/model.rs
@@ -135,7 +135,6 @@ impl wkt::message::Message for ListCryptoKeysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCryptoKeysResponse {
     type PageItem = kms::model::CryptoKey;
 
@@ -439,7 +438,6 @@ impl wkt::message::Message for SearchProtectedResourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchProtectedResourcesResponse {
     type PageItem = crate::model::ProtectedResource;
 

--- a/src/generated/cloud/kms/v1/src/builders.rs
+++ b/src/generated/cloud/kms/v1/src/builders.rs
@@ -204,7 +204,7 @@ pub mod autokey {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKeyHandlesResponse, gax::error::Error>
         {
@@ -280,7 +280,7 @@ pub mod autokey {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -777,7 +777,7 @@ pub mod autokey_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1128,7 +1128,7 @@ pub mod ekm_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEkmConnectionsResponse, gax::error::Error>
         {
@@ -1507,7 +1507,7 @@ pub mod ekm_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1855,7 +1855,7 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKeyRingsResponse, gax::error::Error>
         {
@@ -1934,7 +1934,7 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCryptoKeysResponse, gax::error::Error>
         {
@@ -2025,7 +2025,7 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCryptoKeyVersionsResponse, gax::error::Error>
         {
@@ -2113,7 +2113,7 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListImportJobsResponse, gax::error::Error>
         {
@@ -3623,7 +3623,7 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/kms/v1/src/builders.rs
+++ b/src/generated/cloud/kms/v1/src/builders.rs
@@ -204,7 +204,6 @@ pub mod autokey {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKeyHandlesResponse, gax::error::Error>
@@ -281,7 +280,6 @@ pub mod autokey {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -779,7 +777,6 @@ pub mod autokey_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1131,7 +1128,6 @@ pub mod ekm_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEkmConnectionsResponse, gax::error::Error>
@@ -1511,7 +1507,6 @@ pub mod ekm_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1860,7 +1855,6 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKeyRingsResponse, gax::error::Error>
@@ -1940,7 +1934,6 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCryptoKeysResponse, gax::error::Error>
@@ -2032,7 +2025,6 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCryptoKeyVersionsResponse, gax::error::Error>
@@ -2121,7 +2113,6 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListImportJobsResponse, gax::error::Error>
@@ -3632,7 +3623,6 @@ pub mod key_management_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -369,7 +369,6 @@ impl wkt::message::Message for ListKeyHandlesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListKeyHandlesResponse {
     type PageItem = crate::model::KeyHandle;
 
@@ -837,7 +836,6 @@ impl wkt::message::Message for ListEkmConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEkmConnectionsResponse {
     type PageItem = crate::model::EkmConnection;
 
@@ -4750,7 +4748,6 @@ impl wkt::message::Message for ListKeyRingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListKeyRingsResponse {
     type PageItem = crate::model::KeyRing;
 
@@ -4828,7 +4825,6 @@ impl wkt::message::Message for ListCryptoKeysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCryptoKeysResponse {
     type PageItem = crate::model::CryptoKey;
 
@@ -4907,7 +4903,6 @@ impl wkt::message::Message for ListCryptoKeyVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCryptoKeyVersionsResponse {
     type PageItem = crate::model::CryptoKeyVersion;
 
@@ -4985,7 +4980,6 @@ impl wkt::message::Message for ListImportJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListImportJobsResponse {
     type PageItem = crate::model::ImportJob;
 

--- a/src/generated/cloud/location/src/builders.rs
+++ b/src/generated/cloud/location/src/builders.rs
@@ -68,7 +68,7 @@ pub mod locations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/location/src/builders.rs
+++ b/src/generated/cloud/location/src/builders.rs
@@ -68,7 +68,6 @@ pub mod locations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/location/src/model.rs
+++ b/src/generated/cloud/location/src/model.rs
@@ -135,7 +135,6 @@ impl wkt::message::Message for ListLocationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLocationsResponse {
     type PageItem = crate::model::Location;
 

--- a/src/generated/cloud/managedidentities/v1/src/builders.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builders.rs
@@ -208,7 +208,7 @@ pub mod managed_identities_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDomainsResponse, gax::error::Error>
         {
@@ -846,7 +846,7 @@ pub mod managed_identities_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/managedidentities/v1/src/builders.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builders.rs
@@ -208,7 +208,6 @@ pub mod managed_identities_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDomainsResponse, gax::error::Error>
@@ -847,7 +846,6 @@ pub mod managed_identities_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/managedidentities/v1/src/model.rs
+++ b/src/generated/cloud/managedidentities/v1/src/model.rs
@@ -391,7 +391,6 @@ impl wkt::message::Message for ListDomainsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDomainsResponse {
     type PageItem = crate::model::Domain;
 

--- a/src/generated/cloud/memcache/v1/src/builders.rs
+++ b/src/generated/cloud/memcache/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod cloud_memcache {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -750,7 +750,7 @@ pub mod cloud_memcache {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -867,7 +867,7 @@ pub mod cloud_memcache {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/memcache/v1/src/builders.rs
+++ b/src/generated/cloud/memcache/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod cloud_memcache {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -751,7 +750,6 @@ pub mod cloud_memcache {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -869,7 +867,6 @@ pub mod cloud_memcache {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/memcache/v1/src/model.rs
+++ b/src/generated/cloud/memcache/v1/src/model.rs
@@ -1161,7 +1161,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 

--- a/src/generated/cloud/memorystore/v1/src/builders.rs
+++ b/src/generated/cloud/memorystore/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod memorystore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -517,7 +516,6 @@ pub mod memorystore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -635,7 +633,6 @@ pub mod memorystore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/memorystore/v1/src/builders.rs
+++ b/src/generated/cloud/memorystore/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod memorystore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -516,7 +516,7 @@ pub mod memorystore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -633,7 +633,7 @@ pub mod memorystore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -1927,7 +1927,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 

--- a/src/generated/cloud/metastore/v1/src/builders.rs
+++ b/src/generated/cloud/metastore/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -469,7 +468,6 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMetadataImportsResponse, gax::error::Error>
@@ -1003,7 +1001,6 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -1600,7 +1597,6 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1882,7 +1878,6 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2118,7 +2113,6 @@ pub mod dataproc_metastore_federation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFederationsResponse, gax::error::Error>
@@ -2540,7 +2534,6 @@ pub mod dataproc_metastore_federation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2832,7 +2825,6 @@ pub mod dataproc_metastore_federation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/metastore/v1/src/builders.rs
+++ b/src/generated/cloud/metastore/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -468,7 +468,7 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMetadataImportsResponse, gax::error::Error>
         {
@@ -1001,7 +1001,7 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -1597,7 +1597,7 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1878,7 +1878,7 @@ pub mod dataproc_metastore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2113,7 +2113,7 @@ pub mod dataproc_metastore_federation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFederationsResponse, gax::error::Error>
         {
@@ -2534,7 +2534,7 @@ pub mod dataproc_metastore_federation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2825,7 +2825,7 @@ pub mod dataproc_metastore_federation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -2677,7 +2677,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::Service;
 
@@ -3094,7 +3093,6 @@ impl wkt::message::Message for ListMetadataImportsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMetadataImportsResponse {
     type PageItem = crate::model::MetadataImport;
 
@@ -3462,7 +3460,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 
@@ -4906,7 +4903,6 @@ impl wkt::message::Message for ListFederationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFederationsResponse {
     type PageItem = crate::model::Federation;
 

--- a/src/generated/cloud/migrationcenter/v1/src/builders.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAssetsResponse, gax::error::Error>
         {
@@ -642,7 +642,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListImportJobsResponse, gax::error::Error>
         {
@@ -1173,7 +1173,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListImportDataFilesResponse, gax::error::Error>
         {
@@ -1441,7 +1441,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupsResponse, gax::error::Error>
         {
@@ -2042,7 +2042,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListErrorFramesResponse, gax::error::Error>
         {
@@ -2162,7 +2162,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSourcesResponse, gax::error::Error>
         {
@@ -2562,7 +2562,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPreferenceSetsResponse, gax::error::Error>
         {
@@ -3254,7 +3254,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReportConfigsResponse, gax::error::Error>
         {
@@ -3570,7 +3570,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReportsResponse, gax::error::Error>
         {
@@ -3740,7 +3740,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3857,7 +3857,7 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/migrationcenter/v1/src/builders.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAssetsResponse, gax::error::Error>
@@ -643,7 +642,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListImportJobsResponse, gax::error::Error>
@@ -1175,7 +1173,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListImportDataFilesResponse, gax::error::Error>
@@ -1444,7 +1441,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupsResponse, gax::error::Error>
@@ -2046,7 +2042,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListErrorFramesResponse, gax::error::Error>
@@ -2167,7 +2162,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSourcesResponse, gax::error::Error>
@@ -2568,7 +2562,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPreferenceSetsResponse, gax::error::Error>
@@ -3261,7 +3254,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReportConfigsResponse, gax::error::Error>
@@ -3578,7 +3570,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReportsResponse, gax::error::Error>
@@ -3749,7 +3740,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3867,7 +3857,6 @@ pub mod migration_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -1875,7 +1875,6 @@ impl wkt::message::Message for ListAssetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAssetsResponse {
     type PageItem = crate::model::Asset;
 
@@ -2558,7 +2557,6 @@ impl wkt::message::Message for ListImportJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListImportJobsResponse {
     type PageItem = crate::model::ImportJob;
 
@@ -3010,7 +3008,6 @@ impl wkt::message::Message for ListImportDataFilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListImportDataFilesResponse {
     type PageItem = crate::model::ImportDataFile;
 
@@ -3281,7 +3278,6 @@ impl wkt::message::Message for ListGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGroupsResponse {
     type PageItem = crate::model::Group;
 
@@ -3800,7 +3796,6 @@ impl wkt::message::Message for ListErrorFramesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListErrorFramesResponse {
     type PageItem = crate::model::ErrorFrame;
 
@@ -3981,7 +3976,6 @@ impl wkt::message::Message for ListSourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSourcesResponse {
     type PageItem = crate::model::Source;
 
@@ -4343,7 +4337,6 @@ impl wkt::message::Message for ListPreferenceSetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPreferenceSetsResponse {
     type PageItem = crate::model::PreferenceSet;
 
@@ -5015,7 +5008,6 @@ impl wkt::message::Message for ListReportsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReportsResponse {
     type PageItem = crate::model::Report;
 
@@ -5236,7 +5228,6 @@ impl wkt::message::Message for ListReportConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReportConfigsResponse {
     type PageItem = crate::model::ReportConfig;
 

--- a/src/generated/cloud/modelarmor/v1/src/builders.rs
+++ b/src/generated/cloud/modelarmor/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod model_armor {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTemplatesResponse, gax::error::Error>
@@ -569,7 +568,6 @@ pub mod model_armor {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/modelarmor/v1/src/builders.rs
+++ b/src/generated/cloud/modelarmor/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod model_armor {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTemplatesResponse, gax::error::Error>
         {
@@ -568,7 +568,7 @@ pub mod model_armor {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -458,7 +458,6 @@ impl wkt::message::Message for ListTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTemplatesResponse {
     type PageItem = crate::model::Template;
 

--- a/src/generated/cloud/netapp/v1/src/builders.rs
+++ b/src/generated/cloud/netapp/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStoragePoolsResponse, gax::error::Error>
         {
@@ -635,7 +635,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumesResponse, gax::error::Error>
         {
@@ -1104,7 +1104,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSnapshotsResponse, gax::error::Error>
         {
@@ -1488,7 +1488,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListActiveDirectoriesResponse, gax::error::Error>
         {
@@ -1883,7 +1883,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKmsConfigsResponse, gax::error::Error>
         {
@@ -2387,7 +2387,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReplicationsResponse, gax::error::Error>
         {
@@ -3359,7 +3359,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupVaultsResponse, gax::error::Error>
         {
@@ -3745,7 +3745,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -4131,7 +4131,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupPoliciesResponse, gax::error::Error>
         {
@@ -4383,7 +4383,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQuotaRulesResponse, gax::error::Error>
         {
@@ -4767,7 +4767,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -4884,7 +4884,7 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/netapp/v1/src/builders.rs
+++ b/src/generated/cloud/netapp/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStoragePoolsResponse, gax::error::Error>
@@ -636,7 +635,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVolumesResponse, gax::error::Error>
@@ -1106,7 +1104,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSnapshotsResponse, gax::error::Error>
@@ -1491,7 +1488,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListActiveDirectoriesResponse, gax::error::Error>
@@ -1887,7 +1883,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKmsConfigsResponse, gax::error::Error>
@@ -2392,7 +2387,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReplicationsResponse, gax::error::Error>
@@ -3365,7 +3359,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupVaultsResponse, gax::error::Error>
@@ -3752,7 +3745,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -4139,7 +4131,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupPoliciesResponse, gax::error::Error>
@@ -4392,7 +4383,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQuotaRulesResponse, gax::error::Error>
@@ -4777,7 +4767,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -4895,7 +4884,6 @@ pub mod net_app {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -160,7 +160,6 @@ impl wkt::message::Message for ListActiveDirectoriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListActiveDirectoriesResponse {
     type PageItem = crate::model::ActiveDirectory;
 
@@ -1151,7 +1150,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 
@@ -1779,7 +1777,6 @@ impl wkt::message::Message for ListBackupPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupPoliciesResponse {
     type PageItem = crate::model::BackupPolicy;
 
@@ -2194,7 +2191,6 @@ impl wkt::message::Message for ListBackupVaultsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupVaultsResponse {
     type PageItem = crate::model::BackupVault;
 
@@ -2656,7 +2652,6 @@ impl wkt::message::Message for ListKmsConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListKmsConfigsResponse {
     type PageItem = crate::model::KmsConfig;
 
@@ -3272,7 +3267,6 @@ impl wkt::message::Message for ListQuotaRulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListQuotaRulesResponse {
     type PageItem = crate::model::QuotaRule;
 
@@ -4689,7 +4683,6 @@ impl wkt::message::Message for ListReplicationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReplicationsResponse {
     type PageItem = crate::model::Replication;
 
@@ -5301,7 +5294,6 @@ impl wkt::message::Message for ListSnapshotsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSnapshotsResponse {
     type PageItem = crate::model::Snapshot;
 
@@ -5816,7 +5808,6 @@ impl wkt::message::Message for ListStoragePoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListStoragePoolsResponse {
     type PageItem = crate::model::StoragePool;
 
@@ -6517,7 +6508,6 @@ impl wkt::message::Message for ListVolumesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVolumesResponse {
     type PageItem = crate::model::Volume;
 

--- a/src/generated/cloud/networkconnectivity/v1/src/builders.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHubsResponse, gax::error::Error> {
@@ -457,7 +456,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHubSpokesResponse, gax::error::Error>
@@ -557,7 +555,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::QueryHubStatusResponse, gax::error::Error>
@@ -643,7 +640,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSpokesResponse, gax::error::Error>
@@ -1317,7 +1313,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRoutesResponse, gax::error::Error>
@@ -1397,7 +1392,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRouteTablesResponse, gax::error::Error>
@@ -1518,7 +1512,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupsResponse, gax::error::Error>
@@ -1697,7 +1690,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1979,7 +1971,6 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2214,7 +2205,6 @@ pub mod policy_based_routing_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPolicyBasedRoutesResponse, gax::error::Error>
@@ -2532,7 +2522,6 @@ pub mod policy_based_routing_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2814,7 +2803,6 @@ pub mod policy_based_routing_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/networkconnectivity/v1/src/builders.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHubsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -456,7 +456,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHubSpokesResponse, gax::error::Error>
         {
@@ -555,7 +555,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::QueryHubStatusResponse, gax::error::Error>
         {
@@ -640,7 +640,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSpokesResponse, gax::error::Error>
         {
@@ -1313,7 +1313,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRoutesResponse, gax::error::Error>
         {
@@ -1392,7 +1392,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRouteTablesResponse, gax::error::Error>
         {
@@ -1512,7 +1512,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupsResponse, gax::error::Error>
         {
@@ -1690,7 +1690,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1971,7 +1971,7 @@ pub mod hub_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2205,7 +2205,7 @@ pub mod policy_based_routing_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPolicyBasedRoutesResponse, gax::error::Error>
         {
@@ -2522,7 +2522,7 @@ pub mod policy_based_routing_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2803,7 +2803,7 @@ pub mod policy_based_routing_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -1408,7 +1408,6 @@ impl wkt::message::Message for ListHubsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListHubsResponse {
     type PageItem = crate::model::Hub;
 
@@ -1904,7 +1903,6 @@ impl wkt::message::Message for ListHubSpokesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListHubSpokesResponse {
     type PageItem = crate::model::Spoke;
 
@@ -2074,7 +2072,6 @@ impl wkt::message::Message for QueryHubStatusResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for QueryHubStatusResponse {
     type PageItem = crate::model::HubStatusEntry;
 
@@ -2479,7 +2476,6 @@ impl wkt::message::Message for ListSpokesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSpokesResponse {
     type PageItem = crate::model::Spoke;
 
@@ -3144,7 +3140,6 @@ impl wkt::message::Message for ListRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRoutesResponse {
     type PageItem = crate::model::Route;
 
@@ -3294,7 +3289,6 @@ impl wkt::message::Message for ListRouteTablesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRouteTablesResponse {
     type PageItem = crate::model::RouteTable;
 
@@ -3444,7 +3438,6 @@ impl wkt::message::Message for ListGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGroupsResponse {
     type PageItem = crate::model::Group;
 
@@ -5292,7 +5285,6 @@ impl wkt::message::Message for ListPolicyBasedRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPolicyBasedRoutesResponse {
     type PageItem = crate::model::PolicyBasedRoute;
 

--- a/src/generated/cloud/networkmanagement/v1/src/builders.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod reachability_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectivityTestsResponse, gax::error::Error>
@@ -553,7 +552,6 @@ pub mod reachability_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -835,7 +833,6 @@ pub mod reachability_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1070,7 +1067,6 @@ pub mod vpc_flow_logs_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1481,7 +1477,6 @@ pub mod vpc_flow_logs_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1763,7 +1758,6 @@ pub mod vpc_flow_logs_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/networkmanagement/v1/src/builders.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod reachability_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectivityTestsResponse, gax::error::Error>
         {
@@ -552,7 +552,7 @@ pub mod reachability_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -833,7 +833,7 @@ pub mod reachability_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1067,7 +1067,7 @@ pub mod vpc_flow_logs_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListVpcFlowLogsConfigsResponse,
@@ -1477,7 +1477,7 @@ pub mod vpc_flow_logs_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1758,7 +1758,7 @@ pub mod vpc_flow_logs_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -1486,7 +1486,6 @@ impl wkt::message::Message for ListConnectivityTestsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectivityTestsResponse {
     type PageItem = crate::model::ConnectivityTest;
 
@@ -7960,7 +7959,6 @@ impl wkt::message::Message for ListVpcFlowLogsConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVpcFlowLogsConfigsResponse {
     type PageItem = crate::model::VpcFlowLogsConfig;
 

--- a/src/generated/cloud/networksecurity/v1/src/builders.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builders.rs
@@ -73,7 +73,7 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAuthorizationPoliciesResponse,
@@ -471,7 +471,7 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServerTlsPoliciesResponse, gax::error::Error>
         {
@@ -861,7 +861,7 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClientTlsPoliciesResponse, gax::error::Error>
         {
@@ -1251,7 +1251,7 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1532,7 +1532,7 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/networksecurity/v1/src/builders.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builders.rs
@@ -73,7 +73,6 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -472,7 +471,6 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServerTlsPoliciesResponse, gax::error::Error>
@@ -863,7 +861,6 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClientTlsPoliciesResponse, gax::error::Error>
@@ -1254,7 +1251,6 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1536,7 +1532,6 @@ pub mod network_security {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/networksecurity/v1/src/model.rs
+++ b/src/generated/cloud/networksecurity/v1/src/model.rs
@@ -627,7 +627,6 @@ impl wkt::message::Message for ListAuthorizationPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAuthorizationPoliciesResponse {
     type PageItem = crate::model::AuthorizationPolicy;
 
@@ -1038,7 +1037,6 @@ impl wkt::message::Message for ListClientTlsPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClientTlsPoliciesResponse {
     type PageItem = crate::model::ClientTlsPolicy;
 
@@ -1598,7 +1596,6 @@ impl wkt::message::Message for ListServerTlsPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServerTlsPoliciesResponse {
     type PageItem = crate::model::ServerTlsPolicy;
 

--- a/src/generated/cloud/networkservices/v1/src/builders.rs
+++ b/src/generated/cloud/networkservices/v1/src/builders.rs
@@ -73,7 +73,7 @@ pub mod dep_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListLbTrafficExtensionsResponse,
@@ -501,7 +501,7 @@ pub mod dep_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLbRouteExtensionsResponse, gax::error::Error>
         {
@@ -921,7 +921,7 @@ pub mod dep_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1202,7 +1202,7 @@ pub mod dep_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1436,7 +1436,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEndpointPoliciesResponse, gax::error::Error>
         {
@@ -1819,7 +1819,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGatewaysResponse, gax::error::Error>
         {
@@ -2186,7 +2186,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGrpcRoutesResponse, gax::error::Error>
         {
@@ -2555,7 +2555,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHttpRoutesResponse, gax::error::Error>
         {
@@ -2924,7 +2924,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTcpRoutesResponse, gax::error::Error>
         {
@@ -3293,7 +3293,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTlsRoutesResponse, gax::error::Error>
         {
@@ -3665,7 +3665,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServiceBindingsResponse, gax::error::Error>
         {
@@ -3953,7 +3953,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMeshesResponse, gax::error::Error>
         {
@@ -4317,7 +4317,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -4598,7 +4598,7 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/networkservices/v1/src/builders.rs
+++ b/src/generated/cloud/networkservices/v1/src/builders.rs
@@ -73,7 +73,6 @@ pub mod dep_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -502,7 +501,6 @@ pub mod dep_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLbRouteExtensionsResponse, gax::error::Error>
@@ -923,7 +921,6 @@ pub mod dep_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1205,7 +1202,6 @@ pub mod dep_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1440,7 +1436,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEndpointPoliciesResponse, gax::error::Error>
@@ -1824,7 +1819,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGatewaysResponse, gax::error::Error>
@@ -2192,7 +2186,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGrpcRoutesResponse, gax::error::Error>
@@ -2562,7 +2555,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHttpRoutesResponse, gax::error::Error>
@@ -2932,7 +2924,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTcpRoutesResponse, gax::error::Error>
@@ -3302,7 +3293,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTlsRoutesResponse, gax::error::Error>
@@ -3675,7 +3665,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServiceBindingsResponse, gax::error::Error>
@@ -3964,7 +3953,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMeshesResponse, gax::error::Error>
@@ -4329,7 +4317,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -4611,7 +4598,6 @@ pub mod network_services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/networkservices/v1/src/model.rs
+++ b/src/generated/cloud/networkservices/v1/src/model.rs
@@ -994,7 +994,6 @@ impl wkt::message::Message for ListLbTrafficExtensionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLbTrafficExtensionsResponse {
     type PageItem = crate::model::LbTrafficExtension;
 
@@ -1537,7 +1536,6 @@ impl wkt::message::Message for ListLbRouteExtensionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLbRouteExtensionsResponse {
     type PageItem = crate::model::LbRouteExtension;
 
@@ -2136,7 +2134,6 @@ impl wkt::message::Message for ListEndpointPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEndpointPoliciesResponse {
     type PageItem = crate::model::EndpointPolicy;
 
@@ -2639,7 +2636,6 @@ impl wkt::message::Message for ListGatewaysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGatewaysResponse {
     type PageItem = crate::model::Gateway;
 
@@ -3890,7 +3886,6 @@ impl wkt::message::Message for ListGrpcRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGrpcRoutesResponse {
     type PageItem = crate::model::GrpcRoute;
 
@@ -6006,7 +6001,6 @@ impl wkt::message::Message for ListHttpRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListHttpRoutesResponse {
     type PageItem = crate::model::HttpRoute;
 
@@ -6387,7 +6381,6 @@ impl wkt::message::Message for ListMeshesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMeshesResponse {
     type PageItem = crate::model::Mesh;
 
@@ -6754,7 +6747,6 @@ impl wkt::message::Message for ListServiceBindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServiceBindingsResponse {
     type PageItem = crate::model::ServiceBinding;
 
@@ -7344,7 +7336,6 @@ impl wkt::message::Message for ListTcpRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTcpRoutesResponse {
     type PageItem = crate::model::TcpRoute;
 
@@ -7950,7 +7941,6 @@ impl wkt::message::Message for ListTlsRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTlsRoutesResponse {
     type PageItem = crate::model::TlsRoute;
 

--- a/src/generated/cloud/notebooks/v2/src/builders.rs
+++ b/src/generated/cloud/notebooks/v2/src/builders.rs
@@ -68,7 +68,7 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -1025,7 +1025,7 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1306,7 +1306,7 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/notebooks/v2/src/builders.rs
+++ b/src/generated/cloud/notebooks/v2/src/builders.rs
@@ -68,7 +68,6 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -1026,7 +1025,6 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1308,7 +1306,6 @@ pub mod notebook_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -1976,7 +1976,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 

--- a/src/generated/cloud/oracledatabase/v1/src/builders.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builders.rs
@@ -73,7 +73,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -398,7 +397,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCloudVmClustersResponse, gax::error::Error>
@@ -714,7 +712,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntitlementsResponse, gax::error::Error>
@@ -782,7 +779,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDbServersResponse, gax::error::Error>
@@ -850,7 +846,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDbNodesResponse, gax::error::Error>
@@ -918,7 +913,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGiVersionsResponse, gax::error::Error>
@@ -989,7 +983,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDbSystemShapesResponse, gax::error::Error>
@@ -1062,7 +1055,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1546,7 +1538,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1623,7 +1614,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1704,7 +1694,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1783,7 +1772,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1901,7 +1889,6 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/oracledatabase/v1/src/builders.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builders.rs
@@ -73,7 +73,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListCloudExadataInfrastructuresResponse,
@@ -397,7 +397,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCloudVmClustersResponse, gax::error::Error>
         {
@@ -712,7 +712,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntitlementsResponse, gax::error::Error>
         {
@@ -779,7 +779,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDbServersResponse, gax::error::Error>
         {
@@ -846,7 +846,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDbNodesResponse, gax::error::Error>
         {
@@ -913,7 +913,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGiVersionsResponse, gax::error::Error>
         {
@@ -983,7 +983,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDbSystemShapesResponse, gax::error::Error>
         {
@@ -1055,7 +1055,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAutonomousDatabasesResponse,
@@ -1538,7 +1538,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAutonomousDbVersionsResponse,
@@ -1614,7 +1614,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAutonomousDatabaseCharacterSetsResponse,
@@ -1694,7 +1694,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAutonomousDatabaseBackupsResponse,
@@ -1772,7 +1772,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1889,7 +1889,7 @@ pub mod oracle_database {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/oracledatabase/v1/src/model.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/model.rs
@@ -5118,7 +5118,6 @@ impl wkt::message::Message for ListCloudExadataInfrastructuresResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCloudExadataInfrastructuresResponse {
     type PageItem = crate::model::CloudExadataInfrastructure;
 
@@ -5404,7 +5403,6 @@ impl wkt::message::Message for ListCloudVmClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCloudVmClustersResponse {
     type PageItem = crate::model::CloudVmCluster;
 
@@ -5678,7 +5676,6 @@ impl wkt::message::Message for ListEntitlementsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEntitlementsResponse {
     type PageItem = crate::model::Entitlement;
 
@@ -5786,7 +5783,6 @@ impl wkt::message::Message for ListDbServersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDbServersResponse {
     type PageItem = crate::model::DbServer;
 
@@ -5894,7 +5890,6 @@ impl wkt::message::Message for ListDbNodesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDbNodesResponse {
     type PageItem = crate::model::DbNode;
 
@@ -6003,7 +5998,6 @@ impl wkt::message::Message for ListGiVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGiVersionsResponse {
     type PageItem = crate::model::GiVersion;
 
@@ -6111,7 +6105,6 @@ impl wkt::message::Message for ListDbSystemShapesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDbSystemShapesResponse {
     type PageItem = crate::model::DbSystemShape;
 
@@ -6349,7 +6342,6 @@ impl wkt::message::Message for ListAutonomousDatabasesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAutonomousDatabasesResponse {
     type PageItem = crate::model::AutonomousDatabase;
 
@@ -6747,7 +6739,6 @@ impl wkt::message::Message for ListAutonomousDbVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAutonomousDbVersionsResponse {
     type PageItem = crate::model::AutonomousDbVersion;
 
@@ -6869,7 +6860,6 @@ impl wkt::message::Message for ListAutonomousDatabaseCharacterSetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAutonomousDatabaseCharacterSetsResponse {
     type PageItem = crate::model::AutonomousDatabaseCharacterSet;
 
@@ -6993,7 +6983,6 @@ impl wkt::message::Message for ListAutonomousDatabaseBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAutonomousDatabaseBackupsResponse {
     type PageItem = crate::model::AutonomousDatabaseBackup;
 

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builders.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builders.rs
@@ -203,7 +203,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnvironmentsResponse, gax::error::Error>
@@ -653,7 +652,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkloadsResponse, gax::error::Error>
@@ -919,7 +917,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1194,7 +1191,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1691,7 +1687,6 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1882,7 +1877,6 @@ pub mod image_versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListImageVersionsResponse, gax::error::Error>
@@ -1959,7 +1953,6 @@ pub mod image_versions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builders.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builders.rs
@@ -203,7 +203,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEnvironmentsResponse, gax::error::Error>
         {
@@ -652,7 +652,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkloadsResponse, gax::error::Error>
         {
@@ -917,7 +917,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListUserWorkloadsSecretsResponse,
@@ -1191,7 +1191,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListUserWorkloadsConfigMapsResponse,
@@ -1687,7 +1687,7 @@ pub mod environments {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1877,7 +1877,7 @@ pub mod image_versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListImageVersionsResponse, gax::error::Error>
         {
@@ -1953,7 +1953,7 @@ pub mod image_versions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -200,7 +200,6 @@ impl wkt::message::Message for ListEnvironmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEnvironmentsResponse {
     type PageItem = crate::model::Environment;
 
@@ -1361,7 +1360,6 @@ impl wkt::message::Message for ListUserWorkloadsSecretsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUserWorkloadsSecretsResponse {
     type PageItem = crate::model::UserWorkloadsSecret;
 
@@ -1474,7 +1472,6 @@ impl wkt::message::Message for ListUserWorkloadsConfigMapsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUserWorkloadsConfigMapsResponse {
     type PageItem = crate::model::UserWorkloadsConfigMap;
 
@@ -1596,7 +1593,6 @@ impl wkt::message::Message for ListWorkloadsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkloadsResponse {
     type PageItem = crate::model::list_workloads_response::ComposerWorkload;
 
@@ -5561,7 +5557,6 @@ impl wkt::message::Message for ListImageVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListImageVersionsResponse {
     type PageItem = crate::model::ImageVersion;
 

--- a/src/generated/cloud/orgpolicy/v2/src/builders.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/builders.rs
@@ -68,7 +68,7 @@ pub mod org_policy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConstraintsResponse, gax::error::Error>
         {
@@ -135,7 +135,7 @@ pub mod org_policy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPoliciesResponse, gax::error::Error>
         {
@@ -588,7 +588,7 @@ pub mod org_policy {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomConstraintsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/orgpolicy/v2/src/builders.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/builders.rs
@@ -68,7 +68,6 @@ pub mod org_policy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConstraintsResponse, gax::error::Error>
@@ -136,7 +135,6 @@ pub mod org_policy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPoliciesResponse, gax::error::Error>
@@ -590,7 +588,6 @@ pub mod org_policy {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomConstraintsResponse, gax::error::Error>

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -1259,7 +1259,6 @@ impl wkt::message::Message for ListConstraintsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConstraintsResponse {
     type PageItem = crate::model::Constraint;
 
@@ -1379,7 +1378,6 @@ impl wkt::message::Message for ListPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPoliciesResponse {
     type PageItem = crate::model::Policy;
 
@@ -1780,7 +1778,6 @@ impl wkt::message::Message for ListCustomConstraintsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCustomConstraintsResponse {
     type PageItem = crate::model::CustomConstraint;
 

--- a/src/generated/cloud/osconfig/v1/src/builders.rs
+++ b/src/generated/cloud/osconfig/v1/src/builders.rs
@@ -244,7 +244,7 @@ pub mod os_config_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPatchJobsResponse, gax::error::Error>
         {
@@ -322,7 +322,7 @@ pub mod os_config_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListPatchJobInstanceDetailsResponse,
@@ -503,7 +503,7 @@ pub mod os_config_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPatchDeploymentsResponse, gax::error::Error>
         {
@@ -1130,7 +1130,7 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListOSPolicyAssignmentsResponse,
@@ -1204,7 +1204,7 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListOSPolicyAssignmentRevisionsResponse,
@@ -1409,7 +1409,7 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListOSPolicyAssignmentReportsResponse,
@@ -1531,7 +1531,7 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInventoriesResponse, gax::error::Error>
         {
@@ -1659,7 +1659,7 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListVulnerabilityReportsResponse,

--- a/src/generated/cloud/osconfig/v1/src/builders.rs
+++ b/src/generated/cloud/osconfig/v1/src/builders.rs
@@ -244,7 +244,6 @@ pub mod os_config_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPatchJobsResponse, gax::error::Error>
@@ -323,7 +322,6 @@ pub mod os_config_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -505,7 +503,6 @@ pub mod os_config_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPatchDeploymentsResponse, gax::error::Error>
@@ -1133,7 +1130,6 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1208,7 +1204,6 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1414,7 +1409,6 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1537,7 +1531,6 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInventoriesResponse, gax::error::Error>
@@ -1666,7 +1659,6 @@ pub mod os_config_zonal_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -1522,7 +1522,6 @@ impl wkt::message::Message for ListInventoriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInventoriesResponse {
     type PageItem = crate::model::Inventory;
 
@@ -4300,7 +4299,6 @@ impl wkt::message::Message for ListOSPolicyAssignmentReportsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOSPolicyAssignmentReportsResponse {
     type PageItem = crate::model::OSPolicyAssignmentReport;
 
@@ -5940,7 +5938,6 @@ impl wkt::message::Message for ListOSPolicyAssignmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOSPolicyAssignmentsResponse {
     type PageItem = crate::model::OSPolicyAssignment;
 
@@ -6048,7 +6045,6 @@ impl wkt::message::Message for ListOSPolicyAssignmentRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOSPolicyAssignmentRevisionsResponse {
     type PageItem = crate::model::OSPolicyAssignment;
 
@@ -7186,7 +7182,6 @@ impl wkt::message::Message for ListPatchDeploymentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPatchDeploymentsResponse {
     type PageItem = crate::model::PatchDeployment;
 
@@ -7592,7 +7587,6 @@ impl wkt::message::Message for ListPatchJobInstanceDetailsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPatchJobInstanceDetailsResponse {
     type PageItem = crate::model::PatchJobInstanceDetails;
 
@@ -7788,7 +7782,6 @@ impl wkt::message::Message for ListPatchJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPatchJobsResponse {
     type PageItem = crate::model::PatchJob;
 
@@ -10358,7 +10351,6 @@ impl wkt::message::Message for ListVulnerabilityReportsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVulnerabilityReportsResponse {
     type PageItem = crate::model::VulnerabilityReport;
 

--- a/src/generated/cloud/parallelstore/v1/src/builders.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod parallelstore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -691,7 +690,6 @@ pub mod parallelstore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -809,7 +807,6 @@ pub mod parallelstore {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/parallelstore/v1/src/builders.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod parallelstore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -690,7 +690,7 @@ pub mod parallelstore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -807,7 +807,7 @@ pub mod parallelstore {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -480,7 +480,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 

--- a/src/generated/cloud/parametermanager/v1/src/builders.rs
+++ b/src/generated/cloud/parametermanager/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod parameter_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListParametersResponse, gax::error::Error>
@@ -360,7 +359,6 @@ pub mod parameter_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListParameterVersionsResponse, gax::error::Error>
@@ -718,7 +716,6 @@ pub mod parameter_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/parametermanager/v1/src/builders.rs
+++ b/src/generated/cloud/parametermanager/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod parameter_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListParametersResponse, gax::error::Error>
         {
@@ -359,7 +359,7 @@ pub mod parameter_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListParameterVersionsResponse, gax::error::Error>
         {
@@ -716,7 +716,7 @@ pub mod parameter_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/parametermanager/v1/src/model.rs
+++ b/src/generated/cloud/parametermanager/v1/src/model.rs
@@ -260,7 +260,6 @@ impl wkt::message::Message for ListParametersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListParametersResponse {
     type PageItem = crate::model::Parameter;
 
@@ -747,7 +746,6 @@ impl wkt::message::Message for ListParameterVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListParameterVersionsResponse {
     type PageItem = crate::model::ParameterVersion;
 

--- a/src/generated/cloud/policysimulator/v1/src/builders.rs
+++ b/src/generated/cloud/policysimulator/v1/src/builders.rs
@@ -200,7 +200,7 @@ pub mod simulator {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReplayResultsResponse, gax::error::Error>
         {
@@ -270,7 +270,7 @@ pub mod simulator {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/policysimulator/v1/src/builders.rs
+++ b/src/generated/cloud/policysimulator/v1/src/builders.rs
@@ -200,7 +200,6 @@ pub mod simulator {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReplayResultsResponse, gax::error::Error>
@@ -271,7 +270,6 @@ pub mod simulator {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/policysimulator/v1/src/model.rs
+++ b/src/generated/cloud/policysimulator/v1/src/model.rs
@@ -1240,7 +1240,6 @@ impl wkt::message::Message for ListReplayResultsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReplayResultsResponse {
     type PageItem = crate::model::ReplayResult;
 

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/builders.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/builders.rs
@@ -115,7 +115,7 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntitlementsResponse, gax::error::Error>
         {
@@ -197,7 +197,7 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchEntitlementsResponse, gax::error::Error>
         {
@@ -613,7 +613,7 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGrantsResponse, gax::error::Error>
         {
@@ -692,7 +692,7 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchGrantsResponse, gax::error::Error>
         {
@@ -1054,7 +1054,7 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1171,7 +1171,7 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/builders.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/builders.rs
@@ -115,7 +115,6 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEntitlementsResponse, gax::error::Error>
@@ -198,7 +197,6 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchEntitlementsResponse, gax::error::Error>
@@ -615,7 +613,6 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGrantsResponse, gax::error::Error>
@@ -695,7 +692,6 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchGrantsResponse, gax::error::Error>
@@ -1058,7 +1054,6 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1176,7 +1171,6 @@ pub mod privileged_access_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
@@ -1327,7 +1327,6 @@ impl wkt::message::Message for ListEntitlementsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEntitlementsResponse {
     type PageItem = crate::model::Entitlement;
 
@@ -1525,7 +1524,6 @@ impl wkt::message::Message for SearchEntitlementsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchEntitlementsResponse {
     type PageItem = crate::model::Entitlement;
 
@@ -3113,7 +3111,6 @@ impl wkt::message::Message for ListGrantsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGrantsResponse {
     type PageItem = crate::model::Grant;
 
@@ -3316,7 +3313,6 @@ impl wkt::message::Message for SearchGrantsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchGrantsResponse {
     type PageItem = crate::model::Grant;
 

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/builders.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/builders.rs
@@ -306,7 +306,6 @@ pub mod rapid_migration_assessment {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCollectorsResponse, gax::error::Error>
@@ -870,7 +869,6 @@ pub mod rapid_migration_assessment {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -988,7 +986,6 @@ pub mod rapid_migration_assessment {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/builders.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/builders.rs
@@ -306,7 +306,7 @@ pub mod rapid_migration_assessment {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCollectorsResponse, gax::error::Error>
         {
@@ -869,7 +869,7 @@ pub mod rapid_migration_assessment {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -986,7 +986,7 @@ pub mod rapid_migration_assessment {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
@@ -800,7 +800,6 @@ impl wkt::message::Message for ListCollectorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCollectorsResponse {
     type PageItem = crate::model::Collector;
 

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builders.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builders.rs
@@ -265,7 +265,6 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKeysResponse, gax::error::Error> {
@@ -674,7 +673,6 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIpOverridesResponse, gax::error::Error>
@@ -845,7 +843,6 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFirewallPoliciesResponse, gax::error::Error>
@@ -1129,7 +1126,6 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1208,7 +1204,6 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1287,7 +1282,6 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builders.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builders.rs
@@ -265,7 +265,7 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListKeysResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -673,7 +673,7 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIpOverridesResponse, gax::error::Error>
         {
@@ -843,7 +843,7 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFirewallPoliciesResponse, gax::error::Error>
         {
@@ -1126,7 +1126,7 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListRelatedAccountGroupsResponse,
@@ -1204,7 +1204,7 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListRelatedAccountGroupMembershipsResponse,
@@ -1282,7 +1282,7 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchRelatedAccountGroupMembershipsResponse,

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -3436,7 +3436,6 @@ impl wkt::message::Message for ListKeysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListKeysResponse {
     type PageItem = crate::model::Key;
 
@@ -3726,7 +3725,6 @@ impl wkt::message::Message for ListFirewallPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFirewallPoliciesResponse {
     type PageItem = crate::model::FirewallPolicy;
 
@@ -5707,7 +5705,6 @@ impl wkt::message::Message for ListRelatedAccountGroupMembershipsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRelatedAccountGroupMembershipsResponse {
     type PageItem = crate::model::RelatedAccountGroupMembership;
 
@@ -5821,7 +5818,6 @@ impl wkt::message::Message for ListRelatedAccountGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRelatedAccountGroupsResponse {
     type PageItem = crate::model::RelatedAccountGroup;
 
@@ -5966,7 +5962,6 @@ impl wkt::message::Message for SearchRelatedAccountGroupMembershipsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchRelatedAccountGroupMembershipsResponse {
     type PageItem = crate::model::RelatedAccountGroupMembership;
 
@@ -6205,7 +6200,6 @@ impl wkt::message::Message for ListIpOverridesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIpOverridesResponse {
     type PageItem = crate::model::IpOverrideData;
 

--- a/src/generated/cloud/recommender/v1/src/builders.rs
+++ b/src/generated/cloud/recommender/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod recommender {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInsightsResponse, gax::error::Error>
@@ -248,7 +247,6 @@ pub mod recommender {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRecommendationsResponse, gax::error::Error>

--- a/src/generated/cloud/recommender/v1/src/builders.rs
+++ b/src/generated/cloud/recommender/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod recommender {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInsightsResponse, gax::error::Error>
         {
@@ -247,7 +247,7 @@ pub mod recommender {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRecommendationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/recommender/v1/src/model.rs
+++ b/src/generated/cloud/recommender/v1/src/model.rs
@@ -2335,7 +2335,6 @@ impl wkt::message::Message for ListInsightsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInsightsResponse {
     type PageItem = crate::model::Insight;
 
@@ -2587,7 +2586,6 @@ impl wkt::message::Message for ListRecommendationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRecommendationsResponse {
     type PageItem = crate::model::Recommendation;
 

--- a/src/generated/cloud/redis/cluster/v1/src/builders.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
         {
@@ -599,7 +599,7 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupCollectionsResponse, gax::error::Error>
         {
@@ -710,7 +710,7 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -1081,7 +1081,7 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1198,7 +1198,7 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/redis/cluster/v1/src/builders.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
@@ -600,7 +599,6 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupCollectionsResponse, gax::error::Error>
@@ -712,7 +710,6 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -1084,7 +1081,6 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1202,7 +1198,6 @@ pub mod cloud_redis_cluster {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -233,7 +233,6 @@ impl wkt::message::Message for ListClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClustersResponse {
     type PageItem = crate::model::Cluster;
 
@@ -542,7 +541,6 @@ impl wkt::message::Message for ListBackupCollectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupCollectionsResponse {
     type PageItem = crate::model::BackupCollection;
 
@@ -704,7 +702,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 

--- a/src/generated/cloud/redis/v1/src/builders.rs
+++ b/src/generated/cloud/redis/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod cloud_redis {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -941,7 +940,6 @@ pub mod cloud_redis {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1059,7 +1057,6 @@ pub mod cloud_redis {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/redis/v1/src/builders.rs
+++ b/src/generated/cloud/redis/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod cloud_redis {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -940,7 +940,7 @@ pub mod cloud_redis {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1057,7 +1057,7 @@ pub mod cloud_redis {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -1689,7 +1689,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 

--- a/src/generated/cloud/resourcemanager/v3/src/builders.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builders.rs
@@ -109,7 +109,7 @@ pub mod folders {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFoldersResponse, gax::error::Error>
         {
@@ -182,7 +182,7 @@ pub mod folders {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchFoldersResponse, gax::error::Error>
         {
@@ -942,7 +942,7 @@ pub mod organizations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchOrganizationsResponse, gax::error::Error>
         {
@@ -1284,7 +1284,7 @@ pub mod projects {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProjectsResponse, gax::error::Error>
         {
@@ -1357,7 +1357,7 @@ pub mod projects {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchProjectsResponse, gax::error::Error>
         {
@@ -2075,7 +2075,7 @@ pub mod tag_bindings {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagBindingsResponse, gax::error::Error>
         {
@@ -2318,7 +2318,7 @@ pub mod tag_bindings {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEffectiveTagsResponse, gax::error::Error>
         {
@@ -2631,7 +2631,7 @@ pub mod tag_holds {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagHoldsResponse, gax::error::Error>
         {
@@ -2774,7 +2774,7 @@ pub mod tag_keys {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagKeysResponse, gax::error::Error>
         {
@@ -3436,7 +3436,7 @@ pub mod tag_values {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagValuesResponse, gax::error::Error>
         {

--- a/src/generated/cloud/resourcemanager/v3/src/builders.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builders.rs
@@ -109,7 +109,6 @@ pub mod folders {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFoldersResponse, gax::error::Error>
@@ -183,7 +182,6 @@ pub mod folders {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchFoldersResponse, gax::error::Error>
@@ -944,7 +942,6 @@ pub mod organizations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchOrganizationsResponse, gax::error::Error>
@@ -1287,7 +1284,6 @@ pub mod projects {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProjectsResponse, gax::error::Error>
@@ -1361,7 +1357,6 @@ pub mod projects {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchProjectsResponse, gax::error::Error>
@@ -2080,7 +2075,6 @@ pub mod tag_bindings {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagBindingsResponse, gax::error::Error>
@@ -2324,7 +2318,6 @@ pub mod tag_bindings {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEffectiveTagsResponse, gax::error::Error>
@@ -2638,7 +2631,6 @@ pub mod tag_holds {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagHoldsResponse, gax::error::Error>
@@ -2782,7 +2774,6 @@ pub mod tag_keys {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagKeysResponse, gax::error::Error>
@@ -3445,7 +3436,6 @@ pub mod tag_values {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagValuesResponse, gax::error::Error>

--- a/src/generated/cloud/resourcemanager/v3/src/model.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/model.rs
@@ -370,7 +370,6 @@ impl wkt::message::Message for ListFoldersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFoldersResponse {
     type PageItem = crate::model::Folder;
 
@@ -510,7 +509,6 @@ impl wkt::message::Message for SearchFoldersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchFoldersResponse {
     type PageItem = crate::model::Folder;
 
@@ -1251,7 +1249,6 @@ impl wkt::message::Message for SearchOrganizationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchOrganizationsResponse {
     type PageItem = crate::model::Organization;
 
@@ -1708,7 +1705,6 @@ impl wkt::message::Message for ListProjectsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProjectsResponse {
     type PageItem = crate::model::Project;
 
@@ -1871,7 +1867,6 @@ impl wkt::message::Message for SearchProjectsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchProjectsResponse {
     type PageItem = crate::model::Project;
 
@@ -2519,7 +2514,6 @@ impl wkt::message::Message for ListTagBindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTagBindingsResponse {
     type PageItem = crate::model::TagBinding;
 
@@ -2639,7 +2633,6 @@ impl wkt::message::Message for ListEffectiveTagsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEffectiveTagsResponse {
     type PageItem = crate::model::EffectiveTag;
 
@@ -3101,7 +3094,6 @@ impl wkt::message::Message for ListTagHoldsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTagHoldsResponse {
     type PageItem = crate::model::TagHold;
 
@@ -3367,7 +3359,6 @@ impl wkt::message::Message for ListTagKeysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTagKeysResponse {
     type PageItem = crate::model::TagKey;
 
@@ -3874,7 +3865,6 @@ impl wkt::message::Message for ListTagValuesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTagValuesResponse {
     type PageItem = crate::model::TagValue;
 

--- a/src/generated/cloud/retail/v2/src/builders.rs
+++ b/src/generated/cloud/retail/v2/src/builders.rs
@@ -171,7 +171,6 @@ pub mod analytics_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -315,7 +314,6 @@ pub mod catalog_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCatalogsResponse, gax::error::Error>
@@ -920,7 +918,6 @@ pub mod catalog_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1263,7 +1260,6 @@ pub mod completion_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1598,7 +1594,6 @@ pub mod control_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListControlsResponse, gax::error::Error>
@@ -1675,7 +1670,6 @@ pub mod control_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2095,7 +2089,6 @@ pub mod generative_question_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2496,7 +2489,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelsResponse, gax::error::Error>
@@ -2700,7 +2692,6 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2941,7 +2932,6 @@ pub mod prediction_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3182,7 +3172,6 @@ pub mod product_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProductsResponse, gax::error::Error>
@@ -4158,7 +4147,6 @@ pub mod product_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4300,7 +4288,6 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchResponse, gax::error::Error> {
@@ -4557,7 +4544,6 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -4907,7 +4893,6 @@ pub mod serving_config_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServingConfigsResponse, gax::error::Error>
@@ -5072,7 +5057,6 @@ pub mod serving_config_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -5649,7 +5633,6 @@ pub mod user_event_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/retail/v2/src/builders.rs
+++ b/src/generated/cloud/retail/v2/src/builders.rs
@@ -171,7 +171,7 @@ pub mod analytics_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -314,7 +314,7 @@ pub mod catalog_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCatalogsResponse, gax::error::Error>
         {
@@ -918,7 +918,7 @@ pub mod catalog_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1260,7 +1260,7 @@ pub mod completion_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1594,7 +1594,7 @@ pub mod control_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListControlsResponse, gax::error::Error>
         {
@@ -1670,7 +1670,7 @@ pub mod control_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2089,7 +2089,7 @@ pub mod generative_question_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2489,7 +2489,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelsResponse, gax::error::Error>
         {
@@ -2692,7 +2692,7 @@ pub mod model_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2932,7 +2932,7 @@ pub mod prediction_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3172,7 +3172,7 @@ pub mod product_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProductsResponse, gax::error::Error>
         {
@@ -4147,7 +4147,7 @@ pub mod product_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4288,7 +4288,7 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -4544,7 +4544,7 @@ pub mod search_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -4893,7 +4893,7 @@ pub mod serving_config_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServingConfigsResponse, gax::error::Error>
         {
@@ -5057,7 +5057,7 @@ pub mod serving_config_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -5633,7 +5633,7 @@ pub mod user_event_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -1549,7 +1549,6 @@ impl wkt::message::Message for ListCatalogsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCatalogsResponse {
     type PageItem = crate::model::Catalog;
 
@@ -5413,7 +5412,6 @@ impl wkt::message::Message for ListControlsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListControlsResponse {
     type PageItem = crate::model::Control;
 
@@ -8985,7 +8983,6 @@ impl wkt::message::Message for ListModelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelsResponse {
     type PageItem = crate::model::Model;
 
@@ -11121,7 +11118,6 @@ impl wkt::message::Message for ListProductsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProductsResponse {
     type PageItem = crate::model::Product;
 
@@ -14767,7 +14763,6 @@ impl wkt::message::Message for SearchResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchResponse {
     type PageItem = crate::model::search_response::Facet;
 
@@ -16474,7 +16469,6 @@ impl wkt::message::Message for ListServingConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServingConfigsResponse {
     type PageItem = crate::model::ServingConfig;
 

--- a/src/generated/cloud/run/v2/src/builders.rs
+++ b/src/generated/cloud/run/v2/src/builders.rs
@@ -159,7 +159,7 @@ pub mod builds {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -437,7 +437,7 @@ pub mod executions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExecutionsResponse, gax::error::Error>
         {
@@ -689,7 +689,7 @@ pub mod executions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1059,7 +1059,7 @@ pub mod jobs {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1571,7 +1571,7 @@ pub mod jobs {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -1849,7 +1849,7 @@ pub mod revisions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRevisionsResponse, gax::error::Error>
         {
@@ -2013,7 +2013,7 @@ pub mod revisions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2388,7 +2388,7 @@ pub mod services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -2816,7 +2816,7 @@ pub mod services {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -3094,7 +3094,7 @@ pub mod tasks {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTasksResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -3169,7 +3169,7 @@ pub mod tasks {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/run/v2/src/builders.rs
+++ b/src/generated/cloud/run/v2/src/builders.rs
@@ -159,7 +159,6 @@ pub mod builds {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -438,7 +437,6 @@ pub mod executions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExecutionsResponse, gax::error::Error>
@@ -691,7 +689,6 @@ pub mod executions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1062,7 +1059,6 @@ pub mod jobs {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
@@ -1575,7 +1571,6 @@ pub mod jobs {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -1854,7 +1849,6 @@ pub mod revisions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRevisionsResponse, gax::error::Error>
@@ -2019,7 +2013,6 @@ pub mod revisions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2395,7 +2388,6 @@ pub mod services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -2824,7 +2816,6 @@ pub mod services {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -3103,7 +3094,6 @@ pub mod tasks {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTasksResponse, gax::error::Error> {
@@ -3179,7 +3169,6 @@ pub mod tasks {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -1316,7 +1316,6 @@ impl wkt::message::Message for ListExecutionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExecutionsResponse {
     type PageItem = crate::model::Execution;
 
@@ -2162,7 +2161,6 @@ impl wkt::message::Message for ListJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListJobsResponse {
     type PageItem = crate::model::Job;
 
@@ -4722,7 +4720,6 @@ impl wkt::message::Message for ListRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRevisionsResponse {
     type PageItem = crate::model::Revision;
 
@@ -5754,7 +5751,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::Service;
 
@@ -6544,7 +6540,6 @@ impl wkt::message::Message for ListTasksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTasksResponse {
     type PageItem = crate::model::Task;
 

--- a/src/generated/cloud/scheduler/v1/src/builders.rs
+++ b/src/generated/cloud/scheduler/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod cloud_scheduler {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -435,7 +435,7 @@ pub mod cloud_scheduler {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/scheduler/v1/src/builders.rs
+++ b/src/generated/cloud/scheduler/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod cloud_scheduler {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
@@ -436,7 +435,6 @@ pub mod cloud_scheduler {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -153,7 +153,6 @@ impl wkt::message::Message for ListJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListJobsResponse {
     type PageItem = crate::model::Job;
 

--- a/src/generated/cloud/secretmanager/v1/src/builders.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error>
@@ -395,7 +394,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error>
@@ -874,7 +872,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/secretmanager/v1/src/builders.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error>
         {
@@ -394,7 +394,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error>
         {
@@ -872,7 +872,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -1648,7 +1648,6 @@ impl wkt::message::Message for ListSecretsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecretsResponse {
     type PageItem = crate::model::Secret;
 
@@ -1961,7 +1960,6 @@ impl wkt::message::Message for ListSecretVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecretVersionsResponse {
     type PageItem = crate::model::SecretVersion;
 

--- a/src/generated/cloud/securesourcemanager/v1/src/builders.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -374,7 +373,6 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRepositoriesResponse, gax::error::Error>
@@ -938,7 +936,6 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBranchRulesResponse, gax::error::Error>
@@ -1235,7 +1232,6 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1517,7 +1513,6 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/securesourcemanager/v1/src/builders.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -373,7 +373,7 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRepositoriesResponse, gax::error::Error>
         {
@@ -936,7 +936,7 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBranchRulesResponse, gax::error::Error>
         {
@@ -1232,7 +1232,7 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1513,7 +1513,7 @@ pub mod secure_source_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/securesourcemanager/v1/src/model.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/model.rs
@@ -1197,7 +1197,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 
@@ -1582,7 +1581,6 @@ impl wkt::message::Message for ListRepositoriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRepositoriesResponse {
     type PageItem = crate::model::Repository;
 
@@ -1987,7 +1985,6 @@ impl wkt::message::Message for ListBranchRulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBranchRulesResponse {
     type PageItem = crate::model::BranchRule;
 

--- a/src/generated/cloud/security/privateca/v1/src/builders.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builders.rs
@@ -200,7 +200,7 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCertificatesResponse, gax::error::Error>
         {
@@ -916,7 +916,7 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListCertificateAuthoritiesResponse,
@@ -1552,7 +1552,7 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCaPoolsResponse, gax::error::Error>
         {
@@ -1825,7 +1825,7 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListCertificateRevocationListsResponse,
@@ -2267,7 +2267,7 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListCertificateTemplatesResponse,
@@ -2460,7 +2460,7 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2751,7 +2751,7 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/security/privateca/v1/src/builders.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builders.rs
@@ -200,7 +200,6 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCertificatesResponse, gax::error::Error>
@@ -917,7 +916,6 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1554,7 +1552,6 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCaPoolsResponse, gax::error::Error>
@@ -1828,7 +1825,6 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2271,7 +2267,6 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2465,7 +2460,6 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2757,7 +2751,6 @@ pub mod certificate_authority_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -4964,7 +4964,6 @@ impl wkt::message::Message for ListCertificatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCertificatesResponse {
     type PageItem = crate::model::Certificate;
 
@@ -5700,7 +5699,6 @@ impl wkt::message::Message for ListCertificateAuthoritiesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCertificateAuthoritiesResponse {
     type PageItem = crate::model::CertificateAuthority;
 
@@ -6493,7 +6491,6 @@ impl wkt::message::Message for ListCaPoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCaPoolsResponse {
     type PageItem = crate::model::CaPool;
 
@@ -6700,7 +6697,6 @@ impl wkt::message::Message for ListCertificateRevocationListsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCertificateRevocationListsResponse {
     type PageItem = crate::model::CertificateRevocationList;
 
@@ -7131,7 +7127,6 @@ impl wkt::message::Message for ListCertificateTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCertificateTemplatesResponse {
     type PageItem = crate::model::CertificateTemplate;
 

--- a/src/generated/cloud/securitycenter/v2/src/builders.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builders.rs
@@ -1037,7 +1037,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::GroupFindingsResponse, gax::error::Error>
         {
@@ -1116,7 +1116,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttackPathsResponse, gax::error::Error>
         {
@@ -1192,7 +1192,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBigQueryExportsResponse, gax::error::Error>
         {
@@ -1259,7 +1259,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFindingsResponse, gax::error::Error>
         {
@@ -1347,7 +1347,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMuteConfigsResponse, gax::error::Error>
         {
@@ -1419,7 +1419,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListNotificationConfigsResponse,
@@ -1493,7 +1493,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListResourceValueConfigsResponse,
@@ -1562,7 +1562,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSourcesResponse, gax::error::Error>
         {
@@ -1632,7 +1632,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListValuedResourcesResponse, gax::error::Error>
         {
@@ -2372,7 +2372,7 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/securitycenter/v2/src/builders.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builders.rs
@@ -1037,7 +1037,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::GroupFindingsResponse, gax::error::Error>
@@ -1117,7 +1116,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttackPathsResponse, gax::error::Error>
@@ -1194,7 +1192,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBigQueryExportsResponse, gax::error::Error>
@@ -1262,7 +1259,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFindingsResponse, gax::error::Error>
@@ -1351,7 +1347,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMuteConfigsResponse, gax::error::Error>
@@ -1424,7 +1419,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1499,7 +1493,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1569,7 +1562,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSourcesResponse, gax::error::Error>
@@ -1640,7 +1632,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListValuedResourcesResponse, gax::error::Error>
@@ -2381,7 +2372,6 @@ pub mod security_center {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -10331,7 +10331,6 @@ impl wkt::message::Message for GroupFindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for GroupFindingsResponse {
     type PageItem = crate::model::GroupResult;
 
@@ -10506,7 +10505,6 @@ impl wkt::message::Message for ListAttackPathsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAttackPathsResponse {
     type PageItem = crate::model::AttackPath;
 
@@ -10689,7 +10687,6 @@ impl wkt::message::Message for ListBigQueryExportsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBigQueryExportsResponse {
     type PageItem = crate::model::BigQueryExport;
 
@@ -10935,7 +10932,6 @@ impl wkt::message::Message for ListFindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFindingsResponse {
     type PageItem = crate::model::list_findings_response::ListFindingsResult;
 
@@ -11372,7 +11368,6 @@ impl wkt::message::Message for ListMuteConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMuteConfigsResponse {
     type PageItem = crate::model::MuteConfig;
 
@@ -11485,7 +11480,6 @@ impl wkt::message::Message for ListNotificationConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNotificationConfigsResponse {
     type PageItem = crate::model::NotificationConfig;
 
@@ -11603,7 +11597,6 @@ impl wkt::message::Message for ListResourceValueConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListResourceValueConfigsResponse {
     type PageItem = crate::model::ResourceValueConfig;
 
@@ -11714,7 +11707,6 @@ impl wkt::message::Message for ListSourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSourcesResponse {
     type PageItem = crate::model::Source;
 
@@ -11877,7 +11869,6 @@ impl wkt::message::Message for ListValuedResourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListValuedResourcesResponse {
     type PageItem = crate::model::ValuedResource;
 

--- a/src/generated/cloud/securityposture/v1/src/builders.rs
+++ b/src/generated/cloud/securityposture/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPosturesResponse, gax::error::Error>
         {
@@ -138,7 +138,7 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPostureRevisionsResponse, gax::error::Error>
         {
@@ -616,7 +616,7 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListPostureDeploymentsResponse,
@@ -1026,7 +1026,7 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPostureTemplatesResponse, gax::error::Error>
         {
@@ -1152,7 +1152,7 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1269,7 +1269,7 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/securityposture/v1/src/builders.rs
+++ b/src/generated/cloud/securityposture/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPosturesResponse, gax::error::Error>
@@ -139,7 +138,6 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPostureRevisionsResponse, gax::error::Error>
@@ -618,7 +616,6 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1029,7 +1026,6 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPostureTemplatesResponse, gax::error::Error>
@@ -1156,7 +1152,6 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1274,7 +1269,6 @@ pub mod security_posture {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/securityposture/v1/src/model.rs
+++ b/src/generated/cloud/securityposture/v1/src/model.rs
@@ -1429,7 +1429,6 @@ impl wkt::message::Message for ListPosturesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPosturesResponse {
     type PageItem = crate::model::Posture;
 
@@ -1535,7 +1534,6 @@ impl wkt::message::Message for ListPostureRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPostureRevisionsResponse {
     type PageItem = crate::model::Posture;
 
@@ -2209,7 +2207,6 @@ impl wkt::message::Message for ListPostureDeploymentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPostureDeploymentsResponse {
     type PageItem = crate::model::PostureDeployment;
 
@@ -2647,7 +2644,6 @@ impl wkt::message::Message for ListPostureTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPostureTemplatesResponse {
     type PageItem = crate::model::PostureTemplate;
 

--- a/src/generated/cloud/servicedirectory/v1/src/builders.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/builders.rs
@@ -124,7 +124,6 @@ pub mod lookup_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -321,7 +320,6 @@ pub mod registration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNamespacesResponse, gax::error::Error>
@@ -592,7 +590,6 @@ pub mod registration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -863,7 +860,6 @@ pub mod registration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEndpointsResponse, gax::error::Error>
@@ -1245,7 +1241,6 @@ pub mod registration_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/servicedirectory/v1/src/builders.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/builders.rs
@@ -124,7 +124,7 @@ pub mod lookup_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -320,7 +320,7 @@ pub mod registration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNamespacesResponse, gax::error::Error>
         {
@@ -590,7 +590,7 @@ pub mod registration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -860,7 +860,7 @@ pub mod registration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEndpointsResponse, gax::error::Error>
         {
@@ -1241,7 +1241,7 @@ pub mod registration_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/servicedirectory/v1/src/model.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/model.rs
@@ -561,7 +561,6 @@ impl wkt::message::Message for ListNamespacesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNamespacesResponse {
     type PageItem = crate::model::Namespace;
 
@@ -907,7 +906,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::Service;
 
@@ -1258,7 +1256,6 @@ impl wkt::message::Message for ListEndpointsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEndpointsResponse {
     type PageItem = crate::model::Endpoint;
 

--- a/src/generated/cloud/servicehealth/v1/src/builders.rs
+++ b/src/generated/cloud/servicehealth/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod service_health {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEventsResponse, gax::error::Error>
@@ -192,7 +191,6 @@ pub mod service_health {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -323,7 +321,6 @@ pub mod service_health {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -446,7 +443,6 @@ pub mod service_health {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/servicehealth/v1/src/builders.rs
+++ b/src/generated/cloud/servicehealth/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod service_health {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEventsResponse, gax::error::Error>
         {
@@ -191,7 +191,7 @@ pub mod service_health {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListOrganizationEventsResponse,
@@ -321,7 +321,7 @@ pub mod service_health {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListOrganizationImpactsResponse,
@@ -443,7 +443,7 @@ pub mod service_health {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/servicehealth/v1/src/model.rs
+++ b/src/generated/cloud/servicehealth/v1/src/model.rs
@@ -1537,7 +1537,6 @@ impl wkt::message::Message for ListEventsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEventsResponse {
     type PageItem = crate::model::Event;
 
@@ -1752,7 +1751,6 @@ impl wkt::message::Message for ListOrganizationEventsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOrganizationEventsResponse {
     type PageItem = crate::model::OrganizationEvent;
 
@@ -1960,7 +1958,6 @@ impl wkt::message::Message for ListOrganizationImpactsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOrganizationImpactsResponse {
     type PageItem = crate::model::OrganizationImpact;
 

--- a/src/generated/cloud/speech/v2/src/builders.rs
+++ b/src/generated/cloud/speech/v2/src/builders.rs
@@ -171,7 +171,6 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRecognizersResponse, gax::error::Error>
@@ -981,7 +980,6 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomClassesResponse, gax::error::Error>
@@ -1490,7 +1488,6 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPhraseSetsResponse, gax::error::Error>
@@ -1896,7 +1893,6 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2014,7 +2010,6 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/speech/v2/src/builders.rs
+++ b/src/generated/cloud/speech/v2/src/builders.rs
@@ -171,7 +171,7 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRecognizersResponse, gax::error::Error>
         {
@@ -980,7 +980,7 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCustomClassesResponse, gax::error::Error>
         {
@@ -1488,7 +1488,7 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPhraseSetsResponse, gax::error::Error>
         {
@@ -1893,7 +1893,7 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2010,7 +2010,7 @@ pub mod speech {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -890,7 +890,6 @@ impl wkt::message::Message for ListRecognizersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRecognizersResponse {
     type PageItem = crate::model::Recognizer;
 
@@ -5725,7 +5724,6 @@ impl wkt::message::Message for ListCustomClassesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCustomClassesResponse {
     type PageItem = crate::model::CustomClass;
 
@@ -6152,7 +6150,6 @@ impl wkt::message::Message for ListPhraseSetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPhraseSetsResponse {
     type PageItem = crate::model::PhraseSet;
 

--- a/src/generated/cloud/storageinsights/v1/src/builders.rs
+++ b/src/generated/cloud/storageinsights/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod storage_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReportConfigsResponse, gax::error::Error>
@@ -372,7 +371,6 @@ pub mod storage_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReportDetailsResponse, gax::error::Error>
@@ -496,7 +494,6 @@ pub mod storage_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -614,7 +611,6 @@ pub mod storage_insights {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/storageinsights/v1/src/builders.rs
+++ b/src/generated/cloud/storageinsights/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod storage_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReportConfigsResponse, gax::error::Error>
         {
@@ -371,7 +371,7 @@ pub mod storage_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReportDetailsResponse, gax::error::Error>
         {
@@ -494,7 +494,7 @@ pub mod storage_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -611,7 +611,7 @@ pub mod storage_insights {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -161,7 +161,6 @@ impl wkt::message::Message for ListReportConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReportConfigsResponse {
     type PageItem = crate::model::ReportConfig;
 
@@ -700,7 +699,6 @@ impl wkt::message::Message for ListReportDetailsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReportDetailsResponse {
     type PageItem = crate::model::ReportDetail;
 

--- a/src/generated/cloud/support/v2/src/builders.rs
+++ b/src/generated/cloud/support/v2/src/builders.rs
@@ -68,7 +68,6 @@ pub mod case_attachment_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttachmentsResponse, gax::error::Error>
@@ -203,7 +202,6 @@ pub mod case_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCasesResponse, gax::error::Error> {
@@ -276,7 +274,6 @@ pub mod case_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchCasesResponse, gax::error::Error>
@@ -543,7 +540,6 @@ pub mod case_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -639,7 +635,6 @@ pub mod comment_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCommentsResponse, gax::error::Error>

--- a/src/generated/cloud/support/v2/src/builders.rs
+++ b/src/generated/cloud/support/v2/src/builders.rs
@@ -68,7 +68,7 @@ pub mod case_attachment_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttachmentsResponse, gax::error::Error>
         {
@@ -202,7 +202,7 @@ pub mod case_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCasesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -274,7 +274,7 @@ pub mod case_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchCasesResponse, gax::error::Error>
         {
@@ -540,7 +540,7 @@ pub mod case_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchCaseClassificationsResponse,
@@ -635,7 +635,7 @@ pub mod comment_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCommentsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/support/v2/src/model.rs
+++ b/src/generated/cloud/support/v2/src/model.rs
@@ -269,7 +269,6 @@ impl wkt::message::Message for ListAttachmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAttachmentsResponse {
     type PageItem = crate::model::Attachment;
 
@@ -875,7 +874,6 @@ impl wkt::message::Message for ListCasesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCasesResponse {
     type PageItem = crate::model::Case;
 
@@ -1029,7 +1027,6 @@ impl wkt::message::Message for SearchCasesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchCasesResponse {
     type PageItem = crate::model::Case;
 
@@ -1263,7 +1260,6 @@ impl wkt::message::Message for SearchCaseClassificationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchCaseClassificationsResponse {
     type PageItem = crate::model::CaseClassification;
 
@@ -1449,7 +1445,6 @@ impl wkt::message::Message for ListCommentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCommentsResponse {
     type PageItem = crate::model::Comment;
 

--- a/src/generated/cloud/talent/v4/src/builders.rs
+++ b/src/generated/cloud/talent/v4/src/builders.rs
@@ -253,7 +253,6 @@ pub mod company_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCompaniesResponse, gax::error::Error>
@@ -1143,7 +1142,6 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
@@ -1807,7 +1805,6 @@ pub mod tenant_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTenantsResponse, gax::error::Error>

--- a/src/generated/cloud/talent/v4/src/builders.rs
+++ b/src/generated/cloud/talent/v4/src/builders.rs
@@ -253,7 +253,7 @@ pub mod company_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCompaniesResponse, gax::error::Error>
         {
@@ -1142,7 +1142,7 @@ pub mod job_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1805,7 +1805,7 @@ pub mod tenant_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTenantsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -2080,7 +2080,6 @@ impl wkt::message::Message for ListCompaniesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCompaniesResponse {
     type PageItem = crate::model::Company;
 
@@ -5166,7 +5165,6 @@ impl wkt::message::Message for ListJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListJobsResponse {
     type PageItem = crate::model::Job;
 
@@ -7217,7 +7215,6 @@ impl wkt::message::Message for ListTenantsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTenantsResponse {
     type PageItem = crate::model::Tenant;
 

--- a/src/generated/cloud/tasks/v2/src/builders.rs
+++ b/src/generated/cloud/tasks/v2/src/builders.rs
@@ -68,7 +68,6 @@ pub mod cloud_tasks {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQueuesResponse, gax::error::Error>
@@ -614,7 +613,6 @@ pub mod cloud_tasks {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTasksResponse, gax::error::Error> {
@@ -878,7 +876,6 @@ pub mod cloud_tasks {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/cloud/tasks/v2/src/builders.rs
+++ b/src/generated/cloud/tasks/v2/src/builders.rs
@@ -68,7 +68,7 @@ pub mod cloud_tasks {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQueuesResponse, gax::error::Error>
         {
@@ -613,7 +613,7 @@ pub mod cloud_tasks {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTasksResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -876,7 +876,7 @@ pub mod cloud_tasks {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/tasks/v2/src/model.rs
+++ b/src/generated/cloud/tasks/v2/src/model.rs
@@ -184,7 +184,6 @@ impl wkt::message::Message for ListQueuesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListQueuesResponse {
     type PageItem = crate::model::Queue;
 
@@ -629,7 +628,6 @@ impl wkt::message::Message for ListTasksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTasksResponse {
     type PageItem = crate::model::Task;
 

--- a/src/generated/cloud/telcoautomation/v1/src/builders.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builders.rs
@@ -73,7 +73,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -396,7 +395,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEdgeSlmsResponse, gax::error::Error>
@@ -895,7 +893,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBlueprintsResponse, gax::error::Error>
@@ -1101,7 +1098,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1176,7 +1172,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1257,7 +1252,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1382,7 +1376,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPublicBlueprintsResponse, gax::error::Error>
@@ -1700,7 +1693,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
@@ -1779,7 +1771,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2081,7 +2072,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2260,7 +2250,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2378,7 +2367,6 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/telcoautomation/v1/src/builders.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builders.rs
@@ -73,7 +73,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListOrchestrationClustersResponse,
@@ -395,7 +395,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEdgeSlmsResponse, gax::error::Error>
         {
@@ -893,7 +893,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBlueprintsResponse, gax::error::Error>
         {
@@ -1098,7 +1098,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListBlueprintRevisionsResponse,
@@ -1172,7 +1172,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchBlueprintRevisionsResponse,
@@ -1252,7 +1252,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchDeploymentRevisionsResponse,
@@ -1376,7 +1376,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPublicBlueprintsResponse, gax::error::Error>
         {
@@ -1693,7 +1693,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDeploymentsResponse, gax::error::Error>
         {
@@ -1771,7 +1771,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListDeploymentRevisionsResponse,
@@ -2072,7 +2072,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListHydratedDeploymentsResponse,
@@ -2250,7 +2250,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2367,7 +2367,7 @@ pub mod telco_automation {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -1396,7 +1396,6 @@ impl wkt::message::Message for ListOrchestrationClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOrchestrationClustersResponse {
     type PageItem = crate::model::OrchestrationCluster;
 
@@ -1698,7 +1697,6 @@ impl wkt::message::Message for ListEdgeSlmsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEdgeSlmsResponse {
     type PageItem = crate::model::EdgeSlm;
 
@@ -2150,7 +2148,6 @@ impl wkt::message::Message for ListBlueprintsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBlueprintsResponse {
     type PageItem = crate::model::Blueprint;
 
@@ -2345,7 +2342,6 @@ impl wkt::message::Message for ListBlueprintRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBlueprintRevisionsResponse {
     type PageItem = crate::model::Blueprint;
 
@@ -2472,7 +2468,6 @@ impl wkt::message::Message for SearchBlueprintRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchBlueprintRevisionsResponse {
     type PageItem = crate::model::Blueprint;
 
@@ -2629,7 +2624,6 @@ impl wkt::message::Message for ListPublicBlueprintsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPublicBlueprintsResponse {
     type PageItem = crate::model::PublicBlueprint;
 
@@ -2952,7 +2946,6 @@ impl wkt::message::Message for ListDeploymentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeploymentsResponse {
     type PageItem = crate::model::Deployment;
 
@@ -3059,7 +3052,6 @@ impl wkt::message::Message for ListDeploymentRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeploymentRevisionsResponse {
     type PageItem = crate::model::Deployment;
 
@@ -3187,7 +3179,6 @@ impl wkt::message::Message for SearchDeploymentRevisionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchDeploymentRevisionsResponse {
     type PageItem = crate::model::Deployment;
 
@@ -3629,7 +3620,6 @@ impl wkt::message::Message for ListHydratedDeploymentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListHydratedDeploymentsResponse {
     type PageItem = crate::model::HydratedDeployment;
 

--- a/src/generated/cloud/texttospeech/v1/src/builders.rs
+++ b/src/generated/cloud/texttospeech/v1/src/builders.rs
@@ -188,7 +188,7 @@ pub mod text_to_speech {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -460,7 +460,7 @@ pub mod text_to_speech_long_audio_synthesize {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/texttospeech/v1/src/builders.rs
+++ b/src/generated/cloud/texttospeech/v1/src/builders.rs
@@ -188,7 +188,6 @@ pub mod text_to_speech {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -461,7 +460,6 @@ pub mod text_to_speech_long_audio_synthesize {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/timeseriesinsights/v1/src/builders.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builders.rs
@@ -72,7 +72,6 @@ pub mod timeseries_insights_controller {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataSetsResponse, gax::error::Error>

--- a/src/generated/cloud/timeseriesinsights/v1/src/builders.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builders.rs
@@ -72,7 +72,7 @@ pub mod timeseries_insights_controller {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDataSetsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -851,7 +851,6 @@ impl wkt::message::Message for ListDataSetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDataSetsResponse {
     type PageItem = crate::model::DataSet;
 

--- a/src/generated/cloud/tpu/v2/src/builders.rs
+++ b/src/generated/cloud/tpu/v2/src/builders.rs
@@ -68,7 +68,6 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNodesResponse, gax::error::Error> {
@@ -588,7 +587,6 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQueuedResourcesResponse, gax::error::Error>
@@ -1027,7 +1025,6 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAcceleratorTypesResponse, gax::error::Error>
@@ -1154,7 +1151,6 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRuntimeVersionsResponse, gax::error::Error>
@@ -1342,7 +1338,6 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -1460,7 +1455,6 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/tpu/v2/src/builders.rs
+++ b/src/generated/cloud/tpu/v2/src/builders.rs
@@ -68,7 +68,7 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNodesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -587,7 +587,7 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListQueuedResourcesResponse, gax::error::Error>
         {
@@ -1025,7 +1025,7 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAcceleratorTypesResponse, gax::error::Error>
         {
@@ -1151,7 +1151,7 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRuntimeVersionsResponse, gax::error::Error>
         {
@@ -1338,7 +1338,7 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -1455,7 +1455,7 @@ pub mod tpu {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -2688,7 +2688,6 @@ impl wkt::message::Message for ListNodesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNodesResponse {
     type PageItem = crate::model::Node;
 
@@ -3042,7 +3041,6 @@ impl wkt::message::Message for ListQueuedResourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListQueuedResourcesResponse {
     type PageItem = crate::model::QueuedResource;
 
@@ -3561,7 +3559,6 @@ impl wkt::message::Message for ListAcceleratorTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAcceleratorTypesResponse {
     type PageItem = crate::model::AcceleratorType;
 
@@ -3777,7 +3774,6 @@ impl wkt::message::Message for ListRuntimeVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRuntimeVersionsResponse {
     type PageItem = crate::model::RuntimeVersion;
 

--- a/src/generated/cloud/translate/v3/src/builders.rs
+++ b/src/generated/cloud/translate/v3/src/builders.rs
@@ -1008,7 +1008,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGlossariesResponse, gax::error::Error>
         {
@@ -1251,7 +1251,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGlossaryEntriesResponse, gax::error::Error>
         {
@@ -1591,7 +1591,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatasetsResponse, gax::error::Error>
         {
@@ -1884,7 +1884,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAdaptiveMtDatasetsResponse,
@@ -2192,7 +2192,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAdaptiveMtFilesResponse, gax::error::Error>
         {
@@ -2264,7 +2264,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListAdaptiveMtSentencesResponse,
@@ -2505,7 +2505,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExamplesResponse, gax::error::Error>
         {
@@ -2665,7 +2665,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelsResponse, gax::error::Error>
         {
@@ -2858,7 +2858,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2975,7 +2975,7 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/translate/v3/src/builders.rs
+++ b/src/generated/cloud/translate/v3/src/builders.rs
@@ -1008,7 +1008,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGlossariesResponse, gax::error::Error>
@@ -1252,7 +1251,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGlossaryEntriesResponse, gax::error::Error>
@@ -1593,7 +1591,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatasetsResponse, gax::error::Error>
@@ -1887,7 +1884,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2196,7 +2192,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAdaptiveMtFilesResponse, gax::error::Error>
@@ -2269,7 +2264,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2511,7 +2505,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExamplesResponse, gax::error::Error>
@@ -2672,7 +2665,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListModelsResponse, gax::error::Error>
@@ -2866,7 +2858,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2984,7 +2975,6 @@ pub mod translation_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -353,7 +353,6 @@ impl wkt::message::Message for ListAdaptiveMtDatasetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAdaptiveMtDatasetsResponse {
     type PageItem = crate::model::AdaptiveMtDataset;
 
@@ -1162,7 +1161,6 @@ impl wkt::message::Message for ListAdaptiveMtFilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAdaptiveMtFilesResponse {
     type PageItem = crate::model::AdaptiveMtFile;
 
@@ -1350,7 +1348,6 @@ impl wkt::message::Message for ListAdaptiveMtSentencesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAdaptiveMtSentencesResponse {
     type PageItem = crate::model::AdaptiveMtSentence;
 
@@ -2029,7 +2026,6 @@ impl wkt::message::Message for ListDatasetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatasetsResponse {
     type PageItem = crate::model::Dataset;
 
@@ -2262,7 +2258,6 @@ impl wkt::message::Message for ListExamplesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExamplesResponse {
     type PageItem = crate::model::Example;
 
@@ -2782,7 +2777,6 @@ impl wkt::message::Message for ListModelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListModelsResponse {
     type PageItem = crate::model::Model;
 
@@ -6350,7 +6344,6 @@ impl wkt::message::Message for ListGlossariesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGlossariesResponse {
     type PageItem = crate::model::Glossary;
 
@@ -6519,7 +6512,6 @@ impl wkt::message::Message for ListGlossaryEntriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGlossaryEntriesResponse {
     type PageItem = crate::model::GlossaryEntry;
 

--- a/src/generated/cloud/video/livestream/v1/src/builders.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builders.rs
@@ -167,7 +167,7 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListChannelsResponse, gax::error::Error>
         {
@@ -746,7 +746,7 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInputsResponse, gax::error::Error>
         {
@@ -1106,7 +1106,7 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEventsResponse, gax::error::Error>
         {
@@ -1273,7 +1273,7 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClipsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1792,7 +1792,7 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAssetsResponse, gax::error::Error>
         {
@@ -2008,7 +2008,7 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -2125,7 +2125,7 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/video/livestream/v1/src/builders.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builders.rs
@@ -167,7 +167,6 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListChannelsResponse, gax::error::Error>
@@ -747,7 +746,6 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInputsResponse, gax::error::Error>
@@ -1108,7 +1106,6 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListEventsResponse, gax::error::Error>
@@ -1276,7 +1273,6 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClipsResponse, gax::error::Error> {
@@ -1796,7 +1792,6 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAssetsResponse, gax::error::Error>
@@ -2013,7 +2008,6 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -2131,7 +2125,6 @@ pub mod livestream_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -5414,7 +5414,6 @@ impl wkt::message::Message for ListAssetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAssetsResponse {
     type PageItem = crate::model::Asset;
 
@@ -5670,7 +5669,6 @@ impl wkt::message::Message for ListChannelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListChannelsResponse {
     type PageItem = crate::model::Channel;
 
@@ -6180,7 +6178,6 @@ impl wkt::message::Message for ListInputsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInputsResponse {
     type PageItem = crate::model::Input;
 
@@ -6566,7 +6563,6 @@ impl wkt::message::Message for ListEventsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListEventsResponse {
     type PageItem = crate::model::Event;
 
@@ -6808,7 +6804,6 @@ impl wkt::message::Message for ListClipsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClipsResponse {
     type PageItem = crate::model::Clip;
 

--- a/src/generated/cloud/video/stitcher/v1/src/builders.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builders.rs
@@ -161,7 +161,7 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCdnKeysResponse, gax::error::Error>
         {
@@ -544,7 +544,7 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVodStitchDetailsResponse, gax::error::Error>
         {
@@ -658,7 +658,7 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVodAdTagDetailsResponse, gax::error::Error>
         {
@@ -772,7 +772,7 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLiveAdTagDetailsResponse, gax::error::Error>
         {
@@ -982,7 +982,7 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSlatesResponse, gax::error::Error>
         {
@@ -1465,7 +1465,7 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLiveConfigsResponse, gax::error::Error>
         {
@@ -1858,7 +1858,7 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVodConfigsResponse, gax::error::Error>
         {
@@ -2148,7 +2148,7 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/video/stitcher/v1/src/builders.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builders.rs
@@ -161,7 +161,6 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCdnKeysResponse, gax::error::Error>
@@ -545,7 +544,6 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVodStitchDetailsResponse, gax::error::Error>
@@ -660,7 +658,6 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVodAdTagDetailsResponse, gax::error::Error>
@@ -775,7 +772,6 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLiveAdTagDetailsResponse, gax::error::Error>
@@ -986,7 +982,6 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSlatesResponse, gax::error::Error>
@@ -1470,7 +1465,6 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLiveConfigsResponse, gax::error::Error>
@@ -1864,7 +1858,6 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVodConfigsResponse, gax::error::Error>
@@ -2155,7 +2148,6 @@ pub mod video_stitcher_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -2985,7 +2985,6 @@ impl wkt::message::Message for ListCdnKeysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCdnKeysResponse {
     type PageItem = crate::model::CdnKey;
 
@@ -3271,7 +3270,6 @@ impl wkt::message::Message for ListVodStitchDetailsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVodStitchDetailsResponse {
     type PageItem = crate::model::VodStitchDetail;
 
@@ -3408,7 +3406,6 @@ impl wkt::message::Message for ListVodAdTagDetailsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVodAdTagDetailsResponse {
     type PageItem = crate::model::VodAdTagDetail;
 
@@ -3545,7 +3542,6 @@ impl wkt::message::Message for ListLiveAdTagDetailsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLiveAdTagDetailsResponse {
     type PageItem = crate::model::LiveAdTagDetail;
 
@@ -3825,7 +3821,6 @@ impl wkt::message::Message for ListSlatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSlatesResponse {
     type PageItem = crate::model::Slate;
 
@@ -4194,7 +4189,6 @@ impl wkt::message::Message for ListLiveConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLiveConfigsResponse {
     type PageItem = crate::model::LiveConfig;
 
@@ -4523,7 +4517,6 @@ impl wkt::message::Message for ListVodConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVodConfigsResponse {
     type PageItem = crate::model::VodConfig;
 

--- a/src/generated/cloud/video/transcoder/v1/src/builders.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/builders.rs
@@ -115,7 +115,6 @@ pub mod transcoder_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
@@ -342,7 +341,6 @@ pub mod transcoder_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobTemplatesResponse, gax::error::Error>

--- a/src/generated/cloud/video/transcoder/v1/src/builders.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/builders.rs
@@ -115,7 +115,7 @@ pub mod transcoder_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -341,7 +341,7 @@ pub mod transcoder_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobTemplatesResponse, gax::error::Error>
         {

--- a/src/generated/cloud/video/transcoder/v1/src/model.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/model.rs
@@ -5221,7 +5221,6 @@ impl wkt::message::Message for ListJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListJobsResponse {
     type PageItem = crate::model::Job;
 
@@ -5495,7 +5494,6 @@ impl wkt::message::Message for ListJobTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListJobTemplatesResponse {
     type PageItem = crate::model::JobTemplate;
 

--- a/src/generated/cloud/videointelligence/v1/src/builders.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builders.rs
@@ -191,7 +191,6 @@ pub mod video_intelligence_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/videointelligence/v1/src/builders.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builders.rs
@@ -191,7 +191,7 @@ pub mod video_intelligence_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/vision/v1/src/builders.rs
+++ b/src/generated/cloud/vision/v1/src/builders.rs
@@ -560,7 +560,6 @@ pub mod product_search {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProductSetsResponse, gax::error::Error>
@@ -825,7 +824,6 @@ pub mod product_search {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProductsResponse, gax::error::Error>
@@ -1134,7 +1132,6 @@ pub mod product_search {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReferenceImagesResponse, gax::error::Error>
@@ -1353,7 +1350,6 @@ pub mod product_search {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/cloud/vision/v1/src/builders.rs
+++ b/src/generated/cloud/vision/v1/src/builders.rs
@@ -560,7 +560,7 @@ pub mod product_search {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProductSetsResponse, gax::error::Error>
         {
@@ -824,7 +824,7 @@ pub mod product_search {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProductsResponse, gax::error::Error>
         {
@@ -1132,7 +1132,7 @@ pub mod product_search {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReferenceImagesResponse, gax::error::Error>
         {
@@ -1350,7 +1350,7 @@ pub mod product_search {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListProductsInProductSetResponse,

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -4067,7 +4067,6 @@ impl wkt::message::Message for ListProductsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProductsResponse {
     type PageItem = crate::model::Product;
 
@@ -4348,7 +4347,6 @@ impl wkt::message::Message for ListProductSetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProductSetsResponse {
     type PageItem = crate::model::ProductSet;
 
@@ -4647,7 +4645,6 @@ impl wkt::message::Message for ListReferenceImagesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReferenceImagesResponse {
     type PageItem = crate::model::ReferenceImage;
 
@@ -4911,7 +4908,6 @@ impl wkt::message::Message for ListProductsInProductSetResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProductsInProductSetResponse {
     type PageItem = crate::model::Product;
 

--- a/src/generated/cloud/vmmigration/v1/src/builders.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSourcesResponse, gax::error::Error>
         {
@@ -515,7 +515,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListUtilizationReportsResponse,
@@ -852,7 +852,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListDatacenterConnectorsResponse,
@@ -1369,7 +1369,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMigratingVmsResponse, gax::error::Error>
         {
@@ -2193,7 +2193,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCloneJobsResponse, gax::error::Error>
         {
@@ -2501,7 +2501,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCutoverJobsResponse, gax::error::Error>
         {
@@ -2621,7 +2621,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupsResponse, gax::error::Error>
         {
@@ -3203,7 +3203,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTargetProjectsResponse, gax::error::Error>
         {
@@ -3619,7 +3619,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReplicationCyclesResponse, gax::error::Error>
         {
@@ -3745,7 +3745,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -3862,7 +3862,7 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/vmmigration/v1/src/builders.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSourcesResponse, gax::error::Error>
@@ -516,7 +515,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -854,7 +852,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1372,7 +1369,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMigratingVmsResponse, gax::error::Error>
@@ -2197,7 +2193,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCloneJobsResponse, gax::error::Error>
@@ -2506,7 +2501,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCutoverJobsResponse, gax::error::Error>
@@ -2627,7 +2621,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupsResponse, gax::error::Error>
@@ -3210,7 +3203,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTargetProjectsResponse, gax::error::Error>
@@ -3627,7 +3619,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListReplicationCyclesResponse, gax::error::Error>
@@ -3754,7 +3745,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -3872,7 +3862,6 @@ pub mod vm_migration {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -2283,7 +2283,6 @@ impl wkt::message::Message for ListCloneJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCloneJobsResponse {
     type PageItem = crate::model::CloneJob;
 
@@ -3556,7 +3555,6 @@ impl wkt::message::Message for ListSourcesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSourcesResponse {
     type PageItem = crate::model::Source;
 
@@ -5460,7 +5458,6 @@ impl wkt::message::Message for ListUtilizationReportsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUtilizationReportsResponse {
     type PageItem = crate::model::UtilizationReport;
 
@@ -5710,7 +5707,6 @@ impl wkt::message::Message for ListDatacenterConnectorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatacenterConnectorsResponse {
     type PageItem = crate::model::DatacenterConnector;
 
@@ -7291,7 +7287,6 @@ impl wkt::message::Message for ListMigratingVmsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMigratingVmsResponse {
     type PageItem = crate::model::MigratingVm;
 
@@ -7877,7 +7872,6 @@ impl wkt::message::Message for ListTargetProjectsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTargetProjectsResponse {
     type PageItem = crate::model::TargetProject;
 
@@ -8304,7 +8298,6 @@ impl wkt::message::Message for ListGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGroupsResponse {
     type PageItem = crate::model::Group;
 
@@ -8915,7 +8908,6 @@ impl wkt::message::Message for ListCutoverJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCutoverJobsResponse {
     type PageItem = crate::model::CutoverJob;
 
@@ -9498,7 +9490,6 @@ impl wkt::message::Message for ListReplicationCyclesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListReplicationCyclesResponse {
     type PageItem = crate::model::ReplicationCycle;
 

--- a/src/generated/cloud/vmwareengine/v1/src/builders.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPrivateCloudsResponse, gax::error::Error>
         {
@@ -588,7 +588,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
         {
@@ -997,7 +997,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNodesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1107,7 +1107,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExternalAddressesResponse, gax::error::Error>
         {
@@ -1193,7 +1193,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::FetchNetworkPolicyExternalAddressesResponse,
@@ -1596,7 +1596,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSubnetsResponse, gax::error::Error>
         {
@@ -1799,7 +1799,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListExternalAccessRulesResponse,
@@ -2227,7 +2227,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLoggingServersResponse, gax::error::Error>
         {
@@ -2640,7 +2640,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNodeTypesResponse, gax::error::Error>
         {
@@ -3224,7 +3224,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNetworkPeeringsResponse, gax::error::Error>
         {
@@ -3596,7 +3596,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPeeringRoutesResponse, gax::error::Error>
         {
@@ -3778,7 +3778,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHcxActivationKeysResponse, gax::error::Error>
         {
@@ -3936,7 +3936,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNetworkPoliciesResponse, gax::error::Error>
         {
@@ -4310,7 +4310,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListManagementDnsZoneBindingsResponse,
@@ -5192,7 +5192,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListVmwareEngineNetworksResponse,
@@ -5428,7 +5428,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListPrivateConnectionsResponse,
@@ -5708,7 +5708,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListPrivateConnectionPeeringRoutesResponse,
@@ -6022,7 +6022,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -6303,7 +6303,7 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/vmwareengine/v1/src/builders.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPrivateCloudsResponse, gax::error::Error>
@@ -589,7 +588,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListClustersResponse, gax::error::Error>
@@ -999,7 +997,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNodesResponse, gax::error::Error> {
@@ -1110,7 +1107,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExternalAddressesResponse, gax::error::Error>
@@ -1197,7 +1193,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1601,7 +1596,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSubnetsResponse, gax::error::Error>
@@ -1805,7 +1799,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2234,7 +2227,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLoggingServersResponse, gax::error::Error>
@@ -2648,7 +2640,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNodeTypesResponse, gax::error::Error>
@@ -3233,7 +3224,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNetworkPeeringsResponse, gax::error::Error>
@@ -3606,7 +3596,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPeeringRoutesResponse, gax::error::Error>
@@ -3789,7 +3778,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListHcxActivationKeysResponse, gax::error::Error>
@@ -3948,7 +3936,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNetworkPoliciesResponse, gax::error::Error>
@@ -4323,7 +4310,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -5206,7 +5192,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -5443,7 +5428,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -5724,7 +5708,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -6039,7 +6022,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -6321,7 +6303,6 @@ pub mod vmware_engine {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -210,7 +210,6 @@ impl wkt::message::Message for ListPrivateCloudsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPrivateCloudsResponse {
     type PageItem = crate::model::PrivateCloud;
 
@@ -712,7 +711,6 @@ impl wkt::message::Message for ListClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListClustersResponse {
     type PageItem = crate::model::Cluster;
 
@@ -1082,7 +1080,6 @@ impl wkt::message::Message for ListNodesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNodesResponse {
     type PageItem = crate::model::Node;
 
@@ -1306,7 +1303,6 @@ impl wkt::message::Message for ListExternalAddressesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExternalAddressesResponse {
     type PageItem = crate::model::ExternalAddress;
 
@@ -1432,7 +1428,6 @@ impl wkt::message::Message for FetchNetworkPolicyExternalAddressesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for FetchNetworkPolicyExternalAddressesResponse {
     type PageItem = crate::model::ExternalAddress;
 
@@ -1842,7 +1837,6 @@ impl wkt::message::Message for ListSubnetsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSubnetsResponse {
     type PageItem = crate::model::Subnet;
 
@@ -2120,7 +2114,6 @@ impl wkt::message::Message for ListExternalAccessRulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExternalAccessRulesResponse {
     type PageItem = crate::model::ExternalAccessRule;
 
@@ -2581,7 +2574,6 @@ impl wkt::message::Message for ListLoggingServersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLoggingServersResponse {
     type PageItem = crate::model::LoggingServer;
 
@@ -3127,7 +3119,6 @@ impl wkt::message::Message for ListNodeTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNodeTypesResponse {
     type PageItem = crate::model::NodeType;
 
@@ -3471,7 +3462,6 @@ impl wkt::message::Message for ListHcxActivationKeysResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListHcxActivationKeysResponse {
     type PageItem = crate::model::HcxActivationKey;
 
@@ -4235,7 +4225,6 @@ impl wkt::message::Message for ListNetworkPeeringsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNetworkPeeringsResponse {
     type PageItem = crate::model::NetworkPeering;
 
@@ -4370,7 +4359,6 @@ impl wkt::message::Message for ListPeeringRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPeeringRoutesResponse {
     type PageItem = crate::model::PeeringRoute;
 
@@ -4559,7 +4547,6 @@ impl wkt::message::Message for ListNetworkPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNetworkPoliciesResponse {
     type PageItem = crate::model::NetworkPolicy;
 
@@ -5021,7 +5008,6 @@ impl wkt::message::Message for ListManagementDnsZoneBindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListManagementDnsZoneBindingsResponse {
     type PageItem = crate::model::ManagementDnsZoneBinding;
 
@@ -5820,7 +5806,6 @@ impl wkt::message::Message for ListVmwareEngineNetworksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVmwareEngineNetworksResponse {
     type PageItem = crate::model::VmwareEngineNetwork;
 
@@ -6140,7 +6125,6 @@ impl wkt::message::Message for ListPrivateConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPrivateConnectionsResponse {
     type PageItem = crate::model::PrivateConnection;
 
@@ -6397,7 +6381,6 @@ impl wkt::message::Message for ListPrivateConnectionPeeringRoutesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPrivateConnectionPeeringRoutesResponse {
     type PageItem = crate::model::PeeringRoute;
 

--- a/src/generated/cloud/vpcaccess/v1/src/builders.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builders.rs
@@ -203,7 +203,7 @@ pub mod vpc_access_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectorsResponse, gax::error::Error>
         {
@@ -349,7 +349,7 @@ pub mod vpc_access_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -425,7 +425,7 @@ pub mod vpc_access_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/vpcaccess/v1/src/builders.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builders.rs
@@ -203,7 +203,6 @@ pub mod vpc_access_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectorsResponse, gax::error::Error>
@@ -350,7 +349,6 @@ pub mod vpc_access_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -427,7 +425,6 @@ pub mod vpc_access_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/vpcaccess/v1/src/model.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/model.rs
@@ -466,7 +466,6 @@ impl wkt::message::Message for ListConnectorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectorsResponse {
     type PageItem = crate::model::Connector;
 

--- a/src/generated/cloud/webrisk/v1/src/builders.rs
+++ b/src/generated/cloud/webrisk/v1/src/builders.rs
@@ -395,7 +395,6 @@ pub mod web_risk_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/webrisk/v1/src/builders.rs
+++ b/src/generated/cloud/webrisk/v1/src/builders.rs
@@ -395,7 +395,7 @@ pub mod web_risk_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/websecurityscanner/v1/src/builders.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/builders.rs
@@ -206,7 +206,7 @@ pub mod web_security_scanner {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListScanConfigsResponse, gax::error::Error>
         {
@@ -411,7 +411,7 @@ pub mod web_security_scanner {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListScanRunsResponse, gax::error::Error>
         {
@@ -519,7 +519,7 @@ pub mod web_security_scanner {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCrawledUrlsResponse, gax::error::Error>
         {
@@ -627,7 +627,7 @@ pub mod web_security_scanner {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFindingsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/websecurityscanner/v1/src/builders.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/builders.rs
@@ -206,7 +206,6 @@ pub mod web_security_scanner {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListScanConfigsResponse, gax::error::Error>
@@ -412,7 +411,6 @@ pub mod web_security_scanner {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListScanRunsResponse, gax::error::Error>
@@ -521,7 +519,6 @@ pub mod web_security_scanner {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListCrawledUrlsResponse, gax::error::Error>
@@ -630,7 +627,6 @@ pub mod web_security_scanner {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFindingsResponse, gax::error::Error>

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -3121,7 +3121,6 @@ impl wkt::message::Message for ListScanConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListScanConfigsResponse {
     type PageItem = crate::model::ScanConfig;
 
@@ -3293,7 +3292,6 @@ impl wkt::message::Message for ListScanRunsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListScanRunsResponse {
     type PageItem = crate::model::ScanRun;
 
@@ -3436,7 +3434,6 @@ impl wkt::message::Message for ListCrawledUrlsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListCrawledUrlsResponse {
     type PageItem = crate::model::CrawledUrl;
 
@@ -3592,7 +3589,6 @@ impl wkt::message::Message for ListFindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFindingsResponse {
     type PageItem = crate::model::Finding;
 

--- a/src/generated/cloud/workflows/executions/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod executions {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExecutionsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/workflows/executions/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod executions {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExecutionsResponse, gax::error::Error>

--- a/src/generated/cloud/workflows/executions/v1/src/model.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/model.rs
@@ -917,7 +917,6 @@ impl wkt::message::Message for ListExecutionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExecutionsResponse {
     type PageItem = crate::model::Execution;
 

--- a/src/generated/cloud/workflows/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod workflows {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkflowsResponse, gax::error::Error>
@@ -459,7 +458,6 @@ pub mod workflows {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
@@ -577,7 +575,6 @@ pub mod workflows {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/workflows/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod workflows {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkflowsResponse, gax::error::Error>
         {
@@ -458,7 +458,7 @@ pub mod workflows {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {
@@ -575,7 +575,7 @@ pub mod workflows {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -683,7 +683,6 @@ impl wkt::message::Message for ListWorkflowsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkflowsResponse {
     type PageItem = crate::model::Workflow;
 

--- a/src/generated/cloud/workstations/v1/src/builders.rs
+++ b/src/generated/cloud/workstations/v1/src/builders.rs
@@ -117,7 +117,6 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -556,7 +555,6 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -631,7 +629,6 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1067,7 +1064,6 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkstationsResponse, gax::error::Error>
@@ -1138,7 +1134,6 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1918,7 +1913,6 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/cloud/workstations/v1/src/builders.rs
+++ b/src/generated/cloud/workstations/v1/src/builders.rs
@@ -117,7 +117,7 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListWorkstationClustersResponse,
@@ -555,7 +555,7 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListWorkstationConfigsResponse,
@@ -629,7 +629,7 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListUsableWorkstationConfigsResponse,
@@ -1064,7 +1064,7 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkstationsResponse, gax::error::Error>
         {
@@ -1134,7 +1134,7 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListUsableWorkstationsResponse,
@@ -1913,7 +1913,7 @@ pub mod workstations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/cloud/workstations/v1/src/model.rs
+++ b/src/generated/cloud/workstations/v1/src/model.rs
@@ -1999,7 +1999,6 @@ impl wkt::message::Message for ListWorkstationClustersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkstationClustersResponse {
     type PageItem = crate::model::WorkstationCluster;
 
@@ -2347,7 +2346,6 @@ impl wkt::message::Message for ListWorkstationConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkstationConfigsResponse {
     type PageItem = crate::model::WorkstationConfig;
 
@@ -2469,7 +2467,6 @@ impl wkt::message::Message for ListUsableWorkstationConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUsableWorkstationConfigsResponse {
     type PageItem = crate::model::WorkstationConfig;
 
@@ -2817,7 +2814,6 @@ impl wkt::message::Message for ListWorkstationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkstationsResponse {
     type PageItem = crate::model::Workstation;
 
@@ -2939,7 +2935,6 @@ impl wkt::message::Message for ListUsableWorkstationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUsableWorkstationsResponse {
     type PageItem = crate::model::Workstation;
 

--- a/src/generated/container/v1/src/builders.rs
+++ b/src/generated/container/v1/src/builders.rs
@@ -2386,7 +2386,6 @@ pub mod cluster_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListUsableSubnetworksResponse, gax::error::Error>

--- a/src/generated/container/v1/src/builders.rs
+++ b/src/generated/container/v1/src/builders.rs
@@ -2386,7 +2386,7 @@ pub mod cluster_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListUsableSubnetworksResponse, gax::error::Error>
         {

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -16495,7 +16495,6 @@ impl wkt::message::Message for ListUsableSubnetworksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUsableSubnetworksResponse {
     type PageItem = crate::model::UsableSubnetwork;
 

--- a/src/generated/datastore/admin/v1/src/builders.rs
+++ b/src/generated/datastore/admin/v1/src/builders.rs
@@ -498,7 +498,7 @@ pub mod datastore_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIndexesResponse, gax::error::Error>
         {
@@ -574,7 +574,7 @@ pub mod datastore_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/datastore/admin/v1/src/builders.rs
+++ b/src/generated/datastore/admin/v1/src/builders.rs
@@ -498,7 +498,6 @@ pub mod datastore_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIndexesResponse, gax::error::Error>
@@ -575,7 +574,6 @@ pub mod datastore_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -972,7 +972,6 @@ impl wkt::message::Message for ListIndexesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIndexesResponse {
     type PageItem = crate::model::Index;
 

--- a/src/generated/devtools/artifactregistry/v1/src/builders.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDockerImagesResponse, gax::error::Error>
@@ -189,7 +188,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMavenArtifactsResponse, gax::error::Error>
@@ -301,7 +299,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNpmPackagesResponse, gax::error::Error>
@@ -413,7 +410,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPythonPackagesResponse, gax::error::Error>
@@ -720,7 +716,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRepositoriesResponse, gax::error::Error>
@@ -1073,7 +1068,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPackagesResponse, gax::error::Error>
@@ -1270,7 +1264,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
@@ -1636,7 +1629,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFilesResponse, gax::error::Error> {
@@ -1882,7 +1874,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagsResponse, gax::error::Error> {
@@ -2191,7 +2182,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRulesResponse, gax::error::Error> {
@@ -2804,7 +2794,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttachmentsResponse, gax::error::Error>
@@ -3098,7 +3087,6 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>

--- a/src/generated/devtools/artifactregistry/v1/src/builders.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDockerImagesResponse, gax::error::Error>
         {
@@ -188,7 +188,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMavenArtifactsResponse, gax::error::Error>
         {
@@ -299,7 +299,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNpmPackagesResponse, gax::error::Error>
         {
@@ -410,7 +410,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPythonPackagesResponse, gax::error::Error>
         {
@@ -716,7 +716,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRepositoriesResponse, gax::error::Error>
         {
@@ -1068,7 +1068,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPackagesResponse, gax::error::Error>
         {
@@ -1264,7 +1264,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListVersionsResponse, gax::error::Error>
         {
@@ -1629,7 +1629,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFilesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1874,7 +1874,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTagsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -2182,7 +2182,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRulesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -2794,7 +2794,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAttachmentsResponse, gax::error::Error>
         {
@@ -3087,7 +3087,7 @@ pub mod artifact_registry {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error>
         {

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -725,7 +725,6 @@ impl wkt::message::Message for ListDockerImagesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDockerImagesResponse {
     type PageItem = crate::model::DockerImage;
 
@@ -967,7 +966,6 @@ impl wkt::message::Message for ListMavenArtifactsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMavenArtifactsResponse {
     type PageItem = crate::model::MavenArtifact;
 
@@ -1199,7 +1197,6 @@ impl wkt::message::Message for ListNpmPackagesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNpmPackagesResponse {
     type PageItem = crate::model::NpmPackage;
 
@@ -1430,7 +1427,6 @@ impl wkt::message::Message for ListPythonPackagesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPythonPackagesResponse {
     type PageItem = crate::model::PythonPackage;
 
@@ -1727,7 +1723,6 @@ impl wkt::message::Message for ListAttachmentsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAttachmentsResponse {
     type PageItem = crate::model::Attachment;
 
@@ -2239,7 +2234,6 @@ impl wkt::message::Message for ListFilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFilesResponse {
     type PageItem = crate::model::File;
 
@@ -2667,7 +2661,6 @@ impl wkt::message::Message for ListPackagesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPackagesResponse {
     type PageItem = crate::model::Package;
 
@@ -6312,7 +6305,6 @@ impl wkt::message::Message for ListRepositoriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRepositoriesResponse {
     type PageItem = crate::model::Repository;
 
@@ -6770,7 +6762,6 @@ impl wkt::message::Message for ListRulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRulesResponse {
     type PageItem = crate::model::Rule;
 
@@ -7364,7 +7355,6 @@ impl wkt::message::Message for ListTagsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTagsResponse {
     type PageItem = crate::model::Tag;
 
@@ -7822,7 +7812,6 @@ impl wkt::message::Message for ListVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListVersionsResponse {
     type PageItem = crate::model::Version;
 

--- a/src/generated/devtools/cloudbuild/v1/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builders.rs
@@ -215,7 +215,7 @@ pub mod cloud_build {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBuildsResponse, gax::error::Error>
         {
@@ -641,7 +641,7 @@ pub mod cloud_build {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBuildTriggersResponse, gax::error::Error>
         {
@@ -1359,7 +1359,7 @@ pub mod cloud_build {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkerPoolsResponse, gax::error::Error>
         {

--- a/src/generated/devtools/cloudbuild/v1/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builders.rs
@@ -215,7 +215,6 @@ pub mod cloud_build {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBuildsResponse, gax::error::Error>
@@ -642,7 +641,6 @@ pub mod cloud_build {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBuildTriggersResponse, gax::error::Error>
@@ -1361,7 +1359,6 @@ pub mod cloud_build {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListWorkerPoolsResponse, gax::error::Error>

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -4027,7 +4027,6 @@ impl wkt::message::Message for ListBuildsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBuildsResponse {
     type PageItem = crate::model::Build;
 
@@ -6443,7 +6442,6 @@ impl wkt::message::Message for ListBuildTriggersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBuildTriggersResponse {
     type PageItem = crate::model::BuildTrigger;
 
@@ -8491,7 +8489,6 @@ impl wkt::message::Message for ListWorkerPoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListWorkerPoolsResponse {
     type PageItem = crate::model::WorkerPool;
 

--- a/src/generated/devtools/cloudbuild/v2/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builders.rs
@@ -206,7 +206,6 @@ pub mod repository_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
@@ -712,7 +711,6 @@ pub mod repository_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRepositoriesResponse, gax::error::Error>
@@ -967,7 +965,6 @@ pub mod repository_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/devtools/cloudbuild/v2/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builders.rs
@@ -206,7 +206,7 @@ pub mod repository_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
         {
@@ -711,7 +711,7 @@ pub mod repository_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRepositoriesResponse, gax::error::Error>
         {
@@ -965,7 +965,7 @@ pub mod repository_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::FetchLinkableRepositoriesResponse,

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -771,7 +771,6 @@ impl wkt::message::Message for FetchLinkableRepositoriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for FetchLinkableRepositoriesResponse {
     type PageItem = crate::model::Repository;
 
@@ -1681,7 +1680,6 @@ impl wkt::message::Message for ListConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectionsResponse {
     type PageItem = crate::model::Connection;
 
@@ -2089,7 +2087,6 @@ impl wkt::message::Message for ListRepositoriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRepositoriesResponse {
     type PageItem = crate::model::Repository;
 

--- a/src/generated/devtools/cloudprofiler/v2/src/builders.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/builders.rs
@@ -261,7 +261,6 @@ pub mod export_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProfilesResponse, gax::error::Error>

--- a/src/generated/devtools/cloudprofiler/v2/src/builders.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/builders.rs
@@ -261,7 +261,7 @@ pub mod export_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListProfilesResponse, gax::error::Error>
         {

--- a/src/generated/devtools/cloudprofiler/v2/src/model.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/model.rs
@@ -484,7 +484,6 @@ impl wkt::message::Message for ListProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProfilesResponse {
     type PageItem = crate::model::Profile;
 

--- a/src/generated/firestore/admin/v1/src/builders.rs
+++ b/src/generated/firestore/admin/v1/src/builders.rs
@@ -156,7 +156,7 @@ pub mod firestore_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIndexesResponse, gax::error::Error>
         {
@@ -443,7 +443,7 @@ pub mod firestore_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFieldsResponse, gax::error::Error>
         {
@@ -1685,7 +1685,7 @@ pub mod firestore_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/firestore/admin/v1/src/builders.rs
+++ b/src/generated/firestore/admin/v1/src/builders.rs
@@ -156,7 +156,6 @@ pub mod firestore_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListIndexesResponse, gax::error::Error>
@@ -444,7 +443,6 @@ pub mod firestore_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListFieldsResponse, gax::error::Error>
@@ -1687,7 +1685,6 @@ pub mod firestore_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -2366,7 +2366,6 @@ impl wkt::message::Message for ListIndexesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListIndexesResponse {
     type PageItem = crate::model::Index;
 
@@ -2649,7 +2648,6 @@ impl wkt::message::Message for ListFieldsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFieldsResponse {
     type PageItem = crate::model::Field;
 

--- a/src/generated/grafeas/v1/src/builders.rs
+++ b/src/generated/grafeas/v1/src/builders.rs
@@ -109,7 +109,6 @@ pub mod grafeas {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOccurrencesResponse, gax::error::Error>
@@ -482,7 +481,6 @@ pub mod grafeas {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNotesResponse, gax::error::Error> {
@@ -763,7 +761,6 @@ pub mod grafeas {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNoteOccurrencesResponse, gax::error::Error>

--- a/src/generated/grafeas/v1/src/builders.rs
+++ b/src/generated/grafeas/v1/src/builders.rs
@@ -109,7 +109,7 @@ pub mod grafeas {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOccurrencesResponse, gax::error::Error>
         {
@@ -481,7 +481,7 @@ pub mod grafeas {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNotesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -761,7 +761,7 @@ pub mod grafeas {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListNoteOccurrencesResponse, gax::error::Error>
         {

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -4258,7 +4258,6 @@ impl wkt::message::Message for ListOccurrencesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOccurrencesResponse {
     type PageItem = crate::model::Occurrence;
 
@@ -4566,7 +4565,6 @@ impl wkt::message::Message for ListNotesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNotesResponse {
     type PageItem = crate::model::Note;
 
@@ -4821,7 +4819,6 @@ impl wkt::message::Message for ListNoteOccurrencesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNoteOccurrencesResponse {
     type PageItem = crate::model::Occurrence;
 

--- a/src/generated/iam/admin/v1/src/builders.rs
+++ b/src/generated/iam/admin/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod iam {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServiceAccountsResponse, gax::error::Error>
@@ -1186,7 +1185,6 @@ pub mod iam {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::QueryGrantableRolesResponse, gax::error::Error>
@@ -1260,7 +1258,6 @@ pub mod iam {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRolesResponse, gax::error::Error> {
@@ -1588,7 +1585,6 @@ pub mod iam {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/iam/admin/v1/src/builders.rs
+++ b/src/generated/iam/admin/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod iam {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServiceAccountsResponse, gax::error::Error>
         {
@@ -1185,7 +1185,7 @@ pub mod iam {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::QueryGrantableRolesResponse, gax::error::Error>
         {
@@ -1258,7 +1258,7 @@ pub mod iam {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListRolesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1585,7 +1585,7 @@ pub mod iam {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::QueryTestablePermissionsResponse,

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -439,7 +439,6 @@ impl wkt::message::Message for ListServiceAccountsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServiceAccountsResponse {
     type PageItem = crate::model::ServiceAccount;
 
@@ -1793,7 +1792,6 @@ impl wkt::message::Message for QueryGrantableRolesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for QueryGrantableRolesResponse {
     type PageItem = crate::model::Role;
 
@@ -1952,7 +1950,6 @@ impl wkt::message::Message for ListRolesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListRolesResponse {
     type PageItem = crate::model::Role;
 
@@ -2644,7 +2641,6 @@ impl wkt::message::Message for QueryTestablePermissionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for QueryTestablePermissionsResponse {
     type PageItem = crate::model::Permission;
 

--- a/src/generated/iam/v2/src/builders.rs
+++ b/src/generated/iam/v2/src/builders.rs
@@ -68,7 +68,7 @@ pub mod policies {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPoliciesResponse, gax::error::Error>
         {

--- a/src/generated/iam/v2/src/builders.rs
+++ b/src/generated/iam/v2/src/builders.rs
@@ -68,7 +68,6 @@ pub mod policies {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPoliciesResponse, gax::error::Error>

--- a/src/generated/iam/v2/src/model.rs
+++ b/src/generated/iam/v2/src/model.rs
@@ -551,7 +551,6 @@ impl wkt::message::Message for ListPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPoliciesResponse {
     type PageItem = crate::model::Policy;
 

--- a/src/generated/iam/v3/src/builders.rs
+++ b/src/generated/iam/v3/src/builders.rs
@@ -411,7 +411,7 @@ pub mod policy_bindings {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPolicyBindingsResponse, gax::error::Error>
         {
@@ -489,7 +489,7 @@ pub mod policy_bindings {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchTargetPolicyBindingsResponse,
@@ -1018,7 +1018,7 @@ pub mod principal_access_boundary_policies {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListPrincipalAccessBoundaryPoliciesResponse,
@@ -1098,7 +1098,7 @@ pub mod principal_access_boundary_policies {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::SearchPrincipalAccessBoundaryPolicyBindingsResponse,

--- a/src/generated/iam/v3/src/builders.rs
+++ b/src/generated/iam/v3/src/builders.rs
@@ -411,7 +411,6 @@ pub mod policy_bindings {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListPolicyBindingsResponse, gax::error::Error>
@@ -490,7 +489,6 @@ pub mod policy_bindings {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1020,7 +1018,6 @@ pub mod principal_access_boundary_policies {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1101,7 +1098,6 @@ pub mod principal_access_boundary_policies {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/iam/v3/src/model.rs
+++ b/src/generated/iam/v3/src/model.rs
@@ -865,7 +865,6 @@ impl wkt::message::Message for ListPolicyBindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPolicyBindingsResponse {
     type PageItem = crate::model::PolicyBinding;
 
@@ -1009,7 +1008,6 @@ impl wkt::message::Message for SearchTargetPolicyBindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchTargetPolicyBindingsResponse {
     type PageItem = crate::model::PolicyBinding;
 
@@ -1364,7 +1362,6 @@ impl wkt::message::Message for ListPrincipalAccessBoundaryPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListPrincipalAccessBoundaryPoliciesResponse {
     type PageItem = crate::model::PrincipalAccessBoundaryPolicy;
 
@@ -1482,7 +1479,6 @@ impl wkt::message::Message for SearchPrincipalAccessBoundaryPolicyBindingsRespon
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchPrincipalAccessBoundaryPolicyBindingsResponse {
     type PageItem = crate::model::PolicyBinding;
 

--- a/src/generated/identity/accesscontextmanager/v1/src/builders.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod access_context_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAccessPoliciesResponse, gax::error::Error>
@@ -496,7 +495,6 @@ pub mod access_context_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAccessLevelsResponse, gax::error::Error>
@@ -1002,7 +1000,6 @@ pub mod access_context_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicePerimetersResponse, gax::error::Error>
@@ -1602,7 +1599,6 @@ pub mod access_context_manager {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<

--- a/src/generated/identity/accesscontextmanager/v1/src/builders.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod access_context_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAccessPoliciesResponse, gax::error::Error>
         {
@@ -495,7 +495,7 @@ pub mod access_context_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAccessLevelsResponse, gax::error::Error>
         {
@@ -1000,7 +1000,7 @@ pub mod access_context_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicePerimetersResponse, gax::error::Error>
         {
@@ -1599,7 +1599,7 @@ pub mod access_context_manager {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListGcpUserAccessBindingsResponse,

--- a/src/generated/identity/accesscontextmanager/v1/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/model.rs
@@ -132,7 +132,6 @@ impl wkt::message::Message for ListAccessPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAccessPoliciesResponse {
     type PageItem = crate::model::AccessPolicy;
 
@@ -368,7 +367,6 @@ impl wkt::message::Message for ListAccessLevelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAccessLevelsResponse {
     type PageItem = crate::model::AccessLevel;
 
@@ -776,7 +774,6 @@ impl wkt::message::Message for ListServicePerimetersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicePerimetersResponse {
     type PageItem = crate::model::ServicePerimeter;
 
@@ -1252,7 +1249,6 @@ impl wkt::message::Message for ListGcpUserAccessBindingsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGcpUserAccessBindingsResponse {
     type PageItem = crate::model::GcpUserAccessBinding;
 

--- a/src/generated/logging/v2/src/builders.rs
+++ b/src/generated/logging/v2/src/builders.rs
@@ -193,7 +193,7 @@ pub mod logging_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLogEntriesResponse, gax::error::Error>
         {
@@ -282,7 +282,7 @@ pub mod logging_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListMonitoredResourceDescriptorsResponse,
@@ -412,7 +412,7 @@ pub mod logging_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -599,7 +599,7 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBucketsResponse, gax::error::Error>
         {
@@ -1093,7 +1093,7 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListViewsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1356,7 +1356,7 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSinksResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1789,7 +1789,7 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLinksResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
@@ -1896,7 +1896,7 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExclusionsResponse, gax::error::Error>
         {
@@ -2454,7 +2454,7 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {
@@ -2641,7 +2641,7 @@ pub mod metrics_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLogMetricsResponse, gax::error::Error>
         {
@@ -2893,7 +2893,7 @@ pub mod metrics_service_v_2 {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/logging/v2/src/builders.rs
+++ b/src/generated/logging/v2/src/builders.rs
@@ -193,7 +193,6 @@ pub mod logging_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLogEntriesResponse, gax::error::Error>
@@ -283,7 +282,6 @@ pub mod logging_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -414,7 +412,6 @@ pub mod logging_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -602,7 +599,6 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBucketsResponse, gax::error::Error>
@@ -1097,7 +1093,6 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListViewsResponse, gax::error::Error> {
@@ -1361,7 +1356,6 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSinksResponse, gax::error::Error> {
@@ -1795,7 +1789,6 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLinksResponse, gax::error::Error> {
@@ -1903,7 +1896,6 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListExclusionsResponse, gax::error::Error>
@@ -2462,7 +2454,6 @@ pub mod config_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
@@ -2650,7 +2641,6 @@ pub mod metrics_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLogMetricsResponse, gax::error::Error>
@@ -2903,7 +2893,6 @@ pub mod metrics_service_v_2 {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -1045,7 +1045,6 @@ impl wkt::message::Message for ListLogEntriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLogEntriesResponse {
     type PageItem = crate::model::LogEntry;
 
@@ -1147,7 +1146,6 @@ impl wkt::message::Message for ListMonitoredResourceDescriptorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMonitoredResourceDescriptorsResponse {
     type PageItem = api::model::MonitoredResourceDescriptor;
 
@@ -2505,7 +2503,6 @@ impl wkt::message::Message for ListBucketsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBucketsResponse {
     type PageItem = crate::model::LogBucket;
 
@@ -2879,7 +2876,6 @@ impl wkt::message::Message for ListViewsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListViewsResponse {
     type PageItem = crate::model::LogView;
 
@@ -3204,7 +3200,6 @@ impl wkt::message::Message for ListSinksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSinksResponse {
     type PageItem = crate::model::LogSink;
 
@@ -3675,7 +3670,6 @@ impl wkt::message::Message for ListLinksResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLinksResponse {
     type PageItem = crate::model::Link;
 
@@ -3937,7 +3931,6 @@ impl wkt::message::Message for ListExclusionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListExclusionsResponse {
     type PageItem = crate::model::LogExclusion;
 
@@ -5622,7 +5615,6 @@ impl wkt::message::Message for ListLogMetricsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLogMetricsResponse {
     type PageItem = crate::model::LogMetric;
 

--- a/src/generated/longrunning/src/builders.rs
+++ b/src/generated/longrunning/src/builders.rs
@@ -68,7 +68,7 @@ pub mod operations {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/longrunning/src/builders.rs
+++ b/src/generated/longrunning/src/builders.rs
@@ -68,7 +68,6 @@ pub mod operations {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -320,7 +320,6 @@ impl wkt::message::Message for ListOperationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListOperationsResponse {
     type PageItem = crate::model::Operation;
 

--- a/src/generated/monitoring/dashboard/v1/src/builders.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builders.rs
@@ -124,7 +124,7 @@ pub mod dashboards_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDashboardsResponse, gax::error::Error>
         {

--- a/src/generated/monitoring/dashboard/v1/src/builders.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builders.rs
@@ -124,7 +124,6 @@ pub mod dashboards_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDashboardsResponse, gax::error::Error>

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -1543,7 +1543,6 @@ impl wkt::message::Message for ListDashboardsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDashboardsResponse {
     type PageItem = crate::model::Dashboard;
 

--- a/src/generated/monitoring/v3/src/builders.rs
+++ b/src/generated/monitoring/v3/src/builders.rs
@@ -71,7 +71,6 @@ pub mod alert_policy_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAlertPoliciesResponse, gax::error::Error>
@@ -371,7 +370,6 @@ pub mod group_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupsResponse, gax::error::Error>
@@ -645,7 +643,6 @@ pub mod group_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupMembersResponse, gax::error::Error>
@@ -759,7 +756,6 @@ pub mod metric_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -884,7 +880,6 @@ pub mod metric_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMetricDescriptorsResponse, gax::error::Error>
@@ -1105,7 +1100,6 @@ pub mod metric_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTimeSeriesResponse, gax::error::Error>
@@ -1370,7 +1364,6 @@ pub mod notification_channel_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1495,7 +1488,6 @@ pub mod notification_channel_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1989,7 +1981,6 @@ pub mod query_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::QueryTimeSeriesResponse, gax::error::Error>
@@ -2186,7 +2177,6 @@ pub mod service_monitoring_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
@@ -2480,7 +2470,6 @@ pub mod service_monitoring_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2747,7 +2736,6 @@ pub mod snooze_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSnoozesResponse, gax::error::Error>
@@ -2944,7 +2932,6 @@ pub mod uptime_check_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -3230,7 +3217,6 @@ pub mod uptime_check_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListUptimeCheckIpsResponse, gax::error::Error>

--- a/src/generated/monitoring/v3/src/builders.rs
+++ b/src/generated/monitoring/v3/src/builders.rs
@@ -71,7 +71,7 @@ pub mod alert_policy_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAlertPoliciesResponse, gax::error::Error>
         {
@@ -370,7 +370,7 @@ pub mod group_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupsResponse, gax::error::Error>
         {
@@ -643,7 +643,7 @@ pub mod group_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListGroupMembersResponse, gax::error::Error>
         {
@@ -756,7 +756,7 @@ pub mod metric_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListMonitoredResourceDescriptorsResponse,
@@ -880,7 +880,7 @@ pub mod metric_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListMetricDescriptorsResponse, gax::error::Error>
         {
@@ -1100,7 +1100,7 @@ pub mod metric_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTimeSeriesResponse, gax::error::Error>
         {
@@ -1364,7 +1364,7 @@ pub mod notification_channel_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListNotificationChannelDescriptorsResponse,
@@ -1488,7 +1488,7 @@ pub mod notification_channel_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListNotificationChannelsResponse,
@@ -1981,7 +1981,7 @@ pub mod query_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::QueryTimeSeriesResponse, gax::error::Error>
         {
@@ -2177,7 +2177,7 @@ pub mod service_monitoring_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListServicesResponse, gax::error::Error>
         {
@@ -2470,7 +2470,7 @@ pub mod service_monitoring_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListServiceLevelObjectivesResponse,
@@ -2736,7 +2736,7 @@ pub mod snooze_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSnoozesResponse, gax::error::Error>
         {
@@ -2932,7 +2932,7 @@ pub mod uptime_check_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListUptimeCheckConfigsResponse,
@@ -3217,7 +3217,7 @@ pub mod uptime_check_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListUptimeCheckIpsResponse, gax::error::Error>
         {

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -2850,7 +2850,6 @@ impl wkt::message::Message for ListAlertPoliciesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAlertPoliciesResponse {
     type PageItem = crate::model::AlertPolicy;
 
@@ -4200,7 +4199,6 @@ impl wkt::message::Message for ListGroupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGroupsResponse {
     type PageItem = crate::model::Group;
 
@@ -4536,7 +4534,6 @@ impl wkt::message::Message for ListGroupMembersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListGroupMembersResponse {
     type PageItem = api::model::MonitoredResource;
 
@@ -5434,7 +5431,6 @@ impl wkt::message::Message for ListMonitoredResourceDescriptorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMonitoredResourceDescriptorsResponse {
     type PageItem = api::model::MonitoredResourceDescriptor;
 
@@ -5627,7 +5623,6 @@ impl wkt::message::Message for ListMetricDescriptorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListMetricDescriptorsResponse {
     type PageItem = api::model::MetricDescriptor;
 
@@ -6056,7 +6051,6 @@ impl wkt::message::Message for ListTimeSeriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTimeSeriesResponse {
     type PageItem = crate::model::TimeSeries;
 
@@ -6419,7 +6413,6 @@ impl wkt::message::Message for QueryTimeSeriesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for QueryTimeSeriesResponse {
     type PageItem = crate::model::TimeSeriesData;
 
@@ -7043,7 +7036,6 @@ impl wkt::message::Message for ListNotificationChannelDescriptorsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNotificationChannelDescriptorsResponse {
     type PageItem = crate::model::NotificationChannelDescriptor;
 
@@ -7297,7 +7289,6 @@ impl wkt::message::Message for ListNotificationChannelsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListNotificationChannelsResponse {
     type PageItem = crate::model::NotificationChannel;
 
@@ -10240,7 +10231,6 @@ impl wkt::message::Message for ListServicesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServicesResponse {
     type PageItem = crate::model::Service;
 
@@ -10574,7 +10564,6 @@ impl wkt::message::Message for ListServiceLevelObjectivesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListServiceLevelObjectivesResponse {
     type PageItem = crate::model::ServiceLevelObjective;
 
@@ -11005,7 +10994,6 @@ impl wkt::message::Message for ListSnoozesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSnoozesResponse {
     type PageItem = crate::model::Snooze;
 
@@ -13391,7 +13379,6 @@ impl wkt::message::Message for ListUptimeCheckConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUptimeCheckConfigsResponse {
     type PageItem = crate::model::UptimeCheckConfig;
 
@@ -13675,7 +13662,6 @@ impl wkt::message::Message for ListUptimeCheckIpsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListUptimeCheckIpsResponse {
     type PageItem = crate::model::UptimeCheckIp;
 

--- a/src/generated/openapi-validation/src/builders.rs
+++ b/src/generated/openapi-validation/src/builders.rs
@@ -68,7 +68,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error>
@@ -195,7 +194,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error>
@@ -336,7 +334,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error>
@@ -990,7 +987,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error>
@@ -1086,7 +1082,6 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error>

--- a/src/generated/openapi-validation/src/builders.rs
+++ b/src/generated/openapi-validation/src/builders.rs
@@ -68,7 +68,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error>
         {
@@ -194,7 +194,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error>
         {
@@ -334,7 +334,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error>
         {
@@ -987,7 +987,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error>
         {
@@ -1082,7 +1082,7 @@ pub mod secret_manager_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error>
         {

--- a/src/generated/openapi-validation/src/model.rs
+++ b/src/generated/openapi-validation/src/model.rs
@@ -76,7 +76,6 @@ impl wkt::message::Message for ListLocationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListLocationsResponse {
     type PageItem = crate::model::Location;
 
@@ -243,7 +242,6 @@ impl wkt::message::Message for ListSecretsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecretsResponse {
     type PageItem = crate::model::Secret;
 
@@ -1402,7 +1400,6 @@ impl wkt::message::Message for ListSecretVersionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListSecretVersionsResponse {
     type PageItem = crate::model::SecretVersion;
 

--- a/src/generated/privacy/dlp/v2/src/builders.rs
+++ b/src/generated/privacy/dlp/v2/src/builders.rs
@@ -636,7 +636,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInspectTemplatesResponse, gax::error::Error>
@@ -944,7 +943,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1295,7 +1293,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobTriggersResponse, gax::error::Error>
@@ -1643,7 +1640,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDiscoveryConfigsResponse, gax::error::Error>
@@ -1823,7 +1819,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDlpJobsResponse, gax::error::Error>
@@ -2212,7 +2207,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStoredInfoTypesResponse, gax::error::Error>
@@ -2341,7 +2335,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2426,7 +2419,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTableDataProfilesResponse, gax::error::Error>
@@ -2509,7 +2501,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -2640,7 +2631,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -3134,7 +3124,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
@@ -3211,7 +3200,6 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchConnectionsResponse, gax::error::Error>

--- a/src/generated/privacy/dlp/v2/src/builders.rs
+++ b/src/generated/privacy/dlp/v2/src/builders.rs
@@ -636,7 +636,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInspectTemplatesResponse, gax::error::Error>
         {
@@ -943,7 +943,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListDeidentifyTemplatesResponse,
@@ -1293,7 +1293,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListJobTriggersResponse, gax::error::Error>
         {
@@ -1640,7 +1640,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDiscoveryConfigsResponse, gax::error::Error>
         {
@@ -1819,7 +1819,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDlpJobsResponse, gax::error::Error>
         {
@@ -2207,7 +2207,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListStoredInfoTypesResponse, gax::error::Error>
         {
@@ -2335,7 +2335,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListProjectDataProfilesResponse,
@@ -2419,7 +2419,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTableDataProfilesResponse, gax::error::Error>
         {
@@ -2501,7 +2501,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListColumnDataProfilesResponse,
@@ -2631,7 +2631,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListFileStoreDataProfilesResponse,
@@ -3124,7 +3124,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListConnectionsResponse, gax::error::Error>
         {
@@ -3200,7 +3200,7 @@ pub mod dlp_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::SearchConnectionsResponse, gax::error::Error>
         {

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -13875,7 +13875,6 @@ impl wkt::message::Message for ListInspectTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInspectTemplatesResponse {
     type PageItem = crate::model::InspectTemplate;
 
@@ -14405,7 +14404,6 @@ impl wkt::message::Message for ListDiscoveryConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDiscoveryConfigsResponse {
     type PageItem = crate::model::DiscoveryConfig;
 
@@ -14802,7 +14800,6 @@ impl wkt::message::Message for ListJobTriggersResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListJobTriggersResponse {
     type PageItem = crate::model::JobTrigger;
 
@@ -22153,7 +22150,6 @@ impl wkt::message::Message for ListDlpJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDlpJobsResponse {
     type PageItem = crate::model::DlpJob;
 
@@ -22581,7 +22577,6 @@ impl wkt::message::Message for ListDeidentifyTemplatesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDeidentifyTemplatesResponse {
     type PageItem = crate::model::DeidentifyTemplate;
 
@@ -23537,7 +23532,6 @@ impl wkt::message::Message for ListStoredInfoTypesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListStoredInfoTypesResponse {
     type PageItem = crate::model::StoredInfoType;
 
@@ -23997,7 +23991,6 @@ impl wkt::message::Message for ListProjectDataProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListProjectDataProfilesResponse {
     type PageItem = crate::model::ProjectDataProfile;
 
@@ -24172,7 +24165,6 @@ impl wkt::message::Message for ListTableDataProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTableDataProfilesResponse {
     type PageItem = crate::model::TableDataProfile;
 
@@ -24348,7 +24340,6 @@ impl wkt::message::Message for ListColumnDataProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListColumnDataProfilesResponse {
     type PageItem = crate::model::ColumnDataProfile;
 
@@ -26705,7 +26696,6 @@ impl wkt::message::Message for ListFileStoreDataProfilesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListFileStoreDataProfilesResponse {
     type PageItem = crate::model::FileStoreDataProfile;
 
@@ -27458,7 +27448,6 @@ impl wkt::message::Message for ListConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListConnectionsResponse {
     type PageItem = crate::model::Connection;
 
@@ -27518,7 +27507,6 @@ impl wkt::message::Message for SearchConnectionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for SearchConnectionsResponse {
     type PageItem = crate::model::Connection;
 

--- a/src/generated/spanner/admin/database/v1/src/builders.rs
+++ b/src/generated/spanner/admin/database/v1/src/builders.rs
@@ -68,7 +68,7 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatabasesResponse, gax::error::Error>
         {
@@ -1091,7 +1091,7 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
         {
@@ -1273,7 +1273,7 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListDatabaseOperationsResponse,
@@ -1351,7 +1351,7 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupOperationsResponse, gax::error::Error>
         {
@@ -1427,7 +1427,7 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatabaseRolesResponse, gax::error::Error>
         {
@@ -1758,7 +1758,7 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupSchedulesResponse, gax::error::Error>
         {
@@ -1828,7 +1828,7 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/spanner/admin/database/v1/src/builders.rs
+++ b/src/generated/spanner/admin/database/v1/src/builders.rs
@@ -68,7 +68,6 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatabasesResponse, gax::error::Error>
@@ -1092,7 +1091,6 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupsResponse, gax::error::Error>
@@ -1275,7 +1273,6 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1354,7 +1351,6 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupOperationsResponse, gax::error::Error>
@@ -1431,7 +1427,6 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListDatabaseRolesResponse, gax::error::Error>
@@ -1763,7 +1758,6 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListBackupSchedulesResponse, gax::error::Error>
@@ -1834,7 +1828,6 @@ pub mod database_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -1096,7 +1096,6 @@ impl wkt::message::Message for ListBackupsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupsResponse {
     type PageItem = crate::model::Backup;
 
@@ -1314,7 +1313,6 @@ impl wkt::message::Message for ListBackupOperationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupOperationsResponse {
     type PageItem = longrunning::model::Operation;
 
@@ -2404,7 +2402,6 @@ impl wkt::message::Message for ListBackupSchedulesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListBackupSchedulesResponse {
     type PageItem = crate::model::BackupSchedule;
 
@@ -3192,7 +3189,6 @@ impl wkt::message::Message for ListDatabasesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatabasesResponse {
     type PageItem = crate::model::Database;
 
@@ -4116,7 +4112,6 @@ impl wkt::message::Message for ListDatabaseOperationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatabaseOperationsResponse {
     type PageItem = longrunning::model::Operation;
 
@@ -4790,7 +4785,6 @@ impl wkt::message::Message for ListDatabaseRolesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListDatabaseRolesResponse {
     type PageItem = crate::model::DatabaseRole;
 

--- a/src/generated/spanner/admin/instance/v1/src/builders.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builders.rs
@@ -71,7 +71,6 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstanceConfigsResponse, gax::error::Error>
@@ -453,7 +452,6 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -529,7 +527,6 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
@@ -615,7 +612,6 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1446,7 +1442,6 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<
@@ -1622,7 +1617,6 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/spanner/admin/instance/v1/src/builders.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builders.rs
@@ -71,7 +71,7 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstanceConfigsResponse, gax::error::Error>
         {
@@ -452,7 +452,7 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListInstanceConfigOperationsResponse,
@@ -527,7 +527,7 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListInstancesResponse, gax::error::Error>
         {
@@ -612,7 +612,7 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListInstancePartitionsResponse,
@@ -1442,7 +1442,7 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<
             crate::model::ListInstancePartitionOperationsResponse,
@@ -1617,7 +1617,7 @@ pub mod instance_admin {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -2011,7 +2011,6 @@ impl wkt::message::Message for ListInstanceConfigsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstanceConfigsResponse {
     type PageItem = crate::model::InstanceConfig;
 
@@ -2439,7 +2438,6 @@ impl wkt::message::Message for ListInstanceConfigOperationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstanceConfigOperationsResponse {
     type PageItem = longrunning::model::Operation;
 
@@ -2741,7 +2739,6 @@ impl wkt::message::Message for ListInstancesResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancesResponse {
     type PageItem = crate::model::Instance;
 
@@ -4156,7 +4153,6 @@ impl wkt::message::Message for ListInstancePartitionsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancePartitionsResponse {
     type PageItem = crate::model::InstancePartition;
 
@@ -4380,7 +4376,6 @@ impl wkt::message::Message for ListInstancePartitionOperationsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListInstancePartitionOperationsResponse {
     type PageItem = longrunning::model::Operation;
 

--- a/src/generated/storagetransfer/v1/src/builders.rs
+++ b/src/generated/storagetransfer/v1/src/builders.rs
@@ -279,7 +279,6 @@ pub mod storage_transfer_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTransferJobsResponse, gax::error::Error>
@@ -719,7 +718,6 @@ pub mod storage_transfer_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAgentPoolsResponse, gax::error::Error>
@@ -837,7 +835,6 @@ pub mod storage_transfer_service {
         }
 
         /// Streams the responses back.
-        #[cfg(feature = "unstable-stream")]
         pub async fn stream(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>

--- a/src/generated/storagetransfer/v1/src/builders.rs
+++ b/src/generated/storagetransfer/v1/src/builders.rs
@@ -279,7 +279,7 @@ pub mod storage_transfer_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListTransferJobsResponse, gax::error::Error>
         {
@@ -718,7 +718,7 @@ pub mod storage_transfer_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<crate::model::ListAgentPoolsResponse, gax::error::Error>
         {
@@ -835,7 +835,7 @@ pub mod storage_transfer_service {
         }
 
         /// Streams the responses back.
-        pub async fn stream(
+        pub async fn paginator(
             self,
         ) -> gax::paginator::Paginator<longrunning::model::ListOperationsResponse, gax::error::Error>
         {

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -406,7 +406,6 @@ impl wkt::message::Message for ListTransferJobsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListTransferJobsResponse {
     type PageItem = crate::model::TransferJob;
 
@@ -820,7 +819,6 @@ impl wkt::message::Message for ListAgentPoolsResponse {
     }
 }
 
-#[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for ListAgentPoolsResponse {
     type PageItem = crate::model::AgentPool;
 

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -311,7 +311,7 @@ async fn get_all_secret_names(
     project_id: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();
-    let mut stream = client.list_secrets(project_id).stream().await;
+    let mut stream = client.list_secrets(project_id).paginator().await;
     while let Some(response) = stream.next().await {
         response?
             .secrets

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -311,8 +311,8 @@ async fn get_all_secret_names(
     project_id: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();
-    let mut stream = client.list_secrets(project_id).paginator().await;
-    while let Some(response) = stream.next().await {
+    let mut paginator = client.list_secrets(project_id).paginator().await;
+    while let Some(response) = paginator.next().await {
         response?
             .secrets
             .into_iter()

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -304,7 +304,7 @@ async fn run_many_secret_versions(
     let mut stream = client
         .list_secret_versions(secret_name)
         .set_page_size(PAGE_SIZE)
-        .stream()
+        .paginator()
         .await;
     let mut got = BTreeSet::new();
     while let Some(page) = stream.next().await {
@@ -363,7 +363,7 @@ async fn get_all_secret_names(
     let mut names = Vec::new();
     let mut stream = client
         .list_secrets(format!("projects/{project_id}"))
-        .stream()
+        .paginator()
         .await
         .items();
     while let Some(response) = stream.next().await {
@@ -388,7 +388,7 @@ async fn cleanup_stale_secrets(
     let mut stale_secrets = Vec::new();
     let mut stream = client
         .list_secrets(format!("projects/{project_id}"))
-        .stream()
+        .paginator()
         .await
         .items();
     while let Some(secret) = stream.next().await {

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -301,13 +301,13 @@ async fn run_many_secret_versions(
     let want = want;
 
     const PAGE_SIZE: i32 = 2;
-    let mut stream = client
+    let mut paginator = client
         .list_secret_versions(secret_name)
         .set_page_size(PAGE_SIZE)
         .paginator()
         .await;
     let mut got = BTreeSet::new();
-    while let Some(page) = stream.next().await {
+    while let Some(page) = paginator.next().await {
         let page = page?;
         assert!(page.versions.len() <= PAGE_SIZE as usize, "{page:?}");
         page.versions.into_iter().for_each(|v| {
@@ -361,12 +361,12 @@ async fn get_all_secret_names(
     project_id: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();
-    let mut stream = client
+    let mut paginator = client
         .list_secrets(format!("projects/{project_id}"))
         .paginator()
         .await
         .items();
-    while let Some(response) = stream.next().await {
+    while let Some(response) = paginator.next().await {
         let item = response?;
         names.push(item.name);
     }
@@ -386,12 +386,12 @@ async fn cleanup_stale_secrets(
     let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 
     let mut stale_secrets = Vec::new();
-    let mut stream = client
+    let mut paginator = client
         .list_secrets(format!("projects/{project_id}"))
         .paginator()
         .await
         .items();
-    while let Some(secret) = stream.next().await {
+    while let Some(secret) = paginator.next().await {
         let secret = secret?;
         if secret
             .name

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -222,7 +222,7 @@ async fn cleanup_stale_workflows(
 
     let mut stream = client
         .list_workflows(format!("projects/{project_id}/locations/{location_id}"))
-        .stream()
+        .paginator()
         .await
         .items();
     let mut stale_workflows = Vec::new();

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -220,13 +220,13 @@ async fn cleanup_stale_workflows(
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
     let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 
-    let mut stream = client
+    let mut paginator = client
         .list_workflows(format!("projects/{project_id}/locations/{location_id}"))
         .paginator()
         .await
         .items();
     let mut stale_workflows = Vec::new();
-    while let Some(workflow) = stream.next().await {
+    while let Some(workflow) = paginator.next().await {
         let item = workflow?;
         if let Some("true") = item.labels.get("integration-test").map(String::as_str) {
             if let Some(true) = item.create_time.map(|v| v < stale_deadline) {

--- a/src/integration-tests/tests/pagination.rs
+++ b/src/integration-tests/tests/pagination.rs
@@ -55,13 +55,13 @@ mod mocking {
             });
 
         let client = sm::client::SecretManagerService::from_stub(mock);
-        let mut stream = client
+        let mut paginator = client
             .list_secrets("projects/test-project")
             .paginator()
             .await
             .items();
         let mut names = Vec::new();
-        while let Some(response) = stream.next().await {
+        while let Some(response) = paginator.next().await {
             names.push(response?.name);
         }
 

--- a/src/integration-tests/tests/pagination.rs
+++ b/src/integration-tests/tests/pagination.rs
@@ -57,7 +57,7 @@ mod mocking {
         let client = sm::client::SecretManagerService::from_stub(mock);
         let mut stream = client
             .list_secrets("projects/test-project")
-            .stream()
+            .paginator()
             .await
             .items();
         let mut names = Vec::new();

--- a/src/integration-tests/tests/pagination.rs
+++ b/src/integration-tests/tests/pagination.rs
@@ -25,7 +25,7 @@ mod mocking {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn test_helper() -> TestResult {
+    async fn list_items() -> TestResult {
         let mut mock = MockSecretManagerService::new();
         let mut seq = mockall::Sequence::new();
         mock.expect_list_secrets()
@@ -62,6 +62,61 @@ mod mocking {
             .items();
         let mut names = Vec::new();
         while let Some(response) = paginator.next().await {
+            names.push(response?.name);
+        }
+
+        assert_eq!(
+            names,
+            make_secrets(9, 0)
+                .into_iter()
+                .map(|s| s.name)
+                .collect::<Vec<String>>()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn list_items_as_stream() -> TestResult {
+        use futures::stream::StreamExt;
+
+        let mut mock = MockSecretManagerService::new();
+        let mut seq = mockall::Sequence::new();
+        mock.expect_list_secrets()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|r, _| r.parent == "projects/test-project" && r.page_token.is_empty())
+            .return_once(|_, _| {
+                Ok(sm::model::ListSecretsResponse::default()
+                    .set_next_page_token("test-page-001")
+                    .set_secrets(make_secrets(3, 0)))
+            });
+        mock.expect_list_secrets()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|r, _| r.parent == "projects/test-project" && r.page_token == "test-page-001")
+            .return_once(|_, _| {
+                Ok(sm::model::ListSecretsResponse::default()
+                    .set_next_page_token("test-page-002")
+                    .set_secrets(make_secrets(3, 3)))
+            });
+        mock.expect_list_secrets()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|r, _| r.parent == "projects/test-project" && r.page_token == "test-page-002")
+            .return_once(|_, _| {
+                Ok(sm::model::ListSecretsResponse::default().set_secrets(make_secrets(3, 6)))
+            });
+
+        let client = sm::client::SecretManagerService::from_stub(mock);
+        let mut stream = client
+            .list_secrets("projects/test-project")
+            .paginator()
+            .await
+            .items()
+            .to_stream();
+        let mut names = Vec::new();
+        while let Some(response) = stream.next().await {
             names.push(response?.name);
         }
 


### PR DESCRIPTION
Part of the work for #720 

Makes the `Paginator` class part of gax. It is no longer gated by the `unstable-stream` feature. The `Paginator` picks up a `to_stream()` function which is gated by the `unstable-stream` feature. (Same goes for `ItemPaginator`).

We renamed the `stream()` function to `paginator()` on the paginated builders.

## `unstable-stream` feature in client crates

All downstream crates still have an `unstable-stream` feature. I think we should get rid of them, and let applications opt in via the dependency on gax. If we want to do this, I will send another PR.

We would need to update some of our docs, because we could no longer one-line things like:
```
   cargo add google-cloud-secretmanager-v1 --features unstable-stream
```

## On testing feature configurations...

We now testing gax with and without `unstable-stream`. (By removing both `dev.dependencies` on this feature).