### PR TITLE
cleanup!: hide request builder impls

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -30,7 +30,7 @@ protobuf-subdir             = "src"
 [codec]
 # The default version for all crates. This can be overridden in the crate's
 # `.sidekick.toml` file.
-version = "0.3.0"
+version = "0.2.0"
 # The default release level for all crates.
 release-level = "preview"
 # Disable a number of warnings.

--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -30,7 +30,7 @@ protobuf-subdir             = "src"
 [codec]
 # The default version for all crates. This can be overridden in the crate's
 # `.sidekick.toml` file.
-version = "0.2.0"
+version = "0.3.0"
 # The default release level for all crates.
 release-level = "preview"
 # Disable a number of warnings.

--- a/generator/internal/rust/templates/crate/src/builders.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builders.rs.mustache
@@ -25,7 +25,7 @@ pub mod {{Codec.ModuleName}} {
 
     /// Common implementation for [super::super::client::{{Codec.Name}}] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::{{Codec.Name}}>,
         request: R,
         options: gax::options::RequestOptions,

--- a/generator/testdata/rust/openapi/golden/src/builders.rs
+++ b/generator/testdata/rust/openapi/golden/src/builders.rs
@@ -20,7 +20,7 @@ pub mod secret_manager_service {
 
     /// Common implementation for [super::super::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SecretManagerService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod iam_policy {
 
     /// Common implementation for [super::super::client::IAMPolicy] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::IAMPolicy>,
         request: R,
         options: gax::options::RequestOptions,

--- a/generator/testdata/rust/protobuf/golden/location/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builders.rs
@@ -20,7 +20,7 @@ pub mod locations {
 
     /// Common implementation for [super::super::client::Locations] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Locations>,
         request: R,
         options: gax::options::RequestOptions,

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
@@ -20,7 +20,7 @@ pub mod secret_manager_service {
 
     /// Common implementation for [super::super::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SecretManagerService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/firestore/src/generated/gapic/builders.rs
+++ b/src/firestore/src/generated/gapic/builders.rs
@@ -20,7 +20,7 @@ pub mod firestore {
 
     /// Common implementation for [super::super::client::Firestore] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Firestore>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/api/apikeys/v2/src/builders.rs
+++ b/src/generated/api/apikeys/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod api_keys {
 
     /// Common implementation for [super::super::client::ApiKeys] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ApiKeys>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/api/servicecontrol/v1/src/builders.rs
+++ b/src/generated/api/servicecontrol/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod quota_controller {
 
     /// Common implementation for [super::super::client::QuotaController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::QuotaController>,
         request: R,
         options: gax::options::RequestOptions,
@@ -104,7 +104,7 @@ pub mod service_controller {
 
     /// Common implementation for [super::super::client::ServiceController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ServiceController>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/api/servicecontrol/v2/src/builders.rs
+++ b/src/generated/api/servicecontrol/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod service_controller {
 
     /// Common implementation for [super::super::client::ServiceController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ServiceController>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/api/servicemanagement/v1/src/builders.rs
+++ b/src/generated/api/servicemanagement/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod service_manager {
 
     /// Common implementation for [super::super::client::ServiceManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ServiceManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/api/serviceusage/v1/src/builders.rs
+++ b/src/generated/api/serviceusage/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod service_usage {
 
     /// Common implementation for [super::super::client::ServiceUsage] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ServiceUsage>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/appengine/v1/src/builders.rs
+++ b/src/generated/appengine/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod applications {
 
     /// Common implementation for [super::super::client::Applications] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Applications>,
         request: R,
         options: gax::options::RequestOptions,
@@ -478,7 +478,7 @@ pub mod services {
 
     /// Common implementation for [super::super::client::Services] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Services>,
         request: R,
         options: gax::options::RequestOptions,
@@ -913,7 +913,7 @@ pub mod versions {
 
     /// Common implementation for [super::super::client::Versions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Versions>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1443,7 +1443,7 @@ pub mod instances {
 
     /// Common implementation for [super::super::client::Instances] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Instances>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1860,7 +1860,7 @@ pub mod firewall {
 
     /// Common implementation for [super::super::client::Firewall] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Firewall>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2341,7 +2341,7 @@ pub mod authorized_domains {
 
     /// Common implementation for [super::super::client::AuthorizedDomains] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AuthorizedDomains>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2559,7 +2559,7 @@ pub mod authorized_certificates {
 
     /// Common implementation for [super::super::client::AuthorizedCertificates] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AuthorizedCertificates>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3024,7 +3024,7 @@ pub mod domain_mappings {
 
     /// Common implementation for [super::super::client::DomainMappings] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DomainMappings>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/bigtable/admin/v2/src/builders.rs
+++ b/src/generated/bigtable/admin/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod bigtable_instance_admin {
 
     /// Common implementation for [super::super::client::BigtableInstanceAdmin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::BigtableInstanceAdmin>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2491,7 +2491,7 @@ pub mod bigtable_table_admin {
 
     /// Common implementation for [super::super::client::BigtableTableAdmin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::BigtableTableAdmin>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/accessapproval/v1/src/builders.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod access_approval {
 
     /// Common implementation for [super::super::client::AccessApproval] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AccessApproval>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/advisorynotifications/v1/src/builders.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod advisory_notifications_service {
 
     /// Common implementation for [super::super::client::AdvisoryNotificationsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AdvisoryNotificationsService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/aiplatform/v1/src/builders.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod dataset_service {
 
     /// Common implementation for [super::super::client::DatasetService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DatasetService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2102,7 +2102,7 @@ pub mod deployment_resource_pool_service {
 
     /// Common implementation for [super::super::client::DeploymentResourcePoolService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DeploymentResourcePoolService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3188,7 +3188,7 @@ pub mod endpoint_service {
 
     /// Common implementation for [super::super::client::EndpointService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EndpointService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4510,7 +4510,7 @@ pub mod evaluation_service {
 
     /// Common implementation for [super::super::client::EvaluationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EvaluationService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5132,7 +5132,7 @@ pub mod feature_online_store_admin_service {
 
     /// Common implementation for [super::super::client::FeatureOnlineStoreAdminService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::FeatureOnlineStoreAdminService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -6748,7 +6748,7 @@ pub mod feature_online_store_service {
 
     /// Common implementation for [super::super::client::FeatureOnlineStoreService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::FeatureOnlineStoreService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -7462,7 +7462,7 @@ pub mod feature_registry_service {
 
     /// Common implementation for [super::super::client::FeatureRegistryService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::FeatureRegistryService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -8977,7 +8977,7 @@ pub mod featurestore_online_serving_service {
 
     /// Common implementation for [super::super::client::FeaturestoreOnlineServingService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::FeaturestoreOnlineServingService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -9684,7 +9684,7 @@ pub mod featurestore_service {
 
     /// Common implementation for [super::super::client::FeaturestoreService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::FeaturestoreService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -12137,7 +12137,7 @@ pub mod gen_ai_cache_service {
 
     /// Common implementation for [super::super::client::GenAiCacheService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::GenAiCacheService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -12972,7 +12972,7 @@ pub mod gen_ai_tuning_service {
 
     /// Common implementation for [super::super::client::GenAiTuningService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::GenAiTuningService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -13865,7 +13865,7 @@ pub mod index_endpoint_service {
 
     /// Common implementation for [super::super::client::IndexEndpointService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::IndexEndpointService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -15107,7 +15107,7 @@ pub mod index_service {
 
     /// Common implementation for [super::super::client::IndexService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::IndexService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -16171,7 +16171,7 @@ pub mod job_service {
 
     /// Common implementation for [super::super::client::JobService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::JobService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -18958,7 +18958,7 @@ pub mod llm_utility_service {
 
     /// Common implementation for [super::super::client::LlmUtilityService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::LlmUtilityService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -19694,7 +19694,7 @@ pub mod match_service {
 
     /// Common implementation for [super::super::client::MatchService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::MatchService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -20386,7 +20386,7 @@ pub mod metadata_service {
 
     /// Common implementation for [super::super::client::MetadataService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::MetadataService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -23064,7 +23064,7 @@ pub mod migration_service {
 
     /// Common implementation for [super::super::client::MigrationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::MigrationService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -23810,7 +23810,7 @@ pub mod model_garden_service {
 
     /// Common implementation for [super::super::client::ModelGardenService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ModelGardenService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -24445,7 +24445,7 @@ pub mod model_service {
 
     /// Common implementation for [super::super::client::ModelService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ModelService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -26405,7 +26405,7 @@ pub mod notebook_service {
 
     /// Common implementation for [super::super::client::NotebookService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::NotebookService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -28274,7 +28274,7 @@ pub mod persistent_resource_service {
 
     /// Common implementation for [super::super::client::PersistentResourceService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PersistentResourceService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -29373,7 +29373,7 @@ pub mod pipeline_service {
 
     /// Common implementation for [super::super::client::PipelineService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PipelineService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -30757,7 +30757,7 @@ pub mod prediction_service {
 
     /// Common implementation for [super::super::client::PredictionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PredictionService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -31740,7 +31740,7 @@ pub mod reasoning_engine_execution_service {
 
     /// Common implementation for [super::super::client::ReasoningEngineExecutionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ReasoningEngineExecutionService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -32387,7 +32387,7 @@ pub mod reasoning_engine_service {
 
     /// Common implementation for [super::super::client::ReasoningEngineService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ReasoningEngineService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -33381,7 +33381,7 @@ pub mod schedule_service {
 
     /// Common implementation for [super::super::client::ScheduleService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ScheduleService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -34336,7 +34336,7 @@ pub mod specialist_pool_service {
 
     /// Common implementation for [super::super::client::SpecialistPoolService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SpecialistPoolService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -35336,7 +35336,7 @@ pub mod tensorboard_service {
 
     /// Common implementation for [super::super::client::TensorboardService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TensorboardService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -37839,7 +37839,7 @@ pub mod vertex_rag_data_service {
 
     /// Common implementation for [super::super::client::VertexRagDataService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VertexRagDataService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -39156,7 +39156,7 @@ pub mod vertex_rag_service {
 
     /// Common implementation for [super::super::client::VertexRagService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VertexRagService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -39936,7 +39936,7 @@ pub mod vizier_service {
 
     /// Common implementation for [super::super::client::VizierService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VizierService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/alloydb/v1/src/builders.rs
+++ b/src/generated/cloud/alloydb/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod alloy_db_admin {
 
     /// Common implementation for [super::super::client::AlloyDBAdmin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AlloyDBAdmin>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/apigateway/v1/src/builders.rs
+++ b/src/generated/cloud/apigateway/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod api_gateway_service {
 
     /// Common implementation for [super::super::client::ApiGatewayService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ApiGatewayService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/apigeeconnect/v1/src/builders.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod connection_service {
 
     /// Common implementation for [super::super::client::ConnectionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConnectionService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/apihub/v1/src/builders.rs
+++ b/src/generated/cloud/apihub/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod api_hub {
 
     /// Common implementation for [super::super::client::ApiHub] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ApiHub>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2254,7 +2254,7 @@ pub mod api_hub_dependencies {
 
     /// Common implementation for [super::super::client::ApiHubDependencies] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ApiHubDependencies>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2884,7 +2884,7 @@ pub mod host_project_registration_service {
 
     /// Common implementation for [super::super::client::HostProjectRegistrationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::HostProjectRegistrationService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3456,7 +3456,7 @@ pub mod linting_service {
 
     /// Common implementation for [super::super::client::LintingService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::LintingService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3991,7 +3991,7 @@ pub mod api_hub_plugin {
 
     /// Common implementation for [super::super::client::ApiHubPlugin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ApiHubPlugin>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4467,7 +4467,7 @@ pub mod provisioning {
 
     /// Common implementation for [super::super::client::Provisioning] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Provisioning>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5006,7 +5006,7 @@ pub mod runtime_project_attachment_service {
 
     /// Common implementation for [super::super::client::RuntimeProjectAttachmentService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RuntimeProjectAttachmentService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/apphub/v1/src/builders.rs
+++ b/src/generated/cloud/apphub/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod app_hub {
 
     /// Common implementation for [super::super::client::AppHub] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AppHub>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/asset/v1/src/builders.rs
+++ b/src/generated/cloud/asset/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod asset_service {
 
     /// Common implementation for [super::super::client::AssetService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AssetService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/assuredworkloads/v1/src/builders.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod assured_workloads_service {
 
     /// Common implementation for [super::super::client::AssuredWorkloadsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AssuredWorkloadsService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/backupdr/v1/src/builders.rs
+++ b/src/generated/cloud/backupdr/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod backup_dr {
 
     /// Common implementation for [super::super::client::BackupDR] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::BackupDR>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/baremetalsolution/v2/src/builders.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod bare_metal_solution {
 
     /// Common implementation for [super::super::client::BareMetalSolution] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::BareMetalSolution>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod app_connections_service {
 
     /// Common implementation for [super::super::client::AppConnectionsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AppConnectionsService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod app_connectors_service {
 
     /// Common implementation for [super::super::client::AppConnectorsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AppConnectorsService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod app_gateways_service {
 
     /// Common implementation for [super::super::client::AppGatewaysService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AppGatewaysService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod client_connector_services_service {
 
     /// Common implementation for [super::super::client::ClientConnectorServicesService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ClientConnectorServicesService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod client_gateways_service {
 
     /// Common implementation for [super::super::client::ClientGatewaysService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ClientGatewaysService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod analytics_hub_service {
 
     /// Common implementation for [super::super::client::AnalyticsHubService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AnalyticsHubService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/bigquery/connection/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod connection_service {
 
     /// Common implementation for [super::super::client::ConnectionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConnectionService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod data_policy_service {
 
     /// Common implementation for [super::super::client::DataPolicyService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DataPolicyService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod data_transfer_service {
 
     /// Common implementation for [super::super::client::DataTransferService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DataTransferService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/bigquery/migration/v2/src/builders.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod migration_service {
 
     /// Common implementation for [super::super::client::MigrationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::MigrationService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/bigquery/reservation/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod reservation_service {
 
     /// Common implementation for [super::super::client::ReservationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ReservationService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/bigquery/v2/src/builders.rs
+++ b/src/generated/cloud/bigquery/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod dataset_service {
 
     /// Common implementation for [super::super::client::DatasetService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DatasetService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -471,7 +471,7 @@ pub mod model_service {
 
     /// Common implementation for [super::super::client::ModelService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ModelService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -727,7 +727,7 @@ pub mod project_service {
 
     /// Common implementation for [super::super::client::ProjectService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ProjectService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -797,7 +797,7 @@ pub mod routine_service {
 
     /// Common implementation for [super::super::client::RoutineService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RoutineService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1115,7 +1115,7 @@ pub mod row_access_policy_service {
 
     /// Common implementation for [super::super::client::RowAccessPolicyService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RowAccessPolicyService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1583,7 +1583,7 @@ pub mod table_service {
 
     /// Common implementation for [super::super::client::TableService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TableService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/billing/v1/src/builders.rs
+++ b/src/generated/cloud/billing/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_billing {
 
     /// Common implementation for [super::super::client::CloudBilling] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudBilling>,
         request: R,
         options: gax::options::RequestOptions,
@@ -670,7 +670,7 @@ pub mod cloud_catalog {
 
     /// Common implementation for [super::super::client::CloudCatalog] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudCatalog>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/binaryauthorization/v1/src/builders.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod binauthz_management_service_v_1 {
 
     /// Common implementation for [super::super::client::BinauthzManagementServiceV1] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::BinauthzManagementServiceV1>,
         request: R,
         options: gax::options::RequestOptions,
@@ -397,7 +397,7 @@ pub mod system_policy_v_1 {
 
     /// Common implementation for [super::super::client::SystemPolicyV1] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SystemPolicyV1>,
         request: R,
         options: gax::options::RequestOptions,
@@ -464,7 +464,7 @@ pub mod validation_helper_v_1 {
 
     /// Common implementation for [super::super::client::ValidationHelperV1] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ValidationHelperV1>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/certificatemanager/v1/src/builders.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod certificate_manager {
 
     /// Common implementation for [super::super::client::CertificateManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CertificateManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/builders.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_controls_partner_core {
 
     /// Common implementation for [super::super::client::CloudControlsPartnerCore] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudControlsPartnerCore>,
         request: R,
         options: gax::options::RequestOptions,
@@ -522,7 +522,7 @@ pub mod cloud_controls_partner_monitoring {
 
     /// Common implementation for [super::super::client::CloudControlsPartnerMonitoring] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudControlsPartnerMonitoring>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/clouddms/v1/src/builders.rs
+++ b/src/generated/cloud/clouddms/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod data_migration_service {
 
     /// Common implementation for [super::super::client::DataMigrationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DataMigrationService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builders.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod license_management_service {
 
     /// Common implementation for [super::super::client::LicenseManagementService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::LicenseManagementService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -376,7 +376,7 @@ pub mod consumer_procurement_service {
 
     /// Common implementation for [super::super::client::ConsumerProcurementService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConsumerProcurementService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/confidentialcomputing/v1/src/builders.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod confidential_computing {
 
     /// Common implementation for [super::super::client::ConfidentialComputing] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConfidentialComputing>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/config/v1/src/builders.rs
+++ b/src/generated/cloud/config/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod config {
 
     /// Common implementation for [super::super::client::Config] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Config>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/connectors/v1/src/builders.rs
+++ b/src/generated/cloud/connectors/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod connectors {
 
     /// Common implementation for [super::super::client::Connectors] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Connectors>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/contactcenterinsights/v1/src/builders.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod contact_center_insights {
 
     /// Common implementation for [super::super::client::ContactCenterInsights] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ContactCenterInsights>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builders.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod lineage {
 
     /// Common implementation for [super::super::client::Lineage] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Lineage>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/datacatalog/v1/src/builders.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod data_catalog {
 
     /// Common implementation for [super::super::client::DataCatalog] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DataCatalog>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2331,7 +2331,7 @@ pub mod policy_tag_manager {
 
     /// Common implementation for [super::super::client::PolicyTagManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PolicyTagManager>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3242,7 +3242,7 @@ pub mod policy_tag_manager_serialization {
 
     /// Common implementation for [super::super::client::PolicyTagManagerSerialization] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PolicyTagManagerSerialization>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/datafusion/v1/src/builders.rs
+++ b/src/generated/cloud/datafusion/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod data_fusion {
 
     /// Common implementation for [super::super::client::DataFusion] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DataFusion>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/dataproc/v1/src/builders.rs
+++ b/src/generated/cloud/dataproc/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod autoscaling_policy_service {
 
     /// Common implementation for [super::super::client::AutoscalingPolicyService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AutoscalingPolicyService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -714,7 +714,7 @@ pub mod batch_controller {
 
     /// Common implementation for [super::super::client::BatchController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::BatchController>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1375,7 +1375,7 @@ pub mod cluster_controller {
 
     /// Common implementation for [super::super::client::ClusterController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ClusterController>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2594,7 +2594,7 @@ pub mod job_controller {
 
     /// Common implementation for [super::super::client::JobController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::JobController>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3465,7 +3465,7 @@ pub mod node_group_controller {
 
     /// Common implementation for [super::super::client::NodeGroupController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::NodeGroupController>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4129,7 +4129,7 @@ pub mod session_template_controller {
 
     /// Common implementation for [super::super::client::SessionTemplateController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SessionTemplateController>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4819,7 +4819,7 @@ pub mod session_controller {
 
     /// Common implementation for [super::super::client::SessionController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SessionController>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5609,7 +5609,7 @@ pub mod workflow_template_service {
 
     /// Common implementation for [super::super::client::WorkflowTemplateService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::WorkflowTemplateService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/datastream/v1/src/builders.rs
+++ b/src/generated/cloud/datastream/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod datastream {
 
     /// Common implementation for [super::super::client::Datastream] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Datastream>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/deploy/v1/src/builders.rs
+++ b/src/generated/cloud/deploy/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_deploy {
 
     /// Common implementation for [super::super::client::CloudDeploy] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudDeploy>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/developerconnect/v1/src/builders.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod developer_connect {
 
     /// Common implementation for [super::super::client::DeveloperConnect] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DeveloperConnect>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/dialogflow/cx/v3/src/builders.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builders.rs
@@ -20,7 +20,7 @@ pub mod agents {
 
     /// Common implementation for [super::super::client::Agents] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Agents>,
         request: R,
         options: gax::options::RequestOptions,
@@ -999,7 +999,7 @@ pub mod changelogs {
 
     /// Common implementation for [super::super::client::Changelogs] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Changelogs>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1423,7 +1423,7 @@ pub mod deployments {
 
     /// Common implementation for [super::super::client::Deployments] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Deployments>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1841,7 +1841,7 @@ pub mod entity_types {
 
     /// Common implementation for [super::super::client::EntityTypes] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EntityTypes>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2679,7 +2679,7 @@ pub mod environments {
 
     /// Common implementation for [super::super::client::Environments] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Environments>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3646,7 +3646,7 @@ pub mod experiments {
 
     /// Common implementation for [super::super::client::Experiments] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Experiments>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4299,7 +4299,7 @@ pub mod flows {
 
     /// Common implementation for [super::super::client::Flows] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Flows>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5252,7 +5252,7 @@ pub mod generators {
 
     /// Common implementation for [super::super::client::Generators] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Generators>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5844,7 +5844,7 @@ pub mod intents {
 
     /// Common implementation for [super::super::client::Intents] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Intents>,
         request: R,
         options: gax::options::RequestOptions,
@@ -6649,7 +6649,7 @@ pub mod pages {
 
     /// Common implementation for [super::super::client::Pages] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Pages>,
         request: R,
         options: gax::options::RequestOptions,
@@ -7234,7 +7234,7 @@ pub mod security_settings_service {
 
     /// Common implementation for [super::super::client::SecuritySettingsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SecuritySettingsService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -7837,7 +7837,7 @@ pub mod sessions {
 
     /// Common implementation for [super::super::client::Sessions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Sessions>,
         request: R,
         options: gax::options::RequestOptions,
@@ -8415,7 +8415,7 @@ pub mod session_entity_types {
 
     /// Common implementation for [super::super::client::SessionEntityTypes] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SessionEntityTypes>,
         request: R,
         options: gax::options::RequestOptions,
@@ -9004,7 +9004,7 @@ pub mod test_cases {
 
     /// Common implementation for [super::super::client::TestCases] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TestCases>,
         request: R,
         options: gax::options::RequestOptions,
@@ -10154,7 +10154,7 @@ pub mod transition_route_groups {
 
     /// Common implementation for [super::super::client::TransitionRouteGroups] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TransitionRouteGroups>,
         request: R,
         options: gax::options::RequestOptions,
@@ -10799,7 +10799,7 @@ pub mod versions {
 
     /// Common implementation for [super::super::client::Versions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Versions>,
         request: R,
         options: gax::options::RequestOptions,
@@ -11535,7 +11535,7 @@ pub mod webhooks {
 
     /// Common implementation for [super::super::client::Webhooks] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Webhooks>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/dialogflow/v2/src/builders.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod agents {
 
     /// Common implementation for [super::super::client::Agents] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Agents>,
         request: R,
         options: gax::options::RequestOptions,
@@ -910,7 +910,7 @@ pub mod answer_records {
 
     /// Common implementation for [super::super::client::AnswerRecords] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AnswerRecords>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1352,7 +1352,7 @@ pub mod contexts {
 
     /// Common implementation for [super::super::client::Contexts] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Contexts>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1958,7 +1958,7 @@ pub mod conversations {
 
     /// Common implementation for [super::super::client::Conversations] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Conversations>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3028,7 +3028,7 @@ pub mod conversation_datasets {
 
     /// Common implementation for [super::super::client::ConversationDatasets] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConversationDatasets>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3761,7 +3761,7 @@ pub mod conversation_models {
 
     /// Common implementation for [super::super::client::ConversationModels] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConversationModels>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4765,7 +4765,7 @@ pub mod conversation_profiles {
 
     /// Common implementation for [super::super::client::ConversationProfiles] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConversationProfiles>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5602,7 +5602,7 @@ pub mod documents {
 
     /// Common implementation for [super::super::client::Documents] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Documents>,
         request: R,
         options: gax::options::RequestOptions,
@@ -6599,7 +6599,7 @@ pub mod encryption_spec_service {
 
     /// Common implementation for [super::super::client::EncryptionSpecService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EncryptionSpecService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -7060,7 +7060,7 @@ pub mod entity_types {
 
     /// Common implementation for [super::super::client::EntityTypes] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EntityTypes>,
         request: R,
         options: gax::options::RequestOptions,
@@ -8150,7 +8150,7 @@ pub mod environments {
 
     /// Common implementation for [super::super::client::Environments] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Environments>,
         request: R,
         options: gax::options::RequestOptions,
@@ -8807,7 +8807,7 @@ pub mod fulfillments {
 
     /// Common implementation for [super::super::client::Fulfillments] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Fulfillments>,
         request: R,
         options: gax::options::RequestOptions,
@@ -9213,7 +9213,7 @@ pub mod generators {
 
     /// Common implementation for [super::super::client::Generators] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Generators>,
         request: R,
         options: gax::options::RequestOptions,
@@ -9781,7 +9781,7 @@ pub mod intents {
 
     /// Common implementation for [super::super::client::Intents] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Intents>,
         request: R,
         options: gax::options::RequestOptions,
@@ -10594,7 +10594,7 @@ pub mod knowledge_bases {
 
     /// Common implementation for [super::super::client::KnowledgeBases] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::KnowledgeBases>,
         request: R,
         options: gax::options::RequestOptions,
@@ -11183,7 +11183,7 @@ pub mod participants {
 
     /// Common implementation for [super::super::client::Participants] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Participants>,
         request: R,
         options: gax::options::RequestOptions,
@@ -12067,7 +12067,7 @@ pub mod sessions {
 
     /// Common implementation for [super::super::client::Sessions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Sessions>,
         request: R,
         options: gax::options::RequestOptions,
@@ -12461,7 +12461,7 @@ pub mod session_entity_types {
 
     /// Common implementation for [super::super::client::SessionEntityTypes] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SessionEntityTypes>,
         request: R,
         options: gax::options::RequestOptions,
@@ -13050,7 +13050,7 @@ pub mod versions {
 
     /// Common implementation for [super::super::client::Versions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Versions>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/discoveryengine/v1/src/builders.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod completion_service {
 
     /// Common implementation for [super::super::client::CompletionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CompletionService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -663,7 +663,7 @@ pub mod control_service {
 
     /// Common implementation for [super::super::client::ControlService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ControlService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1119,7 +1119,7 @@ pub mod conversational_search_service {
 
     /// Common implementation for [super::super::client::ConversationalSearchService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConversationalSearchService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2176,7 +2176,7 @@ pub mod data_store_service {
 
     /// Common implementation for [super::super::client::DataStoreService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DataStoreService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2718,7 +2718,7 @@ pub mod document_service {
 
     /// Common implementation for [super::super::client::DocumentService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DocumentService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3475,7 +3475,7 @@ pub mod engine_service {
 
     /// Common implementation for [super::super::client::EngineService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EngineService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4004,7 +4004,7 @@ pub mod grounded_generation_service {
 
     /// Common implementation for [super::super::client::GroundedGenerationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::GroundedGenerationService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4394,7 +4394,7 @@ pub mod project_service {
 
     /// Common implementation for [super::super::client::ProjectService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ProjectService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4680,7 +4680,7 @@ pub mod rank_service {
 
     /// Common implementation for [super::super::client::RankService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RankService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4956,7 +4956,7 @@ pub mod recommendation_service {
 
     /// Common implementation for [super::super::client::RecommendationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RecommendationService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5247,7 +5247,7 @@ pub mod schema_service {
 
     /// Common implementation for [super::super::client::SchemaService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SchemaService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5805,7 +5805,7 @@ pub mod search_service {
 
     /// Common implementation for [super::super::client::SearchService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SearchService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -6520,7 +6520,7 @@ pub mod search_tuning_service {
 
     /// Common implementation for [super::super::client::SearchTuningService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SearchTuningService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -6886,7 +6886,7 @@ pub mod site_search_engine_service {
 
     /// Common implementation for [super::super::client::SiteSearchEngineService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SiteSearchEngineService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -8058,7 +8058,7 @@ pub mod user_event_service {
 
     /// Common implementation for [super::super::client::UserEventService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::UserEventService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/documentai/v1/src/builders.rs
+++ b/src/generated/cloud/documentai/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod document_processor_service {
 
     /// Common implementation for [super::super::client::DocumentProcessorService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DocumentProcessorService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/domains/v1/src/builders.rs
+++ b/src/generated/cloud/domains/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod domains {
 
     /// Common implementation for [super::super::client::Domains] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Domains>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/edgecontainer/v1/src/builders.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod edge_container {
 
     /// Common implementation for [super::super::client::EdgeContainer] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EdgeContainer>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/edgenetwork/v1/src/builders.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod edge_network {
 
     /// Common implementation for [super::super::client::EdgeNetwork] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EdgeNetwork>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/essentialcontacts/v1/src/builders.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod essential_contacts_service {
 
     /// Common implementation for [super::super::client::EssentialContactsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EssentialContactsService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/eventarc/v1/src/builders.rs
+++ b/src/generated/cloud/eventarc/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod eventarc {
 
     /// Common implementation for [super::super::client::Eventarc] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Eventarc>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/filestore/v1/src/builders.rs
+++ b/src/generated/cloud/filestore/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_filestore_manager {
 
     /// Common implementation for [super::super::client::CloudFilestoreManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudFilestoreManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/financialservices/v1/src/builders.rs
+++ b/src/generated/cloud/financialservices/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod aml {
 
     /// Common implementation for [super::super::client::Aml] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Aml>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/functions/v2/src/builders.rs
+++ b/src/generated/cloud/functions/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod function_service {
 
     /// Common implementation for [super::super::client::FunctionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::FunctionService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/gkebackup/v1/src/builders.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod backup_for_gke {
 
     /// Common implementation for [super::super::client::BackupForGKE] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::BackupForGKE>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/builders.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod gateway_control {
 
     /// Common implementation for [super::super::client::GatewayControl] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::GatewayControl>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/gkehub/v1/src/builders.rs
+++ b/src/generated/cloud/gkehub/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod gke_hub {
 
     /// Common implementation for [super::super::client::GkeHub] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::GkeHub>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/gkemulticloud/v1/src/builders.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod attached_clusters {
 
     /// Common implementation for [super::super::client::AttachedClusters] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AttachedClusters>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1005,7 +1005,7 @@ pub mod aws_clusters {
 
     /// Common implementation for [super::super::client::AwsClusters] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AwsClusters>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2439,7 +2439,7 @@ pub mod azure_clusters {
 
     /// Common implementation for [super::super::client::AzureClusters] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AzureClusters>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/gsuiteaddons/v1/src/builders.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod g_suite_add_ons {
 
     /// Common implementation for [super::super::client::GSuiteAddOns] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::GSuiteAddOns>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/iap/v1/src/builders.rs
+++ b/src/generated/cloud/iap/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod identity_aware_proxy_admin_service {
 
     /// Common implementation for [super::super::client::IdentityAwareProxyAdminService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::IdentityAwareProxyAdminService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -607,7 +607,7 @@ pub mod identity_aware_proxy_o_auth_service {
 
     /// Common implementation for [super::super::client::IdentityAwareProxyOAuthService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::IdentityAwareProxyOAuthService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/ids/v1/src/builders.rs
+++ b/src/generated/cloud/ids/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod ids {
 
     /// Common implementation for [super::super::client::Ids] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Ids>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/kms/inventory/v1/src/builders.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod key_dashboard_service {
 
     /// Common implementation for [super::super::client::KeyDashboardService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::KeyDashboardService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -118,7 +118,7 @@ pub mod key_tracking_service {
 
     /// Common implementation for [super::super::client::KeyTrackingService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::KeyTrackingService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/kms/v1/src/builders.rs
+++ b/src/generated/cloud/kms/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod autokey {
 
     /// Common implementation for [super::super::client::Autokey] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Autokey>,
         request: R,
         options: gax::options::RequestOptions,
@@ -582,7 +582,7 @@ pub mod autokey_admin {
 
     /// Common implementation for [super::super::client::AutokeyAdmin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AutokeyAdmin>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1080,7 +1080,7 @@ pub mod ekm_service {
 
     /// Common implementation for [super::super::client::EkmService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EkmService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1812,7 +1812,7 @@ pub mod key_management_service {
 
     /// Common implementation for [super::super::client::KeyManagementService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::KeyManagementService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/language/v2/src/builders.rs
+++ b/src/generated/cloud/language/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod language_service {
 
     /// Common implementation for [super::super::client::LanguageService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::LanguageService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/location/src/builders.rs
+++ b/src/generated/cloud/location/src/builders.rs
@@ -20,7 +20,7 @@ pub mod locations {
 
     /// Common implementation for [super::super::client::Locations] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Locations>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/managedidentities/v1/src/builders.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod managed_identities_service {
 
     /// Common implementation for [super::super::client::ManagedIdentitiesService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ManagedIdentitiesService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/memcache/v1/src/builders.rs
+++ b/src/generated/cloud/memcache/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_memcache {
 
     /// Common implementation for [super::super::client::CloudMemcache] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudMemcache>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/memorystore/v1/src/builders.rs
+++ b/src/generated/cloud/memorystore/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod memorystore {
 
     /// Common implementation for [super::super::client::Memorystore] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Memorystore>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/metastore/v1/src/builders.rs
+++ b/src/generated/cloud/metastore/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod dataproc_metastore {
 
     /// Common implementation for [super::super::client::DataprocMetastore] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DataprocMetastore>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2066,7 +2066,7 @@ pub mod dataproc_metastore_federation {
 
     /// Common implementation for [super::super::client::DataprocMetastoreFederation] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DataprocMetastoreFederation>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/migrationcenter/v1/src/builders.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod migration_center {
 
     /// Common implementation for [super::super::client::MigrationCenter] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::MigrationCenter>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/modelarmor/v1/src/builders.rs
+++ b/src/generated/cloud/modelarmor/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod model_armor {
 
     /// Common implementation for [super::super::client::ModelArmor] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ModelArmor>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/netapp/v1/src/builders.rs
+++ b/src/generated/cloud/netapp/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod net_app {
 
     /// Common implementation for [super::super::client::NetApp] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::NetApp>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/networkconnectivity/v1/src/builders.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod hub_service {
 
     /// Common implementation for [super::super::client::HubService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::HubService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2163,7 +2163,7 @@ pub mod policy_based_routing_service {
 
     /// Common implementation for [super::super::client::PolicyBasedRoutingService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PolicyBasedRoutingService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/networkmanagement/v1/src/builders.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod reachability_service {
 
     /// Common implementation for [super::super::client::ReachabilityService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ReachabilityService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1051,7 +1051,7 @@ pub mod vpc_flow_logs_service {
 
     /// Common implementation for [super::super::client::VpcFlowLogsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VpcFlowLogsService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/networksecurity/v1/src/builders.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod network_security {
 
     /// Common implementation for [super::super::client::NetworkSecurity] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::NetworkSecurity>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/networkservices/v1/src/builders.rs
+++ b/src/generated/cloud/networkservices/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod dep_service {
 
     /// Common implementation for [super::super::client::DepService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DepService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1389,7 +1389,7 @@ pub mod network_services {
 
     /// Common implementation for [super::super::client::NetworkServices] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::NetworkServices>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/notebooks/v2/src/builders.rs
+++ b/src/generated/cloud/notebooks/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod notebook_service {
 
     /// Common implementation for [super::super::client::NotebookService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::NotebookService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/optimization/v1/src/builders.rs
+++ b/src/generated/cloud/optimization/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod fleet_routing {
 
     /// Common implementation for [super::super::client::FleetRouting] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::FleetRouting>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/oracledatabase/v1/src/builders.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod oracle_database {
 
     /// Common implementation for [super::super::client::OracleDatabase] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::OracleDatabase>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builders.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod environments {
 
     /// Common implementation for [super::super::client::Environments] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Environments>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1831,7 +1831,7 @@ pub mod image_versions {
 
     /// Common implementation for [super::super::client::ImageVersions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ImageVersions>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/orgpolicy/v2/src/builders.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod org_policy {
 
     /// Common implementation for [super::super::client::OrgPolicy] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::OrgPolicy>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/osconfig/v1/src/builders.rs
+++ b/src/generated/cloud/osconfig/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod os_config_service {
 
     /// Common implementation for [super::super::client::OsConfigService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::OsConfigService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -827,7 +827,7 @@ pub mod os_config_zonal_service {
 
     /// Common implementation for [super::super::client::OsConfigZonalService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::OsConfigZonalService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/oslogin/v1/src/builders.rs
+++ b/src/generated/cloud/oslogin/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod os_login_service {
 
     /// Common implementation for [super::super::client::OsLoginService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::OsLoginService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/parallelstore/v1/src/builders.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod parallelstore {
 
     /// Common implementation for [super::super::client::Parallelstore] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Parallelstore>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/parametermanager/v1/src/builders.rs
+++ b/src/generated/cloud/parametermanager/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod parameter_manager {
 
     /// Common implementation for [super::super::client::ParameterManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ParameterManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/policysimulator/v1/src/builders.rs
+++ b/src/generated/cloud/policysimulator/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod simulator {
 
     /// Common implementation for [super::super::client::Simulator] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Simulator>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/builders.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/builders.rs
@@ -20,7 +20,7 @@ pub mod policy_troubleshooter {
 
     /// Common implementation for [super::super::client::PolicyTroubleshooter] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PolicyTroubleshooter>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/policytroubleshooter/v1/src/builders.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod iam_checker {
 
     /// Common implementation for [super::super::client::IamChecker] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::IamChecker>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/builders.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod privileged_access_manager {
 
     /// Common implementation for [super::super::client::PrivilegedAccessManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PrivilegedAccessManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/builders.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod rapid_migration_assessment {
 
     /// Common implementation for [super::super::client::RapidMigrationAssessment] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RapidMigrationAssessment>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builders.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod recaptcha_enterprise_service {
 
     /// Common implementation for [super::super::client::RecaptchaEnterpriseService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RecaptchaEnterpriseService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/recommender/v1/src/builders.rs
+++ b/src/generated/cloud/recommender/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod recommender {
 
     /// Common implementation for [super::super::client::Recommender] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Recommender>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/redis/cluster/v1/src/builders.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_redis_cluster {
 
     /// Common implementation for [super::super::client::CloudRedisCluster] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudRedisCluster>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/redis/v1/src/builders.rs
+++ b/src/generated/cloud/redis/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_redis {
 
     /// Common implementation for [super::super::client::CloudRedis] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudRedis>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/resourcemanager/v3/src/builders.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builders.rs
@@ -20,7 +20,7 @@ pub mod folders {
 
     /// Common implementation for [super::super::client::Folders] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Folders>,
         request: R,
         options: gax::options::RequestOptions,
@@ -852,7 +852,7 @@ pub mod organizations {
 
     /// Common implementation for [super::super::client::Organizations] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Organizations>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1198,7 +1198,7 @@ pub mod projects {
 
     /// Common implementation for [super::super::client::Projects] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Projects>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2032,7 +2032,7 @@ pub mod tag_bindings {
 
     /// Common implementation for [super::super::client::TagBindings] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TagBindings>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2414,7 +2414,7 @@ pub mod tag_holds {
 
     /// Common implementation for [super::super::client::TagHolds] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TagHolds>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2734,7 +2734,7 @@ pub mod tag_keys {
 
     /// Common implementation for [super::super::client::TagKeys] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TagKeys>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3397,7 +3397,7 @@ pub mod tag_values {
 
     /// Common implementation for [super::super::client::TagValues] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TagValues>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/retail/v2/src/builders.rs
+++ b/src/generated/cloud/retail/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod analytics_service {
 
     /// Common implementation for [super::super::client::AnalyticsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AnalyticsService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -267,7 +267,7 @@ pub mod catalog_service {
 
     /// Common implementation for [super::super::client::CatalogService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CatalogService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1016,7 +1016,7 @@ pub mod completion_service {
 
     /// Common implementation for [super::super::client::CompletionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CompletionService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1359,7 +1359,7 @@ pub mod control_service {
 
     /// Common implementation for [super::super::client::ControlService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ControlService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1771,7 +1771,7 @@ pub mod generative_question_service {
 
     /// Common implementation for [super::super::client::GenerativeQuestionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::GenerativeQuestionService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2207,7 +2207,7 @@ pub mod model_service {
 
     /// Common implementation for [super::super::client::ModelService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ModelService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2812,7 +2812,7 @@ pub mod prediction_service {
 
     /// Common implementation for [super::super::client::PredictionService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PredictionService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3053,7 +3053,7 @@ pub mod product_service {
 
     /// Common implementation for [super::super::client::ProductService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ProductService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4270,7 +4270,7 @@ pub mod search_service {
 
     /// Common implementation for [super::super::client::SearchService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SearchService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -4669,7 +4669,7 @@ pub mod serving_config_service {
 
     /// Common implementation for [super::super::client::ServingConfigService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ServingConfigService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -5204,7 +5204,7 @@ pub mod user_event_service {
 
     /// Common implementation for [super::super::client::UserEventService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::UserEventService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/run/v2/src/builders.rs
+++ b/src/generated/cloud/run/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod builds {
 
     /// Common implementation for [super::super::client::Builds] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Builds>,
         request: R,
         options: gax::options::RequestOptions,
@@ -349,7 +349,7 @@ pub mod executions {
 
     /// Common implementation for [super::super::client::Executions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Executions>,
         request: R,
         options: gax::options::RequestOptions,
@@ -881,7 +881,7 @@ pub mod jobs {
 
     /// Common implementation for [super::super::client::Jobs] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Jobs>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1765,7 +1765,7 @@ pub mod revisions {
 
     /// Common implementation for [super::super::client::Revisions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Revisions>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2209,7 +2209,7 @@ pub mod services {
 
     /// Common implementation for [super::super::client::Services] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Services>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3014,7 +3014,7 @@ pub mod tasks {
 
     /// Common implementation for [super::super::client::Tasks] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Tasks>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/scheduler/v1/src/builders.rs
+++ b/src/generated/cloud/scheduler/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_scheduler {
 
     /// Common implementation for [super::super::client::CloudScheduler] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudScheduler>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/secretmanager/v1/src/builders.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod secret_manager_service {
 
     /// Common implementation for [super::super::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SecretManagerService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/securesourcemanager/v1/src/builders.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod secure_source_manager {
 
     /// Common implementation for [super::super::client::SecureSourceManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SecureSourceManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/security/privateca/v1/src/builders.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod certificate_authority_service {
 
     /// Common implementation for [super::super::client::CertificateAuthorityService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CertificateAuthorityService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/security/publicca/v1/src/builders.rs
+++ b/src/generated/cloud/security/publicca/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod public_certificate_authority_service {
 
     /// Common implementation for [super::super::client::PublicCertificateAuthorityService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PublicCertificateAuthorityService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/securitycenter/v2/src/builders.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod security_center {
 
     /// Common implementation for [super::super::client::SecurityCenter] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SecurityCenter>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/securityposture/v1/src/builders.rs
+++ b/src/generated/cloud/securityposture/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod security_posture {
 
     /// Common implementation for [super::super::client::SecurityPosture] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SecurityPosture>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/servicedirectory/v1/src/builders.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod lookup_service {
 
     /// Common implementation for [super::super::client::LookupService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::LookupService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -217,7 +217,7 @@ pub mod registration_service {
 
     /// Common implementation for [super::super::client::RegistrationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RegistrationService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/servicehealth/v1/src/builders.rs
+++ b/src/generated/cloud/servicehealth/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod service_health {
 
     /// Common implementation for [super::super::client::ServiceHealth] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ServiceHealth>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/shell/v1/src/builders.rs
+++ b/src/generated/cloud/shell/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_shell_service {
 
     /// Common implementation for [super::super::client::CloudShellService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudShellService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/speech/v2/src/builders.rs
+++ b/src/generated/cloud/speech/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod speech {
 
     /// Common implementation for [super::super::client::Speech] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Speech>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/sql/v1/src/builders.rs
+++ b/src/generated/cloud/sql/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod sql_backup_runs_service {
 
     /// Common implementation for [super::super::client::SqlBackupRunsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlBackupRunsService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -263,7 +263,7 @@ pub mod sql_connect_service {
 
     /// Common implementation for [super::super::client::SqlConnectService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlConnectService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -412,7 +412,7 @@ pub mod sql_databases_service {
 
     /// Common implementation for [super::super::client::SqlDatabasesService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlDatabasesService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -761,7 +761,7 @@ pub mod sql_flags_service {
 
     /// Common implementation for [super::super::client::SqlFlagsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlFlagsService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -827,7 +827,7 @@ pub mod sql_instances_service {
 
     /// Common implementation for [super::super::client::SqlInstancesService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlInstancesService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2636,7 +2636,7 @@ pub mod sql_operations_service {
 
     /// Common implementation for [super::super::client::SqlOperationsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlOperationsService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2814,7 +2814,7 @@ pub mod sql_ssl_certs_service {
 
     /// Common implementation for [super::super::client::SqlSslCertsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlSslCertsService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3045,7 +3045,7 @@ pub mod sql_tiers_service {
 
     /// Common implementation for [super::super::client::SqlTiersService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlTiersService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -3111,7 +3111,7 @@ pub mod sql_users_service {
 
     /// Common implementation for [super::super::client::SqlUsersService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SqlUsersService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/storageinsights/v1/src/builders.rs
+++ b/src/generated/cloud/storageinsights/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod storage_insights {
 
     /// Common implementation for [super::super::client::StorageInsights] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::StorageInsights>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/support/v2/src/builders.rs
+++ b/src/generated/cloud/support/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod case_attachment_service {
 
     /// Common implementation for [super::super::client::CaseAttachmentService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CaseAttachmentService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -118,7 +118,7 @@ pub mod case_service {
 
     /// Common implementation for [super::super::client::CaseService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CaseService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -595,7 +595,7 @@ pub mod comment_service {
 
     /// Common implementation for [super::super::client::CommentService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CommentService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/talent/v4/src/builders.rs
+++ b/src/generated/cloud/talent/v4/src/builders.rs
@@ -20,7 +20,7 @@ pub mod company_service {
 
     /// Common implementation for [super::super::client::CompanyService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CompanyService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -349,7 +349,7 @@ pub mod completion {
 
     /// Common implementation for [super::super::client::Completion] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Completion>,
         request: R,
         options: gax::options::RequestOptions,
@@ -507,7 +507,7 @@ pub mod event_service {
 
     /// Common implementation for [super::super::client::EventService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::EventService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -630,7 +630,7 @@ pub mod job_service {
 
     /// Common implementation for [super::super::client::JobService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::JobService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1574,7 +1574,7 @@ pub mod tenant_service {
 
     /// Common implementation for [super::super::client::TenantService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TenantService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/tasks/v2/src/builders.rs
+++ b/src/generated/cloud/tasks/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_tasks {
 
     /// Common implementation for [super::super::client::CloudTasks] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudTasks>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/telcoautomation/v1/src/builders.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod telco_automation {
 
     /// Common implementation for [super::super::client::TelcoAutomation] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TelcoAutomation>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/texttospeech/v1/src/builders.rs
+++ b/src/generated/cloud/texttospeech/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod text_to_speech {
 
     /// Common implementation for [super::super::client::TextToSpeech] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TextToSpeech>,
         request: R,
         options: gax::options::RequestOptions,
@@ -284,7 +284,7 @@ pub mod text_to_speech_long_audio_synthesize {
 
     /// Common implementation for [super::super::client::TextToSpeechLongAudioSynthesize] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TextToSpeechLongAudioSynthesize>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/timeseriesinsights/v1/src/builders.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod timeseries_insights_controller {
 
     /// Common implementation for [super::super::client::TimeseriesInsightsController] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TimeseriesInsightsController>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/tpu/v2/src/builders.rs
+++ b/src/generated/cloud/tpu/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod tpu {
 
     /// Common implementation for [super::super::client::Tpu] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Tpu>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/translate/v3/src/builders.rs
+++ b/src/generated/cloud/translate/v3/src/builders.rs
@@ -20,7 +20,7 @@ pub mod translation_service {
 
     /// Common implementation for [super::super::client::TranslationService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TranslationService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/video/livestream/v1/src/builders.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod livestream_service {
 
     /// Common implementation for [super::super::client::LivestreamService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::LivestreamService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/video/stitcher/v1/src/builders.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod video_stitcher_service {
 
     /// Common implementation for [super::super::client::VideoStitcherService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VideoStitcherService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/video/transcoder/v1/src/builders.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod transcoder_service {
 
     /// Common implementation for [super::super::client::TranscoderService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TranscoderService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/videointelligence/v1/src/builders.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod video_intelligence_service {
 
     /// Common implementation for [super::super::client::VideoIntelligenceService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VideoIntelligenceService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/vision/v1/src/builders.rs
+++ b/src/generated/cloud/vision/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod image_annotator {
 
     /// Common implementation for [super::super::client::ImageAnnotator] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ImageAnnotator>,
         request: R,
         options: gax::options::RequestOptions,
@@ -453,7 +453,7 @@ pub mod product_search {
 
     /// Common implementation for [super::super::client::ProductSearch] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ProductSearch>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/vmmigration/v1/src/builders.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod vm_migration {
 
     /// Common implementation for [super::super::client::VmMigration] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VmMigration>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/vmwareengine/v1/src/builders.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod vmware_engine {
 
     /// Common implementation for [super::super::client::VmwareEngine] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VmwareEngine>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/vpcaccess/v1/src/builders.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod vpc_access_service {
 
     /// Common implementation for [super::super::client::VpcAccessService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::VpcAccessService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/webrisk/v1/src/builders.rs
+++ b/src/generated/cloud/webrisk/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod web_risk_service {
 
     /// Common implementation for [super::super::client::WebRiskService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::WebRiskService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/websecurityscanner/v1/src/builders.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod web_security_scanner {
 
     /// Common implementation for [super::super::client::WebSecurityScanner] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::WebSecurityScanner>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/workflows/executions/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod executions {
 
     /// Common implementation for [super::super::client::Executions] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Executions>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/workflows/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod workflows {
 
     /// Common implementation for [super::super::client::Workflows] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Workflows>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/cloud/workstations/v1/src/builders.rs
+++ b/src/generated/cloud/workstations/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod workstations {
 
     /// Common implementation for [super::super::client::Workstations] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Workstations>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/container/v1/src/builders.rs
+++ b/src/generated/container/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cluster_manager {
 
     /// Common implementation for [super::super::client::ClusterManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ClusterManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/datastore/admin/v1/src/builders.rs
+++ b/src/generated/datastore/admin/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod datastore_admin {
 
     /// Common implementation for [super::super::client::DatastoreAdmin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DatastoreAdmin>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/devtools/artifactregistry/v1/src/builders.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod artifact_registry {
 
     /// Common implementation for [super::super::client::ArtifactRegistry] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ArtifactRegistry>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/devtools/cloudbuild/v1/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod cloud_build {
 
     /// Common implementation for [super::super::client::CloudBuild] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::CloudBuild>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/devtools/cloudbuild/v2/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod repository_manager {
 
     /// Common implementation for [super::super::client::RepositoryManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::RepositoryManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/devtools/cloudprofiler/v2/src/builders.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod profiler_service {
 
     /// Common implementation for [super::super::client::ProfilerService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ProfilerService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -213,7 +213,7 @@ pub mod export_service {
 
     /// Common implementation for [super::super::client::ExportService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ExportService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/devtools/cloudtrace/v2/src/builders.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod trace_service {
 
     /// Common implementation for [super::super::client::TraceService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::TraceService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/devtools/containeranalysis/v1/src/builders.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod container_analysis {
 
     /// Common implementation for [super::super::client::ContainerAnalysis] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ContainerAnalysis>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/firestore/admin/v1/src/builders.rs
+++ b/src/generated/firestore/admin/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod firestore_admin {
 
     /// Common implementation for [super::super::client::FirestoreAdmin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::FirestoreAdmin>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/grafeas/v1/src/builders.rs
+++ b/src/generated/grafeas/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod grafeas {
 
     /// Common implementation for [super::super::client::Grafeas] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Grafeas>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/iam/admin/v1/src/builders.rs
+++ b/src/generated/iam/admin/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod iam {
 
     /// Common implementation for [super::super::client::Iam] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Iam>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/iam/credentials/v1/src/builders.rs
+++ b/src/generated/iam/credentials/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod iam_credentials {
 
     /// Common implementation for [super::super::client::IAMCredentials] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::IAMCredentials>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/iam/v1/src/builders.rs
+++ b/src/generated/iam/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod iam_policy {
 
     /// Common implementation for [super::super::client::IAMPolicy] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::IAMPolicy>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/iam/v2/src/builders.rs
+++ b/src/generated/iam/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod policies {
 
     /// Common implementation for [super::super::client::Policies] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Policies>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/iam/v3/src/builders.rs
+++ b/src/generated/iam/v3/src/builders.rs
@@ -20,7 +20,7 @@ pub mod policy_bindings {
 
     /// Common implementation for [super::super::client::PolicyBindings] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PolicyBindings>,
         request: R,
         options: gax::options::RequestOptions,
@@ -588,7 +588,7 @@ pub mod principal_access_boundary_policies {
 
     /// Common implementation for [super::super::client::PrincipalAccessBoundaryPolicies] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::PrincipalAccessBoundaryPolicies>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/identity/accesscontextmanager/v1/src/builders.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod access_context_manager {
 
     /// Common implementation for [super::super::client::AccessContextManager] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AccessContextManager>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/logging/v2/src/builders.rs
+++ b/src/generated/logging/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod logging_service_v_2 {
 
     /// Common implementation for [super::super::client::LoggingServiceV2] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::LoggingServiceV2>,
         request: R,
         options: gax::options::RequestOptions,
@@ -554,7 +554,7 @@ pub mod config_service_v_2 {
 
     /// Common implementation for [super::super::client::ConfigServiceV2] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ConfigServiceV2>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2602,7 +2602,7 @@ pub mod metrics_service_v_2 {
 
     /// Common implementation for [super::super::client::MetricsServiceV2] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::MetricsServiceV2>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/longrunning/src/builders.rs
+++ b/src/generated/longrunning/src/builders.rs
@@ -20,7 +20,7 @@ pub mod operations {
 
     /// Common implementation for [super::super::client::Operations] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::Operations>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/monitoring/dashboard/v1/src/builders.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod dashboards_service {
 
     /// Common implementation for [super::super::client::DashboardsService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DashboardsService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/monitoring/metricsscope/v1/src/builders.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod metrics_scopes {
 
     /// Common implementation for [super::super::client::MetricsScopes] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::MetricsScopes>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/monitoring/v3/src/builders.rs
+++ b/src/generated/monitoring/v3/src/builders.rs
@@ -20,7 +20,7 @@ pub mod alert_policy_service {
 
     /// Common implementation for [super::super::client::AlertPolicyService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::AlertPolicyService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -323,7 +323,7 @@ pub mod group_service {
 
     /// Common implementation for [super::super::client::GroupService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::GroupService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -706,7 +706,7 @@ pub mod metric_service {
 
     /// Common implementation for [super::super::client::MetricService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::MetricService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1311,7 +1311,7 @@ pub mod notification_channel_service {
 
     /// Common implementation for [super::super::client::NotificationChannelService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::NotificationChannelService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -1941,7 +1941,7 @@ pub mod query_service {
 
     /// Common implementation for [super::super::client::QueryService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::QueryService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2041,7 +2041,7 @@ pub mod service_monitoring_service {
 
     /// Common implementation for [super::super::client::ServiceMonitoringService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::ServiceMonitoringService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2671,7 +2671,7 @@ pub mod snooze_service {
 
     /// Common implementation for [super::super::client::SnoozeService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SnoozeService>,
         request: R,
         options: gax::options::RequestOptions,
@@ -2915,7 +2915,7 @@ pub mod uptime_check_service {
 
     /// Common implementation for [super::super::client::UptimeCheckService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::UptimeCheckService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/openapi-validation/src/builders.rs
+++ b/src/generated/openapi-validation/src/builders.rs
@@ -20,7 +20,7 @@ pub mod secret_manager_service {
 
     /// Common implementation for [super::super::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::SecretManagerService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/privacy/dlp/v2/src/builders.rs
+++ b/src/generated/privacy/dlp/v2/src/builders.rs
@@ -20,7 +20,7 @@ pub mod dlp_service {
 
     /// Common implementation for [super::super::client::DlpService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DlpService>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/spanner/admin/database/v1/src/builders.rs
+++ b/src/generated/spanner/admin/database/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod database_admin {
 
     /// Common implementation for [super::super::client::DatabaseAdmin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::DatabaseAdmin>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/spanner/admin/instance/v1/src/builders.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod instance_admin {
 
     /// Common implementation for [super::super::client::InstanceAdmin] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::InstanceAdmin>,
         request: R,
         options: gax::options::RequestOptions,

--- a/src/generated/storagetransfer/v1/src/builders.rs
+++ b/src/generated/storagetransfer/v1/src/builders.rs
@@ -20,7 +20,7 @@ pub mod storage_transfer_service {
 
     /// Common implementation for [super::super::client::StorageTransferService] request builders.
     #[derive(Clone, Debug)]
-    pub struct RequestBuilder<R: std::default::Default> {
+    pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: Arc<dyn super::super::stubs::dynamic::StorageTransferService>,
         request: R,
         options: gax::options::RequestOptions,


### PR DESCRIPTION
Noticed in #1541 

These types only exist to simplify the implementation. They do not need to be public.

https://docs.rs/google-cloud-kms-v1/latest/google_cloud_kms_v1/builders/autokey/struct.RequestBuilder.html

I am too lazy to call this a break. The only thing lost are the typenames. These things had no public fields/methods. Meh. :shrug: 