### PR TITLE
fix(generator): load mixin dependencies

### DIFF
--- a/generator/go.mod
+++ b/generator/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/yuin/goldmark v1.7.8
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb
 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb
 	google.golang.org/protobuf v1.36.5
 )
 
@@ -29,7 +30,6 @@ require (
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/grpc v1.71.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/generator/internal/parser/testdata/test_noempty_mixin.proto
+++ b/generator/internal/parser/testdata/test_noempty_mixin.proto
@@ -1,0 +1,69 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+
+// A service to unit test the protobuf translator.
+service TestService {
+  option (google.api.default_host) = "test.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  // Creates a new Foo resource.
+  rpc CreateFoo(CreateFooRequest) returns (Foo) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*}/foos"
+      body: "foo"
+    };
+    option (google.api.method_signature) = "parent,foo_id,foo";
+  }
+}
+
+// The resource message.
+message Foo {
+  option (google.api.resource) = {
+    type: "test.googleapis.com/Foo"
+    pattern: "projects/{project}/foos/{foo}"
+  };
+
+  // Output only. The resource name of the resource, in the format
+  // `projects/{project}/foos/{foo}`.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The contents.
+  string content = 2;
+}
+
+message CreateFooRequest {
+  // Required. The resource name of the project, in the format
+  // `projects/{project}`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "cloudresourcemanager.googleapis.com/Project"
+    }
+  ];
+
+  // Required. This must be unique within the project.
+  string foo_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. A [Foo][test.Foo] with initial field values.
+  Foo foo = 3 [(google.api.field_behavior) = REQUIRED];
+}


### PR DESCRIPTION
Fixes #1598

At least I can generate the code for Rust, and it was failing before.
