### PR TITLE
feat(generator/dart): calculate required fields

### DIFF
--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -169,14 +169,6 @@ func enumValueName(e *api.EnumValue) string {
 	return strcase.ToLowerCamel(e.Name)
 }
 
-func bodyAccessor(m *api.Method) string {
-	if m.PathInfo.BodyFieldPath == "*" {
-		// no accessor needed, use the whole request
-		return ""
-	}
-	return "." + strcase.ToCamel(m.PathInfo.BodyFieldPath)
-}
-
 func httpPathFmt(_ *api.PathInfo) string {
 	fmt := ""
 	// TODO(#1034): Determine the correct format for Dart.

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -63,7 +63,10 @@ func TestTemplatesAvailable(t *testing.T) {
 func TestMessageNames(t *testing.T) {
 	r := sample.Replication()
 	a := sample.Automatic()
-	model := api.NewTestAPI([]*api.Message{r, a}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI(
+		[]*api.Message{r, a, sample.CustomerManagedEncryption()},
+		[]*api.Enum{},
+		[]*api.Service{})
 	model.PackageName = "test"
 	annotateModel(model, map[string]string{})
 
@@ -86,13 +89,13 @@ func TestMessageNames(t *testing.T) {
 func TestEnumNames(t *testing.T) {
 	parent := &api.Message{
 		Name:    "SecretVersion",
-		ID:      ".test.SecretVersion",
+		ID:      sample.SecretVersion().ID,
 		Package: "test",
 		Fields: []*api.Field{
 			{
 				Name:     "automatic",
 				Typez:    api.MESSAGE_TYPE,
-				TypezID:  ".test.Automatic",
+				TypezID:  sample.Automatic().ID,
 				Optional: true,
 				Repeated: false,
 			},
@@ -110,7 +113,10 @@ func TestEnumNames(t *testing.T) {
 		Package: "test",
 	}
 
-	model := api.NewTestAPI([]*api.Message{parent}, []*api.Enum{nested, non_nested}, []*api.Service{})
+	model := api.NewTestAPI(
+		[]*api.Message{parent, sample.Automatic(), sample.CustomerManagedEncryption()},
+		[]*api.Enum{nested, non_nested},
+		[]*api.Service{})
 	model.PackageName = "test"
 	annotateModel(model, map[string]string{})
 

--- a/generator/internal/dart/darttemplate.go
+++ b/generator/internal/dart/darttemplate.go
@@ -54,6 +54,7 @@ type serviceAnnotations struct {
 	// The service name using Dart naming conventions.
 	Name        string
 	DocLines    []string
+	Methods     []*api.Method
 	FieldName   string
 	StructName  string
 	DefaultHost string
@@ -64,6 +65,7 @@ type messageAnnotation struct {
 	DocLines         []string
 	ConstructorBody  string // A custom body for the message's constructor.
 	BasicFields      []*api.Field
+	HasFields        bool
 	HasToStringLines bool
 	ToStringLines    []string
 }
@@ -93,10 +95,10 @@ type oneOfAnnotation struct {
 }
 
 type fieldAnnotation struct {
-	Name             string
-	Type             string
-	DocLines         []string
-	AsQueryParameter string
+	Name     string
+	Type     string
+	DocLines []string
+	Required bool
 }
 
 type enumAnnotation struct {
@@ -165,6 +167,12 @@ func annotateModel(model *api.API, options map[string]string) (*modelAnnotations
 		}
 	}
 
+	// Register any missing WKT.
+	registerMissingWkt(model.State)
+
+	// Calculate required fields.
+	requiredFields := calculateRequiredFields(model)
+
 	// Traverse and annotate the enums defined in this API.
 	for _, e := range model.Enums {
 		annotateEnum(e, model.State)
@@ -172,7 +180,7 @@ func annotateModel(model *api.API, options map[string]string) (*modelAnnotations
 
 	// Traverse and annotate the messages defined in this API.
 	for _, m := range model.Messages {
-		traverseMessage(m, model.State, packageMapping, imports)
+		annotateMessage(m, model.State, packageMapping, imports, requiredFields)
 	}
 
 	for _, s := range model.Services {
@@ -215,6 +223,28 @@ func annotateModel(model *api.API, options map[string]string) (*modelAnnotations
 
 	model.Codec = ann
 	return ann, nil
+}
+
+func registerMissingWkt(state *api.APIState) {
+	// If these definitions weren't provided by protoc then provide our own
+	// placeholders.
+	for _, message := range []struct {
+		ID      string
+		Name    string
+		Package string
+	}{
+		{".google.protobuf.Any", "Any", "google.protobuf"},
+		{".google.protobuf.Empty", "Empty", "google.protobuf"},
+	} {
+		_, ok := state.MessageByID[message.ID]
+		if !ok {
+			state.MessageByID[message.ID] = &api.Message{
+				ID:      message.ID,
+				Name:    message.Name,
+				Package: message.Package,
+			}
+		}
+	}
 }
 
 // Calculate package dependencies based on `package:` imports.
@@ -261,20 +291,44 @@ func calculateImports(usedImports map[string]string) []string {
 	return imports
 }
 
-func annotateService(s *api.Service, state *api.APIState, packageMapping map[string]string, imports map[string]string) {
-	// Require package:http when generating services.
-	imports["http"] = httpImport
+func calculateRequiredFields(model *api.API) map[string]*api.Field {
+	required := map[string]*api.Field{}
 
+	for _, s := range model.Services {
+		// Some methods are skipped.
+		methods := language.FilterSlice(s.Methods, func(m *api.Method) bool {
+			return generateMethod(m)
+		})
+
+		for _, method := range methods {
+			for _, field := range language.PathParams(method, model.State) {
+				required[field.ID] = field
+			}
+
+			for _, field := range method.InputType.Fields {
+				if field.Name == method.PathInfo.BodyFieldPath {
+					required[field.ID] = field
+				}
+			}
+		}
+	}
+
+	return required
+}
+
+func annotateService(s *api.Service, state *api.APIState, packageMapping map[string]string, imports map[string]string) {
 	// Some methods are skipped.
 	methods := language.FilterSlice(s.Methods, func(m *api.Method) bool {
 		return generateMethod(m)
 	})
+
 	for _, m := range methods {
 		annotateMethod(m, state, packageMapping, imports)
 	}
 	ann := &serviceAnnotations{
 		Name:        s.Name,
 		DocLines:    formatDocComments(s.Documentation, state),
+		Methods:     methods,
 		FieldName:   strcase.ToLowerCamel(s.Name),
 		StructName:  s.Name,
 		DefaultHost: s.DefaultHost,
@@ -282,24 +336,19 @@ func annotateService(s *api.Service, state *api.APIState, packageMapping map[str
 	s.Codec = ann
 }
 
-func traverseMessage(m *api.Message, state *api.APIState, packageMapping map[string]string, imports map[string]string) {
-	annotateMessage(m, state, packageMapping, imports)
-
-	for _, e := range m.Enums {
-		annotateEnum(e, state)
-	}
-
-	for _, m := range m.Messages {
-		traverseMessage(m, state, packageMapping, imports)
-	}
-}
-
-func annotateMessage(m *api.Message, state *api.APIState, packageMapping map[string]string, imports map[string]string) {
+func annotateMessage(m *api.Message, state *api.APIState, packageMapping map[string]string,
+	imports map[string]string, requiredFields map[string]*api.Field) {
 	for _, f := range m.Fields {
-		annotateField(f, state, packageMapping, imports)
+		annotateField(f, state, packageMapping, imports, requiredFields)
 	}
 	for _, f := range m.OneOfs {
 		annotateOneOf(f, state)
+	}
+	for _, e := range m.Enums {
+		annotateEnum(e, state)
+	}
+	for _, m := range m.Messages {
+		annotateMessage(m, state, packageMapping, imports, requiredFields)
 	}
 
 	constructorBody := ";"
@@ -317,6 +366,7 @@ func annotateMessage(m *api.Message, state *api.APIState, packageMapping map[str
 		BasicFields: language.FilterSlice(m.Fields, func(s *api.Field) bool {
 			return !s.IsOneOf
 		}),
+		HasFields:        len(m.Fields) > 0,
 		HasToStringLines: len(toStringLines) > 0,
 		ToStringLines:    toStringLines,
 	}
@@ -337,27 +387,40 @@ func createToStringLines(message *api.Message) []string {
 			continue
 		}
 
-		// if (name != null) 'name=$name',
-		lines = append(lines, fmt.Sprintf("if (%s != null) '%s=$%s',", name, name, name))
+		if codec.Required {
+			// 'name=$name',
+			lines = append(lines, fmt.Sprintf("'%s=$%s',", name, name))
+		} else {
+			// if (name != null) 'name=$name',
+			lines = append(lines, fmt.Sprintf("if (%s != null) '%s=$%s',", name, name, name))
+		}
 	}
 
 	return lines
 }
 
 func annotateMethod(method *api.Method, state *api.APIState, packageMapping map[string]string, imports map[string]string) {
+	// Ignore imports added from the input and output messages.
+	tempImports := map[string]string{}
+	tempRequiredFields := map[string]*api.Field{}
+	if method.InputType.Codec == nil {
+		annotateMessage(method.InputType, state, packageMapping, tempImports, tempRequiredFields)
+	}
+	if method.OutputType.Codec == nil {
+		annotateMessage(method.OutputType, state, packageMapping, tempImports, tempRequiredFields)
+	}
+
 	pathInfoAnnotation := &pathInfoAnnotation{
-		Method:   method.PathInfo.Verb,
 		PathFmt:  httpPathFmt(method.PathInfo),
 		PathArgs: httpPathArgs(method.PathInfo),
-		HasBody:  method.PathInfo.BodyFieldPath != "",
 	}
 	method.PathInfo.Codec = pathInfoAnnotation
+
 	annotation := &methodAnnotation{
 		Name:         strcase.ToLowerCamel(method.Name),
 		RequestType:  resolveTypeName(state.MessageByID[method.InputTypeID], packageMapping, imports),
 		ResponseType: resolveTypeName(state.MessageByID[method.OutputTypeID], packageMapping, imports),
 		DocLines:     formatDocComments(method.Documentation, state),
-		BodyAccessor: bodyAccessor(method),
 		PathParams:   language.PathParams(method, state),
 		QueryParams:  language.QueryParams(method, state),
 	}
@@ -371,11 +434,15 @@ func annotateOneOf(field *api.OneOf, state *api.APIState) {
 	}
 }
 
-func annotateField(field *api.Field, state *api.APIState, packageMapping map[string]string, imports map[string]string) {
+func annotateField(field *api.Field, state *api.APIState, packageMapping map[string]string,
+	imports map[string]string, requiredFields map[string]*api.Field) {
+	_, ok := requiredFields[field.ID]
+
 	field.Codec = &fieldAnnotation{
 		Name:     strcase.ToLowerCamel(field.Name),
 		Type:     fieldType(field, state, packageMapping, imports),
 		DocLines: formatDocComments(field.Documentation, state),
+		Required: ok,
 	}
 }
 

--- a/generator/internal/dart/templates/lib/field.mustache
+++ b/generator/internal/dart/templates/lib/field.mustache
@@ -17,4 +17,4 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-final {{{Codec.Type}}}? {{Codec.Name}};
+final {{{Codec.Type}}}{{^Codec.Required}}?{{/Codec.Required}} {{Codec.Name}};

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -23,11 +23,11 @@ class {{Codec.Name}} extends CloudMessage {
   {{> field}}
   {{/Fields}}
 
-  {{Codec.Name}}({
+  {{Codec.Name}}({{#Codec.HasFields}}{
   {{#Fields}}
-    this.{{Codec.Name}},
+    {{#Codec.Required}}required {{/Codec.Required}}this.{{Codec.Name}},
   {{/Fields}}
-  }){{Codec.ConstructorBody}}
+  }{{/Codec.HasFields}}){{Codec.ConstructorBody}}
 
   @override
   {{#Codec.HasToStringLines}}

--- a/generator/internal/dart/templates/lib/service.mustache
+++ b/generator/internal/dart/templates/lib/service.mustache
@@ -21,7 +21,7 @@ class {{Codec.Name}} extends CloudService {
   static const String host = '{{DefaultHost}}';
 
   {{Codec.Name}}({required super.client});
-  {{#Methods}}
+  {{#Codec.Methods}}
   {{> method}}
-  {{/Methods}}
+  {{/Codec.Methods}}
 }

--- a/generator/internal/sample/api.go
+++ b/generator/internal/sample/api.go
@@ -132,14 +132,16 @@ func MethodListSecretVersions() *api.Method {
 		ID:            "..Service.ListVersion",
 		Documentation: "Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This call does not return secret data.",
 		InputTypeID:   ListSecretVersionsRequest().ID,
+		InputType:     ListSecretVersionsRequest(),
 		OutputTypeID:  ListSecretVersionsResponse().ID,
+		OutputType:    ListSecretVersionsResponse(),
 		PathInfo: &api.PathInfo{
 			Verb:          http.MethodPost,
 			BodyFieldPath: "*",
 			PathTemplate: []api.PathSegment{
 				api.NewLiteralPathSegment("v1"),
 				api.NewLiteralPathSegment("projects"),
-				api.NewFieldPathPathSegment("project"),
+				api.NewFieldPathPathSegment("parent"),
 				api.NewLiteralPathSegment("secrets"),
 				api.NewFieldPathPathSegment("secret"),
 				api.NewVerbPathSegment("listSecretVersions"),
@@ -204,6 +206,7 @@ func ListSecretVersionsRequest() *api.Message {
 			{
 				Name:     "parent",
 				JSONName: "parent",
+				ID:       Secret().ID + ".parent",
 				Typez:    api.MESSAGE_TYPE,
 				TypezID:  Secret().ID,
 			},
@@ -243,6 +246,7 @@ func Secret() *api.Message {
 				Name:     "replication",
 				JSONName: "replication",
 				Typez:    api.MESSAGE_TYPE,
+				TypezID:  Replication().ID,
 			},
 		},
 	}
@@ -264,6 +268,7 @@ func SecretVersion() *api.Message {
 				Name:     "state",
 				JSONName: "state",
 				Typez:    api.ENUM_TYPE,
+				TypezID:  EnumState().ID,
 			},
 		},
 	}
@@ -282,6 +287,7 @@ func EnumState() *api.Enum {
 	)
 	return &api.Enum{
 		Name:    "State",
+		ID:      ".test.EnumState",
 		Package: Package,
 		Values: []*api.EnumValue{
 			stateEnabled,
@@ -299,7 +305,7 @@ func Replication() *api.Message {
 			{
 				Name:     "automatic",
 				Typez:    api.MESSAGE_TYPE,
-				TypezID:  ".test.Automatic",
+				TypezID:  "..Automatic",
 				Optional: true,
 				Repeated: false,
 			},

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -24,7 +24,6 @@ import 'dart:typed_data';
 
 import 'package:google_cloud_common/common.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
-import 'package:http/http.dart';
 
 /// Secret Manager Service
 ///
@@ -769,7 +768,7 @@ class ListSecretsRequest extends CloudMessage {
   /// Required. The resource name of the project associated with the
   /// [Secrets][google.cloud.secretmanager.v1.Secret], in the format `projects/*`
   /// or `projects/*/locations/*`
-  final String? parent;
+  final String parent;
 
   /// Optional. The maximum number of results to be returned in a single page. If
   /// set to 0, the server decides the number of results to return. If the
@@ -788,7 +787,7 @@ class ListSecretsRequest extends CloudMessage {
   final String? filter;
 
   ListSecretsRequest({
-    this.parent,
+    required this.parent,
     this.pageSize,
     this.pageToken,
     this.filter,
@@ -797,7 +796,7 @@ class ListSecretsRequest extends CloudMessage {
   @override
   String toString() {
     final contents = [
-      if (parent != null) 'parent=$parent',
+      'parent=$parent',
       if (pageSize != null) 'pageSize=$pageSize',
       if (pageToken != null) 'pageToken=$pageToken',
       if (filter != null) 'filter=$filter',
@@ -848,7 +847,7 @@ class CreateSecretRequest extends CloudMessage {
   /// Required. The resource name of the project to associate with the
   /// [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`
   /// or `projects/*/locations/*`.
-  final String? parent;
+  final String parent;
 
   /// Required. This must be unique within the project.
   ///
@@ -859,18 +858,18 @@ class CreateSecretRequest extends CloudMessage {
 
   /// Required. A [Secret][google.cloud.secretmanager.v1.Secret] with initial
   /// field values.
-  final Secret? secret;
+  final Secret secret;
 
   CreateSecretRequest({
-    this.parent,
+    required this.parent,
     this.secretId,
-    this.secret,
+    required this.secret,
   });
 
   @override
   String toString() {
     final contents = [
-      if (parent != null) 'parent=$parent',
+      'parent=$parent',
       if (secretId != null) 'secretId=$secretId',
     ].join(',');
     return 'CreateSecretRequest($contents)';
@@ -885,21 +884,21 @@ class AddSecretVersionRequest extends CloudMessage {
   /// [Secret][google.cloud.secretmanager.v1.Secret] to associate with the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
   /// `projects/*/secrets/*` or `projects/*/locations/*/secrets/*`.
-  final String? parent;
+  final String parent;
 
   /// Required. The secret payload of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
   final SecretPayload? payload;
 
   AddSecretVersionRequest({
-    this.parent,
+    required this.parent,
     this.payload,
   });
 
   @override
   String toString() {
     final contents = [
-      if (parent != null) 'parent=$parent',
+      'parent=$parent',
     ].join(',');
     return 'AddSecretVersionRequest($contents)';
   }
@@ -912,16 +911,16 @@ class GetSecretRequest extends CloudMessage {
   /// Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
   /// `projects/*/secrets/*` or `projects/*/locations/*/secrets/*`.
-  final String? name;
+  final String name;
 
   GetSecretRequest({
-    this.name,
+    required this.name,
   });
 
   @override
   String toString() {
     final contents = [
-      if (name != null) 'name=$name',
+      'name=$name',
     ].join(',');
     return 'GetSecretRequest($contents)';
   }
@@ -935,7 +934,7 @@ class ListSecretVersionsRequest extends CloudMessage {
   /// [Secret][google.cloud.secretmanager.v1.Secret] associated with the
   /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] to list, in
   /// the format `projects/*/secrets/*` or `projects/*/locations/*/secrets/*`.
-  final String? parent;
+  final String parent;
 
   /// Optional. The maximum number of results to be returned in a single page. If
   /// set to 0, the server decides the number of results to return. If the
@@ -954,7 +953,7 @@ class ListSecretVersionsRequest extends CloudMessage {
   final String? filter;
 
   ListSecretVersionsRequest({
-    this.parent,
+    required this.parent,
     this.pageSize,
     this.pageToken,
     this.filter,
@@ -963,7 +962,7 @@ class ListSecretVersionsRequest extends CloudMessage {
   @override
   String toString() {
     final contents = [
-      if (parent != null) 'parent=$parent',
+      'parent=$parent',
       if (pageSize != null) 'pageSize=$pageSize',
       if (pageToken != null) 'pageToken=$pageToken',
       if (filter != null) 'filter=$filter',
@@ -1021,16 +1020,16 @@ class GetSecretVersionRequest extends CloudMessage {
   /// `projects/*/locations/*/secrets/*/versions/latest` is an alias to the most
   /// recently created
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  final String? name;
+  final String name;
 
   GetSecretVersionRequest({
-    this.name,
+    required this.name,
   });
 
   @override
   String toString() {
     final contents = [
-      if (name != null) 'name=$name',
+      'name=$name',
     ].join(',');
     return 'GetSecretVersionRequest($contents)';
   }
@@ -1042,13 +1041,13 @@ class UpdateSecretRequest extends CloudMessage {
 
   /// Required. [Secret][google.cloud.secretmanager.v1.Secret] with updated field
   /// values.
-  final Secret? secret;
+  final Secret secret;
 
   /// Required. Specifies the fields to be updated.
   final FieldMask? updateMask;
 
   UpdateSecretRequest({
-    this.secret,
+    required this.secret,
     this.updateMask,
   });
 
@@ -1069,16 +1068,16 @@ class AccessSecretVersionRequest extends CloudMessage {
   /// `projects/*/locations/*/secrets/*/versions/latest` is an alias to the most
   /// recently created
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  final String? name;
+  final String name;
 
   AccessSecretVersionRequest({
-    this.name,
+    required this.name,
   });
 
   @override
   String toString() {
     final contents = [
-      if (name != null) 'name=$name',
+      'name=$name',
     ].join(',');
     return 'AccessSecretVersionRequest($contents)';
   }
@@ -1118,7 +1117,7 @@ class DeleteSecretRequest extends CloudMessage {
   /// Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format
   /// `projects/*/secrets/*`.
-  final String? name;
+  final String name;
 
   /// Optional. Etag of the [Secret][google.cloud.secretmanager.v1.Secret]. The
   /// request succeeds if it matches the etag of the currently stored secret
@@ -1126,14 +1125,14 @@ class DeleteSecretRequest extends CloudMessage {
   final String? etag;
 
   DeleteSecretRequest({
-    this.name,
+    required this.name,
     this.etag,
   });
 
   @override
   String toString() {
     final contents = [
-      if (name != null) 'name=$name',
+      'name=$name',
       if (etag != null) 'etag=$etag',
     ].join(',');
     return 'DeleteSecretRequest($contents)';
@@ -1148,7 +1147,7 @@ class DisableSecretVersionRequest extends CloudMessage {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to disable in
   /// the format `projects/*/secrets/*/versions/*` or
   /// `projects/*/locations/*/secrets/*/versions/*`.
-  final String? name;
+  final String name;
 
   /// Optional. Etag of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request
@@ -1157,14 +1156,14 @@ class DisableSecretVersionRequest extends CloudMessage {
   final String? etag;
 
   DisableSecretVersionRequest({
-    this.name,
+    required this.name,
     this.etag,
   });
 
   @override
   String toString() {
     final contents = [
-      if (name != null) 'name=$name',
+      'name=$name',
       if (etag != null) 'etag=$etag',
     ].join(',');
     return 'DisableSecretVersionRequest($contents)';
@@ -1179,7 +1178,7 @@ class EnableSecretVersionRequest extends CloudMessage {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to enable in
   /// the format `projects/*/secrets/*/versions/*` or
   /// `projects/*/locations/*/secrets/*/versions/*`.
-  final String? name;
+  final String name;
 
   /// Optional. Etag of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request
@@ -1188,14 +1187,14 @@ class EnableSecretVersionRequest extends CloudMessage {
   final String? etag;
 
   EnableSecretVersionRequest({
-    this.name,
+    required this.name,
     this.etag,
   });
 
   @override
   String toString() {
     final contents = [
-      if (name != null) 'name=$name',
+      'name=$name',
       if (etag != null) 'etag=$etag',
     ].join(',');
     return 'EnableSecretVersionRequest($contents)';
@@ -1210,7 +1209,7 @@ class DestroySecretVersionRequest extends CloudMessage {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to destroy in
   /// the format `projects/*/secrets/*/versions/*` or
   /// `projects/*/locations/*/secrets/*/versions/*`.
-  final String? name;
+  final String name;
 
   /// Optional. Etag of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. The request
@@ -1219,14 +1218,14 @@ class DestroySecretVersionRequest extends CloudMessage {
   final String? etag;
 
   DestroySecretVersionRequest({
-    this.name,
+    required this.name,
     this.etag,
   });
 
   @override
   String toString() {
     final contents = [
-      if (name != null) 'name=$name',
+      'name=$name',
       if (etag != null) 'etag=$etag',
     ].join(',');
     return 'DestroySecretVersionRequest($contents)';

--- a/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
@@ -26,4 +26,3 @@ resolution: workspace
 dependencies:
   google_cloud_common: any
   google_cloud_protobuf: any
-  http: any


### PR DESCRIPTION
Calculate required fields:
- calculate which message fields are definitely required (fields that are path params are required as well as fields that are used as the body of calls)
- use the required info to inform nullability of generated message fields (see `golden/secretmanager/lib/secretmanager.dart`)
- some cleanup of the sample test data in `sample/api.go` (IDs and relationships)
- extracted from https://github.com/googleapis/google-cloud-rust/pull/1454
