### PR TITLE
impl(generator/rust): preserve path argument names

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -118,7 +118,7 @@ type pathInfoAnnotation struct {
 	Method        string
 	MethodToLower string
 	PathFmt       string
-	PathArgs      []string
+	PathArgs      []pathArg
 	HasPathArgs   bool
 	HasBody       bool
 }

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -799,19 +799,27 @@ func derefFieldPath(fieldPath string, message *api.Message, state *api.APIState)
 	return expression.String()
 }
 
-func httpPathArgs(h *api.PathInfo, method *api.Method, state *api.APIState) []string {
+type pathArg struct {
+	Name     string
+	Accessor string
+}
+
+func httpPathArgs(h *api.PathInfo, method *api.Method, state *api.APIState) []pathArg {
 	message, ok := state.MessageByID[method.InputTypeID]
 	if !ok {
 		slog.Error("cannot find input message for", "method", method)
-		return []string{}
+		return []pathArg{}
 	}
-	var args []string
+	var params []pathArg
 	for _, arg := range h.PathTemplate {
 		if arg.FieldPath != nil {
-			args = append(args, derefFieldPath(*arg.FieldPath, message, state))
+			params = append(params, pathArg{
+				Name:     *arg.FieldPath,
+				Accessor: derefFieldPath(*arg.FieldPath, message, state),
+			})
 		}
 	}
-	return args
+	return params
 }
 
 // Convert a name to `snake_case`. The Rust naming conventions use this style

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -2020,7 +2020,7 @@ func TestEnumNames(t *testing.T) {
 	}
 }
 
-func Test_RustPathFmt(t *testing.T) {
+func TestPathFmt(t *testing.T) {
 	for _, test := range []struct {
 		want     string
 		pathInfo *api.PathInfo
@@ -2067,7 +2067,7 @@ func Test_RustPathFmt(t *testing.T) {
 
 }
 
-func Test_RustPathArgs(t *testing.T) {
+func TestPathArgs(t *testing.T) {
 	subMessage := &api.Message{
 		Name: "Body",
 		ID:   ".test.Body",
@@ -2101,7 +2101,7 @@ func Test_RustPathArgs(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{subMessage, message}, []*api.Enum{}, []*api.Service{service})
 
 	for _, test := range []struct {
-		want     []string
+		want     []pathArg
 		pathInfo *api.PathInfo
 	}{
 		{
@@ -2113,7 +2113,7 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{".a"},
+			[]pathArg{{Name: "a", Accessor: ".a"}},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),
@@ -2121,7 +2121,12 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{`.b.as_ref().ok_or_else(|| gclient::path_parameter::missing("b"))?`},
+			[]pathArg{
+				{
+					Name:     "b",
+					Accessor: `.b.as_ref().ok_or_else(|| gclient::path_parameter::missing("b"))?`,
+				},
+			},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),
@@ -2130,7 +2135,7 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{`.c.value()`},
+			[]pathArg{{Name: "c", Accessor: `.c.value()`}},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),
@@ -2139,7 +2144,12 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{`.d.as_ref().ok_or_else(|| gclient::path_parameter::missing("d"))?.value()`},
+			[]pathArg{
+				{
+					Name:     "d",
+					Accessor: `.d.as_ref().ok_or_else(|| gclient::path_parameter::missing("d"))?.value()`,
+				},
+			},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),
@@ -2148,7 +2158,12 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{`.e.as_ref().ok_or_else(|| gclient::path_parameter::missing("e"))?.a`},
+			[]pathArg{
+				{
+					Name:     "e.a",
+					Accessor: `.e.as_ref().ok_or_else(|| gclient::path_parameter::missing("e"))?.a`,
+				},
+			},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),
@@ -2157,8 +2172,13 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{`.e.as_ref().ok_or_else(|| gclient::path_parameter::missing("e"))?` +
-				`.b.as_ref().ok_or_else(|| gclient::path_parameter::missing("b"))?`},
+			[]pathArg{
+				{
+					Name: "e.b",
+					Accessor: `.e.as_ref().ok_or_else(|| gclient::path_parameter::missing("e"))?` +
+						`.b.as_ref().ok_or_else(|| gclient::path_parameter::missing("b"))?`,
+				},
+			},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),
@@ -2167,8 +2187,13 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{`.e.as_ref().ok_or_else(|| gclient::path_parameter::missing("e"))?` +
-				`.c.value()`},
+			[]pathArg{
+				{
+					Name: "e.c",
+					Accessor: `.e.as_ref().ok_or_else(|| gclient::path_parameter::missing("e"))?` +
+						`.c.value()`,
+				},
+			},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),
@@ -2177,9 +2202,14 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{`.e.as_ref().ok_or_else(|| gclient::path_parameter::missing("e"))?` +
-				`.d.as_ref().ok_or_else(|| gclient::path_parameter::missing("d"))?` +
-				`.value()`},
+			[]pathArg{
+				{
+					Name: "e.d",
+					Accessor: `.e.as_ref().ok_or_else(|| gclient::path_parameter::missing("e"))?` +
+						`.d.as_ref().ok_or_else(|| gclient::path_parameter::missing("d"))?` +
+						`.value()`,
+				},
+			},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),
@@ -2188,7 +2218,16 @@ func Test_RustPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]string{".a", `.b.as_ref().ok_or_else(|| gclient::path_parameter::missing("b"))?`},
+			[]pathArg{
+				{
+					Name:     "a",
+					Accessor: ".a",
+				},
+				{
+					Name:     "b",
+					Accessor: `.b.as_ref().ok_or_else(|| gclient::path_parameter::missing("b"))?`,
+				},
+			},
 			&api.PathInfo{
 				PathTemplate: []api.PathSegment{
 					api.NewLiteralPathSegment("v1"),

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -66,7 +66,7 @@ impl super::stubs::{{Codec.Name}} for {{Codec.Name}} {
                 {{#PathInfo.Codec.HasPathArgs}}
                 format!("{{PathInfo.Codec.PathFmt}}"
                     {{#PathInfo.Codec.PathArgs}}
-                        , req{{{.}}}
+                        , req{{{Accessor}}}
                     {{/PathInfo.Codec.PathArgs}}
                 )
                 {{/PathInfo.Codec.HasPathArgs}}


### PR DESCRIPTION
We will need them to compute a full x-goog-request-params in gRPC-based
clients.

Part of the work for #1384
