### PR TITLE
docs(lro): to_stream methods

### DIFF
--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -24,6 +24,9 @@ keywords.workspace   = true
 license.workspace    = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+features = ["unstable-stream"]
+
 [dependencies]
 futures     = { version = "0.3", optional = true }
 pin-project = { version = "1", optional = true }


### PR DESCRIPTION
I missed this in #1468 

FWIW, I do not think there is a good way to test this locally. I think this package stuff is specific to how docs.rs builds the crates given to it.