### PR TITLE
feat(wkt): convert the unit type to `Empty`

### DIFF
--- a/src/wkt/src/prost.rs
+++ b/src/wkt/src/prost.rs
@@ -55,6 +55,12 @@ impl Convert<prost_types::Duration> for crate::Duration {
     }
 }
 
+impl Convert<crate::Empty> for () {
+    fn cnv(self) -> crate::Empty {
+        crate::Empty::default()
+    }
+}
+
 impl Convert<crate::FieldMask> for prost_types::FieldMask {
     fn cnv(self) -> crate::FieldMask {
         crate::FieldMask::default().set_paths(self.paths)

--- a/src/wkt/src/prost.rs
+++ b/src/wkt/src/prost.rs
@@ -297,4 +297,9 @@ mod test {
         let got: crate::Value = convert.cnv();
         assert_eq!(got, input);
     }
+
+    #[test]
+    fn empty_from_unit() {
+        let _: crate::Empty = ().cnv();
+    }
 }


### PR DESCRIPTION
Tonic converts `google.protobuf.Empty` to the unit type in method returns. We
(currently) return `wkt::Empty`, we should probably do the same as Tonic, but
this will do for now.

Part of the work for #1549
