### PR TITLE
docs(wkt): time and chrono conversions

### DIFF
--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -24,6 +24,11 @@ keywords.workspace   = true
 license.workspace    = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+# Generate documentation for some of the optional conversions. It is too early
+# for `prost`.
+features = ["chrono", "time"]
+
 [features]
 chrono = ["dep:chrono"]
 prost  = ["dep:prost-types"]


### PR DESCRIPTION
Fixes #1468 

Add convenient conversion functions for `wkt` <-> {`time`, `duration`} to the docs.

---

https://docs.rs/rustls/latest/rustls/crypto/aws_lc_rs/fn.default_provider.html

![image](https://github.com/user-attachments/assets/15f30894-49a0-45f1-aa62-46f34b961bfe)

I am hoping `cargo doc` is the thing that adds this tag, and we do not need to document the methods individually. I did not find that "Available on crate feature `aws_lc_rs` only" text in the source code anywhere.