### PR TITLE
docs(gax): include streaming APIs

### DIFF
--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -25,6 +25,12 @@ keywords.workspace   = true
 license.workspace    = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+# We want to generate documentation for streaming APIs, gated by this feature.
+# We do not want to generate documentation for `unstable-sdk-client`, which
+# gates internal tpes.
+features = ["unstable-stream"]
+
 [dependencies]
 base64      = "0.22"
 bytes       = "1"


### PR DESCRIPTION
Part of the work for #1468 

Paginator will (hopefully soon) pick up a `fn to_stream()` which is gated by the `unstable-stream` feature. We want this to appear in our docs.

While client crates currently have an `unstable-stream` feature which is gating their `stream()` methods, and preventing the methods from appearing in our docs, we plan to change the method to `paginator()` and make it always available. (Hence there are no changes to client crates).

See: https://docs.rs/about/metadata

---

Aside: Remind me where I can look at the generated documentation to make sure this change actually works...