### PR TITLE
test(firestore): add basic integration tests

### DIFF
--- a/.gcb/builds/main.tf
+++ b/.gcb/builds/main.tf
@@ -37,6 +37,7 @@ module "services" {
 module "resources" {
   source  = "./resources"
   project = var.project
+  region  = var.region
 }
 
 # Create the service account needed for GCB and grant it the necessary

--- a/.gcb/builds/resources/main.tf
+++ b/.gcb/builds/resources/main.tf
@@ -16,6 +16,10 @@ variable "project" {
   type = string
 }
 
+variable "region" {
+  type = string
+}
+
 # Create a bucket to cache build artifacts.
 resource "google_storage_bucket" "build-cache" {
   name          = "${var.project}-build-cache"
@@ -44,6 +48,14 @@ resource "google_storage_bucket" "build-cache" {
       type = "Delete"
     }
   }
+}
+
+# Create a Firestore database for the integration tests.
+resource "google_firestore_database" "default" {
+  project     = var.project
+  name        = "(default)"
+  location_id = "us-central1"
+  type        = "FIRESTORE_NATIVE"
 }
 
 output "build-cache" {

--- a/.gcb/builds/services/main.tf
+++ b/.gcb/builds/services/main.tf
@@ -26,6 +26,18 @@ resource "google_project_service" "cloudbuild" {
   disable_dependent_services = true
 }
 
+resource "google_project_service" "firestore" {
+  project = var.project
+  service = "firestore.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}
+
 resource "google_project_service" "secretmanager" {
   project = var.project
   service = "secretmanager.googleapis.com"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4742,6 +4752,7 @@ dependencies = [
  "bytes",
  "crc32c",
  "futures",
+ "google-cloud-firestore",
  "google-cloud-gax",
  "google-cloud-iam-v1",
  "google-cloud-location",
@@ -4923,7 +4934,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5480,6 +5491,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5577,7 +5600,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5839,7 +5875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -6083,8 +6119,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "socket2",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -143,17 +143,26 @@ project.
 
 ### One time set up
 
-We use [Secret Manager] to run integration tests. Follow the
-[Enable the Secret Manager API] guide to, as it says, enable the API and make
-sure that billing is enabled in your projects.
+We use [Secret Manager], [Workflows], and [Firestore] to run integration tests.
+Follow the [Enable the Secret Manager API] guide to, as it says, enable the API
+and make sure that billing is enabled in your projects. To enable the Workflows
+and Firestore API you can run this command:
+
+```bash
+gcloud services enable workflows.googleapis.com firestore.googleapis.com
+```
 
 Verify this is working with something like:
 
 ```bash
+gcloud firestore databases list
 gcloud secrets list
+gcloud workflows list
 ```
 
 It is fine if the list is empty, you just don't want an error.
+
+### Create a service account
 
 The integration tests need a service account in your project. This service
 account is used to:
@@ -175,6 +184,24 @@ For extra safety, disable the service account:
 ```bash
 GOOGLE_CLOUD_PROJECT="$(gcloud config get project)"
 gcloud iam service-accounts disable rust-sdk-test@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com
+```
+
+### Create a database
+
+The integration tests need the default Firestore database in your project.
+You can create this database using:
+
+```bash
+gcloud firestore databases create --location=us-central1
+```
+
+If the database already exists you should verify that this is a Firestore native
+database:
+
+```bash
+gcloud firestore databases describe --format='value(type)'
+# Expected output:
+# FIRESTORE_NATIVE
 ```
 
 ### Running
@@ -268,9 +295,11 @@ files using:
 git ls-files -z -- '*.tf' ':!:**/testdata/**' | xargs -0 terraform fmt
 ```
 
-[enable the secret manager api]: docs/configuring-secret-manager
+[enable the secret manager api]: https://cloud.google.com/secret-manager/docs/configuring-secret-manager
+[firestore]: https://cloud.google.com/firestore/
 [getting-started-rust]: https://www.rust-lang.org/learn/get-started
 [golang-install]: https://go.dev/doc/install
 [google cloud cli]: https://cloud.google.com/cli
 [install terraform]: https://developer.hashicorp.com/terraform/install
 [secret manager]: https://cloud.google.com/secret-manager/
+[workflows]: https://cloud.google.com/workflows/

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -36,7 +36,7 @@ prost-types = "0.13"
 serde       = { version = "1", features = ["serde_derive"] }
 serde_json  = { version = "1" }
 serde_with  = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-tonic       = "0.12"
+tonic       = { version = "0.12", features = ["tls", "tls-native-roots"] }
 tokio       = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing     = "0.1"
 # Local crates

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -38,6 +38,10 @@ tracing            = "0.1"
 tracing-subscriber = "0.3"
 wkt                = { path = "../../src/wkt", package = "google-cloud-wkt" }
 
+[dependencies.firestore]
+package = "google-cloud-firestore"
+path    = "../../src/firestore"
+
 [dependencies.sm]
 package = "google-cloud-secretmanager-v1"
 path    = "../../src/generated/cloud/secretmanager/v1"

--- a/src/integration-tests/src/firestore.rs
+++ b/src/integration-tests/src/firestore.rs
@@ -1,0 +1,162 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use firestore::Error;
+use firestore::Result;
+use firestore::client::Firestore;
+use firestore::model;
+use rand::{Rng, distr::Alphanumeric};
+
+pub const COLLECTION_ID_LENGTH: usize = 32;
+
+fn new_collection_id() -> String {
+    let prefix = "doc-";
+    let collection_id: String = rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(COLLECTION_ID_LENGTH - prefix.len())
+        .map(char::from)
+        .collect();
+    format!("{prefix}{collection_id}")
+}
+
+pub async fn basic(config: Option<gax::options::ClientConfig>) -> Result<()> {
+    // Enable a basic subscriber. Useful to troubleshoot problems and visually
+    // verify tracing is doing something.
+    #[cfg(feature = "log-integration-tests")]
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    cleanup_stale_documents().await?;
+
+    let project_id = crate::project_id()?;
+    let client = if let Some(config) = config {
+        Firestore::new_with_config(config).await?
+    } else {
+        Firestore::new().await?
+    };
+    let collection_id = new_collection_id();
+    let response = client
+        .create_document(
+            format!("projects/{project_id}/databases/(default)/documents"),
+            &collection_id,
+        )
+        .set_document(model::Document::new().set_fields([
+            (
+                "greeting",
+                model::Value::new().set_string_value("Hello World!"),
+            ),
+            (
+                "integration-test",
+                model::Value::new().set_boolean_value(true),
+            ),
+        ]))
+        .send()
+        .await?;
+    println!("SUCCESS on create_document: {response:?}");
+
+    let document_name = response.name;
+    let response = client.get_document(&document_name).send().await?;
+    println!("SUCCESS on get_document: {response:?}");
+
+    let mut documents = client
+        .list_documents(
+            format!("projects/{project_id}/databases/(default)/documents"),
+            &collection_id,
+        )
+        .paginator()
+        .await
+        .items();
+    while let Some(doc) = documents.next().await {
+        let doc = doc?;
+        println!("  ITEM = {doc:?}");
+    }
+    println!("SUCCESS on list_documents: {response:?}");
+
+    let response = client
+        .update_document(
+            model::Document::new()
+                .set_name(&document_name)
+                .set_fields([("greeting", model::Value::new().set_string_value("Goodbye."))]),
+        )
+        .set_update_mask(model::DocumentMask::new().set_field_paths(["greeting"]))
+        .send()
+        .await?;
+    println!("SUCCESS on update_document: {response:?}");
+
+    let response = client.delete_document(&document_name).send().await?;
+    println!("SUCCESS on delete_document: {response:?}");
+
+    Ok(())
+}
+
+async fn cleanup_stale_documents() -> Result<()> {
+    use gax::retry_policy::RetryPolicyExt;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    let stale_deadline = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(Error::other)?;
+    let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
+    let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
+
+    let client = Firestore::new_with_config(
+        gax::options::ClientConfig::new()
+            .set_retry_policy(gax::retry_policy::AlwaysRetry.with_attempt_limit(3)),
+    )
+    .await?;
+
+    let mut stale_documents = Vec::new();
+
+    let project_id = crate::project_id()?;
+    let mut documents = client
+        .list_documents(
+            format!("projects/{project_id}/databases/(default)/documents"),
+            "",
+        )
+        .paginator()
+        .await
+        .items();
+    while let Some(doc) = documents.next().await {
+        let doc = doc?;
+        if let Some(true) = doc.create_time.map(|v| v >= stale_deadline) {
+            continue;
+        }
+        if let Some(integration) = doc.fields.get("integration-test") {
+            if let Some(&true) = integration.get_boolean_value() {
+                stale_documents.push(doc.name);
+            }
+        }
+    }
+    let stale_documents = stale_documents;
+    let pending = stale_documents
+        .iter()
+        .map(|name| client.delete_document(name).send())
+        .collect::<Vec<_>>();
+
+    futures::future::join_all(pending)
+        .await
+        .into_iter()
+        .zip(stale_documents)
+        .for_each(|(r, name)| println!("{name} = {r:?}"));
+
+    Ok(())
+}

--- a/src/integration-tests/src/firestore.rs
+++ b/src/integration-tests/src/firestore.rs
@@ -89,7 +89,7 @@ pub async fn basic(config: Option<gax::options::ClientConfig>) -> Result<()> {
         let doc = doc?;
         println!("  ITEM = {doc:?}");
     }
-    println!("SUCCESS on list_documents: {response:?}");
+    println!("SUCCESS on list_documents:");
 
     let response = client
         .update_document(
@@ -156,7 +156,7 @@ async fn cleanup_stale_documents() -> Result<()> {
         .await
         .into_iter()
         .zip(stale_documents)
-        .for_each(|(r, name)| println!("{name} = {r:?}"));
+        .for_each(|(r, name)| println!("Deleting stale document {name} = {r:?}"));
 
     Ok(())
 }

--- a/src/integration-tests/src/lib.rs
+++ b/src/integration-tests/src/lib.rs
@@ -14,6 +14,7 @@
 
 use gax::error::Error;
 pub type Result<T> = std::result::Result<T, gax::error::Error>;
+pub mod firestore;
 pub mod secret_manager;
 pub mod workflows;
 

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -35,6 +35,16 @@ mod driver {
     #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
     #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_firestore(config: Option<Config>) -> integration_tests::Result<()> {
+        integration_tests::firestore::basic(config)
+            .await
+            .map_err(report)
+    }
+
+    #[test_case(None; "default")]
+    #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
+    #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_secretmanager_protobuf(config: Option<Config>) -> integration_tests::Result<()> {
         integration_tests::secret_manager::protobuf::run(config)
             .await


### PR DESCRIPTION
Since this is the first gRPC-based client some integration tests seem
appropriate. I just tested basic CRUD stuff, pagination and delete are probably
the most interesting.

Fixes #1549 