### PR TITLE
cleanup(wkt)!: hide `wkt::generated` module

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -54,7 +54,7 @@ disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links"
 'package:lro' = 'used-if=lro,package=google-cloud-lro,path=src/lro,version=0.1'
 # I (coryan@) got lazy, it is tedious to auto-detect if this is used in `sidekick`.
 # OTOH, the only case where this is not used is a crate without any messages, i.e., just enums.
-'package:wkt' = 'force-used=true,package=google-cloud-wkt,path=src/wkt,source=google.protobuf,version=0.2'
+'package:wkt' = 'force-used=true,package=google-cloud-wkt,path=src/wkt,source=google.protobuf,version=0.3'
 # These are crates in `google-cloud-rust`. If not used, `sidekick` prunes them
 # from the list of dependencies.
 'package:api'          = 'package=google-cloud-api,source=google.api,path=src/generated/api/types,version=0.2'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bytes",

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -40,4 +40,4 @@ auth  = { version = "0.18", path = "../auth", package = "google-cloud-auth" }
 gax   = { version = "0.21", path = "../gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype = { version = "0.2", path = "../generated/type", package = "google-cloud-type" }
 rpc   = { version = "0.2", path = "../generated/rpc/types", package = "google-cloud-rpc" }
-wkt   = { version = "0.2", path = "../wkt", package = "google-cloud-wkt", features = ["prost"] }
+wkt   = { version = "0.3", path = "../wkt", package = "google-cloud-wkt", features = ["prost"] }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -63,4 +63,4 @@ test-case   = "3"
 tokio       = { version = "1", features = ["test-util"] }
 # Local crates
 echo-server = { path = "echo-server" }
-wkt         = { version = "0.2", path = "../wkt", package = "google-cloud-wkt" }
+wkt         = { version = "0.3", path = "../wkt", package = "google-cloud-wkt" }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -45,7 +45,7 @@ tokio       = { version = "1", features = ["macros", "rt-multi-thread"] }
 # Local crates
 auth = { version = "0.18", path = "../auth", package = "google-cloud-auth" }
 rpc  = { version = "0.2", path = "../generated/rpc/types", package = "google-cloud-rpc" }
-wkt  = { version = "0.2", path = "../wkt", package = "google-cloud-wkt" }
+wkt  = { version = "0.3", path = "../wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 # This is a workaround to integration test features of this crate. Open issue

--- a/src/generated/api/apikeys/v2/Cargo.toml
+++ b/src/generated/api/apikeys/v2/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/api/servicecontrol/v1/Cargo.toml
+++ b/src/generated/api/servicecontrol/v1/Cargo.toml
@@ -40,4 +40,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/api/servicecontrol/v2/Cargo.toml
+++ b/src/generated/api/servicecontrol/v2/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/api/servicemanagement/v1/Cargo.toml
+++ b/src/generated/api/servicemanagement/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/api/serviceusage/v1/Cargo.toml
+++ b/src/generated/api/serviceusage/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/api/types/Cargo.toml
+++ b/src/generated/api/types/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/appengine/v1/Cargo.toml
+++ b/src/generated/appengine/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/apps/script/calendar/Cargo.toml
+++ b/src/generated/apps/script/calendar/Cargo.toml
@@ -31,4 +31,4 @@ apps_script_type = { version = "0.2", path = "../../../../../src/generated/apps/
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/apps/script/docs/Cargo.toml
+++ b/src/generated/apps/script/docs/Cargo.toml
@@ -31,4 +31,4 @@ apps_script_type = { version = "0.2", path = "../../../../../src/generated/apps/
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/apps/script/drive/Cargo.toml
+++ b/src/generated/apps/script/drive/Cargo.toml
@@ -31,4 +31,4 @@ apps_script_type = { version = "0.2", path = "../../../../../src/generated/apps/
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/apps/script/gmail/Cargo.toml
+++ b/src/generated/apps/script/gmail/Cargo.toml
@@ -31,4 +31,4 @@ apps_script_type = { version = "0.2", path = "../../../../../src/generated/apps/
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/apps/script/gtype/Cargo.toml
+++ b/src/generated/apps/script/gtype/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/apps/script/sheets/Cargo.toml
+++ b/src/generated/apps/script/sheets/Cargo.toml
@@ -31,4 +31,4 @@ apps_script_type = { version = "0.2", path = "../../../../../src/generated/apps/
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/apps/script/slides/Cargo.toml
+++ b/src/generated/apps/script/slides/Cargo.toml
@@ -31,4 +31,4 @@ apps_script_type = { version = "0.2", path = "../../../../../src/generated/apps/
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/bigtable/admin/v2/Cargo.toml
+++ b/src/generated/bigtable/admin/v2/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/accessapproval/v1/Cargo.toml
+++ b/src/generated/cloud/accessapproval/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/advisorynotifications/v1/Cargo.toml
+++ b/src/generated/cloud/advisorynotifications/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -44,7 +44,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/alloydb/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/connectors/v1/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/alloydb/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/apigateway/v1/Cargo.toml
+++ b/src/generated/cloud/apigateway/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/apigeeconnect/v1/Cargo.toml
+++ b/src/generated/cloud/apigeeconnect/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/apphub/v1/Cargo.toml
+++ b/src/generated/cloud/apphub/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/asset/v1/Cargo.toml
+++ b/src/generated/cloud/asset/v1/Cargo.toml
@@ -45,7 +45,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/assuredworkloads/v1/Cargo.toml
+++ b/src/generated/cloud/assuredworkloads/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/backupdr/v1/Cargo.toml
+++ b/src/generated/cloud/backupdr/v1/Cargo.toml
@@ -43,7 +43,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/baremetalsolution/v2/Cargo.toml
+++ b/src/generated/cloud/baremetalsolution/v2/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/bigquery/connection/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/connection/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/bigquery/migration/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/migration/v2/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/bigquery/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/v2/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/billing/v1/Cargo.toml
+++ b/src/generated/cloud/billing/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/binaryauthorization/v1/Cargo.toml
+++ b/src/generated/cloud/binaryauthorization/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/certificatemanager/v1/Cargo.toml
+++ b/src/generated/cloud/certificatemanager/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
+++ b/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/clouddms/v1/Cargo.toml
+++ b/src/generated/cloud/clouddms/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/common/Cargo.toml
+++ b/src/generated/cloud/common/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
+++ b/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/config/v1/Cargo.toml
+++ b/src/generated/cloud/config/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/connectors/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/datacatalog/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/datafusion/v1/Cargo.toml
+++ b/src/generated/cloud/datafusion/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/dataproc/v1/Cargo.toml
+++ b/src/generated/cloud/dataproc/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/datastream/v1/Cargo.toml
+++ b/src/generated/cloud/datastream/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/deploy/v1/Cargo.toml
+++ b/src/generated/cloud/deploy/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/developerconnect/v1/Cargo.toml
+++ b/src/generated/cloud/developerconnect/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -43,7 +43,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/domains/v1/Cargo.toml
+++ b/src/generated/cloud/domains/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/edgecontainer/v1/Cargo.toml
+++ b/src/generated/cloud/edgecontainer/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/edgenetwork/v1/Cargo.toml
+++ b/src/generated/cloud/edgenetwork/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/essentialcontacts/v1/Cargo.toml
+++ b/src/generated/cloud/essentialcontacts/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/eventarc/v1/Cargo.toml
+++ b/src/generated/cloud/eventarc/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/filestore/v1/Cargo.toml
+++ b/src/generated/cloud/filestore/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/financialservices/v1/Cargo.toml
+++ b/src/generated/cloud/financialservices/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/functions/v2/Cargo.toml
+++ b/src/generated/cloud/functions/v2/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/gkebackup/v1/Cargo.toml
+++ b/src/generated/cloud/gkebackup/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
+++ b/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/gkehub/configmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/configmanagement/v1/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/gkehub/multiclusteringress/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/multiclusteringress/v1/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/gkemulticloud/v1/Cargo.toml
+++ b/src/generated/cloud/gkemulticloud/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
+++ b/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
@@ -44,4 +44,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/iap/v1/Cargo.toml
+++ b/src/generated/cloud/iap/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/ids/v1/Cargo.toml
+++ b/src/generated/cloud/ids/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/kms/inventory/v1/Cargo.toml
+++ b/src/generated/cloud/kms/inventory/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/language/v2/Cargo.toml
+++ b/src/generated/cloud/language/v2/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/managedidentities/v1/Cargo.toml
+++ b/src/generated/cloud/managedidentities/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/memcache/v1/Cargo.toml
+++ b/src/generated/cloud/memcache/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/memorystore/v1/Cargo.toml
+++ b/src/generated/cloud/memorystore/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/metastore/v1/Cargo.toml
+++ b/src/generated/cloud/metastore/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/migrationcenter/v1/Cargo.toml
+++ b/src/generated/cloud/migrationcenter/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/modelarmor/v1/Cargo.toml
+++ b/src/generated/cloud/modelarmor/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/networkconnectivity/v1/Cargo.toml
+++ b/src/generated/cloud/networkconnectivity/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/networkmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/networkmanagement/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/networksecurity/v1/Cargo.toml
+++ b/src/generated/cloud/networksecurity/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/networkservices/v1/Cargo.toml
+++ b/src/generated/cloud/networkservices/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/notebooks/v2/Cargo.toml
+++ b/src/generated/cloud/notebooks/v2/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/optimization/v1/Cargo.toml
+++ b/src/generated/cloud/optimization/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/oracledatabase/v1/Cargo.toml
+++ b/src/generated/cloud/oracledatabase/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/orgpolicy/v1/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v1/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/orgpolicy/v2/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v2/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/osconfig/v1/Cargo.toml
+++ b/src/generated/cloud/osconfig/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/oslogin/v1/Cargo.toml
+++ b/src/generated/cloud/oslogin/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/parallelstore/v1/Cargo.toml
+++ b/src/generated/cloud/parallelstore/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/parametermanager/v1/Cargo.toml
+++ b/src/generated/cloud/parametermanager/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/policysimulator/v1/Cargo.toml
+++ b/src/generated/cloud/policysimulator/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
@@ -41,4 +41,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
@@ -40,4 +40,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
+++ b/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/recommender/logging/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/logging/v1/Cargo.toml
@@ -31,4 +31,4 @@ bytes      = { version = "1", features = ["serde"] }
 recommender = { version = "0.2", path = "../../../../../../src/generated/cloud/recommender/v1", package = "google-cloud-recommender-v1" }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/recommender/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/redis/cluster/v1/Cargo.toml
+++ b/src/generated/cloud/redis/cluster/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/redis/v1/Cargo.toml
+++ b/src/generated/cloud/redis/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/resourcemanager/v3/Cargo.toml
+++ b/src/generated/cloud/resourcemanager/v3/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/retail/v2/Cargo.toml
+++ b/src/generated/cloud/retail/v2/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/scheduler/v1/Cargo.toml
+++ b/src/generated/cloud/scheduler/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/securesourcemanager/v1/Cargo.toml
+++ b/src/generated/cloud/securesourcemanager/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/security/privateca/v1/Cargo.toml
+++ b/src/generated/cloud/security/privateca/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/security/publicca/v1/Cargo.toml
+++ b/src/generated/cloud/security/publicca/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/securityposture/v1/Cargo.toml
+++ b/src/generated/cloud/securityposture/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/servicedirectory/v1/Cargo.toml
+++ b/src/generated/cloud/servicedirectory/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/servicehealth/v1/Cargo.toml
+++ b/src/generated/cloud/servicehealth/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/shell/v1/Cargo.toml
+++ b/src/generated/cloud/shell/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/speech/v2/Cargo.toml
+++ b/src/generated/cloud/speech/v2/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/sql/v1/Cargo.toml
+++ b/src/generated/cloud/sql/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/storageinsights/v1/Cargo.toml
+++ b/src/generated/cloud/storageinsights/v1/Cargo.toml
@@ -41,4 +41,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/support/v2/Cargo.toml
+++ b/src/generated/cloud/support/v2/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/talent/v4/Cargo.toml
+++ b/src/generated/cloud/talent/v4/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/tasks/v2/Cargo.toml
+++ b/src/generated/cloud/tasks/v2/Cargo.toml
@@ -40,4 +40,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/telcoautomation/v1/Cargo.toml
+++ b/src/generated/cloud/telcoautomation/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/texttospeech/v1/Cargo.toml
+++ b/src/generated/cloud/texttospeech/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
+++ b/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/tpu/v2/Cargo.toml
+++ b/src/generated/cloud/tpu/v2/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/video/livestream/v1/Cargo.toml
+++ b/src/generated/cloud/video/livestream/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/video/stitcher/v1/Cargo.toml
+++ b/src/generated/cloud/video/stitcher/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/video/transcoder/v1/Cargo.toml
+++ b/src/generated/cloud/video/transcoder/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/videointelligence/v1/Cargo.toml
+++ b/src/generated/cloud/videointelligence/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/vision/v1/Cargo.toml
+++ b/src/generated/cloud/vision/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/vmmigration/v1/Cargo.toml
+++ b/src/generated/cloud/vmmigration/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/vmwareengine/v1/Cargo.toml
+++ b/src/generated/cloud/vmwareengine/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/vpcaccess/v1/Cargo.toml
+++ b/src/generated/cloud/vpcaccess/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/websecurityscanner/v1/Cargo.toml
+++ b/src/generated/cloud/websecurityscanner/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/workflows/executions/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/executions/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/workstations/v1/Cargo.toml
+++ b/src/generated/cloud/workstations/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/container/v1/Cargo.toml
+++ b/src/generated/container/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/datastore/admin/v1/Cargo.toml
+++ b/src/generated/datastore/admin/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/devtools/artifactregistry/v1/Cargo.toml
+++ b/src/generated/devtools/artifactregistry/v1/Cargo.toml
@@ -43,7 +43,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/devtools/cloudbuild/v1/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/devtools/cloudprofiler/v2/Cargo.toml
+++ b/src/generated/devtools/cloudprofiler/v2/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/devtools/cloudtrace/v2/Cargo.toml
+++ b/src/generated/devtools/cloudtrace/v2/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/devtools/containeranalysis/v1/Cargo.toml
+++ b/src/generated/devtools/containeranalysis/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/firestore/admin/v1/Cargo.toml
+++ b/src/generated/firestore/admin/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/grafeas/v1/Cargo.toml
+++ b/src/generated/grafeas/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/iam/admin/v1/Cargo.toml
+++ b/src/generated/iam/admin/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/iam/credentials/v1/Cargo.toml
+++ b/src/generated/iam/credentials/v1/Cargo.toml
@@ -37,4 +37,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/iam/v2/Cargo.toml
+++ b/src/generated/iam/v2/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/iam/v3/Cargo.toml
+++ b/src/generated/iam/v3/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/identity/accesscontextmanager/type/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/type/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/identity/accesscontextmanager/v1/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/v1/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/logging/type/Cargo.toml
+++ b/src/generated/logging/type/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/logging/v2/Cargo.toml
+++ b/src/generated/logging/v2/Cargo.toml
@@ -42,7 +42,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/monitoring/dashboard/v1/Cargo.toml
+++ b/src/generated/monitoring/dashboard/v1/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/monitoring/metricsscope/v1/Cargo.toml
+++ b/src/generated/monitoring/metricsscope/v1/Cargo.toml
@@ -39,7 +39,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/monitoring/v3/Cargo.toml
+++ b/src/generated/monitoring/v3/Cargo.toml
@@ -40,4 +40,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -38,4 +38,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/oslogin/common/Cargo.toml
+++ b/src/generated/oslogin/common/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/privacy/dlp/v2/Cargo.toml
+++ b/src/generated/privacy/dlp/v2/Cargo.toml
@@ -39,4 +39,4 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/rpc/context/Cargo.toml
+++ b/src/generated/rpc/context/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/rpc/types/Cargo.toml
+++ b/src/generated/rpc/types/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -40,7 +40,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/storagetransfer/v1/Cargo.toml
+++ b/src/generated/storagetransfer/v1/Cargo.toml
@@ -41,7 +41,7 @@ serde      = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
-wkt        = { version = "0.2", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -30,4 +30,4 @@ rust-version.workspace = true
 bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-wkt        = { version = "0.2", path = "../../../src/wkt", package = "google-cloud-wkt" }
+wkt        = { version = "0.3", path = "../../../src/wkt", package = "google-cloud-wkt" }

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -37,7 +37,7 @@ tokio       = { version = "1", features = ["time"] }
 gax         = { version = "0.21", path = "../gax", package = "google-cloud-gax" }
 longrunning = { version = "0.22", path = "../generated/longrunning", package = "google-cloud-longrunning" }
 rpc         = { version = "0.2", path = "../generated/rpc/types", package = "google-cloud-rpc" }
-wkt         = { version = "0.2", path = "../wkt", package = "google-cloud-wkt" }
+wkt         = { version = "0.3", path = "../wkt", package = "google-cloud-wkt" }
 
 [features]
 unstable-stream = ["dep:futures", "dep:pin-project"]

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 description = "Google Cloud Client Libraries for Rust - Well Known Types"
 name        = "google-cloud-wkt"
-version     = "0.2.0"
+version     = "0.3.0"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true

--- a/src/wkt/src/lib.rs
+++ b/src/wkt/src/lib.rs
@@ -31,7 +31,7 @@ mod empty;
 pub use crate::empty::*;
 mod field_mask;
 pub use crate::field_mask::*;
-pub mod generated;
+mod generated;
 pub use crate::generated::*;
 mod timestamp;
 pub use crate::timestamp::*;


### PR DESCRIPTION
Noticed in #1541 

https://docs.rs/google-cloud-wkt/latest/google_cloud_wkt/generated/index.html

We re-export these types, and only ever call them by `wkt::Api` (for example).

We should not be exposing the `generated` module which is an implementation detail.

Technically a breaking change, because `wkt::generated::Api` is no longer a thing.