### PR TITLE
cleanup: vscode config for macros

### DIFF
--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -27,6 +27,7 @@ lines of code), this can be rather slow. We recommend you override these
 defaults in your `settings.json` file:
 
 ```json
+{
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
         "cargo",
         "check",
@@ -34,7 +35,9 @@ defaults in your `settings.json` file:
         "--message-format=json",
         "--keep-going"
     ],
-    "rust-analyzer.check.workspace": false,
+    "rust-analyzer.cargo.features": ["proc-macro"],
+    "rust-analyzer.check.workspace": false
+}
 ```
 
 ## Compile the Code


### PR DESCRIPTION
My VS Code was struggling on macros. They were all red squigglies. This configuration helps VS Code expand and lint macros.

optional: Make the `settings.json` copy-paste-able, as is.