### PR TITLE
feat(generator): options to skip some elements

### DIFF
--- a/generator/internal/api/skip.go
+++ b/generator/internal/api/skip.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"slices"
+	"strings"
+)
+
+func SkipModelElements(model *API, options map[string]string) {
+	ids, ok := options["skipped-ids"]
+	if !ok {
+		return
+	}
+	skippedIDs := map[string]bool{}
+	for _, id := range strings.Split(ids, ",") {
+		skippedIDs[id] = true
+	}
+	for _, m := range model.Messages {
+		skipMessageElements(m, skippedIDs)
+	}
+	model.Enums = slices.DeleteFunc(model.Enums, func(x *Enum) bool { return skippedIDs[x.ID] })
+	model.Messages = slices.DeleteFunc(model.Messages, func(x *Message) bool { return skippedIDs[x.ID] })
+	model.Services = slices.DeleteFunc(model.Services, func(x *Service) bool { return skippedIDs[x.ID] })
+	for _, service := range model.State.ServiceByID {
+		service.Methods = slices.DeleteFunc(service.Methods, func(x *Method) bool { return skippedIDs[x.ID] })
+	}
+}
+
+func skipMessageElements(message *Message, skippedIDs map[string]bool) {
+	for _, m := range message.Messages {
+		skipMessageElements(m, skippedIDs)
+	}
+	message.Messages = slices.DeleteFunc(message.Messages, func(x *Message) bool { return skippedIDs[x.ID] })
+	message.Enums = slices.DeleteFunc(message.Enums, func(x *Enum) bool { return skippedIDs[x.ID] })
+}

