### PR TITLE
cleanup: use `gax::options` directly

### DIFF
--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -41,7 +41,7 @@ impl std::fmt::Debug for {{Codec.Name}} {
 }
 
 impl {{Codec.Name}} {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/generator/testdata/rust/openapi/golden/src/transport.rs
+++ b/generator/testdata/rust/openapi/golden/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for SecretManagerService {
 }
 
 impl SecretManagerService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for IAMPolicy {
 }
 
 impl IAMPolicy {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/generator/testdata/rust/protobuf/golden/location/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Locations {
 }
 
 impl Locations {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for SecretManagerService {
 }
 
 impl SecretManagerService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/api/apikeys/v2/src/transport.rs
+++ b/src/generated/api/apikeys/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ApiKeys {
 }
 
 impl ApiKeys {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/api/servicecontrol/v1/src/transport.rs
+++ b/src/generated/api/servicecontrol/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for QuotaController {
 }
 
 impl QuotaController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -76,7 +76,7 @@ impl std::fmt::Debug for ServiceController {
 }
 
 impl ServiceController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/api/servicecontrol/v2/src/transport.rs
+++ b/src/generated/api/servicecontrol/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ServiceController {
 }
 
 impl ServiceController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/api/servicemanagement/v1/src/transport.rs
+++ b/src/generated/api/servicemanagement/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ServiceManager {
 }
 
 impl ServiceManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/api/serviceusage/v1/src/transport.rs
+++ b/src/generated/api/serviceusage/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ServiceUsage {
 }
 
 impl ServiceUsage {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/appengine/v1/src/transport.rs
+++ b/src/generated/appengine/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Applications {
 }
 
 impl Applications {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -195,7 +195,7 @@ impl std::fmt::Debug for Services {
 }
 
 impl Services {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -362,7 +362,7 @@ impl std::fmt::Debug for Versions {
 }
 
 impl Versions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -552,7 +552,7 @@ impl std::fmt::Debug for Instances {
 }
 
 impl Instances {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -709,7 +709,7 @@ impl std::fmt::Debug for Firewall {
 }
 
 impl Firewall {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -903,7 +903,7 @@ impl std::fmt::Debug for AuthorizedDomains {
 }
 
 impl AuthorizedDomains {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -991,7 +991,7 @@ impl std::fmt::Debug for AuthorizedCertificates {
 }
 
 impl AuthorizedCertificates {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1170,7 +1170,7 @@ impl std::fmt::Debug for DomainMappings {
 }
 
 impl DomainMappings {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/bigtable/admin/v2/src/transport.rs
+++ b/src/generated/bigtable/admin/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for BigtableInstanceAdmin {
 }
 
 impl BigtableInstanceAdmin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -899,7 +899,7 @@ impl std::fmt::Debug for BigtableTableAdmin {
 }
 
 impl BigtableTableAdmin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/accessapproval/v1/src/transport.rs
+++ b/src/generated/cloud/accessapproval/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AccessApproval {
 }
 
 impl AccessApproval {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/advisorynotifications/v1/src/transport.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AdvisoryNotificationsService {
 }
 
 impl AdvisoryNotificationsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/aiplatform/v1/src/transport.rs
+++ b/src/generated/cloud/aiplatform/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DatasetService {
 }
 
 impl DatasetService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -849,7 +849,7 @@ impl std::fmt::Debug for DeploymentResourcePoolService {
 }
 
 impl DeploymentResourcePoolService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1257,7 +1257,7 @@ impl std::fmt::Debug for EndpointService {
 }
 
 impl EndpointService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1742,7 +1742,7 @@ impl std::fmt::Debug for EvaluationService {
 }
 
 impl EvaluationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2012,7 +2012,7 @@ impl std::fmt::Debug for FeatureOnlineStoreAdminService {
 }
 
 impl FeatureOnlineStoreAdminService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2593,7 +2593,7 @@ impl std::fmt::Debug for FeatureOnlineStoreService {
 }
 
 impl FeatureOnlineStoreService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2883,7 +2883,7 @@ impl std::fmt::Debug for FeatureRegistryService {
 }
 
 impl FeatureRegistryService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3426,7 +3426,7 @@ impl std::fmt::Debug for FeaturestoreOnlineServingService {
 }
 
 impl FeaturestoreOnlineServingService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3716,7 +3716,7 @@ impl std::fmt::Debug for FeaturestoreService {
 }
 
 impl FeaturestoreService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -4510,7 +4510,7 @@ impl std::fmt::Debug for GenAiCacheService {
 }
 
 impl GenAiCacheService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -4882,7 +4882,7 @@ impl std::fmt::Debug for GenAiTuningService {
 }
 
 impl GenAiTuningService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -5249,7 +5249,7 @@ impl std::fmt::Debug for IndexEndpointService {
 }
 
 impl IndexEndpointService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -5708,7 +5708,7 @@ impl std::fmt::Debug for IndexService {
 }
 
 impl IndexService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -6135,7 +6135,7 @@ impl std::fmt::Debug for JobService {
 }
 
 impl JobService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -7189,7 +7189,7 @@ impl std::fmt::Debug for LlmUtilityService {
 }
 
 impl LlmUtilityService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -7479,7 +7479,7 @@ impl std::fmt::Debug for MatchService {
 }
 
 impl MatchService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -7769,7 +7769,7 @@ impl std::fmt::Debug for MetadataService {
 }
 
 impl MetadataService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -8773,7 +8773,7 @@ impl std::fmt::Debug for MigrationService {
 }
 
 impl MigrationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -9077,7 +9077,7 @@ impl std::fmt::Debug for ModelGardenService {
 }
 
 impl ModelGardenService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -9350,7 +9350,7 @@ impl std::fmt::Debug for ModelService {
 }
 
 impl ModelService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -10065,7 +10065,7 @@ impl std::fmt::Debug for NotebookService {
 }
 
 impl NotebookService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -10701,7 +10701,7 @@ impl std::fmt::Debug for PersistentResourceService {
 }
 
 impl PersistentResourceService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -11105,7 +11105,7 @@ impl std::fmt::Debug for PipelineService {
 }
 
 impl PipelineService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -11635,7 +11635,7 @@ impl std::fmt::Debug for PredictionService {
 }
 
 impl PredictionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -12005,7 +12005,7 @@ impl std::fmt::Debug for ReasoningEngineExecutionService {
 }
 
 impl ReasoningEngineExecutionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -12272,7 +12272,7 @@ impl std::fmt::Debug for ReasoningEngineService {
 }
 
 impl ReasoningEngineService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -12659,7 +12659,7 @@ impl std::fmt::Debug for ScheduleService {
 }
 
 impl ScheduleService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -13081,7 +13081,7 @@ impl std::fmt::Debug for SpecialistPoolService {
 }
 
 impl SpecialistPoolService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -13478,7 +13478,7 @@ impl std::fmt::Debug for TensorboardService {
 }
 
 impl TensorboardService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -14473,7 +14473,7 @@ impl std::fmt::Debug for VertexRagDataService {
 }
 
 impl VertexRagDataService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -14949,7 +14949,7 @@ impl std::fmt::Debug for VertexRagService {
 }
 
 impl VertexRagService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -15259,7 +15259,7 @@ impl std::fmt::Debug for VizierService {
 }
 
 impl VizierService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/alloydb/v1/src/transport.rs
+++ b/src/generated/cloud/alloydb/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AlloyDBAdmin {
 }
 
 impl AlloyDBAdmin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/apigateway/v1/src/transport.rs
+++ b/src/generated/cloud/apigateway/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ApiGatewayService {
 }
 
 impl ApiGatewayService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/apigeeconnect/v1/src/transport.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ConnectionService {
 }
 
 impl ConnectionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/apihub/v1/src/transport.rs
+++ b/src/generated/cloud/apihub/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ApiHub {
 }
 
 impl ApiHub {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -998,7 +998,7 @@ impl std::fmt::Debug for ApiHubDependencies {
 }
 
 impl ApiHubDependencies {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1263,7 +1263,7 @@ impl std::fmt::Debug for HostProjectRegistrationService {
 }
 
 impl HostProjectRegistrationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1475,7 +1475,7 @@ impl std::fmt::Debug for LintingService {
 }
 
 impl LintingService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1709,7 +1709,7 @@ impl std::fmt::Debug for ApiHubPlugin {
 }
 
 impl ApiHubPlugin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1903,7 +1903,7 @@ impl std::fmt::Debug for Provisioning {
 }
 
 impl Provisioning {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2122,7 +2122,7 @@ impl std::fmt::Debug for RuntimeProjectAttachmentService {
 }
 
 impl RuntimeProjectAttachmentService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/apphub/v1/src/transport.rs
+++ b/src/generated/cloud/apphub/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AppHub {
 }
 
 impl AppHub {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/asset/v1/src/transport.rs
+++ b/src/generated/cloud/asset/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AssetService {
 }
 
 impl AssetService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/assuredworkloads/v1/src/transport.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AssuredWorkloadsService {
 }
 
 impl AssuredWorkloadsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/backupdr/v1/src/transport.rs
+++ b/src/generated/cloud/backupdr/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for BackupDR {
 }
 
 impl BackupDR {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/baremetalsolution/v2/src/transport.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for BareMetalSolution {
 }
 
 impl BareMetalSolution {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AppConnectionsService {
 }
 
 impl AppConnectionsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AppConnectorsService {
 }
 
 impl AppConnectorsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AppGatewaysService {
 }
 
 impl AppGatewaysService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ClientConnectorServicesService {
 }
 
 impl ClientConnectorServicesService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ClientGatewaysService {
 }
 
 impl ClientGatewaysService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AnalyticsHubService {
 }
 
 impl AnalyticsHubService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/bigquery/connection/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ConnectionService {
 }
 
 impl ConnectionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DataPolicyService {
 }
 
 impl DataPolicyService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DataTransferService {
 }
 
 impl DataTransferService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/bigquery/migration/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for MigrationService {
 }
 
 impl MigrationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ReservationService {
 }
 
 impl ReservationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/billing/v1/src/transport.rs
+++ b/src/generated/cloud/billing/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudBilling {
 }
 
 impl CloudBilling {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -301,7 +301,7 @@ impl std::fmt::Debug for CloudCatalog {
 }
 
 impl CloudCatalog {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/binaryauthorization/v1/src/transport.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for BinauthzManagementServiceV1 {
 }
 
 impl BinauthzManagementServiceV1 {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -214,7 +214,7 @@ impl std::fmt::Debug for SystemPolicyV1 {
 }
 
 impl SystemPolicyV1 {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -256,7 +256,7 @@ impl std::fmt::Debug for ValidationHelperV1 {
 }
 
 impl ValidationHelperV1 {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/certificatemanager/v1/src/transport.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CertificateManager {
 }
 
 impl CertificateManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudControlsPartnerCore {
 }
 
 impl CloudControlsPartnerCore {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -229,7 +229,7 @@ impl std::fmt::Debug for CloudControlsPartnerMonitoring {
 }
 
 impl CloudControlsPartnerMonitoring {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/clouddms/v1/src/transport.rs
+++ b/src/generated/cloud/clouddms/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DataMigrationService {
 }
 
 impl DataMigrationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for LicenseManagementService {
 }
 
 impl LicenseManagementService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -193,7 +193,7 @@ impl std::fmt::Debug for ConsumerProcurementService {
 }
 
 impl ConsumerProcurementService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ConfidentialComputing {
 }
 
 impl ConfidentialComputing {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/config/v1/src/transport.rs
+++ b/src/generated/cloud/config/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Config {
 }
 
 impl Config {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/connectors/v1/src/transport.rs
+++ b/src/generated/cloud/connectors/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Connectors {
 }
 
 impl Connectors {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ContactCenterInsights {
 }
 
 impl ContactCenterInsights {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Lineage {
 }
 
 impl Lineage {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/datacatalog/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DataCatalog {
 }
 
 impl DataCatalog {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -991,7 +991,7 @@ impl std::fmt::Debug for PolicyTagManager {
 }
 
 impl PolicyTagManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1398,7 +1398,7 @@ impl std::fmt::Debug for PolicyTagManagerSerialization {
 }
 
 impl PolicyTagManagerSerialization {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/datafusion/v1/src/transport.rs
+++ b/src/generated/cloud/datafusion/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DataFusion {
 }
 
 impl DataFusion {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/dataproc/v1/src/transport.rs
+++ b/src/generated/cloud/dataproc/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AutoscalingPolicyService {
 }
 
 impl AutoscalingPolicyService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -303,7 +303,7 @@ impl std::fmt::Debug for BatchController {
 }
 
 impl BatchController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -559,7 +559,7 @@ impl std::fmt::Debug for ClusterController {
 }
 
 impl ClusterController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -960,7 +960,7 @@ impl std::fmt::Debug for JobController {
 }
 
 impl JobController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1318,7 +1318,7 @@ impl std::fmt::Debug for NodeGroupController {
 }
 
 impl NodeGroupController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1554,7 +1554,7 @@ impl std::fmt::Debug for SessionTemplateController {
 }
 
 impl SessionTemplateController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1829,7 +1829,7 @@ impl std::fmt::Debug for SessionController {
 }
 
 impl SessionController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2107,7 +2107,7 @@ impl std::fmt::Debug for WorkflowTemplateService {
 }
 
 impl WorkflowTemplateService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/datastream/v1/src/transport.rs
+++ b/src/generated/cloud/datastream/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Datastream {
 }
 
 impl Datastream {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/deploy/v1/src/transport.rs
+++ b/src/generated/cloud/deploy/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudDeploy {
 }
 
 impl CloudDeploy {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/developerconnect/v1/src/transport.rs
+++ b/src/generated/cloud/developerconnect/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DeveloperConnect {
 }
 
 impl DeveloperConnect {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Agents {
 }
 
 impl Agents {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -412,7 +412,7 @@ impl std::fmt::Debug for Changelogs {
 }
 
 impl Changelogs {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -580,7 +580,7 @@ impl std::fmt::Debug for Deployments {
 }
 
 impl Deployments {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -747,7 +747,7 @@ impl std::fmt::Debug for EntityTypes {
 }
 
 impl EntityTypes {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1052,7 +1052,7 @@ impl std::fmt::Debug for Environments {
 }
 
 impl Environments {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1400,7 +1400,7 @@ impl std::fmt::Debug for Experiments {
 }
 
 impl Experiments {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1678,7 +1678,7 @@ impl std::fmt::Debug for Flows {
 }
 
 impl Flows {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2024,7 +2024,7 @@ impl std::fmt::Debug for Generators {
 }
 
 impl Generators {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2275,7 +2275,7 @@ impl std::fmt::Debug for Intents {
 }
 
 impl Intents {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2568,7 +2568,7 @@ impl std::fmt::Debug for Pages {
 }
 
 impl Pages {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2809,7 +2809,7 @@ impl std::fmt::Debug for SecuritySettingsService {
 }
 
 impl SecuritySettingsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3055,7 +3055,7 @@ impl std::fmt::Debug for Sessions {
 }
 
 impl Sessions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3265,7 +3265,7 @@ impl std::fmt::Debug for SessionEntityTypes {
 }
 
 impl SessionEntityTypes {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3511,7 +3511,7 @@ impl std::fmt::Debug for TestCases {
 }
 
 impl TestCases {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3914,7 +3914,7 @@ impl std::fmt::Debug for TransitionRouteGroups {
 }
 
 impl TransitionRouteGroups {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -4165,7 +4165,7 @@ impl std::fmt::Debug for Versions {
 }
 
 impl Versions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -4459,7 +4459,7 @@ impl std::fmt::Debug for Webhooks {
 }
 
 impl Webhooks {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/dialogflow/v2/src/transport.rs
+++ b/src/generated/cloud/dialogflow/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Agents {
 }
 
 impl Agents {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -372,7 +372,7 @@ impl std::fmt::Debug for AnswerRecords {
 }
 
 impl AnswerRecords {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -559,7 +559,7 @@ impl std::fmt::Debug for Contexts {
 }
 
 impl Contexts {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -824,7 +824,7 @@ impl std::fmt::Debug for Conversations {
 }
 
 impl Conversations {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1183,7 +1183,7 @@ impl std::fmt::Debug for ConversationDatasets {
 }
 
 impl ConversationDatasets {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1425,7 +1425,7 @@ impl std::fmt::Debug for ConversationModels {
 }
 
 impl ConversationModels {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1744,7 +1744,7 @@ impl std::fmt::Debug for ConversationProfiles {
 }
 
 impl ConversationProfiles {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2050,7 +2050,7 @@ impl std::fmt::Debug for Documents {
 }
 
 impl Documents {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2365,7 +2365,7 @@ impl std::fmt::Debug for EncryptionSpecService {
 }
 
 impl EncryptionSpecService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2548,7 +2548,7 @@ impl std::fmt::Debug for EntityTypes {
 }
 
 impl EntityTypes {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2912,7 +2912,7 @@ impl std::fmt::Debug for Environments {
 }
 
 impl Environments {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3184,7 +3184,7 @@ impl std::fmt::Debug for Fulfillments {
 }
 
 impl Fulfillments {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3365,7 +3365,7 @@ impl std::fmt::Debug for Generators {
 }
 
 impl Generators {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3612,7 +3612,7 @@ impl std::fmt::Debug for Intents {
 }
 
 impl Intents {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -3910,7 +3910,7 @@ impl std::fmt::Debug for KnowledgeBases {
 }
 
 impl KnowledgeBases {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -4158,7 +4158,7 @@ impl std::fmt::Debug for Participants {
 }
 
 impl Participants {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -4485,7 +4485,7 @@ impl std::fmt::Debug for Sessions {
 }
 
 impl Sessions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -4629,7 +4629,7 @@ impl std::fmt::Debug for SessionEntityTypes {
 }
 
 impl SessionEntityTypes {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -4875,7 +4875,7 @@ impl std::fmt::Debug for Versions {
 }
 
 impl Versions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/discoveryengine/v1/src/transport.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CompletionService {
 }
 
 impl CompletionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -234,7 +234,7 @@ impl std::fmt::Debug for ControlService {
 }
 
 impl ControlService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -436,7 +436,7 @@ impl std::fmt::Debug for ConversationalSearchService {
 }
 
 impl ConversationalSearchService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -818,7 +818,7 @@ impl std::fmt::Debug for DataStoreService {
 }
 
 impl DataStoreService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1043,7 +1043,7 @@ impl std::fmt::Debug for DocumentService {
 }
 
 impl DocumentService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1334,7 +1334,7 @@ impl std::fmt::Debug for EngineService {
 }
 
 impl EngineService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1543,7 +1543,7 @@ impl std::fmt::Debug for GroundedGenerationService {
 }
 
 impl GroundedGenerationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1664,7 +1664,7 @@ impl std::fmt::Debug for ProjectService {
 }
 
 impl ProjectService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1776,7 +1776,7 @@ impl std::fmt::Debug for RankService {
 }
 
 impl RankService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1877,7 +1877,7 @@ impl std::fmt::Debug for RecommendationService {
 }
 
 impl RecommendationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1978,7 +1978,7 @@ impl std::fmt::Debug for SchemaService {
 }
 
 impl SchemaService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2177,7 +2177,7 @@ impl std::fmt::Debug for SearchService {
 }
 
 impl SearchService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2298,7 +2298,7 @@ impl std::fmt::Debug for SearchTuningService {
 }
 
 impl SearchTuningService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2435,7 +2435,7 @@ impl std::fmt::Debug for SiteSearchEngineService {
 }
 
 impl SiteSearchEngineService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -2788,7 +2788,7 @@ impl std::fmt::Debug for UserEventService {
 }
 
 impl UserEventService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/documentai/v1/src/transport.rs
+++ b/src/generated/cloud/documentai/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DocumentProcessorService {
 }
 
 impl DocumentProcessorService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/domains/v1/src/transport.rs
+++ b/src/generated/cloud/domains/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Domains {
 }
 
 impl Domains {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/edgecontainer/v1/src/transport.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for EdgeContainer {
 }
 
 impl EdgeContainer {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/edgenetwork/v1/src/transport.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for EdgeNetwork {
 }
 
 impl EdgeNetwork {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/essentialcontacts/v1/src/transport.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for EssentialContactsService {
 }
 
 impl EssentialContactsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/eventarc/v1/src/transport.rs
+++ b/src/generated/cloud/eventarc/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Eventarc {
 }
 
 impl Eventarc {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/filestore/v1/src/transport.rs
+++ b/src/generated/cloud/filestore/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudFilestoreManager {
 }
 
 impl CloudFilestoreManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/financialservices/v1/src/transport.rs
+++ b/src/generated/cloud/financialservices/v1/src/transport.rs
@@ -31,7 +31,7 @@ impl std::fmt::Debug for Aml {
 }
 
 impl Aml {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/functions/v2/src/transport.rs
+++ b/src/generated/cloud/functions/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for FunctionService {
 }
 
 impl FunctionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/gkebackup/v1/src/transport.rs
+++ b/src/generated/cloud/gkebackup/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for BackupForGKE {
 }
 
 impl BackupForGKE {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for GatewayControl {
 }
 
 impl GatewayControl {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/gkehub/v1/src/transport.rs
+++ b/src/generated/cloud/gkehub/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for GkeHub {
 }
 
 impl GkeHub {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/gkemulticloud/v1/src/transport.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AttachedClusters {
 }
 
 impl AttachedClusters {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -372,7 +372,7 @@ impl std::fmt::Debug for AwsClusters {
 }
 
 impl AwsClusters {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -866,7 +866,7 @@ impl std::fmt::Debug for AzureClusters {
 }
 
 impl AzureClusters {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for GSuiteAddOns {
 }
 
 impl GSuiteAddOns {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/iap/v1/src/transport.rs
+++ b/src/generated/cloud/iap/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for IdentityAwareProxyAdminService {
 }
 
 impl IdentityAwareProxyAdminService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -299,7 +299,7 @@ impl std::fmt::Debug for IdentityAwareProxyOAuthService {
 }
 
 impl IdentityAwareProxyOAuthService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/ids/v1/src/transport.rs
+++ b/src/generated/cloud/ids/v1/src/transport.rs
@@ -31,7 +31,7 @@ impl std::fmt::Debug for Ids {
 }
 
 impl Ids {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/kms/inventory/v1/src/transport.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for KeyDashboardService {
 }
 
 impl KeyDashboardService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -80,7 +80,7 @@ impl std::fmt::Debug for KeyTrackingService {
 }
 
 impl KeyTrackingService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/kms/v1/src/transport.rs
+++ b/src/generated/cloud/kms/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Autokey {
 }
 
 impl Autokey {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -269,7 +269,7 @@ impl std::fmt::Debug for AutokeyAdmin {
 }
 
 impl AutokeyAdmin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -503,7 +503,7 @@ impl std::fmt::Debug for EkmService {
 }
 
 impl EkmService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -843,7 +843,7 @@ impl std::fmt::Debug for KeyManagementService {
 }
 
 impl KeyManagementService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/language/v2/src/transport.rs
+++ b/src/generated/cloud/language/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for LanguageService {
 }
 
 impl LanguageService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/location/src/transport.rs
+++ b/src/generated/cloud/location/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Locations {
 }
 
 impl Locations {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/managedidentities/v1/src/transport.rs
+++ b/src/generated/cloud/managedidentities/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ManagedIdentitiesService {
 }
 
 impl ManagedIdentitiesService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/memcache/v1/src/transport.rs
+++ b/src/generated/cloud/memcache/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudMemcache {
 }
 
 impl CloudMemcache {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/memorystore/v1/src/transport.rs
+++ b/src/generated/cloud/memorystore/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Memorystore {
 }
 
 impl Memorystore {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/metastore/v1/src/transport.rs
+++ b/src/generated/cloud/metastore/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DataprocMetastore {
 }
 
 impl DataprocMetastore {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -674,7 +674,7 @@ impl std::fmt::Debug for DataprocMetastoreFederation {
 }
 
 impl DataprocMetastoreFederation {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/migrationcenter/v1/src/transport.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for MigrationCenter {
 }
 
 impl MigrationCenter {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/modelarmor/v1/src/transport.rs
+++ b/src/generated/cloud/modelarmor/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ModelArmor {
 }
 
 impl ModelArmor {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/netapp/v1/src/transport.rs
+++ b/src/generated/cloud/netapp/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for NetApp {
 }
 
 impl NetApp {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/networkconnectivity/v1/src/transport.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for HubService {
 }
 
 impl HubService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -756,7 +756,7 @@ impl std::fmt::Debug for PolicyBasedRoutingService {
 }
 
 impl PolicyBasedRoutingService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/networkmanagement/v1/src/transport.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ReachabilityService {
 }
 
 impl ReachabilityService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -402,7 +402,7 @@ impl std::fmt::Debug for VpcFlowLogsService {
 }
 
 impl VpcFlowLogsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/networksecurity/v1/src/transport.rs
+++ b/src/generated/cloud/networksecurity/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for NetworkSecurity {
 }
 
 impl NetworkSecurity {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/networkservices/v1/src/transport.rs
+++ b/src/generated/cloud/networkservices/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DepService {
 }
 
 impl DepService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -516,7 +516,7 @@ impl std::fmt::Debug for NetworkServices {
 }
 
 impl NetworkServices {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/notebooks/v2/src/transport.rs
+++ b/src/generated/cloud/notebooks/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for NotebookService {
 }
 
 impl NotebookService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/optimization/v1/src/transport.rs
+++ b/src/generated/cloud/optimization/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for FleetRouting {
 }
 
 impl FleetRouting {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/oracledatabase/v1/src/transport.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for OracleDatabase {
 }
 
 impl OracleDatabase {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Environments {
 }
 
 impl Environments {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -654,7 +654,7 @@ impl std::fmt::Debug for ImageVersions {
 }
 
 impl ImageVersions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/orgpolicy/v2/src/transport.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for OrgPolicy {
 }
 
 impl OrgPolicy {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/osconfig/v1/src/transport.rs
+++ b/src/generated/cloud/osconfig/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for OsConfigService {
 }
 
 impl OsConfigService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -355,7 +355,7 @@ impl std::fmt::Debug for OsConfigZonalService {
 }
 
 impl OsConfigZonalService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/oslogin/v1/src/transport.rs
+++ b/src/generated/cloud/oslogin/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for OsLoginService {
 }
 
 impl OsLoginService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/parallelstore/v1/src/transport.rs
+++ b/src/generated/cloud/parallelstore/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Parallelstore {
 }
 
 impl Parallelstore {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/parametermanager/v1/src/transport.rs
+++ b/src/generated/cloud/parametermanager/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ParameterManager {
 }
 
 impl ParameterManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/policysimulator/v1/src/transport.rs
+++ b/src/generated/cloud/policysimulator/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Simulator {
 }
 
 impl Simulator {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/transport.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for PolicyTroubleshooter {
 }
 
 impl PolicyTroubleshooter {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/policytroubleshooter/v1/src/transport.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for IamChecker {
 }
 
 impl IamChecker {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for PrivilegedAccessManager {
 }
 
 impl PrivilegedAccessManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for RapidMigrationAssessment {
 }
 
 impl RapidMigrationAssessment {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for RecaptchaEnterpriseService {
 }
 
 impl RecaptchaEnterpriseService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/recommender/v1/src/transport.rs
+++ b/src/generated/cloud/recommender/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Recommender {
 }
 
 impl Recommender {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/redis/cluster/v1/src/transport.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudRedisCluster {
 }
 
 impl CloudRedisCluster {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/redis/v1/src/transport.rs
+++ b/src/generated/cloud/redis/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudRedis {
 }
 
 impl CloudRedis {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/resourcemanager/v3/src/transport.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Folders {
 }
 
 impl Folders {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -319,7 +319,7 @@ impl std::fmt::Debug for Organizations {
 }
 
 impl Organizations {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -462,7 +462,7 @@ impl std::fmt::Debug for Projects {
 }
 
 impl Projects {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -752,7 +752,7 @@ impl std::fmt::Debug for TagBindings {
 }
 
 impl TagBindings {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -891,7 +891,7 @@ impl std::fmt::Debug for TagHolds {
 }
 
 impl TagHolds {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1012,7 +1012,7 @@ impl std::fmt::Debug for TagKeys {
 }
 
 impl TagKeys {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1269,7 +1269,7 @@ impl std::fmt::Debug for TagValues {
 }
 
 impl TagValues {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/retail/v2/src/transport.rs
+++ b/src/generated/cloud/retail/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AnalyticsService {
 }
 
 impl AnalyticsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -131,7 +131,7 @@ impl std::fmt::Debug for CatalogService {
 }
 
 impl CatalogService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -470,7 +470,7 @@ impl std::fmt::Debug for CompletionService {
 }
 
 impl CompletionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -604,7 +604,7 @@ impl std::fmt::Debug for ControlService {
 }
 
 impl ControlService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -789,7 +789,7 @@ impl std::fmt::Debug for GenerativeQuestionService {
 }
 
 impl GenerativeQuestionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -999,7 +999,7 @@ impl std::fmt::Debug for ModelService {
 }
 
 impl ModelService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1241,7 +1241,7 @@ impl std::fmt::Debug for PredictionService {
 }
 
 impl PredictionService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1325,7 +1325,7 @@ impl std::fmt::Debug for ProductService {
 }
 
 impl ProductService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1681,7 +1681,7 @@ impl std::fmt::Debug for SearchService {
 }
 
 impl SearchService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1765,7 +1765,7 @@ impl std::fmt::Debug for ServingConfigService {
 }
 
 impl ServingConfigService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1992,7 +1992,7 @@ impl std::fmt::Debug for UserEventService {
 }
 
 impl UserEventService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/run/v2/src/transport.rs
+++ b/src/generated/cloud/run/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Builds {
 }
 
 impl Builds {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -153,7 +153,7 @@ impl std::fmt::Debug for Executions {
 }
 
 impl Executions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -347,7 +347,7 @@ impl std::fmt::Debug for Jobs {
 }
 
 impl Jobs {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -659,7 +659,7 @@ impl std::fmt::Debug for Revisions {
 }
 
 impl Revisions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -838,7 +838,7 @@ impl std::fmt::Debug for Services {
 }
 
 impl Services {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1148,7 +1148,7 @@ impl std::fmt::Debug for Tasks {
 }
 
 impl Tasks {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/scheduler/v1/src/transport.rs
+++ b/src/generated/cloud/scheduler/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudScheduler {
 }
 
 impl CloudScheduler {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for SecretManagerService {
 }
 
 impl SecretManagerService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/securesourcemanager/v1/src/transport.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for SecureSourceManager {
 }
 
 impl SecureSourceManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/security/privateca/v1/src/transport.rs
+++ b/src/generated/cloud/security/privateca/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CertificateAuthorityService {
 }
 
 impl CertificateAuthorityService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/security/publicca/v1/src/transport.rs
+++ b/src/generated/cloud/security/publicca/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for PublicCertificateAuthorityService {
 }
 
 impl PublicCertificateAuthorityService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/securitycenter/v2/src/transport.rs
+++ b/src/generated/cloud/securitycenter/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for SecurityCenter {
 }
 
 impl SecurityCenter {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/securityposture/v1/src/transport.rs
+++ b/src/generated/cloud/securityposture/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for SecurityPosture {
 }
 
 impl SecurityPosture {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/servicedirectory/v1/src/transport.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for LookupService {
 }
 
 impl LookupService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -114,7 +114,7 @@ impl std::fmt::Debug for RegistrationService {
 }
 
 impl RegistrationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/servicehealth/v1/src/transport.rs
+++ b/src/generated/cloud/servicehealth/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ServiceHealth {
 }
 
 impl ServiceHealth {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/shell/v1/src/transport.rs
+++ b/src/generated/cloud/shell/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudShellService {
 }
 
 impl CloudShellService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/speech/v2/src/transport.rs
+++ b/src/generated/cloud/speech/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Speech {
 }
 
 impl Speech {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/sql/v1/src/transport.rs
+++ b/src/generated/cloud/sql/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for SqlBackupRunsService {
 }
 
 impl SqlBackupRunsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -161,7 +161,7 @@ impl std::fmt::Debug for SqlConnectService {
 }
 
 impl SqlConnectService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -236,7 +236,7 @@ impl std::fmt::Debug for SqlDatabasesService {
 }
 
 impl SqlDatabasesService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -414,7 +414,7 @@ impl std::fmt::Debug for SqlFlagsService {
 }
 
 impl SqlFlagsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -461,7 +461,7 @@ impl std::fmt::Debug for SqlInstancesService {
 }
 
 impl SqlInstancesService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1338,7 +1338,7 @@ impl std::fmt::Debug for SqlOperationsService {
 }
 
 impl SqlOperationsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1439,7 +1439,7 @@ impl std::fmt::Debug for SqlSslCertsService {
 }
 
 impl SqlSslCertsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1565,7 +1565,7 @@ impl std::fmt::Debug for SqlTiersService {
 }
 
 impl SqlTiersService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1613,7 +1613,7 @@ impl std::fmt::Debug for SqlUsersService {
 }
 
 impl SqlUsersService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/storageinsights/v1/src/transport.rs
+++ b/src/generated/cloud/storageinsights/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for StorageInsights {
 }
 
 impl StorageInsights {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/support/v2/src/transport.rs
+++ b/src/generated/cloud/support/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CaseAttachmentService {
 }
 
 impl CaseAttachmentService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -80,7 +80,7 @@ impl std::fmt::Debug for CaseService {
 }
 
 impl CaseService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -281,7 +281,7 @@ impl std::fmt::Debug for CommentService {
 }
 
 impl CommentService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/talent/v4/src/transport.rs
+++ b/src/generated/cloud/talent/v4/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CompanyService {
 }
 
 impl CompanyService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -198,7 +198,7 @@ impl std::fmt::Debug for Completion {
 }
 
 impl Completion {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -271,7 +271,7 @@ impl std::fmt::Debug for EventService {
 }
 
 impl EventService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -335,7 +335,7 @@ impl std::fmt::Debug for JobService {
 }
 
 impl JobService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -605,7 +605,7 @@ impl std::fmt::Debug for TenantService {
 }
 
 impl TenantService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/tasks/v2/src/transport.rs
+++ b/src/generated/cloud/tasks/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudTasks {
 }
 
 impl CloudTasks {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/telcoautomation/v1/src/transport.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for TelcoAutomation {
 }
 
 impl TelcoAutomation {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/texttospeech/v1/src/transport.rs
+++ b/src/generated/cloud/texttospeech/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for TextToSpeech {
 }
 
 impl TextToSpeech {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -134,7 +134,7 @@ impl std::fmt::Debug for TextToSpeechLongAudioSynthesize {
 }
 
 impl TextToSpeechLongAudioSynthesize {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for TimeseriesInsightsController {
 }
 
 impl TimeseriesInsightsController {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/tpu/v2/src/transport.rs
+++ b/src/generated/cloud/tpu/v2/src/transport.rs
@@ -31,7 +31,7 @@ impl std::fmt::Debug for Tpu {
 }
 
 impl Tpu {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/translate/v3/src/transport.rs
+++ b/src/generated/cloud/translate/v3/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for TranslationService {
 }
 
 impl TranslationService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/video/livestream/v1/src/transport.rs
+++ b/src/generated/cloud/video/livestream/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for LivestreamService {
 }
 
 impl LivestreamService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/video/stitcher/v1/src/transport.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for VideoStitcherService {
 }
 
 impl VideoStitcherService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/video/transcoder/v1/src/transport.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for TranscoderService {
 }
 
 impl TranscoderService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/videointelligence/v1/src/transport.rs
+++ b/src/generated/cloud/videointelligence/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for VideoIntelligenceService {
 }
 
 impl VideoIntelligenceService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/vision/v1/src/transport.rs
+++ b/src/generated/cloud/vision/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ImageAnnotator {
 }
 
 impl ImageAnnotator {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -163,7 +163,7 @@ impl std::fmt::Debug for ProductSearch {
 }
 
 impl ProductSearch {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/vmmigration/v1/src/transport.rs
+++ b/src/generated/cloud/vmmigration/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for VmMigration {
 }
 
 impl VmMigration {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/vmwareengine/v1/src/transport.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for VmwareEngine {
 }
 
 impl VmwareEngine {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/vpcaccess/v1/src/transport.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for VpcAccessService {
 }
 
 impl VpcAccessService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/webrisk/v1/src/transport.rs
+++ b/src/generated/cloud/webrisk/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for WebRiskService {
 }
 
 impl WebRiskService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/websecurityscanner/v1/src/transport.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for WebSecurityScanner {
 }
 
 impl WebSecurityScanner {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/workflows/executions/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Executions {
 }
 
 impl Executions {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/workflows/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Workflows {
 }
 
 impl Workflows {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/cloud/workstations/v1/src/transport.rs
+++ b/src/generated/cloud/workstations/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Workstations {
 }
 
 impl Workstations {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/container/v1/src/transport.rs
+++ b/src/generated/container/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ClusterManager {
 }
 
 impl ClusterManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/datastore/admin/v1/src/transport.rs
+++ b/src/generated/datastore/admin/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DatastoreAdmin {
 }
 
 impl DatastoreAdmin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/devtools/artifactregistry/v1/src/transport.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ArtifactRegistry {
 }
 
 impl ArtifactRegistry {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/devtools/cloudbuild/v1/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for CloudBuild {
 }
 
 impl CloudBuild {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/devtools/cloudbuild/v2/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for RepositoryManager {
 }
 
 impl RepositoryManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/devtools/cloudprofiler/v2/src/transport.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ProfilerService {
 }
 
 impl ProfilerService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -136,7 +136,7 @@ impl std::fmt::Debug for ExportService {
 }
 
 impl ExportService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/devtools/cloudtrace/v2/src/transport.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for TraceService {
 }
 
 impl TraceService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/devtools/containeranalysis/v1/src/transport.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for ContainerAnalysis {
 }
 
 impl ContainerAnalysis {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/firestore/admin/v1/src/transport.rs
+++ b/src/generated/firestore/admin/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for FirestoreAdmin {
 }
 
 impl FirestoreAdmin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/grafeas/v1/src/transport.rs
+++ b/src/generated/grafeas/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Grafeas {
 }
 
 impl Grafeas {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/iam/admin/v1/src/transport.rs
+++ b/src/generated/iam/admin/v1/src/transport.rs
@@ -31,7 +31,7 @@ impl std::fmt::Debug for Iam {
 }
 
 impl Iam {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/iam/credentials/v1/src/transport.rs
+++ b/src/generated/iam/credentials/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for IAMCredentials {
 }
 
 impl IAMCredentials {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/iam/v1/src/transport.rs
+++ b/src/generated/iam/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for IAMPolicy {
 }
 
 impl IAMPolicy {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/iam/v2/src/transport.rs
+++ b/src/generated/iam/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Policies {
 }
 
 impl Policies {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/iam/v3/src/transport.rs
+++ b/src/generated/iam/v3/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for PolicyBindings {
 }
 
 impl PolicyBindings {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -245,7 +245,7 @@ impl std::fmt::Debug for PrincipalAccessBoundaryPolicies {
 }
 
 impl PrincipalAccessBoundaryPolicies {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/identity/accesscontextmanager/v1/src/transport.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AccessContextManager {
 }
 
 impl AccessContextManager {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/logging/v2/src/transport.rs
+++ b/src/generated/logging/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for LoggingServiceV2 {
 }
 
 impl LoggingServiceV2 {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -216,7 +216,7 @@ impl std::fmt::Debug for ConfigServiceV2 {
 }
 
 impl ConfigServiceV2 {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1001,7 +1001,7 @@ impl std::fmt::Debug for MetricsServiceV2 {
 }
 
 impl MetricsServiceV2 {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/longrunning/src/transport.rs
+++ b/src/generated/longrunning/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Operations {
 }
 
 impl Operations {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/monitoring/dashboard/v1/src/transport.rs
+++ b/src/generated/monitoring/dashboard/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DashboardsService {
 }
 
 impl DashboardsService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/monitoring/metricsscope/v1/src/transport.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for MetricsScopes {
 }
 
 impl MetricsScopes {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/monitoring/v3/src/transport.rs
+++ b/src/generated/monitoring/v3/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for AlertPolicyService {
 }
 
 impl AlertPolicyService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -180,7 +180,7 @@ impl std::fmt::Debug for GroupService {
 }
 
 impl GroupService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -358,7 +358,7 @@ impl std::fmt::Debug for MetricService {
 }
 
 impl MetricService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -605,7 +605,7 @@ impl std::fmt::Debug for NotificationChannelService {
 }
 
 impl NotificationChannelService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -853,7 +853,7 @@ impl std::fmt::Debug for QueryService {
 }
 
 impl QueryService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -896,7 +896,7 @@ impl std::fmt::Debug for ServiceMonitoringService {
 }
 
 impl ServiceMonitoringService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1167,7 +1167,7 @@ impl std::fmt::Debug for SnoozeService {
 }
 
 impl SnoozeService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -1284,7 +1284,7 @@ impl std::fmt::Debug for UptimeCheckService {
 }
 
 impl UptimeCheckService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/openapi-validation/src/transport.rs
+++ b/src/generated/openapi-validation/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for SecretManagerService {
 }
 
 impl SecretManagerService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/privacy/dlp/v2/src/transport.rs
+++ b/src/generated/privacy/dlp/v2/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DlpService {
 }
 
 impl DlpService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/spanner/admin/database/v1/src/transport.rs
+++ b/src/generated/spanner/admin/database/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for DatabaseAdmin {
 }
 
 impl DatabaseAdmin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/spanner/admin/instance/v1/src/transport.rs
+++ b/src/generated/spanner/admin/instance/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for InstanceAdmin {
 }
 
 impl InstanceAdmin {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }

--- a/src/generated/storagetransfer/v1/src/transport.rs
+++ b/src/generated/storagetransfer/v1/src/transport.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for StorageTransferService {
 }
 
 impl StorageTransferService {
-    pub async fn new(config: gaxi::ClientConfig) -> Result<Self> {
+    pub async fn new(config: gax::options::ClientConfig) -> Result<Self> {
         let inner = gaxi::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
         Ok(Self { inner })
     }


### PR DESCRIPTION
For ~hilarious~ historical reasons we used `ClientConfig` via `gaxi::`.
Skip the indirection and use the type directly from its source.