### PR TITLE
impl(wkt): `Message` for several wrapper types

### DIFF
--- a/src/wkt/src/wrappers.rs
+++ b/src/wkt/src/wrappers.rs
@@ -145,8 +145,6 @@ macro_rules! impl_message {
 
 impl_message!(DoubleValue);
 impl_message!(FloatValue);
-impl_message!(Int64Value);
-impl_message!(UInt64Value);
 impl_message!(Int32Value);
 impl_message!(UInt32Value);
 impl_message!(BoolValue);
@@ -162,9 +160,7 @@ mod test {
 
     #[test_case(1234.5 as DoubleValue, "DoubleValue")]
     #[test_case(9876.5 as FloatValue, "FloatValue")]
-    #[test_case(-1234567890123456789 as Int64Value, "Int64Value")]
     #[test_case(-123 as Int32Value, "Int32Value")]
-    #[test_case(1234567890123456789 as UInt64Value, "UInt64Value")]
     #[test_case(123 as UInt32Value, "UInt32Value")]
     #[test_case(true as BoolValue, "BoolValue")]
     #[test_case(StringValue::from("I am a string"), "StringValue")]
@@ -190,9 +186,7 @@ mod test {
 
     #[test_case(Int32Value::default(), DoubleValue::default())]
     #[test_case(Int32Value::default(), FloatValue::default())]
-    #[test_case(DoubleValue::default(), Int64Value::default())]
     #[test_case(DoubleValue::default(), Int32Value::default())]
-    #[test_case(DoubleValue::default(), UInt64Value::default())]
     #[test_case(DoubleValue::default(), UInt32Value::default())]
     #[test_case(DoubleValue::default(), BoolValue::default())]
     #[test_case(DoubleValue::default(), StringValue::default())]

--- a/src/wkt/src/wrappers.rs
+++ b/src/wkt/src/wrappers.rs
@@ -111,35 +111,46 @@ pub type StringValue = String;
 /// The JSON representation for `BytesValue` is JSON string.
 pub type BytesValue = bytes::Bytes;
 
-impl crate::message::Message for BoolValue {
-    fn typename() -> &'static str {
-        "type.googleapis.com/google.protobuf.BoolValue"
-    }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
-    where
-        Self: serde::ser::Serialize + Sized,
-    {
-        let map: crate::message::Map = [
-            (
-                "@type",
-                serde_json::Value::String(Self::typename().to_string()),
-            ),
-            ("value", serde_json::Value::Bool(*self)),
-        ]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
-        Ok(map)
-    }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
-    where
-        Self: serde::de::DeserializeOwned,
-    {
-        map.get("value")
-            .and_then(|v| v.as_bool())
-            .ok_or_else(crate::message::missing_value_field)
-    }
+macro_rules! impl_message {
+    ($t: ty) => {
+        impl crate::message::Message for $t {
+            fn typename() -> &'static str {
+                concat!("type.googleapis.com/google.protobuf.", stringify!($t))
+            }
+            fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
+            where
+                Self: serde::ser::Serialize + Sized,
+            {
+                let map: crate::message::Map = [
+                    (
+                        "@type",
+                        serde_json::Value::String(Self::typename().to_string()),
+                    ),
+                    ("value", serde_json::json!(self)),
+                ]
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect();
+                Ok(map)
+            }
+            fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
+            where
+                Self: serde::de::DeserializeOwned,
+            {
+                crate::message::from_value::<Self>(map)
+            }
+        }
+    };
 }
+
+impl_message!(DoubleValue);
+impl_message!(FloatValue);
+impl_message!(Int64Value);
+impl_message!(UInt64Value);
+impl_message!(Int32Value);
+impl_message!(UInt32Value);
+impl_message!(BoolValue);
+impl_message!(StringValue);
 
 #[cfg(test)]
 mod test {
@@ -147,27 +158,51 @@ mod test {
     use super::*;
     use crate::Any;
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+    use test_case::test_case;
 
-    #[test]
-    fn test_bool_value() -> Result {
-        let input: BoolValue = true;
+    #[test_case(1234.5 as DoubleValue, "DoubleValue")]
+    #[test_case(9876.5 as FloatValue, "FloatValue")]
+    #[test_case(-1234567890123456789 as Int64Value, "Int64Value")]
+    #[test_case(-123 as Int32Value, "Int32Value")]
+    #[test_case(1234567890123456789 as UInt64Value, "UInt64Value")]
+    #[test_case(123 as UInt32Value, "UInt32Value")]
+    #[test_case(true as BoolValue, "BoolValue")]
+    #[test_case(StringValue::from("I am a string"), "StringValue")]
+    fn test_wrapper_in_any<T>(input: T, typename: &str) -> Result
+    where
+        T: crate::message::Message
+            + std::fmt::Debug
+            + PartialEq
+            + serde::de::DeserializeOwned
+            + serde::ser::Serialize,
+    {
         let any = Any::try_from(&input)?;
         let got = serde_json::to_value(&any)?;
         let want = serde_json::json!({
-            "@type": "type.googleapis.com/google.protobuf.BoolValue",
-            "value": true
+            "@type": format!("type.googleapis.com/google.protobuf.{}", typename),
+            "value": input,
         });
         assert_eq!(got, want);
-        let output = any.try_into_message::<BoolValue>()?;
+        let output = any.try_into_message::<T>()?;
         assert_eq!(output, input);
         Ok(())
     }
 
-    #[test]
-    fn test_bool_value_error() -> Result {
-        let input = serde_json::Value::Bool(true);
-        let any = Any::try_from(&input)?;
-        assert!(any.try_into_message::<BoolValue>().is_err());
+    #[test_case(Int32Value::default(), DoubleValue::default())]
+    #[test_case(Int32Value::default(), FloatValue::default())]
+    #[test_case(DoubleValue::default(), Int64Value::default())]
+    #[test_case(DoubleValue::default(), Int32Value::default())]
+    #[test_case(DoubleValue::default(), UInt64Value::default())]
+    #[test_case(DoubleValue::default(), UInt32Value::default())]
+    #[test_case(DoubleValue::default(), BoolValue::default())]
+    #[test_case(DoubleValue::default(), StringValue::default())]
+    fn test_wrapper_in_any_with_bad_types<T, U>(from: T, _into: U) -> Result
+    where
+        T: crate::message::Message + std::fmt::Debug + serde::ser::Serialize,
+        U: crate::message::Message + std::fmt::Debug + serde::de::DeserializeOwned,
+    {
+        let any = Any::try_from(&from)?;
+        assert!(any.try_into_message::<U>().is_err());
         Ok(())
     }
 }


### PR DESCRIPTION
Part of the work for #645 

Implement `Message` for the wrapper types (except for `BytesValue`, `UInt64Value`, and `Int64Value`, which require extra care to serialize/deserialize).

Use macros, because the code is repetitive.