### PR TITLE
chore: update builds to Rust 1.85

### DIFF
--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -34,7 +34,7 @@ steps:
       curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.9.1/sccache-v0.9.1-x86_64-unknown-linux-musl.tar.gz |
         tar -C /workspace/.bin -zxf - --strip-components=1
       chmod 755 /workspace/.bin/sccache
-  - name: 'rust:1.84-bookworm'
+  - name: 'rust:1.85-bookworm'
     script: |
       #!/usr/bin/env bash
       set -e

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -20,7 +20,7 @@ on:
   pull_request:
     branches: [main]
 env:
-  GHA_RUST_VERSIONS: '{ "rust:msrv": "1.81", "rust:current": "1.85" }'
+  GHA_RUST_VERSIONS: '{ "rust:msrv": "1.85", "rust:current": "1.85.1" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.23.5" }'
 jobs:
   build:

--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -34,7 +34,7 @@ steps:
         tar -C /workspace/.bin -zxf - --strip-components=1
       chmod 755 /workspace/.bin/sccache
   - id: 'Run auth integration tests'
-    name: 'rust:1.84-bookworm'
+    name: 'rust:1.85-bookworm'
     script: |
       #!/usr/bin/env bash
       set -e


### PR DESCRIPTION
Build with Rust 1.85 and Rust 1.85.1. We will update the second as new
releases are created. I expect the first to be more stable.

Part of the work for #1559
