### PR TITLE
impl(gax-internal): HTTP clients require a feature

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -45,7 +45,7 @@ disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links"
 # These are used by crates with services.
 'package:async-trait' = 'used-if=services,package=async-trait,version=0.1'
 'package:gax'         = 'used-if=services,package=google-cloud-gax,path=src/gax,feature=unstable-sdk-client,version=0.21'
-'package:gaxi'        = 'used-if=services,package=google-cloud-gax-internal,path=src/gax-internal,version=0.1'
+'package:gaxi'        = 'used-if=services,package=google-cloud-gax-internal,path=src/gax-internal,feature=_internal_http_client,version=0.1'
 'package:lazy_static' = 'used-if=services,package=lazy_static,version=1'
 'package:reqwest'     = 'used-if=services,package=reqwest,version=0.12,feature=json'
 'package:serde_json'  = 'used-if=services,package=serde_json,version=1'

--- a/src/generated/api/apikeys/v2/Cargo.toml
+++ b/src/generated/api/apikeys/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/api/servicecontrol/v1/Cargo.toml
+++ b/src/generated/api/servicecontrol/v1/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 logging_type = { version = "0.2", path = "../../../../../src/generated/logging/type", package = "google-cloud-logging-type" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/api/servicecontrol/v2/Cargo.toml
+++ b/src/generated/api/servicecontrol/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/api/servicemanagement/v1/Cargo.toml
+++ b/src/generated/api/servicemanagement/v1/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/api/serviceusage/v1/Cargo.toml
+++ b/src/generated/api/serviceusage/v1/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/appengine/v1/Cargo.toml
+++ b/src/generated/appengine/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/bigtable/admin/v2/Cargo.toml
+++ b/src/generated/bigtable/admin/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/accessapproval/v1/Cargo.toml
+++ b/src/generated/cloud/accessapproval/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/advisorynotifications/v1/Cargo.toml
+++ b/src/generated/cloud/advisorynotifications/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/alloydb/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/apigateway/v1/Cargo.toml
+++ b/src/generated/cloud/apigateway/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/apigeeconnect/v1/Cargo.toml
+++ b/src/generated/cloud/apigeeconnect/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/apphub/v1/Cargo.toml
+++ b/src/generated/cloud/apphub/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/asset/v1/Cargo.toml
+++ b/src/generated/cloud/asset/v1/Cargo.toml
@@ -30,7 +30,7 @@ accesscontextmanager_v1 = { version = "0.2", path = "../../../../../src/generate
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/assuredworkloads/v1/Cargo.toml
+++ b/src/generated/cloud/assuredworkloads/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/backupdr/v1/Cargo.toml
+++ b/src/generated/cloud/backupdr/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/baremetalsolution/v2/Cargo.toml
+++ b/src/generated/cloud/baremetalsolution/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/bigquery/connection/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/connection/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/bigquery/migration/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/migration/v2/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../../src/generated/api/type
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/billing/v1/Cargo.toml
+++ b/src/generated/cloud/billing/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/binaryauthorization/v1/Cargo.toml
+++ b/src/generated/cloud/binaryauthorization/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 grafeas    = { version = "0.2", path = "../../../../../src/generated/grafeas/v1", package = "google-cloud-grafeas-v1" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/certificatemanager/v1/Cargo.toml
+++ b/src/generated/cloud/certificatemanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
+++ b/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/clouddms/v1/Cargo.toml
+++ b/src/generated/cloud/clouddms/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
+++ b/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/config/v1/Cargo.toml
+++ b/src/generated/cloud/config/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/connectors/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/datacatalog/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/datafusion/v1/Cargo.toml
+++ b/src/generated/cloud/datafusion/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/dataproc/v1/Cargo.toml
+++ b/src/generated/cloud/dataproc/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/datastream/v1/Cargo.toml
+++ b/src/generated/cloud/datastream/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/deploy/v1/Cargo.toml
+++ b/src/generated/cloud/deploy/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/developerconnect/v1/Cargo.toml
+++ b/src/generated/cloud/developerconnect/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/domains/v1/Cargo.toml
+++ b/src/generated/cloud/domains/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/edgecontainer/v1/Cargo.toml
+++ b/src/generated/cloud/edgecontainer/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/edgenetwork/v1/Cargo.toml
+++ b/src/generated/cloud/edgenetwork/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/essentialcontacts/v1/Cargo.toml
+++ b/src/generated/cloud/essentialcontacts/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/eventarc/v1/Cargo.toml
+++ b/src/generated/cloud/eventarc/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/filestore/v1/Cargo.toml
+++ b/src/generated/cloud/filestore/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 cloud_common = { version = "0.2", path = "../../../../../src/generated/cloud/common", package = "google-cloud-common" }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/financialservices/v1/Cargo.toml
+++ b/src/generated/cloud/financialservices/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/functions/v2/Cargo.toml
+++ b/src/generated/cloud/functions/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/gkebackup/v1/Cargo.toml
+++ b/src/generated/cloud/gkebackup/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
+++ b/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gkehub_configmanagement_v1 = { version = "0.2", path = "../../../../../src/generated/cloud/gkehub/configmanagement/v1", package = "google-cloud-gkehub-configmanagement-v1" }
 gkehub_multiclusteringress_v1 = { version = "0.2", path = "../../../../../src/generated/cloud/gkehub/multiclusteringress/v1", package = "google-cloud-gkehub-multiclusteringress-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/gkemulticloud/v1/Cargo.toml
+++ b/src/generated/cloud/gkemulticloud/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
+++ b/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
@@ -36,7 +36,7 @@ apps_script_type = { version = "0.2", path = "../../../../../src/generated/apps/
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/iap/v1/Cargo.toml
+++ b/src/generated/cloud/iap/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/ids/v1/Cargo.toml
+++ b/src/generated/cloud/ids/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/kms/inventory/v1/Cargo.toml
+++ b/src/generated/cloud/kms/inventory/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 kms        = { version = "0.2", path = "../../../../../../src/generated/cloud/kms/v1", package = "google-cloud-kms-v1" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/language/v2/Cargo.toml
+++ b/src/generated/cloud/language/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/managedidentities/v1/Cargo.toml
+++ b/src/generated/cloud/managedidentities/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/memcache/v1/Cargo.toml
+++ b/src/generated/cloud/memcache/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/memorystore/v1/Cargo.toml
+++ b/src/generated/cloud/memorystore/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/metastore/v1/Cargo.toml
+++ b/src/generated/cloud/metastore/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/migrationcenter/v1/Cargo.toml
+++ b/src/generated/cloud/migrationcenter/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/modelarmor/v1/Cargo.toml
+++ b/src/generated/cloud/modelarmor/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/networkconnectivity/v1/Cargo.toml
+++ b/src/generated/cloud/networkconnectivity/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/networkmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/networkmanagement/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/networksecurity/v1/Cargo.toml
+++ b/src/generated/cloud/networksecurity/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/networkservices/v1/Cargo.toml
+++ b/src/generated/cloud/networkservices/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/notebooks/v2/Cargo.toml
+++ b/src/generated/cloud/notebooks/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/optimization/v1/Cargo.toml
+++ b/src/generated/cloud/optimization/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/oracledatabase/v1/Cargo.toml
+++ b/src/generated/cloud/oracledatabase/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/orgpolicy/v2/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/osconfig/v1/Cargo.toml
+++ b/src/generated/cloud/osconfig/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/oslogin/v1/Cargo.toml
+++ b/src/generated/cloud/oslogin/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 oslogin_common = { version = "0.2", path = "../../../../../src/generated/oslogin/common", package = "google-cloud-oslogin-common" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/parallelstore/v1/Cargo.toml
+++ b/src/generated/cloud/parallelstore/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/parametermanager/v1/Cargo.toml
+++ b/src/generated/cloud/parametermanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/policysimulator/v1/Cargo.toml
+++ b/src/generated/cloud/policysimulator/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 iam_v2     = { version = "0.2", path = "../../../../../../src/generated/iam/v2", package = "google-cloud-iam-v2" }

--- a/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
+++ b/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/recommender/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/redis/cluster/v1/Cargo.toml
+++ b/src/generated/cloud/redis/cluster/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/redis/v1/Cargo.toml
+++ b/src/generated/cloud/redis/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/resourcemanager/v3/Cargo.toml
+++ b/src/generated/cloud/resourcemanager/v3/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/retail/v2/Cargo.toml
+++ b/src/generated/cloud/retail/v2/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/scheduler/v1/Cargo.toml
+++ b/src/generated/cloud/scheduler/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/securesourcemanager/v1/Cargo.toml
+++ b/src/generated/cloud/securesourcemanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/security/privateca/v1/Cargo.toml
+++ b/src/generated/cloud/security/privateca/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/cloud/security/publicca/v1/Cargo.toml
+++ b/src/generated/cloud/security/publicca/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/securityposture/v1/Cargo.toml
+++ b/src/generated/cloud/securityposture/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/servicedirectory/v1/Cargo.toml
+++ b/src/generated/cloud/servicedirectory/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/servicehealth/v1/Cargo.toml
+++ b/src/generated/cloud/servicehealth/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/cloud/shell/v1/Cargo.toml
+++ b/src/generated/cloud/shell/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/speech/v2/Cargo.toml
+++ b/src/generated/cloud/speech/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/sql/v1/Cargo.toml
+++ b/src/generated/cloud/sql/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/storageinsights/v1/Cargo.toml
+++ b/src/generated/cloud/storageinsights/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/support/v2/Cargo.toml
+++ b/src/generated/cloud/support/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/talent/v4/Cargo.toml
+++ b/src/generated/cloud/talent/v4/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/tasks/v2/Cargo.toml
+++ b/src/generated/cloud/tasks/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/telcoautomation/v1/Cargo.toml
+++ b/src/generated/cloud/telcoautomation/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/texttospeech/v1/Cargo.toml
+++ b/src/generated/cloud/texttospeech/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
+++ b/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/tpu/v2/Cargo.toml
+++ b/src/generated/cloud/tpu/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/video/livestream/v1/Cargo.toml
+++ b/src/generated/cloud/video/livestream/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/video/stitcher/v1/Cargo.toml
+++ b/src/generated/cloud/video/stitcher/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/video/transcoder/v1/Cargo.toml
+++ b/src/generated/cloud/video/transcoder/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/videointelligence/v1/Cargo.toml
+++ b/src/generated/cloud/videointelligence/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/vision/v1/Cargo.toml
+++ b/src/generated/cloud/vision/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/vmmigration/v1/Cargo.toml
+++ b/src/generated/cloud/vmmigration/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/vmwareengine/v1/Cargo.toml
+++ b/src/generated/cloud/vmwareengine/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/vpcaccess/v1/Cargo.toml
+++ b/src/generated/cloud/vpcaccess/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/cloud/websecurityscanner/v1/Cargo.toml
+++ b/src/generated/cloud/websecurityscanner/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/workflows/executions/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/executions/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/cloud/workstations/v1/Cargo.toml
+++ b/src/generated/cloud/workstations/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/container/v1/Cargo.toml
+++ b/src/generated/container/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/datastore/admin/v1/Cargo.toml
+++ b/src/generated/datastore/admin/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/devtools/artifactregistry/v1/Cargo.toml
+++ b/src/generated/devtools/artifactregistry/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/devtools/cloudbuild/v1/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v1/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/devtools/cloudprofiler/v2/Cargo.toml
+++ b/src/generated/devtools/cloudprofiler/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/devtools/cloudtrace/v2/Cargo.toml
+++ b/src/generated/devtools/cloudtrace/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/devtools/containeranalysis/v1/Cargo.toml
+++ b/src/generated/devtools/containeranalysis/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 grafeas    = { version = "0.2", path = "../../../../../src/generated/grafeas/v1", package = "google-cloud-grafeas-v1" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/firestore/admin/v1/Cargo.toml
+++ b/src/generated/firestore/admin/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/grafeas/v1/Cargo.toml
+++ b/src/generated/grafeas/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/iam/admin/v1/Cargo.toml
+++ b/src/generated/iam/admin/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/iam/credentials/v1/Cargo.toml
+++ b/src/generated/iam/credentials/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/iam/v2/Cargo.toml
+++ b/src/generated/iam/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/iam/v3/Cargo.toml
+++ b/src/generated/iam/v3/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/identity/accesscontextmanager/v1/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/v1/Cargo.toml
@@ -30,7 +30,7 @@ accesscontextmanager_type = { version = "0.2", path = "../../../../../src/genera
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }

--- a/src/generated/logging/v2/Cargo.toml
+++ b/src/generated/logging/v2/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../src/generated/api/types", pa
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 logging_type = { version = "0.2", path = "../../../../src/generated/logging/type", package = "google-cloud-logging-type" }
 longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/monitoring/dashboard/v1/Cargo.toml
+++ b/src/generated/monitoring/dashboard/v1/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../../src/generated/api/types",
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/monitoring/metricsscope/v1/Cargo.toml
+++ b/src/generated/monitoring/metricsscope/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }

--- a/src/generated/monitoring/v3/Cargo.toml
+++ b/src/generated/monitoring/v3/Cargo.toml
@@ -30,7 +30,7 @@ api        = { version = "0.2", path = "../../../../src/generated/api/types", pa
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -30,7 +30,7 @@ publish              = false
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/privacy/dlp/v2/Cargo.toml
+++ b/src/generated/privacy/dlp/v2/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 reqwest    = { version = "0.12", features = ["json"] }

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }

--- a/src/generated/storagetransfer/v1/Cargo.toml
+++ b/src/generated/storagetransfer/v1/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.21", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi       = { version = "0.1", path = "../../../../src/gax-internal", package = "google-cloud-gax-internal", features = ["_internal_http_client"] }
 gtype      = { version = "0.2", path = "../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }


### PR DESCRIPTION
All HTTP+JSON clients enable the `_internal_http_client` feature. This
feature does nothing at the moment. A future PR will hide some code
and dependencies behind it.

Part of the work for #1539
