### PR TITLE
feat(generator): support empty return types

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -115,6 +115,15 @@ type Method struct {
 	// OutputType is the output of the Method
 	OutputTypeID string
 	OutputType   *Message
+	// Some methods return nothing and the language mapping represents such
+	// method with a special type such as `void`, or `()`.
+	//
+	// Protobuf uses the well-known type `google.protobuf.Empty` message to
+	// represent this.
+	//
+	// OpenAPIv3 uses a missing content field:
+	//   https://swagger.io/docs/specification/v3_0/describing-responses/#empty-response-body
+	ReturnsEmpty bool
 	// PathInfo information about the HTTP request
 	PathInfo *PathInfo
 	// Pagination holds the `page_token` field if the method conforms to the

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -368,9 +368,11 @@ func makeResponseMessage(api *api.API, operation *v3.Operation, packageName stri
 		return nil, fmt.Errorf("missing Responses in specification for operation %s", operation.OperationId)
 	}
 	if operation.Responses.Default == nil {
-		// Google's OpenAPI v3 specifications only include the "default" response. In the future we may want to support
+		// Google's OpenAPI v3 specifications only include the "default"
+		// response. In the future we may want to support more than this.
 		return nil, fmt.Errorf("expected Default response for operation %s", operation.OperationId)
 	}
+	// TODO(#1590) - support a missing `Content` as an indication of `void`.
 	reference, err := findReferenceInContentMap(operation.Responses.Default.Content)
 	if err != nil {
 		return nil, err

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -440,15 +440,17 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		slog.Error("unsupported http method", "method", m)
 		return nil
 	}
+	outputTypeID := m.GetOutputType()
 	method := &api.Method{
 		ID:                  mFQN,
 		PathInfo:            pathInfo,
 		Name:                m.GetName(),
 		InputTypeID:         m.GetInputType(),
-		OutputTypeID:        m.GetOutputType(),
+		OutputTypeID:        outputTypeID,
 		ClientSideStreaming: m.GetClientStreaming(),
 		ServerSideStreaming: m.GetServerStreaming(),
 		OperationInfo:       parseOperationInfo(packagez, m),
+		ReturnsEmpty:        outputTypeID == ".google.protobuf.Empty",
 	}
 	state.MethodByID[mFQN] = method
 	return method

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -500,10 +500,10 @@ func TestProtobuf_UniqueEnumValues(t *testing.T) {
 
 	less := func(a, b *api.EnumValue) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(fullList, withAlias.Values, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+		t.Errorf("enum values mismatch (-want, +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(uniqueList, withAlias.UniqueNumberValues, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
-		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+		t.Errorf("enum values mismatch (-want, +got):\n%s", diff)
 	}
 }
 
@@ -845,6 +845,22 @@ func TestProtobuf_Service(t *testing.T) {
 					QueryParameters: map[string]bool{"foo_id": true},
 					BodyFieldPath:   "foo",
 				},
+			},
+			{
+				Name:          "DeleteFoo",
+				ID:            ".test.TestService.DeleteFoo",
+				Documentation: "Deletes a Foo resource.",
+				InputTypeID:   ".test.DeleteFooRequest",
+				OutputTypeID:  ".google.protobuf.Empty",
+				PathInfo: &api.PathInfo{
+					Verb: "DELETE",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("name"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+				ReturnsEmpty: true,
 			},
 			{
 				Name:          "UploadFoos",

--- a/generator/internal/parser/testdata/test_service.proto
+++ b/generator/internal/parser/testdata/test_service.proto
@@ -19,6 +19,7 @@ import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/protobuf/empty.proto";
 
 // A service to unit test the protobuf translator.
 service TestService {
@@ -41,6 +42,13 @@ service TestService {
       body: "foo"
     };
     option (google.api.method_signature) = "parent,foo_id,foo";
+  }
+
+  // Deletes a Foo resource.
+  rpc DeleteFoo(DeleteFooRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/foos/*}"
+    };
   }
 
   // A client-side streaming RPC.
@@ -96,4 +104,13 @@ message CreateFooRequest {
 
   // Required. A [Foo][test.Foo] with initial field values.
   Foo foo = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The request message for `DeleteFoo`.
+message DeleteFooRequest {
+  // Required. The resource name in `projects/{project}/foos/{foo}` format.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = { type: "test.googleapis.com/Foo" }
+  ];
 }


### PR DESCRIPTION
Methods can return "nothing". For Protobuf this is represented by the
`.google.protobuf.Empty` message. OpenAPIv3 has the same notion, but it
is represented differently (and I did not implement it).

In some languages we may want to map such return types to a "unit" type,
such as `void` in C++ and friends, or `()` in Rust.

Part of the work for #1549
