### PR TITLE
refactor(lro): use `google-cloud-http-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,7 @@ dependencies = [
  "futures",
  "google-cloud-auth",
  "google-cloud-gax",
+ "google-cloud-http-client",
  "google-cloud-longrunning",
  "google-cloud-lro",
  "google-cloud-rpc",

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -39,9 +39,11 @@ wkt         = { version = "0.2", path = "../wkt", package = "google-cloud-wkt" }
 unstable-stream = ["dep:futures", "dep:pin-project"]
 
 [dev-dependencies]
-auth       = { path = "../auth", package = "google-cloud-auth" }
 axum       = "0.8"
-lro        = { path = ".", package = "google-cloud-lro", features = ["unstable-stream"] }
 reqwest    = "0.12"
 serde_json = "1"
 tokio      = { version = "1", features = ["test-util"] }
+# Local dependencies
+auth       = { path = "../auth", package = "google-cloud-auth" }
+gclient    = { path = "../http-client", package = "google-cloud-http-client" }
+lro        = { path = ".", package = "google-cloud-lro", features = ["unstable-stream"] }

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -44,6 +44,6 @@ reqwest    = "0.12"
 serde_json = "1"
 tokio      = { version = "1", features = ["test-util"] }
 # Local dependencies
-auth       = { path = "../auth", package = "google-cloud-auth" }
-gclient    = { path = "../http-client", package = "google-cloud-http-client" }
-lro        = { path = ".", package = "google-cloud-lro", features = ["unstable-stream"] }
+auth    = { path = "../auth", package = "google-cloud-auth" }
+gclient = { path = "../http-client", package = "google-cloud-http-client" }
+lro     = { path = ".", package = "google-cloud-lro", features = ["unstable-stream"] }

--- a/src/lro/tests/fake_library/builders.rs
+++ b/src/lro/tests/fake_library/builders.rs
@@ -15,7 +15,7 @@
 // Model the sidekick-generated builders for a service using LROs.
 
 use super::*;
-use gax::http_client::ReqwestClient;
+use gclient::ReqwestClient;
 
 #[derive(Clone, Debug)]
 pub struct CreateResource {
@@ -52,7 +52,7 @@ impl CreateResource {
             .stub
             .execute(
                 builder,
-                None::<gax::http_client::NoBody>,
+                None::<gclient::NoBody>,
                 gax::options::RequestOptions::default(),
             )
             .await?;
@@ -128,7 +128,7 @@ impl GetOperation {
             .inner
             .execute(
                 builder,
-                None::<gax::http_client::NoBody>,
+                None::<gclient::NoBody>,
                 gax::options::RequestOptions::default(),
             )
             .await?;

--- a/src/lro/tests/fake_library/client.rs
+++ b/src/lro/tests/fake_library/client.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use gax::http_client::ReqwestClient;
+use gclient::ReqwestClient;
 pub struct Client {
     // A sidekick-generated client contains a `Arc<dyn T>`. The code
     // in this test skips some layers of abstraction.


### PR DESCRIPTION
Use the re-exports from `google-cloud-http-client`, in preparation to
moving the implementation from gax to that library.

Part of the work for #1490
