### PR TITLE
impl(wkt): `BytesValue` in `Any`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4280,6 +4280,7 @@ dependencies = [
 name = "google-cloud-wkt"
 version = "0.2.0"
 dependencies = [
+ "base64",
  "bytes",
  "chrono",
  "google-cloud-wkt",

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -35,6 +35,7 @@ prost  = ["dep:prost-types"]
 time   = []
 
 [dependencies]
+base64      = "0.22"
 bytes       = { version = "1", features = ["serde"] }
 chrono      = { version = "0.4", optional = true }
 prost-types = { version = "0.13", optional = true }

--- a/src/wkt/src/wrappers.rs
+++ b/src/wkt/src/wrappers.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use base64::{engine::general_purpose::STANDARD, Engine};
+
 /// Implements the `google.cloud.DoubleValue` well-known type.
 ///
 /// In early versions of the `proto3` syntax optional primitive types were
@@ -212,8 +214,6 @@ impl crate::message::Message for Int64Value {
             .map_err(crate::AnyError::deser)
     }
 }
-
-use base64::{engine::general_purpose::STANDARD, Engine};
 
 impl crate::message::Message for BytesValue {
     fn typename() -> &'static str {


### PR DESCRIPTION
Fixes #645 

https://protobuf.dev/programming-guides/json/ says:

> JSON value will be the data encoded as a string using standard base64 encoding with paddings. Either standard or URL-safe base64 encoding with/without paddings are accepted."

I think using `STANDARD` as the base64 generator makes the most sense.