### PR TITLE
revert(wkt): convert the unit type to `Empty`

### DIFF
--- a/src/wkt/src/prost.rs
+++ b/src/wkt/src/prost.rs
@@ -55,12 +55,6 @@ impl Convert<prost_types::Duration> for crate::Duration {
     }
 }
 
-impl Convert<crate::Empty> for () {
-    fn cnv(self) -> crate::Empty {
-        crate::Empty::default()
-    }
-}
-
 impl Convert<crate::FieldMask> for prost_types::FieldMask {
     fn cnv(self) -> crate::FieldMask {
         crate::FieldMask::default().set_paths(self.paths)
@@ -296,10 +290,5 @@ mod test {
         let convert: prost_types::Value = input.clone().cnv();
         let got: crate::Value = convert.cnv();
         assert_eq!(got, input);
-    }
-
-    #[test]
-    fn empty_from_unit() {
-        let _: crate::Empty = ().cnv();
     }
 }


### PR DESCRIPTION
After other changes, it turns out we do not need this.

This reverts commit ccb413b8fe6673a1a2a97d082af36533aaba1e6a, #1593

Another followup frm #1539