--- a/generator/internal/api/skip_test.go
+++ b/generator/internal/api/skip_test.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestSkipMessages(t *testing.T) {
+	m0 := &Message{
+		Name:    "Message0",
+		Package: "test",
+		ID:      ".test.Message0",
+	}
+	m1 := &Message{
+		Name:    "Message1",
+		Package: "test",
+		ID:      ".test.Message1",
+	}
+	m2 := &Message{
+		Name:    "Message2",
+		Package: "test",
+		ID:      ".test.Message2",
+	}
+	model := NewTestAPI([]*Message{m0, m1, m2}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, map[string]string{
+		"skipped-ids": ".test.Message1",
+	})
+	want := []*Message{m0, m2}
+
+	if diff := cmp.Diff(want, model.Messages); diff != "" {
+		t.Errorf("mismatch in messages (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestSkipEnums(t *testing.T) {
+	e0 := &Enum{
+		Name:    "Enum0",
+		Package: "test",
+		ID:      ".test.Enum0",
+	}
+	e1 := &Enum{
+		Name:    "Enum1",
+		Package: "test",
+		ID:      ".test.Enum1",
+	}
+	e2 := &Enum{
+		Name:    "Enum2",
+		Package: "test",
+		ID:      ".test.Enum2",
+	}
+	model := NewTestAPI([]*Message{}, []*Enum{e0, e1, e2}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, map[string]string{
+		"skipped-ids": ".test.Enum1",
+	})
+
+	want := []*Enum{e0, e2}
+
+	if diff := cmp.Diff(want, model.Enums); diff != "" {
+		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestSkipNestedMessages(t *testing.T) {
+	m0 := &Message{
+		Name:    "Message0",
+		Package: "test",
+		ID:      ".test.Message2.Message0",
+	}
+	m1 := &Message{
+		Name:    "Message1",
+		Package: "test",
+		ID:      ".test.Message2.Message1",
+	}
+	m2 := &Message{
+		Name:     "Message2",
+		Package:  "test",
+		ID:       ".test.Message2",
+		Messages: []*Message{m0, m1},
+	}
+	model := NewTestAPI([]*Message{m2}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, map[string]string{
+		"skipped-ids": ".test.Message2.Message1",
+	})
+	want := []*Message{m0}
+	if diff := cmp.Diff(want, m2.Messages); diff != "" {
+		t.Errorf("mismatch in messages (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestSkipNestedEnums(t *testing.T) {
+	e0 := &Enum{
+		Name:    "Enum0",
+		Package: "test",
+		ID:      ".test.Message.Enum0",
+	}
+	e1 := &Enum{
+		Name:    "Enum1",
+		Package: "test",
+		ID:      ".test.Message.Enum1",
+	}
+	e2 := &Enum{
+		Name:    "Enum2",
+		Package: "test",
+		ID:      ".test.Message.Enum2",
+	}
+	m := &Message{
+		Name:    "Message",
+		Package: "test",
+		ID:      ".test.Message",
+		Enums:   []*Enum{e0, e1, e2},
+	}
+	model := NewTestAPI([]*Message{m}, []*Enum{}, []*Service{})
+	CrossReference(model)
+	SkipModelElements(model, map[string]string{
+		"skipped-ids": ".test.Message.Enum1",
+	})
+
+	want := []*Enum{e0, e2}
+	if diff := cmp.Diff(want, m.Enums); diff != "" {
+		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestSkipServices(t *testing.T) {
+	s0 := &Service{
+		Name:    "Service0",
+		Package: "test",
+		ID:      ".test.Service0",
+	}
+	s1 := &Service{
+		Name:    "Service1",
+		Package: "test",
+		ID:      ".test.Service1",
+	}
+	s2 := &Service{
+		Name:    "Service2",
+		Package: "test",
+		ID:      ".test.Service2",
+	}
+	model := NewTestAPI([]*Message{}, []*Enum{}, []*Service{s0, s1, s2})
+	CrossReference(model)
+	SkipModelElements(model, map[string]string{
+		"skipped-ids": ".test.Service1",
+	})
+
+	want := []*Service{s0, s2}
+
+	if diff := cmp.Diff(want, model.Services, cmpopts.IgnoreFields(Service{}, "Model")); diff != "" {
+		t.Errorf("mismatch in services (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestSkipMethods(t *testing.T) {
+	s0 := &Service{
+		Name:    "Service0",
+		Package: "test",
+		ID:      ".test.Service0",
+	}
+	s1 := &Service{
+		Name:    "Service1",
+		Package: "test",
+		ID:      ".test.Service1",
+		Methods: []*Method{
+			{
+				Name: "Method0",
+				ID:   ".test.Service1.Method0",
+			},
+			{
+				Name: "Method1",
+				ID:   ".test.Service1.Method1",
+			},
+			{
+				Name: "Method2",
+				ID:   ".test.Service1.Method2",
+			},
+		},
+	}
+	s2 := &Service{
+		Name:    "Service2",
+		Package: "test",
+		ID:      ".test.Service2",
+	}
+	model := NewTestAPI([]*Message{}, []*Enum{}, []*Service{s0, s1, s2})
+	CrossReference(model)
+	SkipModelElements(model, map[string]string{
+		"skipped-ids": ".test.Service1.Method1",
+	})
+
+	wantServices := []*Service{s0, s1, s2}
+	if diff := cmp.Diff(wantServices, model.Services, cmpopts.IgnoreFields(Service{}, "Model")); diff != "" {
+		t.Errorf("mismatch in services (-want, +got)\n:%s", diff)
+	}
+
+	wantMethods := []*Method{
+		{
+			Name: "Method0",
+			ID:   ".test.Service1.Method0",
+		},
+		{
+			Name: "Method2",
+			ID:   ".test.Service1.Method2",
+		},
+	}
+	if diff := cmp.Diff(wantMethods, s1.Methods); diff != "" {
+		t.Errorf("mismatch in methods (-want, +got)\n:%s", diff)
+	}
+}

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -77,6 +77,7 @@ func refreshDir(rootConfig *config.Config, cmdLine *CommandLine, output string) 
 	if err := api.CrossReference(model); err != nil {
 		return err
 	}
+	api.SkipModelElements(model, config.Source)
 	// Verify all the services, messages and enums are in the same package.
 	if err := api.Validate(model); err != nil {
 		return err


### PR DESCRIPTION
Sometimes we need to skip some elements in the generated code. The
current motivation is to skip conversion functions to and from Prost
types.

Part of the work for #1414
