### PR TITLE
feat(generator/rust): skip duplicate enum values

### DIFF
--- a/generator/internal/rust/templates/common/enum.mustache
+++ b/generator/internal/rust/templates/common/enum.mustache
@@ -21,13 +21,13 @@ limitations under the License.
 pub struct {{Codec.Name}}(i32);
 
 impl {{Codec.Name}} {
-    {{#Values}}
+    {{#Codec.UniqueNames}}
 
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
     pub const {{Codec.Name}}: {{Codec.EnumType}} = {{Codec.EnumType}}::new({{Number}});
-    {{/Values}}
+    {{/Codec.UniqueNames}}
 
     /// Creates a new {{Codec.Name}} instance.
     pub(crate) const fn new(value: i32) -> Self {


### PR DESCRIPTION
After converting the enum value names to Rust style we may find some
duplicates. With this change the generator can skip the dups. In all
practical cases the dups are harmless, they differ in case but have the
name numeric value. We warn if this assumption fails.

part of the work for #829
