### PR TITLE
feat(generator/rust): modules link their message

### DIFF
--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -190,7 +190,7 @@ impl gax::paginator::PageableResponse for {{Name}} {
 {{/Pagination}}
 {{#Codec.HasNestedTypes}}
 
-/// Defines additional types related to {{Name}}
+/// Defines additional types related to [{{Name}}].
 pub mod {{Codec.ModuleName}} {
     {{! Very rarely, this is unused. It is easier to always disable the warning. }}
     #[allow(unused_imports)]

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/model.rs
@@ -712,7 +712,7 @@ impl wkt::message::Message for AuditLogConfig {
     }
 }
 
-/// Defines additional types related to AuditLogConfig
+/// Defines additional types related to [AuditLogConfig].
 pub mod audit_log_config {
     #[allow(unused_imports)]
     use super::*;
@@ -898,7 +898,7 @@ impl wkt::message::Message for BindingDelta {
     }
 }
 
-/// Defines additional types related to BindingDelta
+/// Defines additional types related to [BindingDelta].
 pub mod binding_delta {
     #[allow(unused_imports)]
     use super::*;
@@ -1031,7 +1031,7 @@ impl wkt::message::Message for AuditConfigDelta {
     }
 }
 
-/// Defines additional types related to AuditConfigDelta
+/// Defines additional types related to [AuditConfigDelta].
 pub mod audit_config_delta {
     #[allow(unused_imports)]
     use super::*;

--- a/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
@@ -248,7 +248,7 @@ impl wkt::message::Message for QuotaFailure {
     }
 }
 
-/// Defines additional types related to QuotaFailure
+/// Defines additional types related to [QuotaFailure].
 pub mod quota_failure {
     #[allow(unused_imports)]
     use super::*;
@@ -343,7 +343,7 @@ impl wkt::message::Message for PreconditionFailure {
     }
 }
 
-/// Defines additional types related to PreconditionFailure
+/// Defines additional types related to [PreconditionFailure].
 pub mod precondition_failure {
     #[allow(unused_imports)]
     use super::*;
@@ -444,7 +444,7 @@ impl wkt::message::Message for BadRequest {
     }
 }
 
-/// Defines additional types related to BadRequest
+/// Defines additional types related to [BadRequest].
 pub mod bad_request {
     #[allow(unused_imports)]
     use super::*;
@@ -682,7 +682,7 @@ impl wkt::message::Message for Help {
     }
 }
 
-/// Defines additional types related to Help
+/// Defines additional types related to [Help].
 pub mod help {
     #[allow(unused_imports)]
     use super::*;

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -324,7 +324,7 @@ impl wkt::message::Message for Secret {
     }
 }
 
-/// Defines additional types related to Secret
+/// Defines additional types related to [Secret].
 pub mod secret {
     #[allow(unused_imports)]
     use super::*;
@@ -519,7 +519,7 @@ impl wkt::message::Message for SecretVersion {
     }
 }
 
-/// Defines additional types related to SecretVersion
+/// Defines additional types related to [SecretVersion].
 pub mod secret_version {
     #[allow(unused_imports)]
     use super::*;
@@ -688,7 +688,7 @@ impl wkt::message::Message for Replication {
     }
 }
 
-/// Defines additional types related to Replication
+/// Defines additional types related to [Replication].
 pub mod replication {
     #[allow(unused_imports)]
     use super::*;
@@ -783,7 +783,7 @@ pub mod replication {
         }
     }
 
-    /// Defines additional types related to UserManaged
+    /// Defines additional types related to [UserManaged].
     pub mod user_managed {
         #[allow(unused_imports)]
         use super::*;
@@ -997,7 +997,7 @@ impl wkt::message::Message for ReplicationStatus {
     }
 }
 
-/// Defines additional types related to ReplicationStatus
+/// Defines additional types related to [ReplicationStatus].
 pub mod replication_status {
     #[allow(unused_imports)]
     use super::*;
@@ -1091,7 +1091,7 @@ pub mod replication_status {
         }
     }
 
-    /// Defines additional types related to UserManagedStatus
+    /// Defines additional types related to [UserManagedStatus].
     pub mod user_managed_status {
         #[allow(unused_imports)]
         use super::*;

--- a/src/firestore/src/generated/gapic/model.rs
+++ b/src/firestore/src/generated/gapic/model.rs
@@ -304,7 +304,7 @@ impl wkt::message::Message for Precondition {
     }
 }
 
-/// Defines additional types related to Precondition
+/// Defines additional types related to [Precondition].
 pub mod precondition {
     #[allow(unused_imports)]
     use super::*;
@@ -428,7 +428,7 @@ impl wkt::message::Message for TransactionOptions {
     }
 }
 
-/// Defines additional types related to TransactionOptions
+/// Defines additional types related to [TransactionOptions].
 pub mod transaction_options {
     #[allow(unused_imports)]
     use super::*;
@@ -539,7 +539,7 @@ pub mod transaction_options {
         }
     }
 
-    /// Defines additional types related to ReadOnly
+    /// Defines additional types related to [ReadOnly].
     pub mod read_only {
         #[allow(unused_imports)]
         use super::*;
@@ -994,7 +994,7 @@ impl wkt::message::Message for Value {
     }
 }
 
-/// Defines additional types related to Value
+/// Defines additional types related to [Value].
 pub mod value {
     #[allow(unused_imports)]
     use super::*;
@@ -1293,7 +1293,7 @@ impl wkt::message::Message for GetDocumentRequest {
     }
 }
 
-/// Defines additional types related to GetDocumentRequest
+/// Defines additional types related to [GetDocumentRequest].
 pub mod get_document_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1532,7 +1532,7 @@ impl wkt::message::Message for ListDocumentsRequest {
     }
 }
 
-/// Defines additional types related to ListDocumentsRequest
+/// Defines additional types related to [ListDocumentsRequest].
 pub mod list_documents_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2024,7 +2024,7 @@ impl wkt::message::Message for BatchGetDocumentsRequest {
     }
 }
 
-/// Defines additional types related to BatchGetDocumentsRequest
+/// Defines additional types related to [BatchGetDocumentsRequest].
 pub mod batch_get_documents_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2191,7 +2191,7 @@ impl wkt::message::Message for BatchGetDocumentsResponse {
     }
 }
 
-/// Defines additional types related to BatchGetDocumentsResponse
+/// Defines additional types related to [BatchGetDocumentsResponse].
 pub mod batch_get_documents_response {
     #[allow(unused_imports)]
     use super::*;
@@ -2662,7 +2662,7 @@ impl wkt::message::Message for RunQueryRequest {
     }
 }
 
-/// Defines additional types related to RunQueryRequest
+/// Defines additional types related to [RunQueryRequest].
 pub mod run_query_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2871,7 +2871,7 @@ impl wkt::message::Message for RunQueryResponse {
     }
 }
 
-/// Defines additional types related to RunQueryResponse
+/// Defines additional types related to [RunQueryResponse].
 pub mod run_query_response {
     #[allow(unused_imports)]
     use super::*;
@@ -3105,7 +3105,7 @@ impl wkt::message::Message for RunAggregationQueryRequest {
     }
 }
 
-/// Defines additional types related to RunAggregationQueryRequest
+/// Defines additional types related to [RunAggregationQueryRequest].
 pub mod run_aggregation_query_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3443,7 +3443,7 @@ impl wkt::message::Message for PartitionQueryRequest {
     }
 }
 
-/// Defines additional types related to PartitionQueryRequest
+/// Defines additional types related to [PartitionQueryRequest].
 pub mod partition_query_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3875,7 +3875,7 @@ impl wkt::message::Message for ListenRequest {
     }
 }
 
-/// Defines additional types related to ListenRequest
+/// Defines additional types related to [ListenRequest].
 pub mod listen_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4093,7 +4093,7 @@ impl wkt::message::Message for ListenResponse {
     }
 }
 
-/// Defines additional types related to ListenResponse
+/// Defines additional types related to [ListenResponse].
 pub mod listen_response {
     #[allow(unused_imports)]
     use super::*;
@@ -4368,7 +4368,7 @@ impl wkt::message::Message for Target {
     }
 }
 
-/// Defines additional types related to Target
+/// Defines additional types related to [Target].
 pub mod target {
     #[allow(unused_imports)]
     use super::*;
@@ -4491,7 +4491,7 @@ pub mod target {
         }
     }
 
-    /// Defines additional types related to QueryTarget
+    /// Defines additional types related to [QueryTarget].
     pub mod query_target {
         #[allow(unused_imports)]
         use super::*;
@@ -4678,7 +4678,7 @@ impl wkt::message::Message for TargetChange {
     }
 }
 
-/// Defines additional types related to TargetChange
+/// Defines additional types related to [TargetChange].
 pub mod target_change {
     #[allow(unused_imports)]
     use super::*;
@@ -4866,7 +4866,7 @@ impl wkt::message::Message for ListCollectionIdsRequest {
     }
 }
 
-/// Defines additional types related to ListCollectionIdsRequest
+/// Defines additional types related to [ListCollectionIdsRequest].
 pub mod list_collection_ids_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5301,7 +5301,7 @@ impl wkt::message::Message for StructuredQuery {
     }
 }
 
-/// Defines additional types related to StructuredQuery
+/// Defines additional types related to [StructuredQuery].
 pub mod structured_query {
     #[allow(unused_imports)]
     use super::*;
@@ -5485,7 +5485,7 @@ pub mod structured_query {
         }
     }
 
-    /// Defines additional types related to Filter
+    /// Defines additional types related to [Filter].
     pub mod filter {
         #[allow(unused_imports)]
         use super::*;
@@ -5583,7 +5583,7 @@ pub mod structured_query {
         }
     }
 
-    /// Defines additional types related to CompositeFilter
+    /// Defines additional types related to [CompositeFilter].
     pub mod composite_filter {
         #[allow(unused_imports)]
         use super::*;
@@ -5707,7 +5707,7 @@ pub mod structured_query {
         }
     }
 
-    /// Defines additional types related to FieldFilter
+    /// Defines additional types related to [FieldFilter].
     pub mod field_filter {
         #[allow(unused_imports)]
         use super::*;
@@ -5938,7 +5938,7 @@ pub mod structured_query {
         }
     }
 
-    /// Defines additional types related to UnaryFilter
+    /// Defines additional types related to [UnaryFilter].
     pub mod unary_filter {
         #[allow(unused_imports)]
         use super::*;
@@ -6281,7 +6281,7 @@ pub mod structured_query {
         }
     }
 
-    /// Defines additional types related to FindNearest
+    /// Defines additional types related to [FindNearest].
     pub mod find_nearest {
         #[allow(unused_imports)]
         use super::*;
@@ -6512,7 +6512,7 @@ impl wkt::message::Message for StructuredAggregationQuery {
     }
 }
 
-/// Defines additional types related to StructuredAggregationQuery
+/// Defines additional types related to [StructuredAggregationQuery].
 pub mod structured_aggregation_query {
     #[allow(unused_imports)]
     use super::*;
@@ -6710,7 +6710,7 @@ pub mod structured_aggregation_query {
         }
     }
 
-    /// Defines additional types related to Aggregation
+    /// Defines additional types related to [Aggregation].
     pub mod aggregation {
         #[allow(unused_imports)]
         use super::*;
@@ -7350,7 +7350,7 @@ impl wkt::message::Message for Write {
     }
 }
 
-/// Defines additional types related to Write
+/// Defines additional types related to [Write].
 pub mod write {
     #[allow(unused_imports)]
     use super::*;
@@ -7435,7 +7435,7 @@ impl wkt::message::Message for DocumentTransform {
     }
 }
 
-/// Defines additional types related to DocumentTransform
+/// Defines additional types related to [DocumentTransform].
 pub mod document_transform {
     #[allow(unused_imports)]
     use super::*;
@@ -7676,7 +7676,7 @@ pub mod document_transform {
         }
     }
 
-    /// Defines additional types related to FieldTransform
+    /// Defines additional types related to [FieldTransform].
     pub mod field_transform {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/api/apikeys/v2/src/model.rs
+++ b/src/generated/api/apikeys/v2/src/model.rs
@@ -825,7 +825,7 @@ impl wkt::message::Message for Restrictions {
     }
 }
 
-/// Defines additional types related to Restrictions
+/// Defines additional types related to [Restrictions].
 pub mod restrictions {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -107,7 +107,7 @@ impl wkt::message::Message for CheckError {
     }
 }
 
-/// Defines additional types related to CheckError
+/// Defines additional types related to [CheckError].
 pub mod check_error {
     #[allow(unused_imports)]
     use super::*;
@@ -525,7 +525,7 @@ impl wkt::message::Message for Distribution {
     }
 }
 
-/// Defines additional types related to Distribution
+/// Defines additional types related to [Distribution].
 pub mod distribution {
     #[allow(unused_imports)]
     use super::*;
@@ -1143,7 +1143,7 @@ impl wkt::message::Message for LogEntry {
     }
 }
 
-/// Defines additional types related to LogEntry
+/// Defines additional types related to [LogEntry].
 pub mod log_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -1494,7 +1494,7 @@ impl wkt::message::Message for MetricValue {
     }
 }
 
-/// Defines additional types related to MetricValue
+/// Defines additional types related to [MetricValue].
 pub mod metric_value {
     #[allow(unused_imports)]
     use super::*;
@@ -1763,7 +1763,7 @@ impl wkt::message::Message for Operation {
     }
 }
 
-/// Defines additional types related to Operation
+/// Defines additional types related to [Operation].
 pub mod operation {
     #[allow(unused_imports)]
     use super::*;
@@ -2011,7 +2011,7 @@ impl wkt::message::Message for QuotaOperation {
     }
 }
 
-/// Defines additional types related to QuotaOperation
+/// Defines additional types related to [QuotaOperation].
 pub mod quota_operation {
     #[allow(unused_imports)]
     use super::*;
@@ -2263,7 +2263,7 @@ impl wkt::message::Message for QuotaError {
     }
 }
 
-/// Defines additional types related to QuotaError
+/// Defines additional types related to [QuotaError].
 pub mod quota_error {
     #[allow(unused_imports)]
     use super::*;
@@ -2504,7 +2504,7 @@ impl wkt::message::Message for CheckResponse {
     }
 }
 
-/// Defines additional types related to CheckResponse
+/// Defines additional types related to [CheckResponse].
 pub mod check_response {
     #[allow(unused_imports)]
     use super::*;
@@ -2633,7 +2633,7 @@ pub mod check_response {
         }
     }
 
-    /// Defines additional types related to ConsumerInfo
+    /// Defines additional types related to [ConsumerInfo].
     pub mod consumer_info {
         #[allow(unused_imports)]
         use super::*;
@@ -2863,7 +2863,7 @@ impl wkt::message::Message for ReportResponse {
     }
 }
 
-/// Defines additional types related to ReportResponse
+/// Defines additional types related to [ReportResponse].
 pub mod report_response {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -151,7 +151,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -319,7 +319,7 @@ impl wkt::message::Message for Diagnostic {
     }
 }
 
-/// Defines additional types related to Diagnostic
+/// Defines additional types related to [Diagnostic].
 pub mod diagnostic {
     #[allow(unused_imports)]
     use super::*;
@@ -477,7 +477,7 @@ impl wkt::message::Message for ConfigFile {
     }
 }
 
-/// Defines additional types related to ConfigFile
+/// Defines additional types related to [ConfigFile].
 pub mod config_file {
     #[allow(unused_imports)]
     use super::*;
@@ -804,7 +804,7 @@ impl wkt::message::Message for Rollout {
     }
 }
 
-/// Defines additional types related to Rollout
+/// Defines additional types related to [Rollout].
 pub mod rollout {
     #[allow(unused_imports)]
     use super::*;
@@ -1334,7 +1334,7 @@ impl wkt::message::Message for GetServiceConfigRequest {
     }
 }
 
-/// Defines additional types related to GetServiceConfigRequest
+/// Defines additional types related to [GetServiceConfigRequest].
 pub mod get_service_config_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/api/serviceusage/v1/src/model.rs
+++ b/src/generated/api/serviceusage/v1/src/model.rs
@@ -437,7 +437,7 @@ impl wkt::message::Message for DisableServiceRequest {
     }
 }
 
-/// Defines additional types related to DisableServiceRequest
+/// Defines additional types related to [DisableServiceRequest].
 pub mod disable_service_request {
     #[allow(unused_imports)]
     use super::*;
@@ -807,7 +807,7 @@ impl wkt::message::Message for BatchEnableServicesResponse {
     }
 }
 
-/// Defines additional types related to BatchEnableServicesResponse
+/// Defines additional types related to [BatchEnableServicesResponse].
 pub mod batch_enable_services_response {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -286,7 +286,7 @@ impl wkt::message::Message for JwtLocation {
     }
 }
 
-/// Defines additional types related to JwtLocation
+/// Defines additional types related to [JwtLocation].
 pub mod jwt_location {
     #[allow(unused_imports)]
     use super::*;
@@ -851,7 +851,7 @@ impl wkt::message::Message for BackendRule {
     }
 }
 
-/// Defines additional types related to BackendRule
+/// Defines additional types related to [BackendRule].
 pub mod backend_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -1067,7 +1067,7 @@ impl wkt::message::Message for Billing {
     }
 }
 
-/// Defines additional types related to Billing
+/// Defines additional types related to [Billing].
 pub mod billing {
     #[allow(unused_imports)]
     use super::*;
@@ -1734,7 +1734,7 @@ impl wkt::message::Message for PythonSettings {
     }
 }
 
-/// Defines additional types related to PythonSettings
+/// Defines additional types related to [PythonSettings].
 pub mod python_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -2144,7 +2144,7 @@ impl wkt::message::Message for MethodSettings {
     }
 }
 
-/// Defines additional types related to MethodSettings
+/// Defines additional types related to [MethodSettings].
 pub mod method_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -2510,7 +2510,7 @@ impl wkt::message::Message for Property {
     }
 }
 
-/// Defines additional types related to Property
+/// Defines additional types related to [Property].
 pub mod property {
     #[allow(unused_imports)]
     use super::*;
@@ -2960,7 +2960,7 @@ impl wkt::message::Message for Distribution {
     }
 }
 
-/// Defines additional types related to Distribution
+/// Defines additional types related to [Distribution].
 pub mod distribution {
     #[allow(unused_imports)]
     use super::*;
@@ -3157,7 +3157,7 @@ pub mod distribution {
         }
     }
 
-    /// Defines additional types related to BucketOptions
+    /// Defines additional types related to [BucketOptions].
     pub mod bucket_options {
         #[allow(unused_imports)]
         use super::*;
@@ -3818,7 +3818,7 @@ impl wkt::message::Message for FieldInfo {
     }
 }
 
-/// Defines additional types related to FieldInfo
+/// Defines additional types related to [FieldInfo].
 pub mod field_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4513,7 +4513,7 @@ impl wkt::message::Message for HttpRule {
     }
 }
 
-/// Defines additional types related to HttpRule
+/// Defines additional types related to [HttpRule].
 pub mod http_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -4735,7 +4735,7 @@ impl wkt::message::Message for LabelDescriptor {
     }
 }
 
-/// Defines additional types related to LabelDescriptor
+/// Defines additional types related to [LabelDescriptor].
 pub mod label_descriptor {
     #[allow(unused_imports)]
     use super::*;
@@ -4963,7 +4963,7 @@ impl wkt::message::Message for Logging {
     }
 }
 
-/// Defines additional types related to Logging
+/// Defines additional types related to [Logging].
 pub mod logging {
     #[allow(unused_imports)]
     use super::*;
@@ -5329,7 +5329,7 @@ impl wkt::message::Message for MetricDescriptor {
     }
 }
 
-/// Defines additional types related to MetricDescriptor
+/// Defines additional types related to [MetricDescriptor].
 pub mod metric_descriptor {
     #[allow(unused_imports)]
     use super::*;
@@ -5416,7 +5416,7 @@ pub mod metric_descriptor {
         }
     }
 
-    /// Defines additional types related to MetricDescriptorMetadata
+    /// Defines additional types related to [MetricDescriptorMetadata].
     pub mod metric_descriptor_metadata {
         #[allow(unused_imports)]
         use super::*;
@@ -6067,7 +6067,7 @@ impl wkt::message::Message for Monitoring {
     }
 }
 
-/// Defines additional types related to Monitoring
+/// Defines additional types related to [Monitoring].
 pub mod monitoring {
     #[allow(unused_imports)]
     use super::*;
@@ -6812,7 +6812,7 @@ impl wkt::message::Message for ResourceDescriptor {
     }
 }
 
-/// Defines additional types related to ResourceDescriptor
+/// Defines additional types related to [ResourceDescriptor].
 pub mod resource_descriptor {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -161,7 +161,7 @@ impl wkt::message::Message for ErrorHandler {
     }
 }
 
-/// Defines additional types related to ErrorHandler
+/// Defines additional types related to [ErrorHandler].
 pub mod error_handler {
     #[allow(unused_imports)]
     use super::*;
@@ -421,7 +421,7 @@ impl wkt::message::Message for UrlMap {
     }
 }
 
-/// Defines additional types related to UrlMap
+/// Defines additional types related to [UrlMap].
 pub mod url_map {
     #[allow(unused_imports)]
     use super::*;
@@ -3192,7 +3192,7 @@ impl wkt::message::Message for Application {
     }
 }
 
-/// Defines additional types related to Application
+/// Defines additional types related to [Application].
 pub mod application {
     #[allow(unused_imports)]
     use super::*;
@@ -3600,7 +3600,7 @@ impl wkt::message::Message for AuditData {
     }
 }
 
-/// Defines additional types related to AuditData
+/// Defines additional types related to [AuditData].
 pub mod audit_data {
     #[allow(unused_imports)]
     use super::*;
@@ -4418,7 +4418,7 @@ impl wkt::message::Message for SslSettings {
     }
 }
 
-/// Defines additional types related to SslSettings
+/// Defines additional types related to [SslSettings].
 pub mod ssl_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -4540,7 +4540,7 @@ impl wkt::message::Message for ResourceRecord {
     }
 }
 
-/// Defines additional types related to ResourceRecord
+/// Defines additional types related to [ResourceRecord].
 pub mod resource_record {
     #[allow(unused_imports)]
     use super::*;
@@ -4681,7 +4681,7 @@ impl wkt::message::Message for FirewallRule {
     }
 }
 
-/// Defines additional types related to FirewallRule
+/// Defines additional types related to [FirewallRule].
 pub mod firewall_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -4951,7 +4951,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -4975,7 +4975,7 @@ pub mod instance {
         }
     }
 
-    /// Defines additional types related to Liveness
+    /// Defines additional types related to [Liveness].
     pub mod liveness {
         #[allow(unused_imports)]
         use super::*;
@@ -5203,7 +5203,7 @@ impl wkt::message::Message for NetworkSettings {
     }
 }
 
-/// Defines additional types related to NetworkSettings
+/// Defines additional types related to [NetworkSettings].
 pub mod network_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -5452,7 +5452,7 @@ impl wkt::message::Message for OperationMetadataV1 {
     }
 }
 
-/// Defines additional types related to OperationMetadataV1
+/// Defines additional types related to [OperationMetadataV1].
 pub mod operation_metadata_v_1 {
     #[allow(unused_imports)]
     use super::*;
@@ -5659,7 +5659,7 @@ impl wkt::message::Message for TrafficSplit {
     }
 }
 
-/// Defines additional types related to TrafficSplit
+/// Defines additional types related to [TrafficSplit].
 pub mod traffic_split {
     #[allow(unused_imports)]
     use super::*;
@@ -6398,7 +6398,7 @@ impl wkt::message::Message for Version {
     }
 }
 
-/// Defines additional types related to Version
+/// Defines additional types related to [Version].
 pub mod version {
     #[allow(unused_imports)]
     use super::*;
@@ -6508,7 +6508,7 @@ impl wkt::message::Message for EndpointsApiService {
     }
 }
 
-/// Defines additional types related to EndpointsApiService
+/// Defines additional types related to [EndpointsApiService].
 pub mod endpoints_api_service {
     #[allow(unused_imports)]
     use super::*;
@@ -7368,7 +7368,7 @@ impl wkt::message::Message for VpcAccessConnector {
     }
 }
 
-/// Defines additional types related to VpcAccessConnector
+/// Defines additional types related to [VpcAccessConnector].
 pub mod vpc_access_connector {
     #[allow(unused_imports)]
     use super::*;
@@ -7491,7 +7491,7 @@ impl wkt::message::Message for Entrypoint {
     }
 }
 
-/// Defines additional types related to Entrypoint
+/// Defines additional types related to [Entrypoint].
 pub mod entrypoint {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/apps/script/calendar/src/model.rs
+++ b/src/generated/apps/script/calendar/src/model.rs
@@ -136,7 +136,7 @@ impl wkt::message::Message for CalendarAddOnManifest {
     }
 }
 
-/// Defines additional types related to CalendarAddOnManifest
+/// Defines additional types related to [CalendarAddOnManifest].
 pub mod calendar_add_on_manifest {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/apps/script/gmail/src/model.rs
+++ b/src/generated/apps/script/gmail/src/model.rs
@@ -228,7 +228,7 @@ impl wkt::message::Message for UniversalAction {
     }
 }
 
-/// Defines additional types related to UniversalAction
+/// Defines additional types related to [UniversalAction].
 pub mod universal_action {
     #[allow(unused_imports)]
     use super::*;
@@ -295,7 +295,7 @@ impl wkt::message::Message for ComposeTrigger {
     }
 }
 
-/// Defines additional types related to ComposeTrigger
+/// Defines additional types related to [ComposeTrigger].
 pub mod compose_trigger {
     #[allow(unused_imports)]
     use super::*;
@@ -444,7 +444,7 @@ impl wkt::message::Message for ContextualTrigger {
     }
 }
 
-/// Defines additional types related to ContextualTrigger
+/// Defines additional types related to [ContextualTrigger].
 pub mod contextual_trigger {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/apps/script/gtype/src/model.rs
+++ b/src/generated/apps/script/gtype/src/model.rs
@@ -57,7 +57,7 @@ impl wkt::message::Message for AddOnWidgetSet {
     }
 }
 
-/// Defines additional types related to AddOnWidgetSet
+/// Defines additional types related to [AddOnWidgetSet].
 pub mod add_on_widget_set {
     #[allow(unused_imports)]
     use super::*;
@@ -352,7 +352,7 @@ impl wkt::message::Message for UniversalActionExtensionPoint {
     }
 }
 
-/// Defines additional types related to UniversalActionExtensionPoint
+/// Defines additional types related to [UniversalActionExtensionPoint].
 pub mod universal_action_extension_point {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -747,7 +747,7 @@ impl wkt::message::Message for CreateClusterMetadata {
     }
 }
 
-/// Defines additional types related to CreateClusterMetadata
+/// Defines additional types related to [CreateClusterMetadata].
 pub mod create_cluster_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -806,7 +806,7 @@ pub mod create_cluster_metadata {
         }
     }
 
-    /// Defines additional types related to TableProgress
+    /// Defines additional types related to [TableProgress].
     pub mod table_progress {
         #[allow(unused_imports)]
         use super::*;
@@ -2464,7 +2464,7 @@ impl wkt::message::Message for RestoreTableRequest {
     }
 }
 
-/// Defines additional types related to RestoreTableRequest
+/// Defines additional types related to [RestoreTableRequest].
 pub mod restore_table_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2615,7 +2615,7 @@ impl wkt::message::Message for RestoreTableMetadata {
     }
 }
 
-/// Defines additional types related to RestoreTableMetadata
+/// Defines additional types related to [RestoreTableMetadata].
 pub mod restore_table_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -2768,7 +2768,7 @@ impl wkt::message::Message for CreateTableRequest {
     }
 }
 
-/// Defines additional types related to CreateTableRequest
+/// Defines additional types related to [CreateTableRequest].
 pub mod create_table_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2965,7 +2965,7 @@ impl wkt::message::Message for DropRowRangeRequest {
     }
 }
 
-/// Defines additional types related to DropRowRangeRequest
+/// Defines additional types related to [DropRowRangeRequest].
 pub mod drop_row_range_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3474,7 +3474,7 @@ impl wkt::message::Message for ModifyColumnFamiliesRequest {
     }
 }
 
-/// Defines additional types related to ModifyColumnFamiliesRequest
+/// Defines additional types related to [ModifyColumnFamiliesRequest].
 pub mod modify_column_families_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3628,7 +3628,7 @@ pub mod modify_column_families_request {
         }
     }
 
-    /// Defines additional types related to Modification
+    /// Defines additional types related to [Modification].
     pub mod modification {
         #[allow(unused_imports)]
         use super::*;
@@ -3847,7 +3847,7 @@ impl wkt::message::Message for CheckConsistencyRequest {
     }
 }
 
-/// Defines additional types related to CheckConsistencyRequest
+/// Defines additional types related to [CheckConsistencyRequest].
 pub mod check_consistency_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5652,7 +5652,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -6014,7 +6014,7 @@ impl wkt::message::Message for Cluster {
     }
 }
 
-/// Defines additional types related to Cluster
+/// Defines additional types related to [Cluster].
 pub mod cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -6537,7 +6537,7 @@ impl wkt::message::Message for AppProfile {
     }
 }
 
-/// Defines additional types related to AppProfile
+/// Defines additional types related to [AppProfile].
 pub mod app_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -6648,7 +6648,7 @@ pub mod app_profile {
         }
     }
 
-    /// Defines additional types related to MultiClusterRoutingUseAny
+    /// Defines additional types related to [MultiClusterRoutingUseAny].
     pub mod multi_cluster_routing_use_any {
         #[allow(unused_imports)]
         use super::*;
@@ -6811,7 +6811,7 @@ pub mod app_profile {
         }
     }
 
-    /// Defines additional types related to DataBoostIsolationReadOnly
+    /// Defines additional types related to [DataBoostIsolationReadOnly].
     pub mod data_boost_isolation_read_only {
         #[allow(unused_imports)]
         use super::*;
@@ -7264,7 +7264,7 @@ impl wkt::message::Message for RestoreInfo {
     }
 }
 
-/// Defines additional types related to RestoreInfo
+/// Defines additional types related to [RestoreInfo].
 pub mod restore_info {
     #[allow(unused_imports)]
     use super::*;
@@ -7567,7 +7567,7 @@ impl wkt::message::Message for Table {
     }
 }
 
-/// Defines additional types related to Table
+/// Defines additional types related to [Table].
 pub mod table {
     #[allow(unused_imports)]
     use super::*;
@@ -7624,7 +7624,7 @@ pub mod table {
         }
     }
 
-    /// Defines additional types related to ClusterState
+    /// Defines additional types related to [ClusterState].
     pub mod cluster_state {
         #[allow(unused_imports)]
         use super::*;
@@ -8002,7 +8002,7 @@ impl wkt::message::Message for AuthorizedView {
     }
 }
 
-/// Defines additional types related to AuthorizedView
+/// Defines additional types related to [AuthorizedView].
 pub mod authorized_view {
     #[allow(unused_imports)]
     use super::*;
@@ -8382,7 +8382,7 @@ impl wkt::message::Message for GcRule {
     }
 }
 
-/// Defines additional types related to GcRule
+/// Defines additional types related to [GcRule].
 pub mod gc_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -8535,7 +8535,7 @@ impl wkt::message::Message for EncryptionInfo {
     }
 }
 
-/// Defines additional types related to EncryptionInfo
+/// Defines additional types related to [EncryptionInfo].
 pub mod encryption_info {
     #[allow(unused_imports)]
     use super::*;
@@ -8722,7 +8722,7 @@ impl wkt::message::Message for Snapshot {
     }
 }
 
-/// Defines additional types related to Snapshot
+/// Defines additional types related to [Snapshot].
 pub mod snapshot {
     #[allow(unused_imports)]
     use super::*;
@@ -8970,7 +8970,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -9549,7 +9549,7 @@ impl wkt::message::Message for Type {
     }
 }
 
-/// Defines additional types related to Type
+/// Defines additional types related to [Type].
 pub mod r#type {
     #[allow(unused_imports)]
     use super::*;
@@ -9589,7 +9589,7 @@ pub mod r#type {
         }
     }
 
-    /// Defines additional types related to Bytes
+    /// Defines additional types related to [Bytes].
     pub mod bytes {
         #[allow(unused_imports)]
         use super::*;
@@ -9663,7 +9663,7 @@ pub mod r#type {
             }
         }
 
-        /// Defines additional types related to Encoding
+        /// Defines additional types related to [Encoding].
         pub mod encoding {
             #[allow(unused_imports)]
             use super::*;
@@ -9737,7 +9737,7 @@ pub mod r#type {
         }
     }
 
-    /// Defines additional types related to String
+    /// Defines additional types related to [String].
     pub mod string {
         #[allow(unused_imports)]
         use super::*;
@@ -9850,7 +9850,7 @@ pub mod r#type {
             }
         }
 
-        /// Defines additional types related to Encoding
+        /// Defines additional types related to [Encoding].
         pub mod encoding {
             #[allow(unused_imports)]
             use super::*;
@@ -9954,7 +9954,7 @@ pub mod r#type {
         }
     }
 
-    /// Defines additional types related to Int64
+    /// Defines additional types related to [Int64].
     pub mod int_64 {
         #[allow(unused_imports)]
         use super::*;
@@ -10067,7 +10067,7 @@ pub mod r#type {
             }
         }
 
-        /// Defines additional types related to Encoding
+        /// Defines additional types related to [Encoding].
         pub mod encoding {
             #[allow(unused_imports)]
             use super::*;
@@ -10252,7 +10252,7 @@ pub mod r#type {
         }
     }
 
-    /// Defines additional types related to Timestamp
+    /// Defines additional types related to [Timestamp].
     pub mod timestamp {
         #[allow(unused_imports)]
         use super::*;
@@ -10326,7 +10326,7 @@ pub mod r#type {
             }
         }
 
-        /// Defines additional types related to Encoding
+        /// Defines additional types related to [Encoding].
         pub mod encoding {
             #[allow(unused_imports)]
             use super::*;
@@ -10419,7 +10419,7 @@ pub mod r#type {
         }
     }
 
-    /// Defines additional types related to Struct
+    /// Defines additional types related to [Struct].
     pub mod r#struct {
         #[allow(unused_imports)]
         use super::*;
@@ -10617,7 +10617,7 @@ pub mod r#type {
             }
         }
 
-        /// Defines additional types related to Encoding
+        /// Defines additional types related to [Encoding].
         pub mod encoding {
             #[allow(unused_imports)]
             use super::*;
@@ -11059,7 +11059,7 @@ pub mod r#type {
         }
     }
 
-    /// Defines additional types related to Aggregate
+    /// Defines additional types related to [Aggregate].
     pub mod aggregate {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/accessapproval/v1/src/model.rs
+++ b/src/generated/cloud/accessapproval/v1/src/model.rs
@@ -142,7 +142,7 @@ impl wkt::message::Message for AccessReason {
     }
 }
 
-/// Defines additional types related to AccessReason
+/// Defines additional types related to [AccessReason].
 pub mod access_reason {
     #[allow(unused_imports)]
     use super::*;
@@ -346,7 +346,7 @@ impl wkt::message::Message for SignatureInfo {
     }
 }
 
-/// Defines additional types related to SignatureInfo
+/// Defines additional types related to [SignatureInfo].
 pub mod signature_info {
     #[allow(unused_imports)]
     use super::*;
@@ -709,7 +709,7 @@ impl wkt::message::Message for ApprovalRequest {
     }
 }
 
-/// Defines additional types related to ApprovalRequest
+/// Defines additional types related to [ApprovalRequest].
 pub mod approval_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/advisorynotifications/v1/src/model.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/model.rs
@@ -272,7 +272,7 @@ impl wkt::message::Message for Message {
     }
 }
 
-/// Defines additional types related to Message
+/// Defines additional types related to [Message].
 pub mod message {
     #[allow(unused_imports)]
     use super::*;
@@ -376,7 +376,7 @@ impl wkt::message::Message for Attachment {
     }
 }
 
-/// Defines additional types related to Attachment
+/// Defines additional types related to [Attachment].
 pub mod attachment {
     #[allow(unused_imports)]
     use super::*;
@@ -442,7 +442,7 @@ impl wkt::message::Message for Csv {
     }
 }
 
-/// Defines additional types related to Csv
+/// Defines additional types related to [Csv].
 pub mod csv {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/aiplatform/v1/src/model.rs
+++ b/src/generated/cloud/aiplatform/v1/src/model.rs
@@ -339,7 +339,7 @@ impl wkt::message::Message for ApiAuth {
     }
 }
 
-/// Defines additional types related to ApiAuth
+/// Defines additional types related to [ApiAuth].
 pub mod api_auth {
     #[allow(unused_imports)]
     use super::*;
@@ -562,7 +562,7 @@ impl wkt::message::Message for Artifact {
     }
 }
 
-/// Defines additional types related to Artifact
+/// Defines additional types related to [Artifact].
 pub mod artifact {
     #[allow(unused_imports)]
     use super::*;
@@ -1160,7 +1160,7 @@ impl wkt::message::Message for BatchPredictionJob {
     }
 }
 
-/// Defines additional types related to BatchPredictionJob
+/// Defines additional types related to [BatchPredictionJob].
 pub mod batch_prediction_job {
     #[allow(unused_imports)]
     use super::*;
@@ -1288,7 +1288,7 @@ pub mod batch_prediction_job {
         }
     }
 
-    /// Defines additional types related to InputConfig
+    /// Defines additional types related to [InputConfig].
     pub mod input_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1606,7 +1606,7 @@ pub mod batch_prediction_job {
         }
     }
 
-    /// Defines additional types related to OutputConfig
+    /// Defines additional types related to [OutputConfig].
     pub mod output_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1787,7 +1787,7 @@ pub mod batch_prediction_job {
         }
     }
 
-    /// Defines additional types related to OutputInfo
+    /// Defines additional types related to [OutputInfo].
     pub mod output_info {
         #[allow(unused_imports)]
         use super::*;
@@ -2028,7 +2028,7 @@ impl wkt::message::Message for CachedContent {
     }
 }
 
-/// Defines additional types related to CachedContent
+/// Defines additional types related to [CachedContent].
 pub mod cached_content {
     #[allow(unused_imports)]
     use super::*;
@@ -2490,7 +2490,7 @@ impl wkt::message::Message for Part {
     }
 }
 
-/// Defines additional types related to Part
+/// Defines additional types related to [Part].
 pub mod part {
     #[allow(unused_imports)]
     use super::*;
@@ -2865,7 +2865,7 @@ impl wkt::message::Message for GenerationConfig {
     }
 }
 
-/// Defines additional types related to GenerationConfig
+/// Defines additional types related to [GenerationConfig].
 pub mod generation_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2987,7 +2987,7 @@ pub mod generation_config {
         }
     }
 
-    /// Defines additional types related to RoutingConfig
+    /// Defines additional types related to [RoutingConfig].
     pub mod routing_config {
         #[allow(unused_imports)]
         use super::*;
@@ -3024,7 +3024,7 @@ pub mod generation_config {
             }
         }
 
-        /// Defines additional types related to AutoRoutingMode
+        /// Defines additional types related to [AutoRoutingMode].
         pub mod auto_routing_mode {
             #[allow(unused_imports)]
             use super::*;
@@ -3200,7 +3200,7 @@ impl wkt::message::Message for SafetySetting {
     }
 }
 
-/// Defines additional types related to SafetySetting
+/// Defines additional types related to [SafetySetting].
 pub mod safety_setting {
     #[allow(unused_imports)]
     use super::*;
@@ -3419,7 +3419,7 @@ impl wkt::message::Message for SafetyRating {
     }
 }
 
-/// Defines additional types related to SafetyRating
+/// Defines additional types related to [SafetyRating].
 pub mod safety_rating {
     #[allow(unused_imports)]
     use super::*;
@@ -3827,7 +3827,7 @@ impl wkt::message::Message for Candidate {
     }
 }
 
-/// Defines additional types related to Candidate
+/// Defines additional types related to [Candidate].
 pub mod candidate {
     #[allow(unused_imports)]
     use super::*;
@@ -3988,7 +3988,7 @@ impl wkt::message::Message for LogprobsResult {
     }
 }
 
-/// Defines additional types related to LogprobsResult
+/// Defines additional types related to [LogprobsResult].
 pub mod logprobs_result {
     #[allow(unused_imports)]
     use super::*;
@@ -4238,7 +4238,7 @@ impl wkt::message::Message for GroundingChunk {
     }
 }
 
-/// Defines additional types related to GroundingChunk
+/// Defines additional types related to [GroundingChunk].
 pub mod grounding_chunk {
     #[allow(unused_imports)]
     use super::*;
@@ -5463,7 +5463,7 @@ impl wkt::message::Message for WorkerPoolSpec {
     }
 }
 
-/// Defines additional types related to WorkerPoolSpec
+/// Defines additional types related to [WorkerPoolSpec].
 pub mod worker_pool_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -5734,7 +5734,7 @@ impl wkt::message::Message for Scheduling {
     }
 }
 
-/// Defines additional types related to Scheduling
+/// Defines additional types related to [Scheduling].
 pub mod scheduling {
     #[allow(unused_imports)]
     use super::*;
@@ -6358,7 +6358,7 @@ impl wkt::message::Message for ActiveLearningConfig {
     }
 }
 
-/// Defines additional types related to ActiveLearningConfig
+/// Defines additional types related to [ActiveLearningConfig].
 pub mod active_learning_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6502,7 +6502,7 @@ impl wkt::message::Message for SampleConfig {
     }
 }
 
-/// Defines additional types related to SampleConfig
+/// Defines additional types related to [SampleConfig].
 pub mod sample_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6998,7 +6998,7 @@ impl wkt::message::Message for ImportDataConfig {
     }
 }
 
-/// Defines additional types related to ImportDataConfig
+/// Defines additional types related to [ImportDataConfig].
 pub mod import_data_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7262,7 +7262,7 @@ impl wkt::message::Message for ExportDataConfig {
     }
 }
 
-/// Defines additional types related to ExportDataConfig
+/// Defines additional types related to [ExportDataConfig].
 pub mod export_data_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8993,7 +8993,7 @@ impl wkt::message::Message for SearchDataItemsRequest {
     }
 }
 
-/// Defines additional types related to SearchDataItemsRequest
+/// Defines additional types related to [SearchDataItemsRequest].
 pub mod search_data_items_request {
     #[allow(unused_imports)]
     use super::*;
@@ -11179,7 +11179,7 @@ impl wkt::message::Message for DeployedModel {
     }
 }
 
-/// Defines additional types related to DeployedModel
+/// Defines additional types related to [DeployedModel].
 pub mod deployed_model {
     #[allow(unused_imports)]
     use super::*;
@@ -11568,7 +11568,7 @@ impl wkt::message::Message for SpeculativeDecodingSpec {
     }
 }
 
-/// Defines additional types related to SpeculativeDecodingSpec
+/// Defines additional types related to [SpeculativeDecodingSpec].
 pub mod speculative_decoding_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -13062,7 +13062,7 @@ impl wkt::message::Message for EvaluatedAnnotation {
     }
 }
 
-/// Defines additional types related to EvaluatedAnnotation
+/// Defines additional types related to [EvaluatedAnnotation].
 pub mod evaluated_annotation {
     #[allow(unused_imports)]
     use super::*;
@@ -13256,7 +13256,7 @@ impl wkt::message::Message for ErrorAnalysisAnnotation {
     }
 }
 
-/// Defines additional types related to ErrorAnalysisAnnotation
+/// Defines additional types related to [ErrorAnalysisAnnotation].
 pub mod error_analysis_annotation {
     #[allow(unused_imports)]
     use super::*;
@@ -14212,7 +14212,7 @@ impl wkt::message::Message for EvaluateInstancesRequest {
     }
 }
 
-/// Defines additional types related to EvaluateInstancesRequest
+/// Defines additional types related to [EvaluateInstancesRequest].
 pub mod evaluate_instances_request {
     #[allow(unused_imports)]
     use super::*;
@@ -15140,7 +15140,7 @@ impl wkt::message::Message for EvaluateInstancesResponse {
     }
 }
 
-/// Defines additional types related to EvaluateInstancesResponse
+/// Defines additional types related to [EvaluateInstancesResponse].
 pub mod evaluate_instances_response {
     #[allow(unused_imports)]
     use super::*;
@@ -18613,7 +18613,7 @@ impl wkt::message::Message for PointwiseMetricInstance {
     }
 }
 
-/// Defines additional types related to PointwiseMetricInstance
+/// Defines additional types related to [PointwiseMetricInstance].
 pub mod pointwise_metric_instance {
     #[allow(unused_imports)]
     use super::*;
@@ -18812,7 +18812,7 @@ impl wkt::message::Message for PairwiseMetricInstance {
     }
 }
 
-/// Defines additional types related to PairwiseMetricInstance
+/// Defines additional types related to [PairwiseMetricInstance].
 pub mod pairwise_metric_instance {
     #[allow(unused_imports)]
     use super::*;
@@ -19719,7 +19719,7 @@ impl wkt::message::Message for CometSpec {
     }
 }
 
-/// Defines additional types related to CometSpec
+/// Defines additional types related to [CometSpec].
 pub mod comet_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -19973,7 +19973,7 @@ impl wkt::message::Message for MetricxSpec {
     }
 }
 
-/// Defines additional types related to MetricxSpec
+/// Defines additional types related to [MetricxSpec].
 pub mod metricx_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -20222,7 +20222,7 @@ impl wkt::message::Message for Event {
     }
 }
 
-/// Defines additional types related to Event
+/// Defines additional types related to [Event].
 pub mod event {
     #[allow(unused_imports)]
     use super::*;
@@ -20452,7 +20452,7 @@ impl wkt::message::Message for Execution {
     }
 }
 
-/// Defines additional types related to Execution
+/// Defines additional types related to [Execution].
 pub mod execution {
     #[allow(unused_imports)]
     use super::*;
@@ -21176,7 +21176,7 @@ impl wkt::message::Message for ExplanationParameters {
     }
 }
 
-/// Defines additional types related to ExplanationParameters
+/// Defines additional types related to [ExplanationParameters].
 pub mod explanation_parameters {
     #[allow(unused_imports)]
     use super::*;
@@ -21509,7 +21509,7 @@ impl wkt::message::Message for SmoothGradConfig {
     }
 }
 
-/// Defines additional types related to SmoothGradConfig
+/// Defines additional types related to [SmoothGradConfig].
 pub mod smooth_grad_config {
     #[allow(unused_imports)]
     use super::*;
@@ -21587,7 +21587,7 @@ impl wkt::message::Message for FeatureNoiseSigma {
     }
 }
 
-/// Defines additional types related to FeatureNoiseSigma
+/// Defines additional types related to [FeatureNoiseSigma].
 pub mod feature_noise_sigma {
     #[allow(unused_imports)]
     use super::*;
@@ -21819,7 +21819,7 @@ impl wkt::message::Message for Examples {
     }
 }
 
-/// Defines additional types related to Examples
+/// Defines additional types related to [Examples].
 pub mod examples {
     #[allow(unused_imports)]
     use super::*;
@@ -21873,7 +21873,7 @@ pub mod examples {
         }
     }
 
-    /// Defines additional types related to ExampleGcsSource
+    /// Defines additional types related to [ExampleGcsSource].
     pub mod example_gcs_source {
         #[allow(unused_imports)]
         use super::*;
@@ -22006,7 +22006,7 @@ impl wkt::message::Message for Presets {
     }
 }
 
-/// Defines additional types related to Presets
+/// Defines additional types related to [Presets].
 pub mod presets {
     #[allow(unused_imports)]
     use super::*;
@@ -22247,7 +22247,7 @@ impl wkt::message::Message for ExplanationMetadataOverride {
     }
 }
 
-/// Defines additional types related to ExplanationMetadataOverride
+/// Defines additional types related to [ExplanationMetadataOverride].
 pub mod explanation_metadata_override {
     #[allow(unused_imports)]
     use super::*;
@@ -22371,7 +22371,7 @@ impl wkt::message::Message for ExamplesOverride {
     }
 }
 
-/// Defines additional types related to ExamplesOverride
+/// Defines additional types related to [ExamplesOverride].
 pub mod examples_override {
     #[allow(unused_imports)]
     use super::*;
@@ -22614,7 +22614,7 @@ impl wkt::message::Message for ExplanationMetadata {
     }
 }
 
-/// Defines additional types related to ExplanationMetadata
+/// Defines additional types related to [ExplanationMetadata].
 pub mod explanation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -22877,7 +22877,7 @@ pub mod explanation_metadata {
         }
     }
 
-    /// Defines additional types related to InputMetadata
+    /// Defines additional types related to [InputMetadata].
     pub mod input_metadata {
         #[allow(unused_imports)]
         use super::*;
@@ -23074,7 +23074,7 @@ pub mod explanation_metadata {
             }
         }
 
-        /// Defines additional types related to Visualization
+        /// Defines additional types related to [Visualization].
         pub mod visualization {
             #[allow(unused_imports)]
             use super::*;
@@ -23621,7 +23621,7 @@ pub mod explanation_metadata {
         }
     }
 
-    /// Defines additional types related to OutputMetadata
+    /// Defines additional types related to [OutputMetadata].
     pub mod output_metadata {
         #[allow(unused_imports)]
         use super::*;
@@ -23864,7 +23864,7 @@ impl wkt::message::Message for Feature {
     }
 }
 
-/// Defines additional types related to Feature
+/// Defines additional types related to [Feature].
 pub mod feature {
     #[allow(unused_imports)]
     use super::*;
@@ -23927,7 +23927,7 @@ pub mod feature {
         }
     }
 
-    /// Defines additional types related to MonitoringStatsAnomaly
+    /// Defines additional types related to [MonitoringStatsAnomaly].
     pub mod monitoring_stats_anomaly {
         #[allow(unused_imports)]
         use super::*;
@@ -24242,7 +24242,7 @@ impl wkt::message::Message for FeatureGroup {
     }
 }
 
-/// Defines additional types related to FeatureGroup
+/// Defines additional types related to [FeatureGroup].
 pub mod feature_group {
     #[allow(unused_imports)]
     use super::*;
@@ -24349,7 +24349,7 @@ pub mod feature_group {
         }
     }
 
-    /// Defines additional types related to BigQuery
+    /// Defines additional types related to [BigQuery].
     pub mod big_query {
         #[allow(unused_imports)]
         use super::*;
@@ -24773,7 +24773,7 @@ impl wkt::message::Message for FeatureOnlineStore {
     }
 }
 
-/// Defines additional types related to FeatureOnlineStore
+/// Defines additional types related to [FeatureOnlineStore].
 pub mod feature_online_store {
     #[allow(unused_imports)]
     use super::*;
@@ -24814,7 +24814,7 @@ pub mod feature_online_store {
         }
     }
 
-    /// Defines additional types related to Bigtable
+    /// Defines additional types related to [Bigtable].
     pub mod bigtable {
         #[allow(unused_imports)]
         use super::*;
@@ -26306,7 +26306,7 @@ impl wkt::message::Message for FeatureViewDataKey {
     }
 }
 
-/// Defines additional types related to FeatureViewDataKey
+/// Defines additional types related to [FeatureViewDataKey].
 pub mod feature_view_data_key {
     #[allow(unused_imports)]
     use super::*;
@@ -26544,7 +26544,7 @@ impl wkt::message::Message for FetchFeatureValuesResponse {
     }
 }
 
-/// Defines additional types related to FetchFeatureValuesResponse
+/// Defines additional types related to [FetchFeatureValuesResponse].
 pub mod fetch_feature_values_response {
     #[allow(unused_imports)]
     use super::*;
@@ -26585,7 +26585,7 @@ pub mod fetch_feature_values_response {
         }
     }
 
-    /// Defines additional types related to FeatureNameValuePairList
+    /// Defines additional types related to [FeatureNameValuePairList].
     pub mod feature_name_value_pair_list {
         #[allow(unused_imports)]
         use super::*;
@@ -26660,7 +26660,7 @@ pub mod fetch_feature_values_response {
             }
         }
 
-        /// Defines additional types related to FeatureNameValuePair
+        /// Defines additional types related to [FeatureNameValuePair].
         pub mod feature_name_value_pair {
             #[allow(unused_imports)]
             use super::*;
@@ -26849,7 +26849,7 @@ impl wkt::message::Message for NearestNeighborQuery {
     }
 }
 
-/// Defines additional types related to NearestNeighborQuery
+/// Defines additional types related to [NearestNeighborQuery].
 pub mod nearest_neighbor_query {
     #[allow(unused_imports)]
     use super::*;
@@ -27105,7 +27105,7 @@ pub mod nearest_neighbor_query {
         }
     }
 
-    /// Defines additional types related to NumericFilter
+    /// Defines additional types related to [NumericFilter].
     pub mod numeric_filter {
         #[allow(unused_imports)]
         use super::*;
@@ -27356,7 +27356,7 @@ impl wkt::message::Message for NearestNeighbors {
     }
 }
 
-/// Defines additional types related to NearestNeighbors
+/// Defines additional types related to [NearestNeighbors].
 pub mod nearest_neighbors {
     #[allow(unused_imports)]
     use super::*;
@@ -28345,7 +28345,7 @@ impl wkt::message::Message for FeatureView {
     }
 }
 
-/// Defines additional types related to FeatureView
+/// Defines additional types related to [FeatureView].
 pub mod feature_view {
     #[allow(unused_imports)]
     use super::*;
@@ -28633,7 +28633,7 @@ pub mod feature_view {
         }
     }
 
-    /// Defines additional types related to IndexConfig
+    /// Defines additional types related to [IndexConfig].
     pub mod index_config {
         #[allow(unused_imports)]
         use super::*;
@@ -28837,7 +28837,7 @@ pub mod feature_view {
         }
     }
 
-    /// Defines additional types related to FeatureRegistrySource
+    /// Defines additional types related to [FeatureRegistrySource].
     pub mod feature_registry_source {
         #[allow(unused_imports)]
         use super::*;
@@ -29166,7 +29166,7 @@ impl wkt::message::Message for FeatureViewSync {
     }
 }
 
-/// Defines additional types related to FeatureViewSync
+/// Defines additional types related to [FeatureViewSync].
 pub mod feature_view_sync {
     #[allow(unused_imports)]
     use super::*;
@@ -29402,7 +29402,7 @@ impl wkt::message::Message for Featurestore {
     }
 }
 
-/// Defines additional types related to Featurestore
+/// Defines additional types related to [Featurestore].
 pub mod featurestore {
     #[allow(unused_imports)]
     use super::*;
@@ -29459,7 +29459,7 @@ pub mod featurestore {
         }
     }
 
-    /// Defines additional types related to OnlineServingConfig
+    /// Defines additional types related to [OnlineServingConfig].
     pub mod online_serving_config {
         #[allow(unused_imports)]
         use super::*;
@@ -29695,7 +29695,7 @@ impl wkt::message::Message for FeaturestoreMonitoringConfig {
     }
 }
 
-/// Defines additional types related to FeaturestoreMonitoringConfig
+/// Defines additional types related to [FeaturestoreMonitoringConfig].
 pub mod featurestore_monitoring_config {
     #[allow(unused_imports)]
     use super::*;
@@ -29815,7 +29815,7 @@ pub mod featurestore_monitoring_config {
         }
     }
 
-    /// Defines additional types related to ImportFeaturesAnalysis
+    /// Defines additional types related to [ImportFeaturesAnalysis].
     pub mod import_features_analysis {
         #[allow(unused_imports)]
         use super::*;
@@ -30031,7 +30031,7 @@ pub mod featurestore_monitoring_config {
         }
     }
 
-    /// Defines additional types related to ThresholdConfig
+    /// Defines additional types related to [ThresholdConfig].
     pub mod threshold_config {
         #[allow(unused_imports)]
         use super::*;
@@ -30296,7 +30296,7 @@ impl wkt::message::Message for ReadFeatureValuesResponse {
     }
 }
 
-/// Defines additional types related to ReadFeatureValuesResponse
+/// Defines additional types related to [ReadFeatureValuesResponse].
 pub mod read_feature_values_response {
     #[allow(unused_imports)]
     use super::*;
@@ -30438,7 +30438,7 @@ pub mod read_feature_values_response {
         }
     }
 
-    /// Defines additional types related to EntityView
+    /// Defines additional types related to [EntityView].
     pub mod entity_view {
         #[allow(unused_imports)]
         use super::*;
@@ -30549,7 +30549,7 @@ pub mod read_feature_values_response {
             }
         }
 
-        /// Defines additional types related to Data
+        /// Defines additional types related to [Data].
         pub mod data {
             #[allow(unused_imports)]
             use super::*;
@@ -30941,7 +30941,7 @@ impl wkt::message::Message for FeatureValue {
     }
 }
 
-/// Defines additional types related to FeatureValue
+/// Defines additional types related to [FeatureValue].
 pub mod feature_value {
     #[allow(unused_imports)]
     use super::*;
@@ -31797,7 +31797,7 @@ impl wkt::message::Message for ImportFeatureValuesRequest {
     }
 }
 
-/// Defines additional types related to ImportFeatureValuesRequest
+/// Defines additional types related to [ImportFeatureValuesRequest].
 pub mod import_feature_values_request {
     #[allow(unused_imports)]
     use super::*;
@@ -32129,7 +32129,7 @@ impl wkt::message::Message for BatchReadFeatureValuesRequest {
     }
 }
 
-/// Defines additional types related to BatchReadFeatureValuesRequest
+/// Defines additional types related to [BatchReadFeatureValuesRequest].
 pub mod batch_read_feature_values_request {
     #[allow(unused_imports)]
     use super::*;
@@ -32436,7 +32436,7 @@ impl wkt::message::Message for ExportFeatureValuesRequest {
     }
 }
 
-/// Defines additional types related to ExportFeatureValuesRequest
+/// Defines additional types related to [ExportFeatureValuesRequest].
 pub mod export_feature_values_request {
     #[allow(unused_imports)]
     use super::*;
@@ -32730,7 +32730,7 @@ impl wkt::message::Message for FeatureValueDestination {
     }
 }
 
-/// Defines additional types related to FeatureValueDestination
+/// Defines additional types related to [FeatureValueDestination].
 pub mod feature_value_destination {
     #[allow(unused_imports)]
     use super::*;
@@ -34451,7 +34451,7 @@ impl wkt::message::Message for DeleteFeatureValuesRequest {
     }
 }
 
-/// Defines additional types related to DeleteFeatureValuesRequest
+/// Defines additional types related to [DeleteFeatureValuesRequest].
 pub mod delete_feature_values_request {
     #[allow(unused_imports)]
     use super::*;
@@ -34691,7 +34691,7 @@ impl wkt::message::Message for DeleteFeatureValuesResponse {
     }
 }
 
-/// Defines additional types related to DeleteFeatureValuesResponse
+/// Defines additional types related to [DeleteFeatureValuesResponse].
 pub mod delete_feature_values_response {
     #[allow(unused_imports)]
     use super::*;
@@ -34898,7 +34898,7 @@ impl wkt::message::Message for EntityIdSelector {
     }
 }
 
-/// Defines additional types related to EntityIdSelector
+/// Defines additional types related to [EntityIdSelector].
 pub mod entity_id_selector {
     #[allow(unused_imports)]
     use super::*;
@@ -36046,7 +36046,7 @@ impl wkt::message::Message for Index {
     }
 }
 
-/// Defines additional types related to Index
+/// Defines additional types related to [Index].
 pub mod index {
     #[allow(unused_imports)]
     use super::*;
@@ -36225,7 +36225,7 @@ impl wkt::message::Message for IndexDatapoint {
     }
 }
 
-/// Defines additional types related to IndexDatapoint
+/// Defines additional types related to [IndexDatapoint].
 pub mod index_datapoint {
     #[allow(unused_imports)]
     use super::*;
@@ -36480,7 +36480,7 @@ pub mod index_datapoint {
         }
     }
 
-    /// Defines additional types related to NumericRestriction
+    /// Defines additional types related to [NumericRestriction].
     pub mod numeric_restriction {
         #[allow(unused_imports)]
         use super::*;
@@ -37233,7 +37233,7 @@ impl wkt::message::Message for DeployedIndexAuthConfig {
     }
 }
 
-/// Defines additional types related to DeployedIndexAuthConfig
+/// Defines additional types related to [DeployedIndexAuthConfig].
 pub mod deployed_index_auth_config {
     #[allow(unused_imports)]
     use super::*;
@@ -38762,7 +38762,7 @@ impl wkt::message::Message for NearestNeighborSearchOperationMetadata {
     }
 }
 
-/// Defines additional types related to NearestNeighborSearchOperationMetadata
+/// Defines additional types related to [NearestNeighborSearchOperationMetadata].
 pub mod nearest_neighbor_search_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -38846,7 +38846,7 @@ pub mod nearest_neighbor_search_operation_metadata {
         }
     }
 
-    /// Defines additional types related to RecordError
+    /// Defines additional types related to [RecordError].
     pub mod record_error {
         #[allow(unused_imports)]
         use super::*;
@@ -39435,7 +39435,7 @@ impl wkt::message::Message for GoogleDriveSource {
     }
 }
 
-/// Defines additional types related to GoogleDriveSource
+/// Defines additional types related to [GoogleDriveSource].
 pub mod google_drive_source {
     #[allow(unused_imports)]
     use super::*;
@@ -39483,7 +39483,7 @@ pub mod google_drive_source {
         }
     }
 
-    /// Defines additional types related to ResourceId
+    /// Defines additional types related to [ResourceId].
     pub mod resource_id {
         #[allow(unused_imports)]
         use super::*;
@@ -39602,7 +39602,7 @@ impl wkt::message::Message for SlackSource {
     }
 }
 
-/// Defines additional types related to SlackSource
+/// Defines additional types related to [SlackSource].
 pub mod slack_source {
     #[allow(unused_imports)]
     use super::*;
@@ -39659,7 +39659,7 @@ pub mod slack_source {
         }
     }
 
-    /// Defines additional types related to SlackChannels
+    /// Defines additional types related to [SlackChannels].
     pub mod slack_channels {
         #[allow(unused_imports)]
         use super::*;
@@ -39758,7 +39758,7 @@ impl wkt::message::Message for JiraSource {
     }
 }
 
-/// Defines additional types related to JiraSource
+/// Defines additional types related to [JiraSource].
 pub mod jira_source {
     #[allow(unused_imports)]
     use super::*;
@@ -39887,7 +39887,7 @@ impl wkt::message::Message for SharePointSources {
     }
 }
 
-/// Defines additional types related to SharePointSources
+/// Defines additional types related to [SharePointSources].
 pub mod share_point_sources {
     #[allow(unused_imports)]
     use super::*;
@@ -40123,7 +40123,7 @@ pub mod share_point_sources {
         }
     }
 
-    /// Defines additional types related to SharePointSource
+    /// Defines additional types related to [SharePointSource].
     pub mod share_point_source {
         #[allow(unused_imports)]
         use super::*;
@@ -42092,7 +42092,7 @@ impl wkt::message::Message for SearchModelDeploymentMonitoringStatsAnomaliesRequ
     }
 }
 
-/// Defines additional types related to SearchModelDeploymentMonitoringStatsAnomaliesRequest
+/// Defines additional types related to [SearchModelDeploymentMonitoringStatsAnomaliesRequest].
 pub mod search_model_deployment_monitoring_stats_anomalies_request {
     #[allow(unused_imports)]
     use super::*;
@@ -43571,7 +43571,7 @@ impl wkt::message::Message for FindNeighborsRequest {
     }
 }
 
-/// Defines additional types related to FindNeighborsRequest
+/// Defines additional types related to [FindNeighborsRequest].
 pub mod find_neighbors_request {
     #[allow(unused_imports)]
     use super::*;
@@ -43716,7 +43716,7 @@ pub mod find_neighbors_request {
         }
     }
 
-    /// Defines additional types related to Query
+    /// Defines additional types related to [Query].
     pub mod query {
         #[allow(unused_imports)]
         use super::*;
@@ -43798,7 +43798,7 @@ impl wkt::message::Message for FindNeighborsResponse {
     }
 }
 
-/// Defines additional types related to FindNeighborsResponse
+/// Defines additional types related to [FindNeighborsResponse].
 pub mod find_neighbors_response {
     #[allow(unused_imports)]
     use super::*;
@@ -44097,7 +44097,7 @@ impl wkt::message::Message for MetadataSchema {
     }
 }
 
-/// Defines additional types related to MetadataSchema
+/// Defines additional types related to [MetadataSchema].
 pub mod metadata_schema {
     #[allow(unused_imports)]
     use super::*;
@@ -46956,7 +46956,7 @@ impl wkt::message::Message for MetadataStore {
     }
 }
 
-/// Defines additional types related to MetadataStore
+/// Defines additional types related to [MetadataStore].
 pub mod metadata_store {
     #[allow(unused_imports)]
     use super::*;
@@ -47216,7 +47216,7 @@ impl wkt::message::Message for MigratableResource {
     }
 }
 
-/// Defines additional types related to MigratableResource
+/// Defines additional types related to [MigratableResource].
 pub mod migratable_resource {
     #[allow(unused_imports)]
     use super::*;
@@ -47418,7 +47418,7 @@ pub mod migratable_resource {
         }
     }
 
-    /// Defines additional types related to DataLabelingDataset
+    /// Defines additional types related to [DataLabelingDataset].
     pub mod data_labeling_dataset {
         #[allow(unused_imports)]
         use super::*;
@@ -47869,7 +47869,7 @@ impl wkt::message::Message for MigrateResourceRequest {
     }
 }
 
-/// Defines additional types related to MigrateResourceRequest
+/// Defines additional types related to [MigrateResourceRequest].
 pub mod migrate_resource_request {
     #[allow(unused_imports)]
     use super::*;
@@ -48097,7 +48097,7 @@ pub mod migrate_resource_request {
         }
     }
 
-    /// Defines additional types related to MigrateDataLabelingDatasetConfig
+    /// Defines additional types related to [MigrateDataLabelingDatasetConfig].
     pub mod migrate_data_labeling_dataset_config {
         #[allow(unused_imports)]
         use super::*;
@@ -48308,7 +48308,7 @@ impl wkt::message::Message for MigrateResourceResponse {
     }
 }
 
-/// Defines additional types related to MigrateResourceResponse
+/// Defines additional types related to [MigrateResourceResponse].
 pub mod migrate_resource_response {
     #[allow(unused_imports)]
     use super::*;
@@ -48380,7 +48380,7 @@ impl wkt::message::Message for BatchMigrateResourcesOperationMetadata {
     }
 }
 
-/// Defines additional types related to BatchMigrateResourcesOperationMetadata
+/// Defines additional types related to [BatchMigrateResourcesOperationMetadata].
 pub mod batch_migrate_resources_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -48518,7 +48518,7 @@ pub mod batch_migrate_resources_operation_metadata {
         }
     }
 
-    /// Defines additional types related to PartialResult
+    /// Defines additional types related to [PartialResult].
     pub mod partial_result {
         #[allow(unused_imports)]
         use super::*;
@@ -49233,7 +49233,7 @@ impl wkt::message::Message for Model {
     }
 }
 
-/// Defines additional types related to Model
+/// Defines additional types related to [Model].
 pub mod model {
     #[allow(unused_imports)]
     use super::*;
@@ -49305,7 +49305,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to ExportFormat
+    /// Defines additional types related to [ExportFormat].
     pub mod export_format {
         #[allow(unused_imports)]
         use super::*;
@@ -49600,7 +49600,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to BaseModelSource
+    /// Defines additional types related to [BaseModelSource].
     pub mod base_model_source {
         #[allow(unused_imports)]
         use super::*;
@@ -50404,7 +50404,7 @@ impl wkt::message::Message for ModelSourceInfo {
     }
 }
 
-/// Defines additional types related to ModelSourceInfo
+/// Defines additional types related to [ModelSourceInfo].
 pub mod model_source_info {
     #[allow(unused_imports)]
     use super::*;
@@ -50702,7 +50702,7 @@ impl wkt::message::Message for Probe {
     }
 }
 
-/// Defines additional types related to Probe
+/// Defines additional types related to [Probe].
 pub mod probe {
     #[allow(unused_imports)]
     use super::*;
@@ -51373,7 +51373,7 @@ impl wkt::message::Message for ModelDeploymentMonitoringJob {
     }
 }
 
-/// Defines additional types related to ModelDeploymentMonitoringJob
+/// Defines additional types related to [ModelDeploymentMonitoringJob].
 pub mod model_deployment_monitoring_job {
     #[allow(unused_imports)]
     use super::*;
@@ -51569,7 +51569,7 @@ impl wkt::message::Message for ModelDeploymentMonitoringBigQueryTable {
     }
 }
 
-/// Defines additional types related to ModelDeploymentMonitoringBigQueryTable
+/// Defines additional types related to [ModelDeploymentMonitoringBigQueryTable].
 pub mod model_deployment_monitoring_big_query_table {
     #[allow(unused_imports)]
     use super::*;
@@ -51867,7 +51867,7 @@ impl wkt::message::Message for ModelMonitoringStatsAnomalies {
     }
 }
 
-/// Defines additional types related to ModelMonitoringStatsAnomalies
+/// Defines additional types related to [ModelMonitoringStatsAnomalies].
 pub mod model_monitoring_stats_anomalies {
     #[allow(unused_imports)]
     use super::*;
@@ -52161,7 +52161,7 @@ impl wkt::message::Message for ModelEvaluation {
     }
 }
 
-/// Defines additional types related to ModelEvaluation
+/// Defines additional types related to [ModelEvaluation].
 pub mod model_evaluation {
     #[allow(unused_imports)]
     use super::*;
@@ -52330,7 +52330,7 @@ impl wkt::message::Message for ModelEvaluationSlice {
     }
 }
 
-/// Defines additional types related to ModelEvaluationSlice
+/// Defines additional types related to [ModelEvaluationSlice].
 pub mod model_evaluation_slice {
     #[allow(unused_imports)]
     use super::*;
@@ -52403,7 +52403,7 @@ pub mod model_evaluation_slice {
         }
     }
 
-    /// Defines additional types related to Slice
+    /// Defines additional types related to [Slice].
     pub mod slice {
         #[allow(unused_imports)]
         use super::*;
@@ -52451,7 +52451,7 @@ pub mod model_evaluation_slice {
             }
         }
 
-        /// Defines additional types related to SliceSpec
+        /// Defines additional types related to [SliceSpec].
         pub mod slice_spec {
             #[allow(unused_imports)]
             use super::*;
@@ -52661,7 +52661,7 @@ pub mod model_evaluation_slice {
                 }
             }
 
-            /// Defines additional types related to SliceConfig
+            /// Defines additional types related to [SliceConfig].
             pub mod slice_config {
                 #[allow(unused_imports)]
                 use super::*;
@@ -52814,7 +52814,7 @@ pub mod model_evaluation_slice {
                 }
             }
 
-            /// Defines additional types related to Value
+            /// Defines additional types related to [Value].
             pub mod value {
                 #[allow(unused_imports)]
                 use super::*;
@@ -53007,7 +53007,7 @@ impl wkt::message::Message for ModelMonitoringObjectiveConfig {
     }
 }
 
-/// Defines additional types related to ModelMonitoringObjectiveConfig
+/// Defines additional types related to [ModelMonitoringObjectiveConfig].
 pub mod model_monitoring_objective_config {
     #[allow(unused_imports)]
     use super::*;
@@ -53181,7 +53181,7 @@ pub mod model_monitoring_objective_config {
         }
     }
 
-    /// Defines additional types related to TrainingDataset
+    /// Defines additional types related to [TrainingDataset].
     pub mod training_dataset {
         #[allow(unused_imports)]
         use super::*;
@@ -53395,7 +53395,7 @@ pub mod model_monitoring_objective_config {
         }
     }
 
-    /// Defines additional types related to ExplanationConfig
+    /// Defines additional types related to [ExplanationConfig].
     pub mod explanation_config {
         #[allow(unused_imports)]
         use super::*;
@@ -53509,7 +53509,7 @@ pub mod model_monitoring_objective_config {
             }
         }
 
-        /// Defines additional types related to ExplanationBaseline
+        /// Defines additional types related to [ExplanationBaseline].
         pub mod explanation_baseline {
             #[allow(unused_imports)]
             use super::*;
@@ -53690,7 +53690,7 @@ impl wkt::message::Message for ModelMonitoringAlertConfig {
     }
 }
 
-/// Defines additional types related to ModelMonitoringAlertConfig
+/// Defines additional types related to [ModelMonitoringAlertConfig].
 pub mod model_monitoring_alert_config {
     #[allow(unused_imports)]
     use super::*;
@@ -53795,7 +53795,7 @@ impl wkt::message::Message for ThresholdConfig {
     }
 }
 
-/// Defines additional types related to ThresholdConfig
+/// Defines additional types related to [ThresholdConfig].
 pub mod threshold_config {
     #[allow(unused_imports)]
     use super::*;
@@ -53855,7 +53855,7 @@ impl wkt::message::Message for SamplingStrategy {
     }
 }
 
-/// Defines additional types related to SamplingStrategy
+/// Defines additional types related to [SamplingStrategy].
 pub mod sampling_strategy {
     #[allow(unused_imports)]
     use super::*;
@@ -54978,7 +54978,7 @@ impl wkt::message::Message for ExportModelRequest {
     }
 }
 
-/// Defines additional types related to ExportModelRequest
+/// Defines additional types related to [ExportModelRequest].
 pub mod export_model_request {
     #[allow(unused_imports)]
     use super::*;
@@ -55118,7 +55118,7 @@ impl wkt::message::Message for ExportModelOperationMetadata {
     }
 }
 
-/// Defines additional types related to ExportModelOperationMetadata
+/// Defines additional types related to [ExportModelOperationMetadata].
 pub mod export_model_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -55347,7 +55347,7 @@ impl wkt::message::Message for CopyModelRequest {
     }
 }
 
-/// Defines additional types related to CopyModelRequest
+/// Defines additional types related to [CopyModelRequest].
 pub mod copy_model_request {
     #[allow(unused_imports)]
     use super::*;
@@ -56428,7 +56428,7 @@ impl wkt::message::Message for NasJobSpec {
     }
 }
 
-/// Defines additional types related to NasJobSpec
+/// Defines additional types related to [NasJobSpec].
 pub mod nas_job_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -56535,7 +56535,7 @@ pub mod nas_job_spec {
         }
     }
 
-    /// Defines additional types related to MultiTrialAlgorithmSpec
+    /// Defines additional types related to [MultiTrialAlgorithmSpec].
     pub mod multi_trial_algorithm_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -56581,7 +56581,7 @@ pub mod nas_job_spec {
             }
         }
 
-        /// Defines additional types related to MetricSpec
+        /// Defines additional types related to [MetricSpec].
         pub mod metric_spec {
             #[allow(unused_imports)]
             use super::*;
@@ -56919,7 +56919,7 @@ impl wkt::message::Message for NasJobOutput {
     }
 }
 
-/// Defines additional types related to NasJobOutput
+/// Defines additional types related to [NasJobOutput].
 pub mod nas_job_output {
     #[allow(unused_imports)]
     use super::*;
@@ -57067,7 +57067,7 @@ impl wkt::message::Message for NasTrial {
     }
 }
 
-/// Defines additional types related to NasTrial
+/// Defines additional types related to [NasTrial].
 pub mod nas_trial {
     #[allow(unused_imports)]
     use super::*;
@@ -57794,7 +57794,7 @@ impl wkt::message::Message for NotebookExecutionJob {
     }
 }
 
-/// Defines additional types related to NotebookExecutionJob
+/// Defines additional types related to [NotebookExecutionJob].
 pub mod notebook_execution_job {
     #[allow(unused_imports)]
     use super::*;
@@ -58807,7 +58807,7 @@ impl wkt::message::Message for NotebookRuntime {
     }
 }
 
-/// Defines additional types related to NotebookRuntime
+/// Defines additional types related to [NotebookRuntime].
 pub mod notebook_runtime {
     #[allow(unused_imports)]
     use super::*;
@@ -60526,7 +60526,7 @@ impl wkt::message::Message for PostStartupScriptConfig {
     }
 }
 
-/// Defines additional types related to PostStartupScriptConfig
+/// Defines additional types related to [PostStartupScriptConfig].
 pub mod post_startup_script_config {
     #[allow(unused_imports)]
     use super::*;
@@ -61287,7 +61287,7 @@ impl wkt::message::Message for PersistentResource {
     }
 }
 
-/// Defines additional types related to PersistentResource
+/// Defines additional types related to [PersistentResource].
 pub mod persistent_resource {
     #[allow(unused_imports)]
     use super::*;
@@ -61474,7 +61474,7 @@ impl wkt::message::Message for ResourcePool {
     }
 }
 
-/// Defines additional types related to ResourcePool
+/// Defines additional types related to [ResourcePool].
 pub mod resource_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -62641,7 +62641,7 @@ impl wkt::message::Message for PipelineJob {
     }
 }
 
-/// Defines additional types related to PipelineJob
+/// Defines additional types related to [PipelineJob].
 pub mod pipeline_job {
     #[allow(unused_imports)]
     use super::*;
@@ -62771,7 +62771,7 @@ pub mod pipeline_job {
         }
     }
 
-    /// Defines additional types related to RuntimeConfig
+    /// Defines additional types related to [RuntimeConfig].
     pub mod runtime_config {
         #[allow(unused_imports)]
         use super::*;
@@ -62843,7 +62843,7 @@ pub mod pipeline_job {
             }
         }
 
-        /// Defines additional types related to InputArtifact
+        /// Defines additional types related to [InputArtifact].
         pub mod input_artifact {
             #[allow(unused_imports)]
             use super::*;
@@ -63169,7 +63169,7 @@ impl wkt::message::Message for PipelineTaskDetail {
     }
 }
 
-/// Defines additional types related to PipelineTaskDetail
+/// Defines additional types related to [PipelineTaskDetail].
 pub mod pipeline_task_detail {
     #[allow(unused_imports)]
     use super::*;
@@ -63474,7 +63474,7 @@ impl wkt::message::Message for PipelineTaskExecutorDetail {
     }
 }
 
-/// Defines additional types related to PipelineTaskExecutorDetail
+/// Defines additional types related to [PipelineTaskExecutorDetail].
 pub mod pipeline_task_executor_detail {
     #[allow(unused_imports)]
     use super::*;
@@ -66151,7 +66151,7 @@ impl wkt::message::Message for GenerateContentResponse {
     }
 }
 
-/// Defines additional types related to GenerateContentResponse
+/// Defines additional types related to [GenerateContentResponse].
 pub mod generate_content_response {
     #[allow(unused_imports)]
     use super::*;
@@ -66219,7 +66219,7 @@ pub mod generate_content_response {
         }
     }
 
-    /// Defines additional types related to PromptFeedback
+    /// Defines additional types related to [PromptFeedback].
     pub mod prompt_feedback {
         #[allow(unused_imports)]
         use super::*;
@@ -66544,7 +66544,7 @@ impl wkt::message::Message for PublisherModel {
     }
 }
 
-/// Defines additional types related to PublisherModel
+/// Defines additional types related to [PublisherModel].
 pub mod publisher_model {
     #[allow(unused_imports)]
     use super::*;
@@ -66692,7 +66692,7 @@ pub mod publisher_model {
         }
     }
 
-    /// Defines additional types related to ResourceReference
+    /// Defines additional types related to [ResourceReference].
     pub mod resource_reference {
         #[allow(unused_imports)]
         use super::*;
@@ -67033,7 +67033,7 @@ pub mod publisher_model {
         }
     }
 
-    /// Defines additional types related to CallToAction
+    /// Defines additional types related to [CallToAction].
     pub mod call_to_action {
         #[allow(unused_imports)]
         use super::*;
@@ -67500,7 +67500,7 @@ pub mod publisher_model {
             }
         }
 
-        /// Defines additional types related to Deploy
+        /// Defines additional types related to [Deploy].
         pub mod deploy {
             #[allow(unused_imports)]
             use super::*;
@@ -67909,7 +67909,7 @@ impl wkt::message::Message for ReasoningEngineSpec {
     }
 }
 
-/// Defines additional types related to ReasoningEngineSpec
+/// Defines additional types related to [ReasoningEngineSpec].
 pub mod reasoning_engine_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -68722,7 +68722,7 @@ impl wkt::message::Message for ReservationAffinity {
     }
 }
 
-/// Defines additional types related to ReservationAffinity
+/// Defines additional types related to [ReservationAffinity].
 pub mod reservation_affinity {
     #[allow(unused_imports)]
     use super::*;
@@ -69286,7 +69286,7 @@ impl wkt::message::Message for Schedule {
     }
 }
 
-/// Defines additional types related to Schedule
+/// Defines additional types related to [Schedule].
 pub mod schedule {
     #[allow(unused_imports)]
     use super::*;
@@ -70622,7 +70622,7 @@ impl wkt::message::Message for Study {
     }
 }
 
-/// Defines additional types related to Study
+/// Defines additional types related to [Study].
 pub mod study {
     #[allow(unused_imports)]
     use super::*;
@@ -70890,7 +70890,7 @@ impl wkt::message::Message for Trial {
     }
 }
 
-/// Defines additional types related to Trial
+/// Defines additional types related to [Trial].
 pub mod trial {
     #[allow(unused_imports)]
     use super::*;
@@ -71165,7 +71165,7 @@ impl wkt::message::Message for StudyTimeConstraint {
     }
 }
 
-/// Defines additional types related to StudyTimeConstraint
+/// Defines additional types related to [StudyTimeConstraint].
 pub mod study_time_constraint {
     #[allow(unused_imports)]
     use super::*;
@@ -71405,7 +71405,7 @@ impl wkt::message::Message for StudySpec {
     }
 }
 
-/// Defines additional types related to StudySpec
+/// Defines additional types related to [StudySpec].
 pub mod study_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -71471,7 +71471,7 @@ pub mod study_spec {
         }
     }
 
-    /// Defines additional types related to MetricSpec
+    /// Defines additional types related to [MetricSpec].
     pub mod metric_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -71824,7 +71824,7 @@ pub mod study_spec {
         }
     }
 
-    /// Defines additional types related to ParameterSpec
+    /// Defines additional types related to [ParameterSpec].
     pub mod parameter_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -72178,7 +72178,7 @@ pub mod study_spec {
             }
         }
 
-        /// Defines additional types related to ConditionalParameterSpec
+        /// Defines additional types related to [ConditionalParameterSpec].
         pub mod conditional_parameter_spec {
             #[allow(unused_imports)]
             use super::*;
@@ -73028,7 +73028,7 @@ impl wkt::message::Message for Measurement {
     }
 }
 
-/// Defines additional types related to Measurement
+/// Defines additional types related to [Measurement].
 pub mod measurement {
     #[allow(unused_imports)]
     use super::*;
@@ -73465,7 +73465,7 @@ impl wkt::message::Message for TimeSeriesDataPoint {
     }
 }
 
-/// Defines additional types related to TimeSeriesDataPoint
+/// Defines additional types related to [TimeSeriesDataPoint].
 pub mod time_series_data_point {
     #[allow(unused_imports)]
     use super::*;
@@ -74300,7 +74300,7 @@ impl wkt::message::Message for ReadTensorboardUsageResponse {
     }
 }
 
-/// Defines additional types related to ReadTensorboardUsageResponse
+/// Defines additional types related to [ReadTensorboardUsageResponse].
 pub mod read_tensorboard_usage_response {
     #[allow(unused_imports)]
     use super::*;
@@ -76467,7 +76467,7 @@ impl wkt::message::Message for TensorboardTimeSeries {
     }
 }
 
-/// Defines additional types related to TensorboardTimeSeries
+/// Defines additional types related to [TensorboardTimeSeries].
 pub mod tensorboard_time_series {
     #[allow(unused_imports)]
     use super::*;
@@ -76724,7 +76724,7 @@ impl wkt::message::Message for Tool {
     }
 }
 
-/// Defines additional types related to Tool
+/// Defines additional types related to [Tool].
 pub mod tool {
     #[allow(unused_imports)]
     use super::*;
@@ -77002,7 +77002,7 @@ impl wkt::message::Message for ExecutableCode {
     }
 }
 
-/// Defines additional types related to ExecutableCode
+/// Defines additional types related to [ExecutableCode].
 pub mod executable_code {
     #[allow(unused_imports)]
     use super::*;
@@ -77104,7 +77104,7 @@ impl wkt::message::Message for CodeExecutionResult {
     }
 }
 
-/// Defines additional types related to CodeExecutionResult
+/// Defines additional types related to [CodeExecutionResult].
 pub mod code_execution_result {
     #[allow(unused_imports)]
     use super::*;
@@ -77277,7 +77277,7 @@ impl wkt::message::Message for Retrieval {
     }
 }
 
-/// Defines additional types related to Retrieval
+/// Defines additional types related to [Retrieval].
 pub mod retrieval {
     #[allow(unused_imports)]
     use super::*;
@@ -77374,7 +77374,7 @@ impl wkt::message::Message for VertexRagStore {
     }
 }
 
-/// Defines additional types related to VertexRagStore
+/// Defines additional types related to [VertexRagStore].
 pub mod vertex_rag_store {
     #[allow(unused_imports)]
     use super::*;
@@ -77571,7 +77571,7 @@ impl wkt::message::Message for DynamicRetrievalConfig {
     }
 }
 
-/// Defines additional types related to DynamicRetrievalConfig
+/// Defines additional types related to [DynamicRetrievalConfig].
 pub mod dynamic_retrieval_config {
     #[allow(unused_imports)]
     use super::*;
@@ -77726,7 +77726,7 @@ impl wkt::message::Message for FunctionCallingConfig {
     }
 }
 
-/// Defines additional types related to FunctionCallingConfig
+/// Defines additional types related to [FunctionCallingConfig].
 pub mod function_calling_config {
     #[allow(unused_imports)]
     use super::*;
@@ -77902,7 +77902,7 @@ impl wkt::message::Message for RagRetrievalConfig {
     }
 }
 
-/// Defines additional types related to RagRetrievalConfig
+/// Defines additional types related to [RagRetrievalConfig].
 pub mod rag_retrieval_config {
     #[allow(unused_imports)]
     use super::*;
@@ -78010,7 +78010,7 @@ pub mod rag_retrieval_config {
         }
     }
 
-    /// Defines additional types related to Filter
+    /// Defines additional types related to [Filter].
     pub mod filter {
         #[allow(unused_imports)]
         use super::*;
@@ -78139,7 +78139,7 @@ pub mod rag_retrieval_config {
         }
     }
 
-    /// Defines additional types related to Ranking
+    /// Defines additional types related to [Ranking].
     pub mod ranking {
         #[allow(unused_imports)]
         use super::*;
@@ -78949,7 +78949,7 @@ impl wkt::message::Message for InputDataConfig {
     }
 }
 
-/// Defines additional types related to InputDataConfig
+/// Defines additional types related to [InputDataConfig].
 pub mod input_data_config {
     #[allow(unused_imports)]
     use super::*;
@@ -79699,7 +79699,7 @@ impl wkt::message::Message for TuningJob {
     }
 }
 
-/// Defines additional types related to TuningJob
+/// Defines additional types related to [TuningJob].
 pub mod tuning_job {
     #[allow(unused_imports)]
     use super::*;
@@ -79873,7 +79873,7 @@ impl wkt::message::Message for SupervisedTuningDatasetDistribution {
     }
 }
 
-/// Defines additional types related to SupervisedTuningDatasetDistribution
+/// Defines additional types related to [SupervisedTuningDatasetDistribution].
 pub mod supervised_tuning_dataset_distribution {
     #[allow(unused_imports)]
     use super::*;
@@ -80154,7 +80154,7 @@ impl wkt::message::Message for TuningDataStats {
     }
 }
 
-/// Defines additional types related to TuningDataStats
+/// Defines additional types related to [TuningDataStats].
 pub mod tuning_data_stats {
     #[allow(unused_imports)]
     use super::*;
@@ -80221,7 +80221,7 @@ impl wkt::message::Message for SupervisedHyperParameters {
     }
 }
 
-/// Defines additional types related to SupervisedHyperParameters
+/// Defines additional types related to [SupervisedHyperParameters].
 pub mod supervised_hyper_parameters {
     #[allow(unused_imports)]
     use super::*;
@@ -80467,7 +80467,7 @@ impl wkt::message::Message for TunedModelRef {
     }
 }
 
-/// Defines additional types related to TunedModelRef
+/// Defines additional types related to [TunedModelRef].
 pub mod tuned_model_ref {
     #[allow(unused_imports)]
     use super::*;
@@ -80883,7 +80883,7 @@ impl wkt::message::Message for Tensor {
     }
 }
 
-/// Defines additional types related to Tensor
+/// Defines additional types related to [Tensor].
 pub mod tensor {
     #[allow(unused_imports)]
     use super::*;
@@ -81147,7 +81147,7 @@ impl wkt::message::Message for UserActionReference {
     }
 }
 
-/// Defines additional types related to UserActionReference
+/// Defines additional types related to [UserActionReference].
 pub mod user_action_reference {
     #[allow(unused_imports)]
     use super::*;
@@ -81263,7 +81263,7 @@ impl wkt::message::Message for Value {
     }
 }
 
-/// Defines additional types related to Value
+/// Defines additional types related to [Value].
 pub mod value {
     #[allow(unused_imports)]
     use super::*;
@@ -81355,7 +81355,7 @@ impl wkt::message::Message for RagEmbeddingModelConfig {
     }
 }
 
-/// Defines additional types related to RagEmbeddingModelConfig
+/// Defines additional types related to [RagEmbeddingModelConfig].
 pub mod rag_embedding_model_config {
     #[allow(unused_imports)]
     use super::*;
@@ -81596,7 +81596,7 @@ impl wkt::message::Message for RagVectorDbConfig {
     }
 }
 
-/// Defines additional types related to RagVectorDbConfig
+/// Defines additional types related to [RagVectorDbConfig].
 pub mod rag_vector_db_config {
     #[allow(unused_imports)]
     use super::*;
@@ -81751,7 +81751,7 @@ impl wkt::message::Message for FileStatus {
     }
 }
 
-/// Defines additional types related to FileStatus
+/// Defines additional types related to [FileStatus].
 pub mod file_status {
     #[allow(unused_imports)]
     use super::*;
@@ -81856,7 +81856,7 @@ impl wkt::message::Message for CorpusStatus {
     }
 }
 
-/// Defines additional types related to CorpusStatus
+/// Defines additional types related to [CorpusStatus].
 pub mod corpus_status {
     #[allow(unused_imports)]
     use super::*;
@@ -82066,7 +82066,7 @@ impl wkt::message::Message for RagCorpus {
     }
 }
 
-/// Defines additional types related to RagCorpus
+/// Defines additional types related to [RagCorpus].
 pub mod rag_corpus {
     #[allow(unused_imports)]
     use super::*;
@@ -82363,7 +82363,7 @@ impl wkt::message::Message for RagFile {
     }
 }
 
-/// Defines additional types related to RagFile
+/// Defines additional types related to [RagFile].
 pub mod rag_file {
     #[allow(unused_imports)]
     use super::*;
@@ -82465,7 +82465,7 @@ impl wkt::message::Message for RagFileChunkingConfig {
     }
 }
 
-/// Defines additional types related to RagFileChunkingConfig
+/// Defines additional types related to [RagFileChunkingConfig].
 pub mod rag_file_chunking_config {
     #[allow(unused_imports)]
     use super::*;
@@ -82620,7 +82620,7 @@ impl wkt::message::Message for RagFileParsingConfig {
     }
 }
 
-/// Defines additional types related to RagFileParsingConfig
+/// Defines additional types related to [RagFileParsingConfig].
 pub mod rag_file_parsing_config {
     #[allow(unused_imports)]
     use super::*;
@@ -83042,7 +83042,7 @@ impl wkt::message::Message for ImportRagFilesConfig {
     }
 }
 
-/// Defines additional types related to ImportRagFilesConfig
+/// Defines additional types related to [ImportRagFilesConfig].
 pub mod import_rag_files_config {
     #[allow(unused_imports)]
     use super::*;
@@ -83497,7 +83497,7 @@ impl wkt::message::Message for UploadRagFileResponse {
     }
 }
 
-/// Defines additional types related to UploadRagFileResponse
+/// Defines additional types related to [UploadRagFileResponse].
 pub mod upload_rag_file_response {
     #[allow(unused_imports)]
     use super::*;
@@ -83695,7 +83695,7 @@ impl wkt::message::Message for ImportRagFilesResponse {
     }
 }
 
-/// Defines additional types related to ImportRagFilesResponse
+/// Defines additional types related to [ImportRagFilesResponse].
 pub mod import_rag_files_response {
     #[allow(unused_imports)]
     use super::*;
@@ -84158,7 +84158,7 @@ impl wkt::message::Message for RagQuery {
     }
 }
 
-/// Defines additional types related to RagQuery
+/// Defines additional types related to [RagQuery].
 pub mod rag_query {
     #[allow(unused_imports)]
     use super::*;
@@ -84275,7 +84275,7 @@ impl wkt::message::Message for RetrieveContextsRequest {
     }
 }
 
-/// Defines additional types related to RetrieveContextsRequest
+/// Defines additional types related to [RetrieveContextsRequest].
 pub mod retrieve_contexts_request {
     #[allow(unused_imports)]
     use super::*;
@@ -84334,7 +84334,7 @@ pub mod retrieve_contexts_request {
         }
     }
 
-    /// Defines additional types related to VertexRagStore
+    /// Defines additional types related to [VertexRagStore].
     pub mod vertex_rag_store {
         #[allow(unused_imports)]
         use super::*;
@@ -84434,7 +84434,7 @@ impl wkt::message::Message for RagContexts {
     }
 }
 
-/// Defines additional types related to RagContexts
+/// Defines additional types related to [RagContexts].
 pub mod rag_contexts {
     #[allow(unused_imports)]
     use super::*;
@@ -84655,7 +84655,7 @@ impl wkt::message::Message for AugmentPromptRequest {
     }
 }
 
-/// Defines additional types related to AugmentPromptRequest
+/// Defines additional types related to [AugmentPromptRequest].
 pub mod augment_prompt_request {
     #[allow(unused_imports)]
     use super::*;
@@ -84842,7 +84842,7 @@ impl wkt::message::Message for CorroborateContentRequest {
     }
 }
 
-/// Defines additional types related to CorroborateContentRequest
+/// Defines additional types related to [CorroborateContentRequest].
 pub mod corroborate_content_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/alloydb/connectors/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/connectors/v1/src/model.rs
@@ -82,7 +82,7 @@ impl wkt::message::Message for MetadataExchangeRequest {
     }
 }
 
-/// Defines additional types related to MetadataExchangeRequest
+/// Defines additional types related to [MetadataExchangeRequest].
 pub mod metadata_exchange_request {
     #[allow(unused_imports)]
     use super::*;
@@ -190,7 +190,7 @@ impl wkt::message::Message for MetadataExchangeResponse {
     }
 }
 
-/// Defines additional types related to MetadataExchangeResponse
+/// Defines additional types related to [MetadataExchangeResponse].
 pub mod metadata_exchange_response {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -303,7 +303,7 @@ impl wkt::message::Message for MigrationSource {
     }
 }
 
-/// Defines additional types related to MigrationSource
+/// Defines additional types related to [MigrationSource].
 pub mod migration_source {
     #[allow(unused_imports)]
     use super::*;
@@ -443,7 +443,7 @@ impl wkt::message::Message for EncryptionInfo {
     }
 }
 
-/// Defines additional types related to EncryptionInfo
+/// Defines additional types related to [EncryptionInfo].
 pub mod encryption_info {
     #[allow(unused_imports)]
     use super::*;
@@ -556,7 +556,7 @@ impl wkt::message::Message for SslConfig {
     }
 }
 
-/// Defines additional types related to SslConfig
+/// Defines additional types related to [SslConfig].
 pub mod ssl_config {
     #[allow(unused_imports)]
     use super::*;
@@ -940,7 +940,7 @@ impl wkt::message::Message for AutomatedBackupPolicy {
     }
 }
 
-/// Defines additional types related to AutomatedBackupPolicy
+/// Defines additional types related to [AutomatedBackupPolicy].
 pub mod automated_backup_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -1371,7 +1371,7 @@ impl wkt::message::Message for MaintenanceUpdatePolicy {
     }
 }
 
-/// Defines additional types related to MaintenanceUpdatePolicy
+/// Defines additional types related to [MaintenanceUpdatePolicy].
 pub mod maintenance_update_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -1998,7 +1998,7 @@ impl wkt::message::Message for Cluster {
     }
 }
 
-/// Defines additional types related to Cluster
+/// Defines additional types related to [Cluster].
 pub mod cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -2820,7 +2820,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -3183,7 +3183,7 @@ pub mod instance {
         }
     }
 
-    /// Defines additional types related to InstanceNetworkConfig
+    /// Defines additional types related to [InstanceNetworkConfig].
     pub mod instance_network_config {
         #[allow(unused_imports)]
         use super::*;
@@ -3843,7 +3843,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -4218,7 +4218,7 @@ impl wkt::message::Message for SupportedDatabaseFlag {
     }
 }
 
-/// Defines additional types related to SupportedDatabaseFlag
+/// Defines additional types related to [SupportedDatabaseFlag].
 pub mod supported_database_flag {
     #[allow(unused_imports)]
     use super::*;
@@ -4468,7 +4468,7 @@ impl wkt::message::Message for User {
     }
 }
 
-/// Defines additional types related to User
+/// Defines additional types related to [User].
 pub mod user {
     #[allow(unused_imports)]
     use super::*;
@@ -5421,7 +5421,7 @@ impl wkt::message::Message for RestoreClusterRequest {
     }
 }
 
-/// Defines additional types related to RestoreClusterRequest
+/// Defines additional types related to [RestoreClusterRequest].
 pub mod restore_cluster_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6084,7 +6084,7 @@ impl wkt::message::Message for BatchCreateInstanceStatus {
     }
 }
 
-/// Defines additional types related to BatchCreateInstanceStatus
+/// Defines additional types related to [BatchCreateInstanceStatus].
 pub mod batch_create_instance_status {
     #[allow(unused_imports)]
     use super::*;
@@ -6477,7 +6477,7 @@ impl wkt::message::Message for InjectFaultRequest {
     }
 }
 
-/// Defines additional types related to InjectFaultRequest
+/// Defines additional types related to [InjectFaultRequest].
 pub mod inject_fault_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6720,7 +6720,7 @@ impl wkt::message::Message for ExecuteSqlRequest {
     }
 }
 
-/// Defines additional types related to ExecuteSqlRequest
+/// Defines additional types related to [ExecuteSqlRequest].
 pub mod execute_sql_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6855,7 +6855,7 @@ impl wkt::message::Message for ExecuteSqlMetadata {
     }
 }
 
-/// Defines additional types related to ExecuteSqlMetadata
+/// Defines additional types related to [ExecuteSqlMetadata].
 pub mod execute_sql_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -7801,7 +7801,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/apigateway/v1/src/model.rs
+++ b/src/generated/cloud/apigateway/v1/src/model.rs
@@ -138,7 +138,7 @@ impl wkt::message::Message for Api {
     }
 }
 
-/// Defines additional types related to Api
+/// Defines additional types related to [Api].
 pub mod api {
     #[allow(unused_imports)]
     use super::*;
@@ -405,7 +405,7 @@ impl wkt::message::Message for ApiConfig {
     }
 }
 
-/// Defines additional types related to ApiConfig
+/// Defines additional types related to [ApiConfig].
 pub mod api_config {
     #[allow(unused_imports)]
     use super::*;
@@ -742,7 +742,7 @@ impl wkt::message::Message for Gateway {
     }
 }
 
-/// Defines additional types related to Gateway
+/// Defines additional types related to [Gateway].
 pub mod gateway {
     #[allow(unused_imports)]
     use super::*;
@@ -1612,7 +1612,7 @@ impl wkt::message::Message for GetApiConfigRequest {
     }
 }
 
-/// Defines additional types related to GetApiConfigRequest
+/// Defines additional types related to [GetApiConfigRequest].
 pub mod get_api_config_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1923,7 +1923,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -427,7 +427,7 @@ impl wkt::message::Message for Payload {
     }
 }
 
-/// Defines additional types related to Payload
+/// Defines additional types related to [Payload].
 pub mod payload {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/apihub/v1/src/model.rs
+++ b/src/generated/cloud/apihub/v1/src/model.rs
@@ -2465,7 +2465,7 @@ impl wkt::message::Message for ApiHubResource {
     }
 }
 
-/// Defines additional types related to ApiHubResource
+/// Defines additional types related to [ApiHubResource].
 pub mod api_hub_resource {
     #[allow(unused_imports)]
     use super::*;
@@ -3987,7 +3987,7 @@ impl wkt::message::Message for Spec {
     }
 }
 
-/// Defines additional types related to Spec
+/// Defines additional types related to [Spec].
 pub mod spec {
     #[allow(unused_imports)]
     use super::*;
@@ -4537,7 +4537,7 @@ impl wkt::message::Message for Definition {
     }
 }
 
-/// Defines additional types related to Definition
+/// Defines additional types related to [Definition].
 pub mod definition {
     #[allow(unused_imports)]
     use super::*;
@@ -4762,7 +4762,7 @@ impl wkt::message::Message for Attribute {
     }
 }
 
-/// Defines additional types related to Attribute
+/// Defines additional types related to [Attribute].
 pub mod attribute {
     #[allow(unused_imports)]
     use super::*;
@@ -5173,7 +5173,7 @@ impl wkt::message::Message for SpecDetails {
     }
 }
 
-/// Defines additional types related to SpecDetails
+/// Defines additional types related to [SpecDetails].
 pub mod spec_details {
     #[allow(unused_imports)]
     use super::*;
@@ -5253,7 +5253,7 @@ impl wkt::message::Message for OpenApiSpecDetails {
     }
 }
 
-/// Defines additional types related to OpenApiSpecDetails
+/// Defines additional types related to [OpenApiSpecDetails].
 pub mod open_api_spec_details {
     #[allow(unused_imports)]
     use super::*;
@@ -5424,7 +5424,7 @@ impl wkt::message::Message for OperationDetails {
     }
 }
 
-/// Defines additional types related to OperationDetails
+/// Defines additional types related to [OperationDetails].
 pub mod operation_details {
     #[allow(unused_imports)]
     use super::*;
@@ -5482,7 +5482,7 @@ impl wkt::message::Message for HttpOperation {
     }
 }
 
-/// Defines additional types related to HttpOperation
+/// Defines additional types related to [HttpOperation].
 pub mod http_operation {
     #[allow(unused_imports)]
     use super::*;
@@ -5864,7 +5864,7 @@ impl wkt::message::Message for AttributeValues {
     }
 }
 
-/// Defines additional types related to AttributeValues
+/// Defines additional types related to [AttributeValues].
 pub mod attribute_values {
     #[allow(unused_imports)]
     use super::*;
@@ -6117,7 +6117,7 @@ impl wkt::message::Message for Dependency {
     }
 }
 
-/// Defines additional types related to Dependency
+/// Defines additional types related to [Dependency].
 pub mod dependency {
     #[allow(unused_imports)]
     use super::*;
@@ -6340,7 +6340,7 @@ impl wkt::message::Message for DependencyEntityReference {
     }
 }
 
-/// Defines additional types related to DependencyEntityReference
+/// Defines additional types related to [DependencyEntityReference].
 pub mod dependency_entity_reference {
     #[allow(unused_imports)]
     use super::*;
@@ -6407,7 +6407,7 @@ impl wkt::message::Message for DependencyErrorDetail {
     }
 }
 
-/// Defines additional types related to DependencyErrorDetail
+/// Defines additional types related to [DependencyErrorDetail].
 pub mod dependency_error_detail {
     #[allow(unused_imports)]
     use super::*;
@@ -6560,7 +6560,7 @@ impl wkt::message::Message for LintResponse {
     }
 }
 
-/// Defines additional types related to LintResponse
+/// Defines additional types related to [LintResponse].
 pub mod lint_response {
     #[allow(unused_imports)]
     use super::*;
@@ -6985,7 +6985,7 @@ impl wkt::message::Message for ApiHubInstance {
     }
 }
 
-/// Defines additional types related to ApiHubInstance
+/// Defines additional types related to [ApiHubInstance].
 pub mod api_hub_instance {
     #[allow(unused_imports)]
     use super::*;
@@ -7883,7 +7883,7 @@ impl wkt::message::Message for Plugin {
     }
 }
 
-/// Defines additional types related to Plugin
+/// Defines additional types related to [Plugin].
 pub mod plugin {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/apphub/v1/src/model.rs
+++ b/src/generated/cloud/apphub/v1/src/model.rs
@@ -2333,7 +2333,7 @@ impl wkt::message::Message for Application {
     }
 }
 
-/// Defines additional types related to Application
+/// Defines additional types related to [Application].
 pub mod application {
     #[allow(unused_imports)]
     use super::*;
@@ -2430,7 +2430,7 @@ impl wkt::message::Message for Scope {
     }
 }
 
-/// Defines additional types related to Scope
+/// Defines additional types related to [Scope].
 pub mod scope {
     #[allow(unused_imports)]
     use super::*;
@@ -2615,7 +2615,7 @@ impl wkt::message::Message for Criticality {
     }
 }
 
-/// Defines additional types related to Criticality
+/// Defines additional types related to [Criticality].
 pub mod criticality {
     #[allow(unused_imports)]
     use super::*;
@@ -2720,7 +2720,7 @@ impl wkt::message::Message for Environment {
     }
 }
 
-/// Defines additional types related to Environment
+/// Defines additional types related to [Environment].
 pub mod environment {
     #[allow(unused_imports)]
     use super::*;
@@ -2991,7 +2991,7 @@ impl wkt::message::Message for Service {
     }
 }
 
-/// Defines additional types related to Service
+/// Defines additional types related to [Service].
 pub mod service {
     #[allow(unused_imports)]
     use super::*;
@@ -3292,7 +3292,7 @@ impl wkt::message::Message for ServiceProjectAttachment {
     }
 }
 
-/// Defines additional types related to ServiceProjectAttachment
+/// Defines additional types related to [ServiceProjectAttachment].
 pub mod service_project_attachment {
     #[allow(unused_imports)]
     use super::*;
@@ -3521,7 +3521,7 @@ impl wkt::message::Message for Workload {
     }
 }
 
-/// Defines additional types related to Workload
+/// Defines additional types related to [Workload].
 pub mod workload {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -988,7 +988,7 @@ impl wkt::message::Message for OutputConfig {
     }
 }
 
-/// Defines additional types related to OutputConfig
+/// Defines additional types related to [OutputConfig].
 pub mod output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1067,7 +1067,7 @@ impl wkt::message::Message for OutputResult {
     }
 }
 
-/// Defines additional types related to OutputResult
+/// Defines additional types related to [OutputResult].
 pub mod output_result {
     #[allow(unused_imports)]
     use super::*;
@@ -1196,7 +1196,7 @@ impl wkt::message::Message for GcsDestination {
     }
 }
 
-/// Defines additional types related to GcsDestination
+/// Defines additional types related to [GcsDestination].
 pub mod gcs_destination {
     #[allow(unused_imports)]
     use super::*;
@@ -1386,7 +1386,7 @@ impl wkt::message::Message for PartitionSpec {
     }
 }
 
-/// Defines additional types related to PartitionSpec
+/// Defines additional types related to [PartitionSpec].
 pub mod partition_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -1558,7 +1558,7 @@ impl wkt::message::Message for FeedOutputConfig {
     }
 }
 
-/// Defines additional types related to FeedOutputConfig
+/// Defines additional types related to [FeedOutputConfig].
 pub mod feed_output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2405,7 +2405,7 @@ impl wkt::message::Message for IamPolicyAnalysisQuery {
     }
 }
 
-/// Defines additional types related to IamPolicyAnalysisQuery
+/// Defines additional types related to [IamPolicyAnalysisQuery].
 pub mod iam_policy_analysis_query {
     #[allow(unused_imports)]
     use super::*;
@@ -2777,7 +2777,7 @@ pub mod iam_policy_analysis_query {
         }
     }
 
-    /// Defines additional types related to ConditionContext
+    /// Defines additional types related to [ConditionContext].
     pub mod condition_context {
         #[allow(unused_imports)]
         use super::*;
@@ -2957,7 +2957,7 @@ impl wkt::message::Message for AnalyzeIamPolicyResponse {
     }
 }
 
-/// Defines additional types related to AnalyzeIamPolicyResponse
+/// Defines additional types related to [AnalyzeIamPolicyResponse].
 pub mod analyze_iam_policy_response {
     #[allow(unused_imports)]
     use super::*;
@@ -3157,7 +3157,7 @@ impl wkt::message::Message for IamPolicyAnalysisOutputConfig {
     }
 }
 
-/// Defines additional types related to IamPolicyAnalysisOutputConfig
+/// Defines additional types related to [IamPolicyAnalysisOutputConfig].
 pub mod iam_policy_analysis_output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3289,7 +3289,7 @@ pub mod iam_policy_analysis_output_config {
         }
     }
 
-    /// Defines additional types related to BigQueryDestination
+    /// Defines additional types related to [BigQueryDestination].
     pub mod big_query_destination {
         #[allow(unused_imports)]
         use super::*;
@@ -3598,7 +3598,7 @@ impl wkt::message::Message for SavedQuery {
     }
 }
 
-/// Defines additional types related to SavedQuery
+/// Defines additional types related to [SavedQuery].
 pub mod saved_query {
     #[allow(unused_imports)]
     use super::*;
@@ -3673,7 +3673,7 @@ pub mod saved_query {
         }
     }
 
-    /// Defines additional types related to QueryContent
+    /// Defines additional types related to [QueryContent].
     pub mod query_content {
         #[allow(unused_imports)]
         use super::*;
@@ -4073,7 +4073,7 @@ impl wkt::message::Message for AnalyzeMoveRequest {
     }
 }
 
-/// Defines additional types related to AnalyzeMoveRequest
+/// Defines additional types related to [AnalyzeMoveRequest].
 pub mod analyze_move_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4274,7 +4274,7 @@ impl wkt::message::Message for MoveAnalysis {
     }
 }
 
-/// Defines additional types related to MoveAnalysis
+/// Defines additional types related to [MoveAnalysis].
 pub mod move_analysis {
     #[allow(unused_imports)]
     use super::*;
@@ -4408,7 +4408,7 @@ impl wkt::message::Message for QueryAssetsOutputConfig {
     }
 }
 
-/// Defines additional types related to QueryAssetsOutputConfig
+/// Defines additional types related to [QueryAssetsOutputConfig].
 pub mod query_assets_output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4729,7 +4729,7 @@ impl wkt::message::Message for QueryAssetsRequest {
     }
 }
 
-/// Defines additional types related to QueryAssetsRequest
+/// Defines additional types related to [QueryAssetsRequest].
 pub mod query_assets_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4915,7 +4915,7 @@ impl wkt::message::Message for QueryAssetsResponse {
     }
 }
 
-/// Defines additional types related to QueryAssetsResponse
+/// Defines additional types related to [QueryAssetsResponse].
 pub mod query_assets_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5233,7 +5233,7 @@ impl wkt::message::Message for BatchGetEffectiveIamPoliciesResponse {
     }
 }
 
-/// Defines additional types related to BatchGetEffectiveIamPoliciesResponse
+/// Defines additional types related to [BatchGetEffectiveIamPoliciesResponse].
 pub mod batch_get_effective_iam_policies_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5318,7 +5318,7 @@ pub mod batch_get_effective_iam_policies_response {
         }
     }
 
-    /// Defines additional types related to EffectiveIamPolicy
+    /// Defines additional types related to [EffectiveIamPolicy].
     pub mod effective_iam_policy {
         #[allow(unused_imports)]
         use super::*;
@@ -5478,7 +5478,7 @@ impl wkt::message::Message for AnalyzerOrgPolicy {
     }
 }
 
-/// Defines additional types related to AnalyzerOrgPolicy
+/// Defines additional types related to [AnalyzerOrgPolicy].
 pub mod analyzer_org_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -5677,7 +5677,7 @@ pub mod analyzer_org_policy {
         }
     }
 
-    /// Defines additional types related to Rule
+    /// Defines additional types related to [Rule].
     pub mod rule {
         #[allow(unused_imports)]
         use super::*;
@@ -5862,7 +5862,7 @@ impl wkt::message::Message for AnalyzerOrgPolicyConstraint {
     }
 }
 
-/// Defines additional types related to AnalyzerOrgPolicyConstraint
+/// Defines additional types related to [AnalyzerOrgPolicyConstraint].
 pub mod analyzer_org_policy_constraint {
     #[allow(unused_imports)]
     use super::*;
@@ -6044,7 +6044,7 @@ pub mod analyzer_org_policy_constraint {
         }
     }
 
-    /// Defines additional types related to Constraint
+    /// Defines additional types related to [Constraint].
     pub mod constraint {
         #[allow(unused_imports)]
         use super::*;
@@ -6324,7 +6324,7 @@ pub mod analyzer_org_policy_constraint {
         }
     }
 
-    /// Defines additional types related to CustomConstraint
+    /// Defines additional types related to [CustomConstraint].
     pub mod custom_constraint {
         #[allow(unused_imports)]
         use super::*;
@@ -6650,7 +6650,7 @@ impl gax::paginator::PageableResponse for AnalyzeOrgPoliciesResponse {
     }
 }
 
-/// Defines additional types related to AnalyzeOrgPoliciesResponse
+/// Defines additional types related to [AnalyzeOrgPoliciesResponse].
 pub mod analyze_org_policies_response {
     #[allow(unused_imports)]
     use super::*;
@@ -6937,7 +6937,7 @@ impl gax::paginator::PageableResponse for AnalyzeOrgPolicyGovernedContainersResp
     }
 }
 
-/// Defines additional types related to AnalyzeOrgPolicyGovernedContainersResponse
+/// Defines additional types related to [AnalyzeOrgPolicyGovernedContainersResponse].
 pub mod analyze_org_policy_governed_containers_response {
     #[allow(unused_imports)]
     use super::*;
@@ -7290,7 +7290,7 @@ impl gax::paginator::PageableResponse for AnalyzeOrgPolicyGovernedAssetsResponse
     }
 }
 
-/// Defines additional types related to AnalyzeOrgPolicyGovernedAssetsResponse
+/// Defines additional types related to [AnalyzeOrgPolicyGovernedAssetsResponse].
 pub mod analyze_org_policy_governed_assets_response {
     #[allow(unused_imports)]
     use super::*;
@@ -7685,7 +7685,7 @@ pub mod analyze_org_policy_governed_assets_response {
         }
     }
 
-    /// Defines additional types related to GovernedAsset
+    /// Defines additional types related to [GovernedAsset].
     pub mod governed_asset {
         #[allow(unused_imports)]
         use super::*;
@@ -7801,7 +7801,7 @@ impl wkt::message::Message for TemporalAsset {
     }
 }
 
-/// Defines additional types related to TemporalAsset
+/// Defines additional types related to [TemporalAsset].
 pub mod temporal_asset {
     #[allow(unused_imports)]
     use super::*;
@@ -8230,7 +8230,7 @@ impl wkt::message::Message for Asset {
     }
 }
 
-/// Defines additional types related to Asset
+/// Defines additional types related to [Asset].
 pub mod asset {
     #[allow(unused_imports)]
     use super::*;
@@ -9709,7 +9709,7 @@ impl wkt::message::Message for IamPolicySearchResult {
     }
 }
 
-/// Defines additional types related to IamPolicySearchResult
+/// Defines additional types related to [IamPolicySearchResult].
 pub mod iam_policy_search_result {
     #[allow(unused_imports)]
     use super::*;
@@ -9758,7 +9758,7 @@ pub mod iam_policy_search_result {
         }
     }
 
-    /// Defines additional types related to Explanation
+    /// Defines additional types related to [Explanation].
     pub mod explanation {
         #[allow(unused_imports)]
         use super::*;
@@ -9877,7 +9877,7 @@ impl wkt::message::Message for ConditionEvaluation {
     }
 }
 
-/// Defines additional types related to ConditionEvaluation
+/// Defines additional types related to [ConditionEvaluation].
 pub mod condition_evaluation {
     #[allow(unused_imports)]
     use super::*;
@@ -10056,7 +10056,7 @@ impl wkt::message::Message for IamPolicyAnalysisResult {
     }
 }
 
-/// Defines additional types related to IamPolicyAnalysisResult
+/// Defines additional types related to [IamPolicyAnalysisResult].
 pub mod iam_policy_analysis_result {
     #[allow(unused_imports)]
     use super::*;
@@ -10212,7 +10212,7 @@ pub mod iam_policy_analysis_result {
         }
     }
 
-    /// Defines additional types related to Access
+    /// Defines additional types related to [Access].
     pub mod access {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -593,7 +593,7 @@ impl wkt::message::Message for Workload {
     }
 }
 
-/// Defines additional types related to Workload
+/// Defines additional types related to [Workload].
 pub mod workload {
     #[allow(unused_imports)]
     use super::*;
@@ -642,7 +642,7 @@ pub mod workload {
         }
     }
 
-    /// Defines additional types related to ResourceInfo
+    /// Defines additional types related to [ResourceInfo].
     pub mod resource_info {
         #[allow(unused_imports)]
         use super::*;
@@ -895,7 +895,7 @@ pub mod workload {
         }
     }
 
-    /// Defines additional types related to SaaEnrollmentResponse
+    /// Defines additional types related to [SaaEnrollmentResponse].
     pub mod saa_enrollment_response {
         #[allow(unused_imports)]
         use super::*;
@@ -1385,7 +1385,7 @@ impl wkt::message::Message for RestrictAllowedResourcesRequest {
     }
 }
 
-/// Defines additional types related to RestrictAllowedResourcesRequest
+/// Defines additional types related to [RestrictAllowedResourcesRequest].
 pub mod restrict_allowed_resources_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1966,7 +1966,7 @@ impl wkt::message::Message for Violation {
     }
 }
 
-/// Defines additional types related to Violation
+/// Defines additional types related to [Violation].
 pub mod violation {
     #[allow(unused_imports)]
     use super::*;
@@ -2039,7 +2039,7 @@ pub mod violation {
         }
     }
 
-    /// Defines additional types related to Remediation
+    /// Defines additional types related to [Remediation].
     pub mod remediation {
         #[allow(unused_imports)]
         use super::*;
@@ -2103,7 +2103,7 @@ pub mod violation {
             }
         }
 
-        /// Defines additional types related to Instructions
+        /// Defines additional types related to [Instructions].
         pub mod instructions {
             #[allow(unused_imports)]
             use super::*;

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -79,7 +79,7 @@ impl wkt::message::Message for NetworkConfig {
     }
 }
 
-/// Defines additional types related to NetworkConfig
+/// Defines additional types related to [NetworkConfig].
 pub mod network_config {
     #[allow(unused_imports)]
     use super::*;
@@ -513,7 +513,7 @@ impl wkt::message::Message for ManagementServer {
     }
 }
 
-/// Defines additional types related to ManagementServer
+/// Defines additional types related to [ManagementServer].
 pub mod management_server {
     #[allow(unused_imports)]
     use super::*;
@@ -1389,7 +1389,7 @@ impl wkt::message::Message for BackupPlan {
     }
 }
 
-/// Defines additional types related to BackupPlan
+/// Defines additional types related to [BackupPlan].
 pub mod backup_plan {
     #[allow(unused_imports)]
     use super::*;
@@ -1559,7 +1559,7 @@ impl wkt::message::Message for BackupRule {
     }
 }
 
-/// Defines additional types related to BackupRule
+/// Defines additional types related to [BackupRule].
 pub mod backup_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -1743,7 +1743,7 @@ impl wkt::message::Message for StandardSchedule {
     }
 }
 
-/// Defines additional types related to StandardSchedule
+/// Defines additional types related to [StandardSchedule].
 pub mod standard_schedule {
     #[allow(unused_imports)]
     use super::*;
@@ -1912,7 +1912,7 @@ impl wkt::message::Message for WeekDayOfMonth {
     }
 }
 
-/// Defines additional types related to WeekDayOfMonth
+/// Defines additional types related to [WeekDayOfMonth].
 pub mod week_day_of_month {
     #[allow(unused_imports)]
     use super::*;
@@ -2459,7 +2459,7 @@ impl wkt::message::Message for BackupPlanAssociation {
     }
 }
 
-/// Defines additional types related to BackupPlanAssociation
+/// Defines additional types related to [BackupPlanAssociation].
 pub mod backup_plan_association {
     #[allow(unused_imports)]
     use super::*;
@@ -2604,7 +2604,7 @@ impl wkt::message::Message for RuleConfigInfo {
     }
 }
 
-/// Defines additional types related to RuleConfigInfo
+/// Defines additional types related to [RuleConfigInfo].
 pub mod rule_config_info {
     #[allow(unused_imports)]
     use super::*;
@@ -3282,7 +3282,7 @@ impl wkt::message::Message for BackupVault {
     }
 }
 
-/// Defines additional types related to BackupVault
+/// Defines additional types related to [BackupVault].
 pub mod backup_vault {
     #[allow(unused_imports)]
     use super::*;
@@ -3671,7 +3671,7 @@ impl wkt::message::Message for DataSource {
     }
 }
 
-/// Defines additional types related to DataSource
+/// Defines additional types related to [DataSource].
 pub mod data_source {
     #[allow(unused_imports)]
     use super::*;
@@ -3903,7 +3903,7 @@ impl wkt::message::Message for BackupConfigInfo {
     }
 }
 
-/// Defines additional types related to BackupConfigInfo
+/// Defines additional types related to [BackupConfigInfo].
 pub mod backup_config_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4267,7 +4267,7 @@ impl wkt::message::Message for DataSourceGcpResource {
     }
 }
 
-/// Defines additional types related to DataSourceGcpResource
+/// Defines additional types related to [DataSourceGcpResource].
 pub mod data_source_gcp_resource {
     #[allow(unused_imports)]
     use super::*;
@@ -4560,7 +4560,7 @@ impl wkt::message::Message for BackupApplianceLockInfo {
     }
 }
 
-/// Defines additional types related to BackupApplianceLockInfo
+/// Defines additional types related to [BackupApplianceLockInfo].
 pub mod backup_appliance_lock_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4692,7 +4692,7 @@ impl wkt::message::Message for BackupLock {
     }
 }
 
-/// Defines additional types related to BackupLock
+/// Defines additional types related to [BackupLock].
 pub mod backup_lock {
     #[allow(unused_imports)]
     use super::*;
@@ -5041,7 +5041,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -6624,7 +6624,7 @@ impl wkt::message::Message for RestoreBackupRequest {
     }
 }
 
-/// Defines additional types related to RestoreBackupRequest
+/// Defines additional types related to [RestoreBackupRequest].
 pub mod restore_backup_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6751,7 +6751,7 @@ impl wkt::message::Message for TargetResource {
     }
 }
 
-/// Defines additional types related to TargetResource
+/// Defines additional types related to [TargetResource].
 pub mod target_resource {
     #[allow(unused_imports)]
     use super::*;
@@ -7532,7 +7532,7 @@ impl wkt::message::Message for ComputeInstanceRestoreProperties {
     }
 }
 
-/// Defines additional types related to ComputeInstanceRestoreProperties
+/// Defines additional types related to [ComputeInstanceRestoreProperties].
 pub mod compute_instance_restore_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -8047,7 +8047,7 @@ impl wkt::message::Message for CustomerEncryptionKey {
     }
 }
 
-/// Defines additional types related to CustomerEncryptionKey
+/// Defines additional types related to [CustomerEncryptionKey].
 pub mod customer_encryption_key {
     #[allow(unused_imports)]
     use super::*;
@@ -8389,7 +8389,7 @@ impl wkt::message::Message for NetworkInterface {
     }
 }
 
-/// Defines additional types related to NetworkInterface
+/// Defines additional types related to [NetworkInterface].
 pub mod network_interface {
     #[allow(unused_imports)]
     use super::*;
@@ -8604,7 +8604,7 @@ impl wkt::message::Message for NetworkPerformanceConfig {
     }
 }
 
-/// Defines additional types related to NetworkPerformanceConfig
+/// Defines additional types related to [NetworkPerformanceConfig].
 pub mod network_performance_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8803,7 +8803,7 @@ impl wkt::message::Message for AccessConfig {
     }
 }
 
-/// Defines additional types related to AccessConfig
+/// Defines additional types related to [AccessConfig].
 pub mod access_config {
     #[allow(unused_imports)]
     use super::*;
@@ -9076,7 +9076,7 @@ impl wkt::message::Message for AllocationAffinity {
     }
 }
 
-/// Defines additional types related to AllocationAffinity
+/// Defines additional types related to [AllocationAffinity].
 pub mod allocation_affinity {
     #[allow(unused_imports)]
     use super::*;
@@ -9287,7 +9287,7 @@ impl wkt::message::Message for Scheduling {
     }
 }
 
-/// Defines additional types related to Scheduling
+/// Defines additional types related to [Scheduling].
 pub mod scheduling {
     #[allow(unused_imports)]
     use super::*;
@@ -9357,7 +9357,7 @@ pub mod scheduling {
         }
     }
 
-    /// Defines additional types related to NodeAffinity
+    /// Defines additional types related to [NodeAffinity].
     pub mod node_affinity {
         #[allow(unused_imports)]
         use super::*;
@@ -9991,7 +9991,7 @@ impl wkt::message::Message for AttachedDisk {
     }
 }
 
-/// Defines additional types related to AttachedDisk
+/// Defines additional types related to [AttachedDisk].
 pub mod attached_disk {
     #[allow(unused_imports)]
     use super::*;
@@ -10328,7 +10328,7 @@ impl wkt::message::Message for GuestOsFeature {
     }
 }
 
-/// Defines additional types related to GuestOsFeature
+/// Defines additional types related to [GuestOsFeature].
 pub mod guest_os_feature {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -421,7 +421,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -1093,7 +1093,7 @@ impl wkt::message::Message for ServerNetworkTemplate {
     }
 }
 
-/// Defines additional types related to ServerNetworkTemplate
+/// Defines additional types related to [ServerNetworkTemplate].
 pub mod server_network_template {
     #[allow(unused_imports)]
     use super::*;
@@ -1157,7 +1157,7 @@ pub mod server_network_template {
         }
     }
 
-    /// Defines additional types related to LogicalInterface
+    /// Defines additional types related to [LogicalInterface].
     pub mod logical_interface {
         #[allow(unused_imports)]
         use super::*;
@@ -1373,7 +1373,7 @@ impl wkt::message::Message for Lun {
     }
 }
 
-/// Defines additional types related to Lun
+/// Defines additional types related to [Lun].
 pub mod lun {
     #[allow(unused_imports)]
     use super::*;
@@ -1950,7 +1950,7 @@ impl wkt::message::Message for Network {
     }
 }
 
-/// Defines additional types related to Network
+/// Defines additional types related to [Network].
 pub mod network {
     #[allow(unused_imports)]
     use super::*;
@@ -2204,7 +2204,7 @@ impl wkt::message::Message for Vrf {
     }
 }
 
-/// Defines additional types related to VRF
+/// Defines additional types related to [VRF].
 pub mod vrf {
     #[allow(unused_imports)]
     use super::*;
@@ -2453,7 +2453,7 @@ impl wkt::message::Message for LogicalInterface {
     }
 }
 
-/// Defines additional types related to LogicalInterface
+/// Defines additional types related to [LogicalInterface].
 pub mod logical_interface {
     #[allow(unused_imports)]
     use super::*;
@@ -3078,7 +3078,7 @@ impl wkt::message::Message for NfsShare {
     }
 }
 
-/// Defines additional types related to NfsShare
+/// Defines additional types related to [NfsShare].
 pub mod nfs_share {
     #[allow(unused_imports)]
     use super::*;
@@ -4077,7 +4077,7 @@ impl wkt::message::Message for ProvisioningConfig {
     }
 }
 
-/// Defines additional types related to ProvisioningConfig
+/// Defines additional types related to [ProvisioningConfig].
 pub mod provisioning_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4465,7 +4465,7 @@ impl wkt::message::Message for ProvisioningQuota {
     }
 }
 
-/// Defines additional types related to ProvisioningQuota
+/// Defines additional types related to [ProvisioningQuota].
 pub mod provisioning_quota {
     #[allow(unused_imports)]
     use super::*;
@@ -4848,7 +4848,7 @@ impl wkt::message::Message for InstanceConfig {
     }
 }
 
-/// Defines additional types related to InstanceConfig
+/// Defines additional types related to [InstanceConfig].
 pub mod instance_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5130,7 +5130,7 @@ impl wkt::message::Message for VolumeConfig {
     }
 }
 
-/// Defines additional types related to VolumeConfig
+/// Defines additional types related to [VolumeConfig].
 pub mod volume_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5311,7 +5311,7 @@ pub mod volume_config {
         }
     }
 
-    /// Defines additional types related to NfsExport
+    /// Defines additional types related to [NfsExport].
     pub mod nfs_export {
         #[allow(unused_imports)]
         use super::*;
@@ -5646,7 +5646,7 @@ impl wkt::message::Message for NetworkConfig {
     }
 }
 
-/// Defines additional types related to NetworkConfig
+/// Defines additional types related to [NetworkConfig].
 pub mod network_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6633,7 +6633,7 @@ impl wkt::message::Message for Volume {
     }
 }
 
-/// Defines additional types related to Volume
+/// Defines additional types related to [Volume].
 pub mod volume {
     #[allow(unused_imports)]
     use super::*;
@@ -7427,7 +7427,7 @@ impl wkt::message::Message for VolumeSnapshot {
     }
 }
 
-/// Defines additional types related to VolumeSnapshot
+/// Defines additional types related to [VolumeSnapshot].
 pub mod volume_snapshot {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
@@ -611,7 +611,7 @@ impl gax::paginator::PageableResponse for ResolveAppConnectionsResponse {
     }
 }
 
-/// Defines additional types related to ResolveAppConnectionsResponse
+/// Defines additional types related to [ResolveAppConnectionsResponse].
 pub mod resolve_app_connections_response {
     #[allow(unused_imports)]
     use super::*;
@@ -837,7 +837,7 @@ impl wkt::message::Message for AppConnection {
     }
 }
 
-/// Defines additional types related to AppConnection
+/// Defines additional types related to [AppConnection].
 pub mod app_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -944,7 +944,7 @@ pub mod app_connection {
         }
     }
 
-    /// Defines additional types related to Gateway
+    /// Defines additional types related to [Gateway].
     pub mod gateway {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -179,7 +179,7 @@ impl wkt::message::Message for NotificationConfig {
     }
 }
 
-/// Defines additional types related to NotificationConfig
+/// Defines additional types related to [NotificationConfig].
 pub mod notification_config {
     #[allow(unused_imports)]
     use super::*;
@@ -907,7 +907,7 @@ impl wkt::message::Message for AppConnector {
     }
 }
 
-/// Defines additional types related to AppConnector
+/// Defines additional types related to [AppConnector].
 pub mod app_connector {
     #[allow(unused_imports)]
     use super::*;
@@ -983,7 +983,7 @@ pub mod app_connector {
         }
     }
 
-    /// Defines additional types related to PrincipalInfo
+    /// Defines additional types related to [PrincipalInfo].
     pub mod principal_info {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
@@ -525,7 +525,7 @@ impl wkt::message::Message for AppGateway {
     }
 }
 
-/// Defines additional types related to AppGateway
+/// Defines additional types related to [AppGateway].
 pub mod app_gateway {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
@@ -146,7 +146,7 @@ impl wkt::message::Message for ClientConnectorService {
     }
 }
 
-/// Defines additional types related to ClientConnectorService
+/// Defines additional types related to [ClientConnectorService].
 pub mod client_connector_service {
     #[allow(unused_imports)]
     use super::*;
@@ -226,7 +226,7 @@ pub mod client_connector_service {
         }
     }
 
-    /// Defines additional types related to Ingress
+    /// Defines additional types related to [Ingress].
     pub mod ingress {
         #[allow(unused_imports)]
         use super::*;
@@ -287,7 +287,7 @@ pub mod client_connector_service {
             }
         }
 
-        /// Defines additional types related to Config
+        /// Defines additional types related to [Config].
         pub mod config {
             #[allow(unused_imports)]
             use super::*;
@@ -482,7 +482,7 @@ pub mod client_connector_service {
         }
     }
 
-    /// Defines additional types related to Egress
+    /// Defines additional types related to [Egress].
     pub mod egress {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
@@ -126,7 +126,7 @@ impl wkt::message::Message for ClientGateway {
     }
 }
 
-/// Defines additional types related to ClientGateway
+/// Defines additional types related to [ClientGateway].
 pub mod client_gateway {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -277,7 +277,7 @@ impl wkt::message::Message for SharingEnvironmentConfig {
     }
 }
 
-/// Defines additional types related to SharingEnvironmentConfig
+/// Defines additional types related to [SharingEnvironmentConfig].
 pub mod sharing_environment_config {
     #[allow(unused_imports)]
     use super::*;
@@ -821,7 +821,7 @@ impl wkt::message::Message for Listing {
     }
 }
 
-/// Defines additional types related to Listing
+/// Defines additional types related to [Listing].
 pub mod listing {
     #[allow(unused_imports)]
     use super::*;
@@ -904,7 +904,7 @@ pub mod listing {
         }
     }
 
-    /// Defines additional types related to BigQueryDatasetSource
+    /// Defines additional types related to [BigQueryDatasetSource].
     pub mod big_query_dataset_source {
         #[allow(unused_imports)]
         use super::*;
@@ -965,7 +965,7 @@ pub mod listing {
             }
         }
 
-        /// Defines additional types related to SelectedResource
+        /// Defines additional types related to [SelectedResource].
         pub mod selected_resource {
             #[allow(unused_imports)]
             use super::*;
@@ -1487,7 +1487,7 @@ impl wkt::message::Message for Subscription {
     }
 }
 
-/// Defines additional types related to Subscription
+/// Defines additional types related to [Subscription].
 pub mod subscription {
     #[allow(unused_imports)]
     use super::*;
@@ -1555,7 +1555,7 @@ pub mod subscription {
         }
     }
 
-    /// Defines additional types related to LinkedResource
+    /// Defines additional types related to [LinkedResource].
     pub mod linked_resource {
         #[allow(unused_imports)]
         use super::*;
@@ -2387,7 +2387,7 @@ impl wkt::message::Message for SubscribeListingRequest {
     }
 }
 
-/// Defines additional types related to SubscribeListingRequest
+/// Defines additional types related to [SubscribeListingRequest].
 pub mod subscribe_listing_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -615,7 +615,7 @@ impl wkt::message::Message for Connection {
     }
 }
 
-/// Defines additional types related to Connection
+/// Defines additional types related to [Connection].
 pub mod connection {
     #[allow(unused_imports)]
     use super::*;
@@ -729,7 +729,7 @@ impl wkt::message::Message for CloudSqlProperties {
     }
 }
 
-/// Defines additional types related to CloudSqlProperties
+/// Defines additional types related to [CloudSqlProperties].
 pub mod cloud_sql_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -1028,7 +1028,7 @@ impl wkt::message::Message for AwsProperties {
     }
 }
 
-/// Defines additional types related to AwsProperties
+/// Defines additional types related to [AwsProperties].
 pub mod aws_properties {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
@@ -497,7 +497,7 @@ impl wkt::message::Message for DataPolicy {
     }
 }
 
-/// Defines additional types related to DataPolicy
+/// Defines additional types related to [DataPolicy].
 pub mod data_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -678,7 +678,7 @@ impl wkt::message::Message for DataMaskingPolicy {
     }
 }
 
-/// Defines additional types related to DataMaskingPolicy
+/// Defines additional types related to [DataMaskingPolicy].
 pub mod data_masking_policy {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -236,7 +236,7 @@ impl wkt::message::Message for DataSourceParameter {
     }
 }
 
-/// Defines additional types related to DataSourceParameter
+/// Defines additional types related to [DataSourceParameter].
 pub mod data_source_parameter {
     #[allow(unused_imports)]
     use super::*;
@@ -564,7 +564,7 @@ impl wkt::message::Message for DataSource {
     }
 }
 
-/// Defines additional types related to DataSource
+/// Defines additional types related to [DataSource].
 pub mod data_source {
     #[allow(unused_imports)]
     use super::*;
@@ -1439,7 +1439,7 @@ impl wkt::message::Message for ListTransferRunsRequest {
     }
 }
 
-/// Defines additional types related to ListTransferRunsRequest
+/// Defines additional types related to [ListTransferRunsRequest].
 pub mod list_transfer_runs_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1959,7 +1959,7 @@ impl wkt::message::Message for StartManualTransferRunsRequest {
     }
 }
 
-/// Defines additional types related to StartManualTransferRunsRequest
+/// Defines additional types related to [StartManualTransferRunsRequest].
 pub mod start_manual_transfer_runs_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2391,7 +2391,7 @@ impl wkt::message::Message for ScheduleOptionsV2 {
     }
 }
 
-/// Defines additional types related to ScheduleOptionsV2
+/// Defines additional types related to [ScheduleOptionsV2].
 pub mod schedule_options_v_2 {
     #[allow(unused_imports)]
     use super::*;
@@ -2908,7 +2908,7 @@ impl wkt::message::Message for TransferConfig {
     }
 }
 
-/// Defines additional types related to TransferConfig
+/// Defines additional types related to [TransferConfig].
 pub mod transfer_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3205,7 +3205,7 @@ impl wkt::message::Message for TransferRun {
     }
 }
 
-/// Defines additional types related to TransferRun
+/// Defines additional types related to [TransferRun].
 pub mod transfer_run {
     #[allow(unused_imports)]
     use super::*;
@@ -3274,7 +3274,7 @@ impl wkt::message::Message for TransferMessage {
     }
 }
 
-/// Defines additional types related to TransferMessage
+/// Defines additional types related to [TransferMessage].
 pub mod transfer_message {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -132,7 +132,7 @@ impl wkt::message::Message for MigrationWorkflow {
     }
 }
 
-/// Defines additional types related to MigrationWorkflow
+/// Defines additional types related to [MigrationWorkflow].
 pub mod migration_workflow {
     #[allow(unused_imports)]
     use super::*;
@@ -467,7 +467,7 @@ impl wkt::message::Message for MigrationTask {
     }
 }
 
-/// Defines additional types related to MigrationTask
+/// Defines additional types related to [MigrationTask].
 pub mod migration_task {
     #[allow(unused_imports)]
     use super::*;
@@ -718,7 +718,7 @@ impl wkt::message::Message for MigrationSubtask {
     }
 }
 
-/// Defines additional types related to MigrationSubtask
+/// Defines additional types related to [MigrationSubtask].
 pub mod migration_subtask {
     #[allow(unused_imports)]
     use super::*;
@@ -869,7 +869,7 @@ impl wkt::message::Message for MigrationTaskResult {
     }
 }
 
-/// Defines additional types related to MigrationTaskResult
+/// Defines additional types related to [MigrationTaskResult].
 pub mod migration_task_result {
     #[allow(unused_imports)]
     use super::*;
@@ -1414,7 +1414,7 @@ impl wkt::message::Message for TypedValue {
     }
 }
 
-/// Defines additional types related to TypedValue
+/// Defines additional types related to [TypedValue].
 pub mod typed_value {
     #[allow(unused_imports)]
     use super::*;
@@ -2116,7 +2116,7 @@ impl wkt::message::Message for TranslationConfigDetails {
     }
 }
 
-/// Defines additional types related to TranslationConfigDetails
+/// Defines additional types related to [TranslationConfigDetails].
 pub mod translation_config_details {
     #[allow(unused_imports)]
     use super::*;
@@ -2694,7 +2694,7 @@ impl wkt::message::Message for Dialect {
     }
 }
 
-/// Defines additional types related to Dialect
+/// Defines additional types related to [Dialect].
 pub mod dialect {
     #[allow(unused_imports)]
     use super::*;
@@ -2829,7 +2829,7 @@ impl wkt::message::Message for TeradataDialect {
     }
 }
 
-/// Defines additional types related to TeradataDialect
+/// Defines additional types related to [TeradataDialect].
 pub mod teradata_dialect {
     #[allow(unused_imports)]
     use super::*;
@@ -3298,7 +3298,7 @@ impl wkt::message::Message for NameMappingKey {
     }
 }
 
-/// Defines additional types related to NameMappingKey
+/// Defines additional types related to [NameMappingKey].
 pub mod name_mapping_key {
     #[allow(unused_imports)]
     use super::*;
@@ -3747,7 +3747,7 @@ impl wkt::message::Message for SourceSpec {
     }
 }
 
-/// Defines additional types related to SourceSpec
+/// Defines additional types related to [SourceSpec].
 pub mod source_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -3883,7 +3883,7 @@ impl wkt::message::Message for Literal {
     }
 }
 
-/// Defines additional types related to Literal
+/// Defines additional types related to [Literal].
 pub mod literal {
     #[allow(unused_imports)]
     use super::*;
@@ -4040,7 +4040,7 @@ impl wkt::message::Message for TranslationReportRecord {
     }
 }
 
-/// Defines additional types related to TranslationReportRecord
+/// Defines additional types related to [TranslationReportRecord].
 pub mod translation_report_record {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -252,7 +252,7 @@ impl wkt::message::Message for Reservation {
     }
 }
 
-/// Defines additional types related to Reservation
+/// Defines additional types related to [Reservation].
 pub mod reservation {
     #[allow(unused_imports)]
     use super::*;
@@ -540,7 +540,7 @@ impl wkt::message::Message for CapacityCommitment {
     }
 }
 
-/// Defines additional types related to CapacityCommitment
+/// Defines additional types related to [CapacityCommitment].
 pub mod capacity_commitment {
     #[allow(unused_imports)]
     use super::*;
@@ -1594,7 +1594,7 @@ impl wkt::message::Message for Assignment {
     }
 }
 
-/// Defines additional types related to Assignment
+/// Defines additional types related to [Assignment].
 pub mod assignment {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -103,7 +103,7 @@ impl wkt::message::Message for BigLakeConfiguration {
     }
 }
 
-/// Defines additional types related to BigLakeConfiguration
+/// Defines additional types related to [BigLakeConfiguration].
 pub mod big_lake_configuration {
     #[allow(unused_imports)]
     use super::*;
@@ -315,7 +315,7 @@ impl wkt::message::Message for DatasetAccessEntry {
     }
 }
 
-/// Defines additional types related to DatasetAccessEntry
+/// Defines additional types related to [DatasetAccessEntry].
 pub mod dataset_access_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -1069,7 +1069,7 @@ impl wkt::message::Message for Dataset {
     }
 }
 
-/// Defines additional types related to Dataset
+/// Defines additional types related to [Dataset].
 pub mod dataset {
     #[allow(unused_imports)]
     use super::*;
@@ -1244,7 +1244,7 @@ impl wkt::message::Message for LinkedDatasetMetadata {
     }
 }
 
-/// Defines additional types related to LinkedDatasetMetadata
+/// Defines additional types related to [LinkedDatasetMetadata].
 pub mod linked_dataset_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -1397,7 +1397,7 @@ impl wkt::message::Message for GetDatasetRequest {
     }
 }
 
-/// Defines additional types related to GetDatasetRequest
+/// Defines additional types related to [GetDatasetRequest].
 pub mod get_dataset_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3454,7 +3454,7 @@ impl wkt::message::Message for ExternalDataConfiguration {
     }
 }
 
-/// Defines additional types related to ExternalDataConfiguration
+/// Defines additional types related to [ExternalDataConfiguration].
 pub mod external_data_configuration {
     #[allow(unused_imports)]
     use super::*;
@@ -3928,7 +3928,7 @@ impl wkt::message::Message for RemoteModelInfo {
     }
 }
 
-/// Defines additional types related to RemoteModelInfo
+/// Defines additional types related to [RemoteModelInfo].
 pub mod remote_model_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4388,7 +4388,7 @@ impl wkt::message::Message for Model {
     }
 }
 
-/// Defines additional types related to Model
+/// Defines additional types related to [Model].
 pub mod model {
     #[allow(unused_imports)]
     use super::*;
@@ -4412,7 +4412,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to SeasonalPeriod
+    /// Defines additional types related to [SeasonalPeriod].
     pub mod seasonal_period {
         #[allow(unused_imports)]
         use super::*;
@@ -4517,7 +4517,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to KmeansEnums
+    /// Defines additional types related to [KmeansEnums].
     pub mod kmeans_enums {
         #[allow(unused_imports)]
         use super::*;
@@ -4610,7 +4610,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to BoostedTreeOptionEnums
+    /// Defines additional types related to [BoostedTreeOptionEnums].
     pub mod boosted_tree_option_enums {
         #[allow(unused_imports)]
         use super::*;
@@ -4826,7 +4826,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to HparamTuningEnums
+    /// Defines additional types related to [HparamTuningEnums].
     pub mod hparam_tuning_enums {
         #[allow(unused_imports)]
         use super::*;
@@ -5283,7 +5283,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to BinaryClassificationMetrics
+    /// Defines additional types related to [BinaryClassificationMetrics].
     pub mod binary_classification_metrics {
         #[allow(unused_imports)]
         use super::*;
@@ -5496,7 +5496,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to MultiClassClassificationMetrics
+    /// Defines additional types related to [MultiClassClassificationMetrics].
     pub mod multi_class_classification_metrics {
         #[allow(unused_imports)]
         use super::*;
@@ -5553,7 +5553,7 @@ pub mod model {
             }
         }
 
-        /// Defines additional types related to ConfusionMatrix
+        /// Defines additional types related to [ConfusionMatrix].
         pub mod confusion_matrix {
             #[allow(unused_imports)]
             use super::*;
@@ -5722,7 +5722,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to ClusteringMetrics
+    /// Defines additional types related to [ClusteringMetrics].
     pub mod clustering_metrics {
         #[allow(unused_imports)]
         use super::*;
@@ -5788,7 +5788,7 @@ pub mod model {
             }
         }
 
-        /// Defines additional types related to Cluster
+        /// Defines additional types related to [Cluster].
         pub mod cluster {
             #[allow(unused_imports)]
             use super::*;
@@ -5895,7 +5895,7 @@ pub mod model {
                 }
             }
 
-            /// Defines additional types related to FeatureValue
+            /// Defines additional types related to [FeatureValue].
             pub mod feature_value {
                 #[allow(unused_imports)]
                 use super::*;
@@ -5940,7 +5940,7 @@ pub mod model {
                     }
                 }
 
-                /// Defines additional types related to CategoricalValue
+                /// Defines additional types related to [CategoricalValue].
                 pub mod categorical_value {
                     #[allow(unused_imports)]
                     use super::*;
@@ -6134,7 +6134,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to ArimaForecastingMetrics
+    /// Defines additional types related to [ArimaForecastingMetrics].
     pub mod arima_forecasting_metrics {
         #[allow(unused_imports)]
         use super::*;
@@ -6611,7 +6611,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to EvaluationMetrics
+    /// Defines additional types related to [EvaluationMetrics].
     pub mod evaluation_metrics {
         #[allow(unused_imports)]
         use super::*;
@@ -6878,7 +6878,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to GlobalExplanation
+    /// Defines additional types related to [GlobalExplanation].
     pub mod global_explanation {
         #[allow(unused_imports)]
         use super::*;
@@ -6950,7 +6950,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to CategoryEncodingMethod
+    /// Defines additional types related to [CategoryEncodingMethod].
     pub mod category_encoding_method {
         #[allow(unused_imports)]
         use super::*;
@@ -7039,7 +7039,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to PcaSolverOptionEnums
+    /// Defines additional types related to [PcaSolverOptionEnums].
     pub mod pca_solver_option_enums {
         #[allow(unused_imports)]
         use super::*;
@@ -7126,7 +7126,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to ModelRegistryOptionEnums
+    /// Defines additional types related to [ModelRegistryOptionEnums].
     pub mod model_registry_option_enums {
         #[allow(unused_imports)]
         use super::*;
@@ -7348,7 +7348,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to TrainingRun
+    /// Defines additional types related to [TrainingRun].
     pub mod training_run {
         #[allow(unused_imports)]
         use super::*;
@@ -8797,7 +8797,7 @@ pub mod model {
             }
         }
 
-        /// Defines additional types related to IterationResult
+        /// Defines additional types related to [IterationResult].
         pub mod iteration_result {
             #[allow(unused_imports)]
             use super::*;
@@ -8916,7 +8916,7 @@ pub mod model {
                 }
             }
 
-            /// Defines additional types related to ArimaResult
+            /// Defines additional types related to [ArimaResult].
             pub mod arima_result {
                 #[allow(unused_imports)]
                 use super::*;
@@ -9371,7 +9371,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to DoubleHparamSearchSpace
+    /// Defines additional types related to [DoubleHparamSearchSpace].
     pub mod double_hparam_search_space {
         #[allow(unused_imports)]
         use super::*;
@@ -9578,7 +9578,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to IntHparamSearchSpace
+    /// Defines additional types related to [IntHparamSearchSpace].
     pub mod int_hparam_search_space {
         #[allow(unused_imports)]
         use super::*;
@@ -9747,7 +9747,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to IntArrayHparamSearchSpace
+    /// Defines additional types related to [IntArrayHparamSearchSpace].
     pub mod int_array_hparam_search_space {
         #[allow(unused_imports)]
         use super::*;
@@ -10297,7 +10297,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to HparamTuningTrial
+    /// Defines additional types related to [HparamTuningTrial].
     pub mod hparam_tuning_trial {
         #[allow(unused_imports)]
         use super::*;
@@ -12163,7 +12163,7 @@ impl wkt::message::Message for JoinRestrictionPolicy {
     }
 }
 
-/// Defines additional types related to JoinRestrictionPolicy
+/// Defines additional types related to [JoinRestrictionPolicy].
 pub mod join_restriction_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -12357,7 +12357,7 @@ impl wkt::message::Message for PrivacyPolicy {
     }
 }
 
-/// Defines additional types related to PrivacyPolicy
+/// Defines additional types related to [PrivacyPolicy].
 pub mod privacy_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -12823,7 +12823,7 @@ impl wkt::message::Message for RangePartitioning {
     }
 }
 
-/// Defines additional types related to RangePartitioning
+/// Defines additional types related to [RangePartitioning].
 pub mod range_partitioning {
     #[allow(unused_imports)]
     use super::*;
@@ -12912,7 +12912,7 @@ impl wkt::message::Message for RestrictionConfig {
     }
 }
 
-/// Defines additional types related to RestrictionConfig
+/// Defines additional types related to [RestrictionConfig].
 pub mod restriction_config {
     #[allow(unused_imports)]
     use super::*;
@@ -13293,7 +13293,7 @@ impl wkt::message::Message for Routine {
     }
 }
 
-/// Defines additional types related to Routine
+/// Defines additional types related to [Routine].
 pub mod routine {
     #[allow(unused_imports)]
     use super::*;
@@ -13387,7 +13387,7 @@ pub mod routine {
         }
     }
 
-    /// Defines additional types related to Argument
+    /// Defines additional types related to [Argument].
     pub mod argument {
         #[allow(unused_imports)]
         use super::*;
@@ -15398,7 +15398,7 @@ impl wkt::message::Message for StandardSqlDataType {
     }
 }
 
-/// Defines additional types related to StandardSqlDataType
+/// Defines additional types related to [StandardSqlDataType].
 pub mod standard_sql_data_type {
     #[allow(unused_imports)]
     use super::*;
@@ -15807,7 +15807,7 @@ impl wkt::message::Message for TableReplicationInfo {
     }
 }
 
-/// Defines additional types related to TableReplicationInfo
+/// Defines additional types related to [TableReplicationInfo].
 pub mod table_replication_info {
     #[allow(unused_imports)]
     use super::*;
@@ -17204,7 +17204,7 @@ impl wkt::message::Message for GetTableRequest {
     }
 }
 
-/// Defines additional types related to GetTableRequest
+/// Defines additional types related to [GetTableRequest].
 pub mod get_table_request {
     #[allow(unused_imports)]
     use super::*;
@@ -18159,7 +18159,7 @@ impl wkt::message::Message for ForeignTypeInfo {
     }
 }
 
-/// Defines additional types related to ForeignTypeInfo
+/// Defines additional types related to [ForeignTypeInfo].
 pub mod foreign_type_info {
     #[allow(unused_imports)]
     use super::*;
@@ -18542,7 +18542,7 @@ impl wkt::message::Message for TableFieldSchema {
     }
 }
 
-/// Defines additional types related to TableFieldSchema
+/// Defines additional types related to [TableFieldSchema].
 pub mod table_field_schema {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/billing/v1/src/model.rs
+++ b/src/generated/cloud/billing/v1/src/model.rs
@@ -1194,7 +1194,7 @@ impl wkt::message::Message for PricingExpression {
     }
 }
 
-/// Defines additional types related to PricingExpression
+/// Defines additional types related to [PricingExpression].
 pub mod pricing_expression {
     #[allow(unused_imports)]
     use super::*;
@@ -1300,7 +1300,7 @@ impl wkt::message::Message for AggregationInfo {
     }
 }
 
-/// Defines additional types related to AggregationInfo
+/// Defines additional types related to [AggregationInfo].
 pub mod aggregation_info {
     #[allow(unused_imports)]
     use super::*;
@@ -1471,7 +1471,7 @@ impl wkt::message::Message for GeoTaxonomy {
     }
 }
 
-/// Defines additional types related to GeoTaxonomy
+/// Defines additional types related to [GeoTaxonomy].
 pub mod geo_taxonomy {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/binaryauthorization/v1/src/model.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/model.rs
@@ -219,7 +219,7 @@ impl wkt::message::Message for Policy {
     }
 }
 
-/// Defines additional types related to Policy
+/// Defines additional types related to [Policy].
 pub mod policy {
     #[allow(unused_imports)]
     use super::*;
@@ -399,7 +399,7 @@ impl wkt::message::Message for AdmissionRule {
     }
 }
 
-/// Defines additional types related to AdmissionRule
+/// Defines additional types related to [AdmissionRule].
 pub mod admission_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -637,7 +637,7 @@ impl wkt::message::Message for Attestor {
     }
 }
 
-/// Defines additional types related to Attestor
+/// Defines additional types related to [Attestor].
 pub mod attestor {
     #[allow(unused_imports)]
     use super::*;
@@ -785,7 +785,7 @@ impl wkt::message::Message for PkixPublicKey {
     }
 }
 
-/// Defines additional types related to PkixPublicKey
+/// Defines additional types related to [PkixPublicKey].
 pub mod pkix_public_key {
     #[allow(unused_imports)]
     use super::*;
@@ -1042,7 +1042,7 @@ impl wkt::message::Message for AttestorPublicKey {
     }
 }
 
-/// Defines additional types related to AttestorPublicKey
+/// Defines additional types related to [AttestorPublicKey].
 pub mod attestor_public_key {
     #[allow(unused_imports)]
     use super::*;
@@ -1577,7 +1577,7 @@ impl wkt::message::Message for ValidateAttestationOccurrenceResponse {
     }
 }
 
-/// Defines additional types related to ValidateAttestationOccurrenceResponse
+/// Defines additional types related to [ValidateAttestationOccurrenceResponse].
 pub mod validate_attestation_occurrence_response {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/certificatemanager/v1/src/model.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/model.rs
@@ -441,7 +441,7 @@ impl wkt::message::Message for CertificateIssuanceConfig {
     }
 }
 
-/// Defines additional types related to CertificateIssuanceConfig
+/// Defines additional types related to [CertificateIssuanceConfig].
 pub mod certificate_issuance_config {
     #[allow(unused_imports)]
     use super::*;
@@ -503,7 +503,7 @@ pub mod certificate_issuance_config {
         }
     }
 
-    /// Defines additional types related to CertificateAuthorityConfig
+    /// Defines additional types related to [CertificateAuthorityConfig].
     pub mod certificate_authority_config {
         #[allow(unused_imports)]
         use super::*;
@@ -2171,7 +2171,7 @@ impl wkt::message::Message for Certificate {
     }
 }
 
-/// Defines additional types related to Certificate
+/// Defines additional types related to [Certificate].
 pub mod certificate {
     #[allow(unused_imports)]
     use super::*;
@@ -2353,7 +2353,7 @@ pub mod certificate {
         }
     }
 
-    /// Defines additional types related to ManagedCertificate
+    /// Defines additional types related to [ManagedCertificate].
     pub mod managed_certificate {
         #[allow(unused_imports)]
         use super::*;
@@ -2405,7 +2405,7 @@ pub mod certificate {
             }
         }
 
-        /// Defines additional types related to ProvisioningIssue
+        /// Defines additional types related to [ProvisioningIssue].
         pub mod provisioning_issue {
             #[allow(unused_imports)]
             use super::*;
@@ -2536,7 +2536,7 @@ pub mod certificate {
             }
         }
 
-        /// Defines additional types related to AuthorizationAttemptInfo
+        /// Defines additional types related to [AuthorizationAttemptInfo].
         pub mod authorization_attempt_info {
             #[allow(unused_imports)]
             use super::*;
@@ -2915,7 +2915,7 @@ impl wkt::message::Message for CertificateMap {
     }
 }
 
-/// Defines additional types related to CertificateMap
+/// Defines additional types related to [CertificateMap].
 pub mod certificate_map {
     #[allow(unused_imports)]
     use super::*;
@@ -3029,7 +3029,7 @@ pub mod certificate_map {
         }
     }
 
-    /// Defines additional types related to GclbTarget
+    /// Defines additional types related to [GclbTarget].
     pub mod gclb_target {
         #[allow(unused_imports)]
         use super::*;
@@ -3272,7 +3272,7 @@ impl wkt::message::Message for CertificateMapEntry {
     }
 }
 
-/// Defines additional types related to CertificateMapEntry
+/// Defines additional types related to [CertificateMapEntry].
 pub mod certificate_map_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -3474,7 +3474,7 @@ impl wkt::message::Message for DnsAuthorization {
     }
 }
 
-/// Defines additional types related to DnsAuthorization
+/// Defines additional types related to [DnsAuthorization].
 pub mod dns_authorization {
     #[allow(unused_imports)]
     use super::*;
@@ -4032,7 +4032,7 @@ impl wkt::message::Message for TrustConfig {
     }
 }
 
-/// Defines additional types related to TrustConfig
+/// Defines additional types related to [TrustConfig].
 pub mod trust_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4098,7 +4098,7 @@ pub mod trust_config {
         }
     }
 
-    /// Defines additional types related to TrustAnchor
+    /// Defines additional types related to [TrustAnchor].
     pub mod trust_anchor {
         #[allow(unused_imports)]
         use super::*;
@@ -4177,7 +4177,7 @@ pub mod trust_config {
         }
     }
 
-    /// Defines additional types related to IntermediateCA
+    /// Defines additional types related to [IntermediateCA].
     pub mod intermediate_ca {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
@@ -294,7 +294,7 @@ impl wkt::message::Message for AccessReason {
     }
 }
 
-/// Defines additional types related to AccessReason
+/// Defines additional types related to [AccessReason].
 pub mod access_reason {
     #[allow(unused_imports)]
     use super::*;
@@ -627,7 +627,7 @@ impl wkt::message::Message for Workload {
     }
 }
 
-/// Defines additional types related to Workload
+/// Defines additional types related to [Workload].
 pub mod workload {
     #[allow(unused_imports)]
     use super::*;
@@ -1001,7 +1001,7 @@ impl wkt::message::Message for WorkloadOnboardingStep {
     }
 }
 
-/// Defines additional types related to WorkloadOnboardingStep
+/// Defines additional types related to [WorkloadOnboardingStep].
 pub mod workload_onboarding_step {
     #[allow(unused_imports)]
     use super::*;
@@ -1407,7 +1407,7 @@ impl wkt::message::Message for CustomerOnboardingStep {
     }
 }
 
-/// Defines additional types related to CustomerOnboardingStep
+/// Defines additional types related to [CustomerOnboardingStep].
 pub mod customer_onboarding_step {
     #[allow(unused_imports)]
     use super::*;
@@ -1604,7 +1604,7 @@ impl wkt::message::Message for EkmConnection {
     }
 }
 
-/// Defines additional types related to EkmConnection
+/// Defines additional types related to [EkmConnection].
 pub mod ekm_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -1770,7 +1770,7 @@ impl wkt::message::Message for PartnerPermissions {
     }
 }
 
-/// Defines additional types related to PartnerPermissions
+/// Defines additional types related to [PartnerPermissions].
 pub mod partner_permissions {
     #[allow(unused_imports)]
     use super::*;
@@ -2123,7 +2123,7 @@ impl wkt::message::Message for EkmMetadata {
     }
 }
 
-/// Defines additional types related to EkmMetadata
+/// Defines additional types related to [EkmMetadata].
 pub mod ekm_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -2346,7 +2346,7 @@ impl wkt::message::Message for Violation {
     }
 }
 
-/// Defines additional types related to Violation
+/// Defines additional types related to [Violation].
 pub mod violation {
     #[allow(unused_imports)]
     use super::*;
@@ -2420,7 +2420,7 @@ pub mod violation {
         }
     }
 
-    /// Defines additional types related to Remediation
+    /// Defines additional types related to [Remediation].
     pub mod remediation {
         #[allow(unused_imports)]
         use super::*;
@@ -2484,7 +2484,7 @@ pub mod violation {
             }
         }
 
-        /// Defines additional types related to Instructions
+        /// Defines additional types related to [Instructions].
         pub mod instructions {
             #[allow(unused_imports)]
             use super::*;

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -770,7 +770,7 @@ impl wkt::message::Message for GenerateSshScriptRequest {
     }
 }
 
-/// Defines additional types related to GenerateSshScriptRequest
+/// Defines additional types related to [GenerateSshScriptRequest].
 pub mod generate_ssh_script_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2377,7 +2377,7 @@ impl wkt::message::Message for ApplyConversionWorkspaceRequest {
     }
 }
 
-/// Defines additional types related to ApplyConversionWorkspaceRequest
+/// Defines additional types related to [ApplyConversionWorkspaceRequest].
 pub mod apply_conversion_workspace_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2659,7 +2659,7 @@ impl wkt::message::Message for SeedConversionWorkspaceRequest {
     }
 }
 
-/// Defines additional types related to SeedConversionWorkspaceRequest
+/// Defines additional types related to [SeedConversionWorkspaceRequest].
 pub mod seed_conversion_workspace_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2809,7 +2809,7 @@ impl wkt::message::Message for ImportMappingRulesRequest {
     }
 }
 
-/// Defines additional types related to ImportMappingRulesRequest
+/// Defines additional types related to [ImportMappingRulesRequest].
 pub mod import_mapping_rules_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2979,7 +2979,7 @@ impl wkt::message::Message for DescribeDatabaseEntitiesRequest {
     }
 }
 
-/// Defines additional types related to DescribeDatabaseEntitiesRequest
+/// Defines additional types related to [DescribeDatabaseEntitiesRequest].
 pub mod describe_database_entities_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3574,7 +3574,7 @@ impl wkt::message::Message for SslConfig {
     }
 }
 
-/// Defines additional types related to SslConfig
+/// Defines additional types related to [SslConfig].
 pub mod ssl_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3929,7 +3929,7 @@ impl wkt::message::Message for PostgreSqlConnectionProfile {
     }
 }
 
-/// Defines additional types related to PostgreSqlConnectionProfile
+/// Defines additional types related to [PostgreSqlConnectionProfile].
 pub mod postgre_sql_connection_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -4165,7 +4165,7 @@ impl wkt::message::Message for OracleConnectionProfile {
     }
 }
 
-/// Defines additional types related to OracleConnectionProfile
+/// Defines additional types related to [OracleConnectionProfile].
 pub mod oracle_connection_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -4413,7 +4413,7 @@ impl wkt::message::Message for SqlAclEntry {
     }
 }
 
-/// Defines additional types related to SqlAclEntry
+/// Defines additional types related to [SqlAclEntry].
 pub mod sql_acl_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -4816,7 +4816,7 @@ impl wkt::message::Message for CloudSqlSettings {
     }
 }
 
-/// Defines additional types related to CloudSqlSettings
+/// Defines additional types related to [CloudSqlSettings].
 pub mod cloud_sql_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -5260,7 +5260,7 @@ impl wkt::message::Message for AlloyDbSettings {
     }
 }
 
-/// Defines additional types related to AlloyDbSettings
+/// Defines additional types related to [AlloyDbSettings].
 pub mod alloy_db_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -5412,7 +5412,7 @@ pub mod alloy_db_settings {
         }
     }
 
-    /// Defines additional types related to PrimaryInstanceSettings
+    /// Defines additional types related to [PrimaryInstanceSettings].
     pub mod primary_instance_settings {
         #[allow(unused_imports)]
         use super::*;
@@ -5755,7 +5755,7 @@ impl wkt::message::Message for ForwardSshTunnelConnectivity {
     }
 }
 
-/// Defines additional types related to ForwardSshTunnelConnectivity
+/// Defines additional types related to [ForwardSshTunnelConnectivity].
 pub mod forward_ssh_tunnel_connectivity {
     #[allow(unused_imports)]
     use super::*;
@@ -6286,7 +6286,7 @@ impl wkt::message::Message for MigrationJob {
     }
 }
 
-/// Defines additional types related to MigrationJob
+/// Defines additional types related to [MigrationJob].
 pub mod migration_job {
     #[allow(unused_imports)]
     use super::*;
@@ -6397,7 +6397,7 @@ pub mod migration_job {
         }
     }
 
-    /// Defines additional types related to PerformanceConfig
+    /// Defines additional types related to [PerformanceConfig].
     pub mod performance_config {
         #[allow(unused_imports)]
         use super::*;
@@ -7080,7 +7080,7 @@ impl wkt::message::Message for ConnectionProfile {
     }
 }
 
-/// Defines additional types related to ConnectionProfile
+/// Defines additional types related to [ConnectionProfile].
 pub mod connection_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -7242,7 +7242,7 @@ impl wkt::message::Message for MigrationJobVerificationError {
     }
 }
 
-/// Defines additional types related to MigrationJobVerificationError
+/// Defines additional types related to [MigrationJobVerificationError].
 pub mod migration_job_verification_error {
     #[allow(unused_imports)]
     use super::*;
@@ -7629,7 +7629,7 @@ impl wkt::message::Message for PrivateConnection {
     }
 }
 
-/// Defines additional types related to PrivateConnection
+/// Defines additional types related to [PrivateConnection].
 pub mod private_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -8211,7 +8211,7 @@ impl wkt::message::Message for BackgroundJobLogEntry {
     }
 }
 
-/// Defines additional types related to BackgroundJobLogEntry
+/// Defines additional types related to [BackgroundJobLogEntry].
 pub mod background_job_log_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -9015,7 +9015,7 @@ impl wkt::message::Message for MappingRule {
     }
 }
 
-/// Defines additional types related to MappingRule
+/// Defines additional types related to [MappingRule].
 pub mod mapping_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -9623,7 +9623,7 @@ impl wkt::message::Message for MultiColumnDatatypeChange {
     }
 }
 
-/// Defines additional types related to MultiColumnDatatypeChange
+/// Defines additional types related to [MultiColumnDatatypeChange].
 pub mod multi_column_datatype_change {
     #[allow(unused_imports)]
     use super::*;
@@ -9887,7 +9887,7 @@ impl wkt::message::Message for ConditionalColumnSetValue {
     }
 }
 
-/// Defines additional types related to ConditionalColumnSetValue
+/// Defines additional types related to [ConditionalColumnSetValue].
 pub mod conditional_column_set_value {
     #[allow(unused_imports)]
     use super::*;
@@ -10243,7 +10243,7 @@ impl wkt::message::Message for ValueTransformation {
     }
 }
 
-/// Defines additional types related to ValueTransformation
+/// Defines additional types related to [ValueTransformation].
 pub mod value_transformation {
     #[allow(unused_imports)]
     use super::*;
@@ -10742,7 +10742,7 @@ impl wkt::message::Message for ApplyHash {
     }
 }
 
-/// Defines additional types related to ApplyHash
+/// Defines additional types related to [ApplyHash].
 pub mod apply_hash {
     #[allow(unused_imports)]
     use super::*;
@@ -11231,7 +11231,7 @@ impl wkt::message::Message for DatabaseEntity {
     }
 }
 
-/// Defines additional types related to DatabaseEntity
+/// Defines additional types related to [DatabaseEntity].
 pub mod database_entity {
     #[allow(unused_imports)]
     use super::*;
@@ -12741,7 +12741,7 @@ impl wkt::message::Message for EntityIssue {
     }
 }
 
-/// Defines additional types related to EntityIssue
+/// Defines additional types related to [EntityIssue].
 pub mod entity_issue {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -135,7 +135,7 @@ impl wkt::message::Message for AssignmentProtocol {
     }
 }
 
-/// Defines additional types related to AssignmentProtocol
+/// Defines additional types related to [AssignmentProtocol].
 pub mod assignment_protocol {
     #[allow(unused_imports)]
     use super::*;
@@ -1120,7 +1120,7 @@ impl wkt::message::Message for Parameter {
     }
 }
 
-/// Defines additional types related to Parameter
+/// Defines additional types related to [Parameter].
 pub mod parameter {
     #[allow(unused_imports)]
     use super::*;
@@ -1234,7 +1234,7 @@ pub mod parameter {
         }
     }
 
-    /// Defines additional types related to Value
+    /// Defines additional types related to [Value].
     pub mod value {
         #[allow(unused_imports)]
         use super::*;
@@ -1648,7 +1648,7 @@ impl wkt::message::Message for ModifyOrderRequest {
     }
 }
 
-/// Defines additional types related to ModifyOrderRequest
+/// Defines additional types related to [ModifyOrderRequest].
 pub mod modify_order_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1816,7 +1816,7 @@ impl wkt::message::Message for CancelOrderRequest {
     }
 }
 
-/// Defines additional types related to CancelOrderRequest
+/// Defines additional types related to [CancelOrderRequest].
 pub mod cancel_order_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/confidentialcomputing/v1/src/model.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/model.rs
@@ -339,7 +339,7 @@ impl wkt::message::Message for VerifyAttestationRequest {
     }
 }
 
-/// Defines additional types related to VerifyAttestationRequest
+/// Defines additional types related to [VerifyAttestationRequest].
 pub mod verify_attestation_request {
     #[allow(unused_imports)]
     use super::*;
@@ -660,7 +660,7 @@ impl wkt::message::Message for TokenOptions {
     }
 }
 
-/// Defines additional types related to TokenOptions
+/// Defines additional types related to [TokenOptions].
 pub mod token_options {
     #[allow(unused_imports)]
     use super::*;
@@ -696,7 +696,7 @@ pub mod token_options {
         }
     }
 
-    /// Defines additional types related to AwsPrincipalTagsOptions
+    /// Defines additional types related to [AwsPrincipalTagsOptions].
     pub mod aws_principal_tags_options {
         #[allow(unused_imports)]
         use super::*;
@@ -732,7 +732,7 @@ pub mod token_options {
             }
         }
 
-        /// Defines additional types related to AllowedPrincipalTags
+        /// Defines additional types related to [AllowedPrincipalTags].
         pub mod allowed_principal_tags {
             #[allow(unused_imports)]
             use super::*;
@@ -878,7 +878,7 @@ impl wkt::message::Message for TpmAttestation {
     }
 }
 
-/// Defines additional types related to TpmAttestation
+/// Defines additional types related to [TpmAttestation].
 pub mod tpm_attestation {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -413,7 +413,7 @@ impl wkt::message::Message for Deployment {
     }
 }
 
-/// Defines additional types related to Deployment
+/// Defines additional types related to [Deployment].
 pub mod deployment {
     #[allow(unused_imports)]
     use super::*;
@@ -779,7 +779,7 @@ impl wkt::message::Message for TerraformBlueprint {
     }
 }
 
-/// Defines additional types related to TerraformBlueprint
+/// Defines additional types related to [TerraformBlueprint].
 pub mod terraform_blueprint {
     #[allow(unused_imports)]
     use super::*;
@@ -1562,7 +1562,7 @@ impl wkt::message::Message for DeleteDeploymentRequest {
     }
 }
 
-/// Defines additional types related to DeleteDeploymentRequest
+/// Defines additional types related to [DeleteDeploymentRequest].
 pub mod delete_deployment_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1808,7 +1808,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -2134,7 +2134,7 @@ impl wkt::message::Message for Revision {
     }
 }
 
-/// Defines additional types related to Revision
+/// Defines additional types related to [Revision].
 pub mod revision {
     #[allow(unused_imports)]
     use super::*;
@@ -2548,7 +2548,7 @@ impl wkt::message::Message for DeploymentOperationMetadata {
     }
 }
 
-/// Defines additional types related to DeploymentOperationMetadata
+/// Defines additional types related to [DeploymentOperationMetadata].
 pub mod deployment_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -2755,7 +2755,7 @@ impl wkt::message::Message for Resource {
     }
 }
 
-/// Defines additional types related to Resource
+/// Defines additional types related to [Resource].
 pub mod resource {
     #[allow(unused_imports)]
     use super::*;
@@ -3885,7 +3885,7 @@ impl wkt::message::Message for Preview {
     }
 }
 
-/// Defines additional types related to Preview
+/// Defines additional types related to [Preview].
 pub mod preview {
     #[allow(unused_imports)]
     use super::*;
@@ -4198,7 +4198,7 @@ impl wkt::message::Message for PreviewOperationMetadata {
     }
 }
 
-/// Defines additional types related to PreviewOperationMetadata
+/// Defines additional types related to [PreviewOperationMetadata].
 pub mod preview_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -5049,7 +5049,7 @@ impl wkt::message::Message for TerraformVersion {
     }
 }
 
-/// Defines additional types related to TerraformVersion
+/// Defines additional types related to [TerraformVersion].
 pub mod terraform_version {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -210,7 +210,7 @@ impl wkt::message::Message for AuthConfig {
     }
 }
 
-/// Defines additional types related to AuthConfig
+/// Defines additional types related to [AuthConfig].
 pub mod auth_config {
     #[allow(unused_imports)]
     use super::*;
@@ -312,7 +312,7 @@ pub mod auth_config {
         }
     }
 
-    /// Defines additional types related to Oauth2JwtBearer
+    /// Defines additional types related to [Oauth2JwtBearer].
     pub mod oauth_2_jwt_bearer {
         #[allow(unused_imports)]
         use super::*;
@@ -819,7 +819,7 @@ impl wkt::message::Message for ConfigVariableTemplate {
     }
 }
 
-/// Defines additional types related to ConfigVariableTemplate
+/// Defines additional types related to [ConfigVariableTemplate].
 pub mod config_variable_template {
     #[allow(unused_imports)]
     use super::*;
@@ -1164,7 +1164,7 @@ impl wkt::message::Message for ConfigVariable {
     }
 }
 
-/// Defines additional types related to ConfigVariable
+/// Defines additional types related to [ConfigVariable].
 pub mod config_variable {
     #[allow(unused_imports)]
     use super::*;
@@ -1263,7 +1263,7 @@ impl wkt::message::Message for RoleGrant {
     }
 }
 
-/// Defines additional types related to RoleGrant
+/// Defines additional types related to [RoleGrant].
 pub mod role_grant {
     #[allow(unused_imports)]
     use super::*;
@@ -1315,7 +1315,7 @@ pub mod role_grant {
         }
     }
 
-    /// Defines additional types related to Resource
+    /// Defines additional types related to [Resource].
     pub mod resource {
         #[allow(unused_imports)]
         use super::*;
@@ -1914,7 +1914,7 @@ impl wkt::message::Message for ConnectionSchemaMetadata {
     }
 }
 
-/// Defines additional types related to ConnectionSchemaMetadata
+/// Defines additional types related to [ConnectionSchemaMetadata].
 pub mod connection_schema_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -2021,7 +2021,7 @@ impl wkt::message::Message for RuntimeEntitySchema {
     }
 }
 
-/// Defines additional types related to RuntimeEntitySchema
+/// Defines additional types related to [RuntimeEntitySchema].
 pub mod runtime_entity_schema {
     #[allow(unused_imports)]
     use super::*;
@@ -2194,7 +2194,7 @@ impl wkt::message::Message for RuntimeActionSchema {
     }
 }
 
-/// Defines additional types related to RuntimeActionSchema
+/// Defines additional types related to [RuntimeActionSchema].
 pub mod runtime_action_schema {
     #[allow(unused_imports)]
     use super::*;
@@ -3065,7 +3065,7 @@ impl wkt::message::Message for ConnectionStatus {
     }
 }
 
-/// Defines additional types related to ConnectionStatus
+/// Defines additional types related to [ConnectionStatus].
 pub mod connection_status {
     #[allow(unused_imports)]
     use super::*;
@@ -3986,7 +3986,7 @@ impl wkt::message::Message for EgressControlConfig {
     }
 }
 
-/// Defines additional types related to EgressControlConfig
+/// Defines additional types related to [EgressControlConfig].
 pub mod egress_control_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4088,7 +4088,7 @@ impl wkt::message::Message for ExtractionRule {
     }
 }
 
-/// Defines additional types related to ExtractionRule
+/// Defines additional types related to [ExtractionRule].
 pub mod extraction_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -4324,7 +4324,7 @@ impl wkt::message::Message for Destination {
     }
 }
 
-/// Defines additional types related to Destination
+/// Defines additional types related to [Destination].
 pub mod destination {
     #[allow(unused_imports)]
     use super::*;
@@ -4816,7 +4816,7 @@ impl wkt::message::Message for RuntimeConfig {
     }
 }
 
-/// Defines additional types related to RuntimeConfig
+/// Defines additional types related to [RuntimeConfig].
 pub mod runtime_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5208,7 +5208,7 @@ impl wkt::message::Message for SslConfig {
     }
 }
 
-/// Defines additional types related to SslConfig
+/// Defines additional types related to [SslConfig].
 pub mod ssl_config {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -217,7 +217,7 @@ impl wkt::message::Message for CalculateStatsResponse {
     }
 }
 
-/// Defines additional types related to CalculateStatsResponse
+/// Defines additional types related to [CalculateStatsResponse].
 pub mod calculate_stats_response {
     #[allow(unused_imports)]
     use super::*;
@@ -271,7 +271,7 @@ pub mod calculate_stats_response {
         }
     }
 
-    /// Defines additional types related to TimeSeries
+    /// Defines additional types related to [TimeSeries].
     pub mod time_series {
         #[allow(unused_imports)]
         use super::*;
@@ -1122,7 +1122,7 @@ impl wkt::message::Message for IngestConversationsRequest {
     }
 }
 
-/// Defines additional types related to IngestConversationsRequest
+/// Defines additional types related to [IngestConversationsRequest].
 pub mod ingest_conversations_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1212,7 +1212,7 @@ pub mod ingest_conversations_request {
         }
     }
 
-    /// Defines additional types related to GcsSource
+    /// Defines additional types related to [GcsSource].
     pub mod gcs_source {
         #[allow(unused_imports)]
         use super::*;
@@ -1480,7 +1480,7 @@ impl wkt::message::Message for IngestConversationsMetadata {
     }
 }
 
-/// Defines additional types related to IngestConversationsMetadata
+/// Defines additional types related to [IngestConversationsMetadata].
 pub mod ingest_conversations_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -2266,7 +2266,7 @@ impl wkt::message::Message for ExportInsightsDataRequest {
     }
 }
 
-/// Defines additional types related to ExportInsightsDataRequest
+/// Defines additional types related to [ExportInsightsDataRequest].
 pub mod export_insights_data_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3118,7 +3118,7 @@ impl wkt::message::Message for ExportIssueModelRequest {
     }
 }
 
-/// Defines additional types related to ExportIssueModelRequest
+/// Defines additional types related to [ExportIssueModelRequest].
 pub mod export_issue_model_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3327,7 +3327,7 @@ impl wkt::message::Message for ImportIssueModelRequest {
     }
 }
 
-/// Defines additional types related to ImportIssueModelRequest
+/// Defines additional types related to [ImportIssueModelRequest].
 pub mod import_issue_model_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4895,7 +4895,7 @@ impl wkt::message::Message for Dimension {
     }
 }
 
-/// Defines additional types related to Dimension
+/// Defines additional types related to [Dimension].
 pub mod dimension {
     #[allow(unused_imports)]
     use super::*;
@@ -5344,7 +5344,7 @@ impl wkt::message::Message for QueryMetricsRequest {
     }
 }
 
-/// Defines additional types related to QueryMetricsRequest
+/// Defines additional types related to [QueryMetricsRequest].
 pub mod query_metrics_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5515,7 +5515,7 @@ impl wkt::message::Message for QueryMetricsResponse {
     }
 }
 
-/// Defines additional types related to QueryMetricsResponse
+/// Defines additional types related to [QueryMetricsResponse].
 pub mod query_metrics_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5600,7 +5600,7 @@ pub mod query_metrics_response {
         }
     }
 
-    /// Defines additional types related to Slice
+    /// Defines additional types related to [Slice].
     pub mod slice {
         #[allow(unused_imports)]
         use super::*;
@@ -5696,7 +5696,7 @@ pub mod query_metrics_response {
             }
         }
 
-        /// Defines additional types related to DataPoint
+        /// Defines additional types related to [DataPoint].
         pub mod data_point {
             #[allow(unused_imports)]
             use super::*;
@@ -5871,7 +5871,7 @@ pub mod query_metrics_response {
                 }
             }
 
-            /// Defines additional types related to ConversationMeasure
+            /// Defines additional types related to [ConversationMeasure].
             pub mod conversation_measure {
                 #[allow(unused_imports)]
                 use super::*;
@@ -6720,7 +6720,7 @@ impl wkt::message::Message for TuneQaScorecardRevisionMetadata {
     }
 }
 
-/// Defines additional types related to TuneQaScorecardRevisionMetadata
+/// Defines additional types related to [TuneQaScorecardRevisionMetadata].
 pub mod tune_qa_scorecard_revision_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -6822,7 +6822,7 @@ pub mod tune_qa_scorecard_revision_metadata {
         }
     }
 
-    /// Defines additional types related to QaQuestionDatasetTuningMetrics
+    /// Defines additional types related to [QaQuestionDatasetTuningMetrics].
     pub mod qa_question_dataset_tuning_metrics {
         #[allow(unused_imports)]
         use super::*;
@@ -7716,7 +7716,7 @@ impl wkt::message::Message for BulkUploadFeedbackLabelsRequest {
     }
 }
 
-/// Defines additional types related to BulkUploadFeedbackLabelsRequest
+/// Defines additional types related to [BulkUploadFeedbackLabelsRequest].
 pub mod bulk_upload_feedback_labels_request {
     #[allow(unused_imports)]
     use super::*;
@@ -7767,7 +7767,7 @@ pub mod bulk_upload_feedback_labels_request {
         }
     }
 
-    /// Defines additional types related to GcsSource
+    /// Defines additional types related to [GcsSource].
     pub mod gcs_source {
         #[allow(unused_imports)]
         use super::*;
@@ -7956,7 +7956,7 @@ impl wkt::message::Message for BulkUploadFeedbackLabelsMetadata {
     }
 }
 
-/// Defines additional types related to BulkUploadFeedbackLabelsMetadata
+/// Defines additional types related to [BulkUploadFeedbackLabelsMetadata].
 pub mod bulk_upload_feedback_labels_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -8178,7 +8178,7 @@ impl wkt::message::Message for BulkDownloadFeedbackLabelsRequest {
     }
 }
 
-/// Defines additional types related to BulkDownloadFeedbackLabelsRequest
+/// Defines additional types related to [BulkDownloadFeedbackLabelsRequest].
 pub mod bulk_download_feedback_labels_request {
     #[allow(unused_imports)]
     use super::*;
@@ -8264,7 +8264,7 @@ pub mod bulk_download_feedback_labels_request {
         }
     }
 
-    /// Defines additional types related to GcsDestination
+    /// Defines additional types related to [GcsDestination].
     pub mod gcs_destination {
         #[allow(unused_imports)]
         use super::*;
@@ -8519,7 +8519,7 @@ impl wkt::message::Message for BulkDownloadFeedbackLabelsMetadata {
     }
 }
 
-/// Defines additional types related to BulkDownloadFeedbackLabelsMetadata
+/// Defines additional types related to [BulkDownloadFeedbackLabelsMetadata].
 pub mod bulk_download_feedback_labels_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -8977,7 +8977,7 @@ impl wkt::message::Message for Conversation {
     }
 }
 
-/// Defines additional types related to Conversation
+/// Defines additional types related to [Conversation].
 pub mod conversation {
     #[allow(unused_imports)]
     use super::*;
@@ -9088,7 +9088,7 @@ pub mod conversation {
         }
     }
 
-    /// Defines additional types related to QualityMetadata
+    /// Defines additional types related to [QualityMetadata].
     pub mod quality_metadata {
         #[allow(unused_imports)]
         use super::*;
@@ -9212,7 +9212,7 @@ pub mod conversation {
         }
     }
 
-    /// Defines additional types related to Transcript
+    /// Defines additional types related to [Transcript].
     pub mod transcript {
         #[allow(unused_imports)]
         use super::*;
@@ -9354,7 +9354,7 @@ pub mod conversation {
             }
         }
 
-        /// Defines additional types related to TranscriptSegment
+        /// Defines additional types related to [TranscriptSegment].
         pub mod transcript_segment {
             #[allow(unused_imports)]
             use super::*;
@@ -9732,7 +9732,7 @@ impl wkt::message::Message for ConversationDataSource {
     }
 }
 
-/// Defines additional types related to ConversationDataSource
+/// Defines additional types related to [ConversationDataSource].
 pub mod conversation_data_source {
     #[allow(unused_imports)]
     use super::*;
@@ -9915,7 +9915,7 @@ impl wkt::message::Message for AnalysisResult {
     }
 }
 
-/// Defines additional types related to AnalysisResult
+/// Defines additional types related to [AnalysisResult].
 pub mod analysis_result {
     #[allow(unused_imports)]
     use super::*;
@@ -10257,7 +10257,7 @@ impl wkt::message::Message for FeedbackLabel {
     }
 }
 
-/// Defines additional types related to FeedbackLabel
+/// Defines additional types related to [FeedbackLabel].
 pub mod feedback_label {
     #[allow(unused_imports)]
     use super::*;
@@ -10717,7 +10717,7 @@ impl wkt::message::Message for CallAnnotation {
     }
 }
 
-/// Defines additional types related to CallAnnotation
+/// Defines additional types related to [CallAnnotation].
 pub mod call_annotation {
     #[allow(unused_imports)]
     use super::*;
@@ -10817,7 +10817,7 @@ impl wkt::message::Message for AnnotationBoundary {
     }
 }
 
-/// Defines additional types related to AnnotationBoundary
+/// Defines additional types related to [AnnotationBoundary].
 pub mod annotation_boundary {
     #[allow(unused_imports)]
     use super::*;
@@ -10923,7 +10923,7 @@ impl wkt::message::Message for Entity {
     }
 }
 
-/// Defines additional types related to Entity
+/// Defines additional types related to [Entity].
 pub mod entity {
     #[allow(unused_imports)]
     use super::*;
@@ -11302,7 +11302,7 @@ impl wkt::message::Message for EntityMentionData {
     }
 }
 
-/// Defines additional types related to EntityMentionData
+/// Defines additional types related to [EntityMentionData].
 pub mod entity_mention_data {
     #[allow(unused_imports)]
     use super::*;
@@ -11617,7 +11617,7 @@ impl wkt::message::Message for IssueModel {
     }
 }
 
-/// Defines additional types related to IssueModel
+/// Defines additional types related to [IssueModel].
 pub mod issue_model {
     #[allow(unused_imports)]
     use super::*;
@@ -11968,7 +11968,7 @@ impl wkt::message::Message for IssueModelLabelStats {
     }
 }
 
-/// Defines additional types related to IssueModelLabelStats
+/// Defines additional types related to [IssueModelLabelStats].
 pub mod issue_model_label_stats {
     #[allow(unused_imports)]
     use super::*;
@@ -12187,7 +12187,7 @@ impl wkt::message::Message for PhraseMatcher {
     }
 }
 
-/// Defines additional types related to PhraseMatcher
+/// Defines additional types related to [PhraseMatcher].
 pub mod phrase_matcher {
     #[allow(unused_imports)]
     use super::*;
@@ -12302,7 +12302,7 @@ impl wkt::message::Message for PhraseMatchRuleGroup {
     }
 }
 
-/// Defines additional types related to PhraseMatchRuleGroup
+/// Defines additional types related to [PhraseMatchRuleGroup].
 pub mod phrase_match_rule_group {
     #[allow(unused_imports)]
     use super::*;
@@ -12490,7 +12490,7 @@ impl wkt::message::Message for PhraseMatchRuleConfig {
     }
 }
 
-/// Defines additional types related to PhraseMatchRuleConfig
+/// Defines additional types related to [PhraseMatchRuleConfig].
 pub mod phrase_match_rule_config {
     #[allow(unused_imports)]
     use super::*;
@@ -12710,7 +12710,7 @@ impl wkt::message::Message for Settings {
     }
 }
 
-/// Defines additional types related to Settings
+/// Defines additional types related to [Settings].
 pub mod settings {
     #[allow(unused_imports)]
     use super::*;
@@ -13346,7 +13346,7 @@ impl wkt::message::Message for RuntimeAnnotation {
     }
 }
 
-/// Defines additional types related to RuntimeAnnotation
+/// Defines additional types related to [RuntimeAnnotation].
 pub mod runtime_annotation {
     #[allow(unused_imports)]
     use super::*;
@@ -13409,7 +13409,7 @@ pub mod runtime_annotation {
         }
     }
 
-    /// Defines additional types related to UserInput
+    /// Defines additional types related to [UserInput].
     pub mod user_input {
         #[allow(unused_imports)]
         use super::*;
@@ -13550,7 +13550,7 @@ impl wkt::message::Message for AnswerFeedback {
     }
 }
 
-/// Defines additional types related to AnswerFeedback
+/// Defines additional types related to [AnswerFeedback].
 pub mod answer_feedback {
     #[allow(unused_imports)]
     use super::*;
@@ -14213,7 +14213,7 @@ impl wkt::message::Message for ConversationParticipant {
     }
 }
 
-/// Defines additional types related to ConversationParticipant
+/// Defines additional types related to [ConversationParticipant].
 pub mod conversation_participant {
     #[allow(unused_imports)]
     use super::*;
@@ -14546,7 +14546,7 @@ impl wkt::message::Message for AnnotatorSelector {
     }
 }
 
-/// Defines additional types related to AnnotatorSelector
+/// Defines additional types related to [AnnotatorSelector].
 pub mod annotator_selector {
     #[allow(unused_imports)]
     use super::*;
@@ -14656,7 +14656,7 @@ pub mod annotator_selector {
         }
     }
 
-    /// Defines additional types related to SummarizationConfig
+    /// Defines additional types related to [SummarizationConfig].
     pub mod summarization_config {
         #[allow(unused_imports)]
         use super::*;
@@ -14815,7 +14815,7 @@ pub mod annotator_selector {
         }
     }
 
-    /// Defines additional types related to QaConfig
+    /// Defines additional types related to [QaConfig].
     pub mod qa_config {
         #[allow(unused_imports)]
         use super::*;
@@ -15033,7 +15033,7 @@ impl wkt::message::Message for QaQuestion {
     }
 }
 
-/// Defines additional types related to QaQuestion
+/// Defines additional types related to [QaQuestion].
 pub mod qa_question {
     #[allow(unused_imports)]
     use super::*;
@@ -15195,7 +15195,7 @@ pub mod qa_question {
         }
     }
 
-    /// Defines additional types related to AnswerChoice
+    /// Defines additional types related to [AnswerChoice].
     pub mod answer_choice {
         #[allow(unused_imports)]
         use super::*;
@@ -15479,7 +15479,7 @@ impl wkt::message::Message for QaScorecardRevision {
     }
 }
 
-/// Defines additional types related to QaScorecardRevision
+/// Defines additional types related to [QaScorecardRevision].
 pub mod qa_scorecard_revision {
     #[allow(unused_imports)]
     use super::*;
@@ -15658,7 +15658,7 @@ impl wkt::message::Message for QaAnswer {
     }
 }
 
-/// Defines additional types related to QaAnswer
+/// Defines additional types related to [QaAnswer].
 pub mod qa_answer {
     #[allow(unused_imports)]
     use super::*;
@@ -15851,7 +15851,7 @@ pub mod qa_answer {
         }
     }
 
-    /// Defines additional types related to AnswerValue
+    /// Defines additional types related to [AnswerValue].
     pub mod answer_value {
         #[allow(unused_imports)]
         use super::*;
@@ -15922,7 +15922,7 @@ pub mod qa_answer {
         }
     }
 
-    /// Defines additional types related to AnswerSource
+    /// Defines additional types related to [AnswerSource].
     pub mod answer_source {
         #[allow(unused_imports)]
         use super::*;
@@ -16150,7 +16150,7 @@ impl wkt::message::Message for QaScorecardResult {
     }
 }
 
-/// Defines additional types related to QaScorecardResult
+/// Defines additional types related to [QaScorecardResult].
 pub mod qa_scorecard_result {
     #[allow(unused_imports)]
     use super::*;
@@ -16307,7 +16307,7 @@ pub mod qa_scorecard_result {
         }
     }
 
-    /// Defines additional types related to ScoreSource
+    /// Defines additional types related to [ScoreSource].
     pub mod score_source {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
@@ -210,7 +210,7 @@ impl wkt::message::Message for Run {
     }
 }
 
-/// Defines additional types related to Run
+/// Defines additional types related to [Run].
 pub mod run {
     #[allow(unused_imports)]
     use super::*;
@@ -535,7 +535,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -1758,7 +1758,7 @@ impl wkt::message::Message for SearchLinksRequest {
     }
 }
 
-/// Defines additional types related to SearchLinksRequest
+/// Defines additional types related to [SearchLinksRequest].
 pub mod search_links_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2223,7 +2223,7 @@ impl wkt::message::Message for Origin {
     }
 }
 
-/// Defines additional types related to Origin
+/// Defines additional types related to [Origin].
 pub mod origin {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -126,7 +126,7 @@ impl wkt::message::Message for BigQueryConnectionSpec {
     }
 }
 
-/// Defines additional types related to BigQueryConnectionSpec
+/// Defines additional types related to [BigQueryConnectionSpec].
 pub mod big_query_connection_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -248,7 +248,7 @@ impl wkt::message::Message for CloudSqlBigQueryConnectionSpec {
     }
 }
 
-/// Defines additional types related to CloudSqlBigQueryConnectionSpec
+/// Defines additional types related to [CloudSqlBigQueryConnectionSpec].
 pub mod cloud_sql_big_query_connection_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -487,7 +487,7 @@ impl wkt::message::Message for DataSource {
     }
 }
 
-/// Defines additional types related to DataSource
+/// Defines additional types related to [DataSource].
 pub mod data_source {
     #[allow(unused_imports)]
     use super::*;
@@ -754,7 +754,7 @@ impl wkt::message::Message for SearchCatalogRequest {
     }
 }
 
-/// Defines additional types related to SearchCatalogRequest
+/// Defines additional types related to [SearchCatalogRequest].
 pub mod search_catalog_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1631,7 +1631,7 @@ impl wkt::message::Message for LookupEntryRequest {
     }
 }
 
-/// Defines additional types related to LookupEntryRequest
+/// Defines additional types related to [LookupEntryRequest].
 pub mod lookup_entry_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2489,7 +2489,7 @@ impl wkt::message::Message for Entry {
     }
 }
 
-/// Defines additional types related to Entry
+/// Defines additional types related to [Entry].
 pub mod entry {
     #[allow(unused_imports)]
     use super::*;
@@ -2677,7 +2677,7 @@ impl wkt::message::Message for DatabaseTableSpec {
     }
 }
 
-/// Defines additional types related to DatabaseTableSpec
+/// Defines additional types related to [DatabaseTableSpec].
 pub mod database_table_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -2786,7 +2786,7 @@ pub mod database_table_spec {
         }
     }
 
-    /// Defines additional types related to DatabaseViewSpec
+    /// Defines additional types related to [DatabaseViewSpec].
     pub mod database_view_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -3122,7 +3122,7 @@ impl wkt::message::Message for RoutineSpec {
     }
 }
 
-/// Defines additional types related to RoutineSpec
+/// Defines additional types related to [RoutineSpec].
 pub mod routine_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -3181,7 +3181,7 @@ pub mod routine_spec {
         }
     }
 
-    /// Defines additional types related to Argument
+    /// Defines additional types related to [Argument].
     pub mod argument {
         #[allow(unused_imports)]
         use super::*;
@@ -3385,7 +3385,7 @@ impl wkt::message::Message for DatasetSpec {
     }
 }
 
-/// Defines additional types related to DatasetSpec
+/// Defines additional types related to [DatasetSpec].
 pub mod dataset_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -3635,7 +3635,7 @@ impl wkt::message::Message for CloudBigtableInstanceSpec {
     }
 }
 
-/// Defines additional types related to CloudBigtableInstanceSpec
+/// Defines additional types related to [CloudBigtableInstanceSpec].
 pub mod cloud_bigtable_instance_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -3774,7 +3774,7 @@ impl wkt::message::Message for ServiceSpec {
     }
 }
 
-/// Defines additional types related to ServiceSpec
+/// Defines additional types related to [ServiceSpec].
 pub mod service_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -3836,7 +3836,7 @@ impl wkt::message::Message for VertexModelSourceInfo {
     }
 }
 
-/// Defines additional types related to VertexModelSourceInfo
+/// Defines additional types related to [VertexModelSourceInfo].
 pub mod vertex_model_source_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4055,7 +4055,7 @@ impl wkt::message::Message for VertexDatasetSpec {
     }
 }
 
-/// Defines additional types related to VertexDatasetSpec
+/// Defines additional types related to [VertexDatasetSpec].
 pub mod vertex_dataset_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -4241,7 +4241,7 @@ impl wkt::message::Message for ModelSpec {
     }
 }
 
-/// Defines additional types related to ModelSpec
+/// Defines additional types related to [ModelSpec].
 pub mod model_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -4290,7 +4290,7 @@ impl wkt::message::Message for FeatureOnlineStoreSpec {
     }
 }
 
-/// Defines additional types related to FeatureOnlineStoreSpec
+/// Defines additional types related to [FeatureOnlineStoreSpec].
 pub mod feature_online_store_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -4471,7 +4471,7 @@ impl wkt::message::Message for Contacts {
     }
 }
 
-/// Defines additional types related to Contacts
+/// Defines additional types related to [Contacts].
 pub mod contacts {
     #[allow(unused_imports)]
     use super::*;
@@ -5520,7 +5520,7 @@ impl wkt::message::Message for ReconcileTagsMetadata {
     }
 }
 
-/// Defines additional types related to ReconcileTagsMetadata
+/// Defines additional types related to [ReconcileTagsMetadata].
 pub mod reconcile_tags_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -5920,7 +5920,7 @@ impl wkt::message::Message for ImportEntriesRequest {
     }
 }
 
-/// Defines additional types related to ImportEntriesRequest
+/// Defines additional types related to [ImportEntriesRequest].
 pub mod import_entries_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6042,7 +6042,7 @@ impl wkt::message::Message for ImportEntriesMetadata {
     }
 }
 
-/// Defines additional types related to ImportEntriesMetadata
+/// Defines additional types related to [ImportEntriesMetadata].
 pub mod import_entries_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -6316,7 +6316,7 @@ impl wkt::message::Message for SetConfigRequest {
     }
 }
 
-/// Defines additional types related to SetConfigRequest
+/// Defines additional types related to [SetConfigRequest].
 pub mod set_config_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6823,7 +6823,7 @@ impl wkt::message::Message for TaggedEntry {
     }
 }
 
-/// Defines additional types related to TaggedEntry
+/// Defines additional types related to [TaggedEntry].
 pub mod tagged_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -6895,7 +6895,7 @@ impl wkt::message::Message for DumpItem {
     }
 }
 
-/// Defines additional types related to DumpItem
+/// Defines additional types related to [DumpItem].
 pub mod dump_item {
     #[allow(unused_imports)]
     use super::*;
@@ -7250,7 +7250,7 @@ impl wkt::message::Message for PhysicalSchema {
     }
 }
 
-/// Defines additional types related to PhysicalSchema
+/// Defines additional types related to [PhysicalSchema].
 pub mod physical_schema {
     #[allow(unused_imports)]
     use super::*;
@@ -7559,7 +7559,7 @@ impl wkt::message::Message for Taxonomy {
     }
 }
 
-/// Defines additional types related to Taxonomy
+/// Defines additional types related to [Taxonomy].
 pub mod taxonomy {
     #[allow(unused_imports)]
     use super::*;
@@ -8639,7 +8639,7 @@ impl wkt::message::Message for ImportTaxonomiesRequest {
     }
 }
 
-/// Defines additional types related to ImportTaxonomiesRequest
+/// Defines additional types related to [ImportTaxonomiesRequest].
 pub mod import_taxonomies_request {
     #[allow(unused_imports)]
     use super::*;
@@ -8847,7 +8847,7 @@ impl wkt::message::Message for ExportTaxonomiesRequest {
     }
 }
 
-/// Defines additional types related to ExportTaxonomiesRequest
+/// Defines additional types related to [ExportTaxonomiesRequest].
 pub mod export_taxonomies_request {
     #[allow(unused_imports)]
     use super::*;
@@ -9138,7 +9138,7 @@ impl wkt::message::Message for ColumnSchema {
     }
 }
 
-/// Defines additional types related to ColumnSchema
+/// Defines additional types related to [ColumnSchema].
 pub mod column_schema {
     #[allow(unused_imports)]
     use super::*;
@@ -9177,7 +9177,7 @@ pub mod column_schema {
         }
     }
 
-    /// Defines additional types related to LookerColumnSpec
+    /// Defines additional types related to [LookerColumnSpec].
     pub mod looker_column_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -9596,7 +9596,7 @@ impl wkt::message::Message for SearchCatalogResult {
     }
 }
 
-/// Defines additional types related to SearchCatalogResult
+/// Defines additional types related to [SearchCatalogResult].
 pub mod search_catalog_result {
     #[allow(unused_imports)]
     use super::*;
@@ -9717,7 +9717,7 @@ impl wkt::message::Message for BigQueryTableSpec {
     }
 }
 
-/// Defines additional types related to BigQueryTableSpec
+/// Defines additional types related to [BigQueryTableSpec].
 pub mod big_query_table_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -10012,7 +10012,7 @@ impl wkt::message::Message for Tag {
     }
 }
 
-/// Defines additional types related to Tag
+/// Defines additional types related to [Tag].
 pub mod tag {
     #[allow(unused_imports)]
     use super::*;
@@ -10237,7 +10237,7 @@ impl wkt::message::Message for TagField {
     }
 }
 
-/// Defines additional types related to TagField
+/// Defines additional types related to [TagField].
 pub mod tag_field {
     #[allow(unused_imports)]
     use super::*;
@@ -10412,7 +10412,7 @@ impl wkt::message::Message for TagTemplate {
     }
 }
 
-/// Defines additional types related to TagTemplate
+/// Defines additional types related to [TagTemplate].
 pub mod tag_template {
     #[allow(unused_imports)]
     use super::*;
@@ -10672,7 +10672,7 @@ impl wkt::message::Message for FieldType {
     }
 }
 
-/// Defines additional types related to FieldType
+/// Defines additional types related to [FieldType].
 pub mod field_type {
     #[allow(unused_imports)]
     use super::*;
@@ -10718,7 +10718,7 @@ pub mod field_type {
         }
     }
 
-    /// Defines additional types related to EnumType
+    /// Defines additional types related to [EnumType].
     pub mod enum_type {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/datafusion/v1/src/model.rs
+++ b/src/generated/cloud/datafusion/v1/src/model.rs
@@ -145,7 +145,7 @@ impl wkt::message::Message for Version {
     }
 }
 
-/// Defines additional types related to Version
+/// Defines additional types related to [Version].
 pub mod version {
     #[allow(unused_imports)]
     use super::*;
@@ -255,7 +255,7 @@ impl wkt::message::Message for Accelerator {
     }
 }
 
-/// Defines additional types related to Accelerator
+/// Defines additional types related to [Accelerator].
 pub mod accelerator {
     #[allow(unused_imports)]
     use super::*;
@@ -788,7 +788,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -187,7 +187,7 @@ impl wkt::message::Message for AutoscalingPolicy {
     }
 }
 
-/// Defines additional types related to AutoscalingPolicy
+/// Defines additional types related to [AutoscalingPolicy].
 pub mod autoscaling_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -282,7 +282,7 @@ impl wkt::message::Message for BasicAutoscalingAlgorithm {
     }
 }
 
-/// Defines additional types related to BasicAutoscalingAlgorithm
+/// Defines additional types related to [BasicAutoscalingAlgorithm].
 pub mod basic_autoscaling_algorithm {
     #[allow(unused_imports)]
     use super::*;
@@ -1372,7 +1372,7 @@ impl wkt::message::Message for Batch {
     }
 }
 
-/// Defines additional types related to Batch
+/// Defines additional types related to [Batch].
 pub mod batch {
     #[allow(unused_imports)]
     use super::*;
@@ -1797,7 +1797,7 @@ impl wkt::message::Message for SparkBatch {
     }
 }
 
-/// Defines additional types related to SparkBatch
+/// Defines additional types related to [SparkBatch].
 pub mod spark_batch {
     #[allow(unused_imports)]
     use super::*;
@@ -2523,7 +2523,7 @@ impl wkt::message::Message for VirtualClusterConfig {
     }
 }
 
-/// Defines additional types related to VirtualClusterConfig
+/// Defines additional types related to [VirtualClusterConfig].
 pub mod virtual_cluster_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3004,7 +3004,7 @@ impl wkt::message::Message for GceClusterConfig {
     }
 }
 
-/// Defines additional types related to GceClusterConfig
+/// Defines additional types related to [GceClusterConfig].
 pub mod gce_cluster_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3483,7 +3483,7 @@ impl wkt::message::Message for InstanceGroupConfig {
     }
 }
 
-/// Defines additional types related to InstanceGroupConfig
+/// Defines additional types related to [InstanceGroupConfig].
 pub mod instance_group_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3803,7 +3803,7 @@ impl wkt::message::Message for InstanceFlexibilityPolicy {
     }
 }
 
-/// Defines additional types related to InstanceFlexibilityPolicy
+/// Defines additional types related to [InstanceFlexibilityPolicy].
 pub mod instance_flexibility_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -4262,7 +4262,7 @@ impl wkt::message::Message for NodeGroup {
     }
 }
 
-/// Defines additional types related to NodeGroup
+/// Defines additional types related to [NodeGroup].
 pub mod node_group {
     #[allow(unused_imports)]
     use super::*;
@@ -4437,7 +4437,7 @@ impl wkt::message::Message for ClusterStatus {
     }
 }
 
-/// Defines additional types related to ClusterStatus
+/// Defines additional types related to [ClusterStatus].
 pub mod cluster_status {
     #[allow(unused_imports)]
     use super::*;
@@ -5112,7 +5112,7 @@ impl wkt::message::Message for LifecycleConfig {
     }
 }
 
-/// Defines additional types related to LifecycleConfig
+/// Defines additional types related to [LifecycleConfig].
 pub mod lifecycle_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5261,7 +5261,7 @@ impl wkt::message::Message for DataprocMetricConfig {
     }
 }
 
-/// Defines additional types related to DataprocMetricConfig
+/// Defines additional types related to [DataprocMetricConfig].
 pub mod dataproc_metric_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6258,7 +6258,7 @@ impl wkt::message::Message for DiagnoseClusterRequest {
     }
 }
 
-/// Defines additional types related to DiagnoseClusterRequest
+/// Defines additional types related to [DiagnoseClusterRequest].
 pub mod diagnose_cluster_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6416,7 +6416,7 @@ impl wkt::message::Message for ReservationAffinity {
     }
 }
 
-/// Defines additional types related to ReservationAffinity
+/// Defines additional types related to [ReservationAffinity].
 pub mod reservation_affinity {
     #[allow(unused_imports)]
     use super::*;
@@ -6526,7 +6526,7 @@ impl wkt::message::Message for LoggingConfig {
     }
 }
 
-/// Defines additional types related to LoggingConfig
+/// Defines additional types related to [LoggingConfig].
 pub mod logging_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6811,7 +6811,7 @@ impl wkt::message::Message for HadoopJob {
     }
 }
 
-/// Defines additional types related to HadoopJob
+/// Defines additional types related to [HadoopJob].
 pub mod hadoop_job {
     #[allow(unused_imports)]
     use super::*;
@@ -7026,7 +7026,7 @@ impl wkt::message::Message for SparkJob {
     }
 }
 
-/// Defines additional types related to SparkJob
+/// Defines additional types related to [SparkJob].
 pub mod spark_job {
     #[allow(unused_imports)]
     use super::*;
@@ -7401,7 +7401,7 @@ impl wkt::message::Message for HiveJob {
     }
 }
 
-/// Defines additional types related to HiveJob
+/// Defines additional types related to [HiveJob].
 pub mod hive_job {
     #[allow(unused_imports)]
     use super::*;
@@ -7567,7 +7567,7 @@ impl wkt::message::Message for SparkSqlJob {
     }
 }
 
-/// Defines additional types related to SparkSqlJob
+/// Defines additional types related to [SparkSqlJob].
 pub mod spark_sql_job {
     #[allow(unused_imports)]
     use super::*;
@@ -7746,7 +7746,7 @@ impl wkt::message::Message for PigJob {
     }
 }
 
-/// Defines additional types related to PigJob
+/// Defines additional types related to [PigJob].
 pub mod pig_job {
     #[allow(unused_imports)]
     use super::*;
@@ -8036,7 +8036,7 @@ impl wkt::message::Message for PrestoJob {
     }
 }
 
-/// Defines additional types related to PrestoJob
+/// Defines additional types related to [PrestoJob].
 pub mod presto_job {
     #[allow(unused_imports)]
     use super::*;
@@ -8210,7 +8210,7 @@ impl wkt::message::Message for TrinoJob {
     }
 }
 
-/// Defines additional types related to TrinoJob
+/// Defines additional types related to [TrinoJob].
 pub mod trino_job {
     #[allow(unused_imports)]
     use super::*;
@@ -8395,7 +8395,7 @@ impl wkt::message::Message for FlinkJob {
     }
 }
 
-/// Defines additional types related to FlinkJob
+/// Defines additional types related to [FlinkJob].
 pub mod flink_job {
     #[allow(unused_imports)]
     use super::*;
@@ -8549,7 +8549,7 @@ impl wkt::message::Message for JobStatus {
     }
 }
 
-/// Defines additional types related to JobStatus
+/// Defines additional types related to [JobStatus].
 pub mod job_status {
     #[allow(unused_imports)]
     use super::*;
@@ -8836,7 +8836,7 @@ impl wkt::message::Message for YarnApplication {
     }
 }
 
-/// Defines additional types related to YarnApplication
+/// Defines additional types related to [YarnApplication].
 pub mod yarn_application {
     #[allow(unused_imports)]
     use super::*;
@@ -9392,7 +9392,7 @@ impl wkt::message::Message for Job {
     }
 }
 
-/// Defines additional types related to Job
+/// Defines additional types related to [Job].
 pub mod job {
     #[allow(unused_imports)]
     use super::*;
@@ -9821,7 +9821,7 @@ impl wkt::message::Message for ListJobsRequest {
     }
 }
 
-/// Defines additional types related to ListJobsRequest
+/// Defines additional types related to [ListJobsRequest].
 pub mod list_jobs_request {
     #[allow(unused_imports)]
     use super::*;
@@ -10467,7 +10467,7 @@ impl wkt::message::Message for BatchOperationMetadata {
     }
 }
 
-/// Defines additional types related to BatchOperationMetadata
+/// Defines additional types related to [BatchOperationMetadata].
 pub mod batch_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -10647,7 +10647,7 @@ impl wkt::message::Message for SessionOperationMetadata {
     }
 }
 
-/// Defines additional types related to SessionOperationMetadata
+/// Defines additional types related to [SessionOperationMetadata].
 pub mod session_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -10782,7 +10782,7 @@ impl wkt::message::Message for ClusterOperationStatus {
     }
 }
 
-/// Defines additional types related to ClusterOperationStatus
+/// Defines additional types related to [ClusterOperationStatus].
 pub mod cluster_operation_status {
     #[allow(unused_imports)]
     use super::*;
@@ -11109,7 +11109,7 @@ impl wkt::message::Message for NodeGroupOperationMetadata {
     }
 }
 
-/// Defines additional types related to NodeGroupOperationMetadata
+/// Defines additional types related to [NodeGroupOperationMetadata].
 pub mod node_group_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -11659,7 +11659,7 @@ impl wkt::message::Message for SessionTemplate {
     }
 }
 
-/// Defines additional types related to SessionTemplate
+/// Defines additional types related to [SessionTemplate].
 pub mod session_template {
     #[allow(unused_imports)]
     use super::*;
@@ -12300,7 +12300,7 @@ impl wkt::message::Message for Session {
     }
 }
 
-/// Defines additional types related to Session
+/// Defines additional types related to [Session].
 pub mod session {
     #[allow(unused_imports)]
     use super::*;
@@ -12489,7 +12489,7 @@ impl wkt::message::Message for JupyterConfig {
     }
 }
 
-/// Defines additional types related to JupyterConfig
+/// Defines additional types related to [JupyterConfig].
 pub mod jupyter_config {
     #[allow(unused_imports)]
     use super::*;
@@ -12918,7 +12918,7 @@ impl wkt::message::Message for ExecutionConfig {
     }
 }
 
-/// Defines additional types related to ExecutionConfig
+/// Defines additional types related to [ExecutionConfig].
 pub mod execution_config {
     #[allow(unused_imports)]
     use super::*;
@@ -13449,7 +13449,7 @@ impl wkt::message::Message for KubernetesClusterConfig {
     }
 }
 
-/// Defines additional types related to KubernetesClusterConfig
+/// Defines additional types related to [KubernetesClusterConfig].
 pub mod kubernetes_cluster_config {
     #[allow(unused_imports)]
     use super::*;
@@ -13598,7 +13598,7 @@ impl wkt::message::Message for GkeNodePoolTarget {
     }
 }
 
-/// Defines additional types related to GkeNodePoolTarget
+/// Defines additional types related to [GkeNodePoolTarget].
 pub mod gke_node_pool_target {
     #[allow(unused_imports)]
     use super::*;
@@ -13763,7 +13763,7 @@ impl wkt::message::Message for GkeNodePoolConfig {
     }
 }
 
-/// Defines additional types related to GkeNodePoolConfig
+/// Defines additional types related to [GkeNodePoolConfig].
 pub mod gke_node_pool_config {
     #[allow(unused_imports)]
     use super::*;
@@ -14040,7 +14040,7 @@ impl wkt::message::Message for AuthenticationConfig {
     }
 }
 
-/// Defines additional types related to AuthenticationConfig
+/// Defines additional types related to [AuthenticationConfig].
 pub mod authentication_config {
     #[allow(unused_imports)]
     use super::*;
@@ -14142,7 +14142,7 @@ impl wkt::message::Message for AutotuningConfig {
     }
 }
 
-/// Defines additional types related to AutotuningConfig
+/// Defines additional types related to [AutotuningConfig].
 pub mod autotuning_config {
     #[allow(unused_imports)]
     use super::*;
@@ -14477,7 +14477,7 @@ impl wkt::message::Message for WorkflowTemplate {
     }
 }
 
-/// Defines additional types related to WorkflowTemplate
+/// Defines additional types related to [WorkflowTemplate].
 pub mod workflow_template {
     #[allow(unused_imports)]
     use super::*;
@@ -14642,7 +14642,7 @@ impl wkt::message::Message for WorkflowTemplatePlacement {
     }
 }
 
-/// Defines additional types related to WorkflowTemplatePlacement
+/// Defines additional types related to [WorkflowTemplatePlacement].
 pub mod workflow_template_placement {
     #[allow(unused_imports)]
     use super::*;
@@ -15153,7 +15153,7 @@ impl wkt::message::Message for OrderedJob {
     }
 }
 
-/// Defines additional types related to OrderedJob
+/// Defines additional types related to [OrderedJob].
 pub mod ordered_job {
     #[allow(unused_imports)]
     use super::*;
@@ -15411,7 +15411,7 @@ impl wkt::message::Message for ParameterValidation {
     }
 }
 
-/// Defines additional types related to ParameterValidation
+/// Defines additional types related to [ParameterValidation].
 pub mod parameter_validation {
     #[allow(unused_imports)]
     use super::*;
@@ -15713,7 +15713,7 @@ impl wkt::message::Message for WorkflowMetadata {
     }
 }
 
-/// Defines additional types related to WorkflowMetadata
+/// Defines additional types related to [WorkflowMetadata].
 pub mod workflow_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -15939,7 +15939,7 @@ impl wkt::message::Message for WorkflowNode {
     }
 }
 
-/// Defines additional types related to WorkflowNode
+/// Defines additional types related to [WorkflowNode].
 pub mod workflow_node {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -354,7 +354,7 @@ impl wkt::message::Message for DiscoverConnectionProfileRequest {
     }
 }
 
-/// Defines additional types related to DiscoverConnectionProfileRequest
+/// Defines additional types related to [DiscoverConnectionProfileRequest].
 pub mod discover_connection_profile_request {
     #[allow(unused_imports)]
     use super::*;
@@ -563,7 +563,7 @@ impl wkt::message::Message for DiscoverConnectionProfileResponse {
     }
 }
 
-/// Defines additional types related to DiscoverConnectionProfileResponse
+/// Defines additional types related to [DiscoverConnectionProfileResponse].
 pub mod discover_connection_profile_response {
     #[allow(unused_imports)]
     use super::*;
@@ -3282,7 +3282,7 @@ impl wkt::message::Message for ForwardSshTunnelConnectivity {
     }
 }
 
-/// Defines additional types related to ForwardSshTunnelConnectivity
+/// Defines additional types related to [ForwardSshTunnelConnectivity].
 pub mod forward_ssh_tunnel_connectivity {
     #[allow(unused_imports)]
     use super::*;
@@ -3462,7 +3462,7 @@ impl wkt::message::Message for PrivateConnection {
     }
 }
 
-/// Defines additional types related to PrivateConnection
+/// Defines additional types related to [PrivateConnection].
 pub mod private_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -3915,7 +3915,7 @@ impl wkt::message::Message for PostgresqlSslConfig {
     }
 }
 
-/// Defines additional types related to PostgresqlSslConfig
+/// Defines additional types related to [PostgresqlSslConfig].
 pub mod postgresql_ssl_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4438,7 +4438,7 @@ impl wkt::message::Message for ConnectionProfile {
     }
 }
 
-/// Defines additional types related to ConnectionProfile
+/// Defines additional types related to [ConnectionProfile].
 pub mod connection_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -4936,7 +4936,7 @@ impl wkt::message::Message for OracleSourceConfig {
     }
 }
 
-/// Defines additional types related to OracleSourceConfig
+/// Defines additional types related to [OracleSourceConfig].
 pub mod oracle_source_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5109,7 +5109,7 @@ pub mod oracle_source_config {
         }
     }
 
-    /// Defines additional types related to BinaryLogParser
+    /// Defines additional types related to [BinaryLogParser].
     pub mod binary_log_parser {
         #[allow(unused_imports)]
         use super::*;
@@ -5886,7 +5886,7 @@ impl wkt::message::Message for SqlServerSourceConfig {
     }
 }
 
-/// Defines additional types related to SqlServerSourceConfig
+/// Defines additional types related to [SqlServerSourceConfig].
 pub mod sql_server_source_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6316,7 +6316,7 @@ impl wkt::message::Message for MysqlSourceConfig {
     }
 }
 
-/// Defines additional types related to MysqlSourceConfig
+/// Defines additional types related to [MysqlSourceConfig].
 pub mod mysql_source_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6547,7 +6547,7 @@ impl wkt::message::Message for SourceConfig {
     }
 }
 
-/// Defines additional types related to SourceConfig
+/// Defines additional types related to [SourceConfig].
 pub mod source_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6634,7 +6634,7 @@ impl wkt::message::Message for JsonFileFormat {
     }
 }
 
-/// Defines additional types related to JsonFileFormat
+/// Defines additional types related to [JsonFileFormat].
 pub mod json_file_format {
     #[allow(unused_imports)]
     use super::*;
@@ -6890,7 +6890,7 @@ impl wkt::message::Message for GcsDestinationConfig {
     }
 }
 
-/// Defines additional types related to GcsDestinationConfig
+/// Defines additional types related to [GcsDestinationConfig].
 pub mod gcs_destination_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7120,7 +7120,7 @@ impl wkt::message::Message for BigQueryDestinationConfig {
     }
 }
 
-/// Defines additional types related to BigQueryDestinationConfig
+/// Defines additional types related to [BigQueryDestinationConfig].
 pub mod big_query_destination_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7188,7 +7188,7 @@ pub mod big_query_destination_config {
         }
     }
 
-    /// Defines additional types related to SourceHierarchyDatasets
+    /// Defines additional types related to [SourceHierarchyDatasets].
     pub mod source_hierarchy_datasets {
         #[allow(unused_imports)]
         use super::*;
@@ -7447,7 +7447,7 @@ impl wkt::message::Message for DestinationConfig {
     }
 }
 
-/// Defines additional types related to DestinationConfig
+/// Defines additional types related to [DestinationConfig].
 pub mod destination_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7706,7 +7706,7 @@ impl wkt::message::Message for Stream {
     }
 }
 
-/// Defines additional types related to Stream
+/// Defines additional types related to [Stream].
 pub mod stream {
     #[allow(unused_imports)]
     use super::*;
@@ -7879,7 +7879,7 @@ pub mod stream {
         }
     }
 
-    /// Defines additional types related to BackfillAllStrategy
+    /// Defines additional types related to [BackfillAllStrategy].
     pub mod backfill_all_strategy {
         #[allow(unused_imports)]
         use super::*;
@@ -8316,7 +8316,7 @@ impl wkt::message::Message for SourceObjectIdentifier {
     }
 }
 
-/// Defines additional types related to SourceObjectIdentifier
+/// Defines additional types related to [SourceObjectIdentifier].
 pub mod source_object_identifier {
     #[allow(unused_imports)]
     use super::*;
@@ -8585,7 +8585,7 @@ impl wkt::message::Message for BackfillJob {
     }
 }
 
-/// Defines additional types related to BackfillJob
+/// Defines additional types related to [BackfillJob].
 pub mod backfill_job {
     #[allow(unused_imports)]
     use super::*;
@@ -8914,7 +8914,7 @@ impl wkt::message::Message for Validation {
     }
 }
 
-/// Defines additional types related to Validation
+/// Defines additional types related to [Validation].
 pub mod validation {
     #[allow(unused_imports)]
     use super::*;
@@ -9054,7 +9054,7 @@ impl wkt::message::Message for ValidationMessage {
     }
 }
 
-/// Defines additional types related to ValidationMessage
+/// Defines additional types related to [ValidationMessage].
 pub mod validation_message {
     #[allow(unused_imports)]
     use super::*;
@@ -9252,7 +9252,7 @@ impl wkt::message::Message for CdcStrategy {
     }
 }
 
-/// Defines additional types related to CdcStrategy
+/// Defines additional types related to [CdcStrategy].
 pub mod cdc_strategy {
     #[allow(unused_imports)]
     use super::*;
@@ -9433,7 +9433,7 @@ pub mod cdc_strategy {
         }
     }
 
-    /// Defines additional types related to SpecificStartPosition
+    /// Defines additional types related to [SpecificStartPosition].
     pub mod specific_start_position {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -399,7 +399,7 @@ impl wkt::message::Message for DeliveryPipeline {
     }
 }
 
-/// Defines additional types related to DeliveryPipeline
+/// Defines additional types related to [DeliveryPipeline].
 pub mod delivery_pipeline {
     #[allow(unused_imports)]
     use super::*;
@@ -666,7 +666,7 @@ impl wkt::message::Message for Strategy {
     }
 }
 
-/// Defines additional types related to Strategy
+/// Defines additional types related to [Strategy].
 pub mod strategy {
     #[allow(unused_imports)]
     use super::*;
@@ -918,7 +918,7 @@ impl wkt::message::Message for Canary {
     }
 }
 
-/// Defines additional types related to Canary
+/// Defines additional types related to [Canary].
 pub mod canary {
     #[allow(unused_imports)]
     use super::*;
@@ -1048,7 +1048,7 @@ impl wkt::message::Message for CustomCanaryDeployment {
     }
 }
 
-/// Defines additional types related to CustomCanaryDeployment
+/// Defines additional types related to [CustomCanaryDeployment].
 pub mod custom_canary_deployment {
     #[allow(unused_imports)]
     use super::*;
@@ -1255,7 +1255,7 @@ impl wkt::message::Message for KubernetesConfig {
     }
 }
 
-/// Defines additional types related to KubernetesConfig
+/// Defines additional types related to [KubernetesConfig].
 pub mod kubernetes_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1384,7 +1384,7 @@ pub mod kubernetes_config {
         }
     }
 
-    /// Defines additional types related to GatewayServiceMesh
+    /// Defines additional types related to [GatewayServiceMesh].
     pub mod gateway_service_mesh {
         #[allow(unused_imports)]
         use super::*;
@@ -1697,7 +1697,7 @@ impl wkt::message::Message for RuntimeConfig {
     }
 }
 
-/// Defines additional types related to RuntimeConfig
+/// Defines additional types related to [RuntimeConfig].
 pub mod runtime_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2950,7 +2950,7 @@ impl wkt::message::Message for Target {
     }
 }
 
-/// Defines additional types related to Target
+/// Defines additional types related to [Target].
 pub mod target {
     #[allow(unused_imports)]
     use super::*;
@@ -3152,7 +3152,7 @@ impl wkt::message::Message for ExecutionConfig {
     }
 }
 
-/// Defines additional types related to ExecutionConfig
+/// Defines additional types related to [ExecutionConfig].
 pub mod execution_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4237,7 +4237,7 @@ impl wkt::message::Message for CustomTargetType {
     }
 }
 
-/// Defines additional types related to CustomTargetType
+/// Defines additional types related to [CustomTargetType].
 pub mod custom_target_type {
     #[allow(unused_imports)]
     use super::*;
@@ -4456,7 +4456,7 @@ impl wkt::message::Message for SkaffoldModules {
     }
 }
 
-/// Defines additional types related to SkaffoldModules
+/// Defines additional types related to [SkaffoldModules].
 pub mod skaffold_modules {
     #[allow(unused_imports)]
     use super::*;
@@ -5264,7 +5264,7 @@ impl wkt::message::Message for DeployPolicy {
     }
 }
 
-/// Defines additional types related to DeployPolicy
+/// Defines additional types related to [DeployPolicy].
 pub mod deploy_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -5540,7 +5540,7 @@ impl wkt::message::Message for PolicyRule {
     }
 }
 
-/// Defines additional types related to PolicyRule
+/// Defines additional types related to [PolicyRule].
 pub mod policy_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -5631,7 +5631,7 @@ impl wkt::message::Message for RolloutRestriction {
     }
 }
 
-/// Defines additional types related to RolloutRestriction
+/// Defines additional types related to [RolloutRestriction].
 pub mod rollout_restriction {
     #[allow(unused_imports)]
     use super::*;
@@ -6358,7 +6358,7 @@ impl wkt::message::Message for Release {
     }
 }
 
-/// Defines additional types related to Release
+/// Defines additional types related to [Release].
 pub mod release {
     #[allow(unused_imports)]
     use super::*;
@@ -6455,7 +6455,7 @@ pub mod release {
         }
     }
 
-    /// Defines additional types related to TargetRender
+    /// Defines additional types related to [TargetRender].
     pub mod target_render {
         #[allow(unused_imports)]
         use super::*;
@@ -7444,7 +7444,7 @@ impl wkt::message::Message for TargetArtifact {
     }
 }
 
-/// Defines additional types related to TargetArtifact
+/// Defines additional types related to [TargetArtifact].
 pub mod target_artifact {
     #[allow(unused_imports)]
     use super::*;
@@ -8254,7 +8254,7 @@ impl wkt::message::Message for Rollout {
     }
 }
 
-/// Defines additional types related to Rollout
+/// Defines additional types related to [Rollout].
 pub mod rollout {
     #[allow(unused_imports)]
     use super::*;
@@ -8977,7 +8977,7 @@ impl wkt::message::Message for Phase {
     }
 }
 
-/// Defines additional types related to Phase
+/// Defines additional types related to [Phase].
 pub mod phase {
     #[allow(unused_imports)]
     use super::*;
@@ -9426,7 +9426,7 @@ impl wkt::message::Message for Job {
     }
 }
 
-/// Defines additional types related to Job
+/// Defines additional types related to [Job].
 pub mod job {
     #[allow(unused_imports)]
     use super::*;
@@ -10830,7 +10830,7 @@ impl wkt::message::Message for JobRun {
     }
 }
 
-/// Defines additional types related to JobRun
+/// Defines additional types related to [JobRun].
 pub mod job_run {
     #[allow(unused_imports)]
     use super::*;
@@ -11011,7 +11011,7 @@ impl wkt::message::Message for DeployJobRun {
     }
 }
 
-/// Defines additional types related to DeployJobRun
+/// Defines additional types related to [DeployJobRun].
 pub mod deploy_job_run {
     #[allow(unused_imports)]
     use super::*;
@@ -11185,7 +11185,7 @@ impl wkt::message::Message for VerifyJobRun {
     }
 }
 
-/// Defines additional types related to VerifyJobRun
+/// Defines additional types related to [VerifyJobRun].
 pub mod verify_job_run {
     #[allow(unused_imports)]
     use super::*;
@@ -11332,7 +11332,7 @@ impl wkt::message::Message for PredeployJobRun {
     }
 }
 
-/// Defines additional types related to PredeployJobRun
+/// Defines additional types related to [PredeployJobRun].
 pub mod predeploy_job_run {
     #[allow(unused_imports)]
     use super::*;
@@ -11472,7 +11472,7 @@ impl wkt::message::Message for PostdeployJobRun {
     }
 }
 
-/// Defines additional types related to PostdeployJobRun
+/// Defines additional types related to [PostdeployJobRun].
 pub mod postdeploy_job_run {
     #[allow(unused_imports)]
     use super::*;
@@ -12448,7 +12448,7 @@ impl wkt::message::Message for AutomationRule {
     }
 }
 
-/// Defines additional types related to AutomationRule
+/// Defines additional types related to [AutomationRule].
 pub mod automation_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -12940,7 +12940,7 @@ impl wkt::message::Message for RepairPhaseConfig {
     }
 }
 
-/// Defines additional types related to RepairPhaseConfig
+/// Defines additional types related to [RepairPhaseConfig].
 pub mod repair_phase_config {
     #[allow(unused_imports)]
     use super::*;
@@ -13145,7 +13145,7 @@ impl wkt::message::Message for AutomationRuleCondition {
     }
 }
 
-/// Defines additional types related to AutomationRuleCondition
+/// Defines additional types related to [AutomationRuleCondition].
 pub mod automation_rule_condition {
     #[allow(unused_imports)]
     use super::*;
@@ -13209,7 +13209,7 @@ impl wkt::message::Message for TimedPromoteReleaseCondition {
     }
 }
 
-/// Defines additional types related to TimedPromoteReleaseCondition
+/// Defines additional types related to [TimedPromoteReleaseCondition].
 pub mod timed_promote_release_condition {
     #[allow(unused_imports)]
     use super::*;
@@ -14047,7 +14047,7 @@ impl wkt::message::Message for AutomationRun {
     }
 }
 
-/// Defines additional types related to AutomationRun
+/// Defines additional types related to [AutomationRun].
 pub mod automation_run {
     #[allow(unused_imports)]
     use super::*;
@@ -14489,7 +14489,7 @@ impl wkt::message::Message for RepairPhase {
     }
 }
 
-/// Defines additional types related to RepairPhase
+/// Defines additional types related to [RepairPhase].
 pub mod repair_phase {
     #[allow(unused_imports)]
     use super::*;
@@ -15233,7 +15233,7 @@ impl wkt::message::Message for DeployPolicyEvaluationEvent {
     }
 }
 
-/// Defines additional types related to DeployPolicyEvaluationEvent
+/// Defines additional types related to [DeployPolicyEvaluationEvent].
 pub mod deploy_policy_evaluation_event {
     #[allow(unused_imports)]
     use super::*;
@@ -15890,7 +15890,7 @@ impl wkt::message::Message for RolloutUpdateEvent {
     }
 }
 
-/// Defines additional types related to RolloutUpdateEvent
+/// Defines additional types related to [RolloutUpdateEvent].
 pub mod rollout_update_event {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -348,7 +348,7 @@ impl wkt::message::Message for Connection {
     }
 }
 
-/// Defines additional types related to Connection
+/// Defines additional types related to [Connection].
 pub mod connection {
     #[allow(unused_imports)]
     use super::*;
@@ -456,7 +456,7 @@ impl wkt::message::Message for InstallationState {
     }
 }
 
-/// Defines additional types related to InstallationState
+/// Defines additional types related to [InstallationState].
 pub mod installation_state {
     #[allow(unused_imports)]
     use super::*;
@@ -603,7 +603,7 @@ impl wkt::message::Message for GitHubConfig {
     }
 }
 
-/// Defines additional types related to GitHubConfig
+/// Defines additional types related to [GitHubConfig].
 pub mod git_hub_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2512,7 +2512,7 @@ impl wkt::message::Message for FetchGitHubInstallationsResponse {
     }
 }
 
-/// Defines additional types related to FetchGitHubInstallationsResponse
+/// Defines additional types related to [FetchGitHubInstallationsResponse].
 pub mod fetch_git_hub_installations_response {
     #[allow(unused_imports)]
     use super::*;
@@ -2632,7 +2632,7 @@ impl wkt::message::Message for FetchGitRefsRequest {
     }
 }
 
-/// Defines additional types related to FetchGitRefsRequest
+/// Defines additional types related to [FetchGitRefsRequest].
 pub mod fetch_git_refs_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -146,7 +146,7 @@ impl wkt::message::Message for AdvancedSettings {
     }
 }
 
-/// Defines additional types related to AdvancedSettings
+/// Defines additional types related to [AdvancedSettings].
 pub mod advanced_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -757,7 +757,7 @@ impl wkt::message::Message for Agent {
     }
 }
 
-/// Defines additional types related to Agent
+/// Defines additional types related to [Agent].
 pub mod agent {
     #[allow(unused_imports)]
     use super::*;
@@ -837,7 +837,7 @@ pub mod agent {
         }
     }
 
-    /// Defines additional types related to GitIntegrationSettings
+    /// Defines additional types related to [GitIntegrationSettings].
     pub mod git_integration_settings {
         #[allow(unused_imports)]
         use super::*;
@@ -1490,7 +1490,7 @@ impl wkt::message::Message for ExportAgentRequest {
     }
 }
 
-/// Defines additional types related to ExportAgentRequest
+/// Defines additional types related to [ExportAgentRequest].
 pub mod export_agent_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1710,7 +1710,7 @@ impl wkt::message::Message for ExportAgentResponse {
     }
 }
 
-/// Defines additional types related to ExportAgentResponse
+/// Defines additional types related to [ExportAgentResponse].
 pub mod export_agent_response {
     #[allow(unused_imports)]
     use super::*;
@@ -1883,7 +1883,7 @@ impl wkt::message::Message for RestoreAgentRequest {
     }
 }
 
-/// Defines additional types related to RestoreAgentRequest
+/// Defines additional types related to [RestoreAgentRequest].
 pub mod restore_agent_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3314,7 +3314,7 @@ impl wkt::message::Message for DataStoreConnectionSignals {
     }
 }
 
-/// Defines additional types related to DataStoreConnectionSignals
+/// Defines additional types related to [DataStoreConnectionSignals].
 pub mod data_store_connection_signals {
     #[allow(unused_imports)]
     use super::*;
@@ -3615,7 +3615,7 @@ pub mod data_store_connection_signals {
         }
     }
 
-    /// Defines additional types related to GroundingSignals
+    /// Defines additional types related to [GroundingSignals].
     pub mod grounding_signals {
         #[allow(unused_imports)]
         use super::*;
@@ -3824,7 +3824,7 @@ pub mod data_store_connection_signals {
         }
     }
 
-    /// Defines additional types related to SafetySignals
+    /// Defines additional types related to [SafetySignals].
     pub mod safety_signals {
         #[allow(unused_imports)]
         use super::*;
@@ -4066,7 +4066,7 @@ impl wkt::message::Message for Deployment {
     }
 }
 
-/// Defines additional types related to Deployment
+/// Defines additional types related to [Deployment].
 pub mod deployment {
     #[allow(unused_imports)]
     use super::*;
@@ -4495,7 +4495,7 @@ impl wkt::message::Message for EntityType {
     }
 }
 
-/// Defines additional types related to EntityType
+/// Defines additional types related to [EntityType].
 pub mod entity_type {
     #[allow(unused_imports)]
     use super::*;
@@ -4874,7 +4874,7 @@ impl wkt::message::Message for ExportEntityTypesRequest {
     }
 }
 
-/// Defines additional types related to ExportEntityTypesRequest
+/// Defines additional types related to [ExportEntityTypesRequest].
 pub mod export_entity_types_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5065,7 +5065,7 @@ impl wkt::message::Message for ExportEntityTypesResponse {
     }
 }
 
-/// Defines additional types related to ExportEntityTypesResponse
+/// Defines additional types related to [ExportEntityTypesResponse].
 pub mod export_entity_types_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5260,7 +5260,7 @@ impl wkt::message::Message for ImportEntityTypesRequest {
     }
 }
 
-/// Defines additional types related to ImportEntityTypesRequest
+/// Defines additional types related to [ImportEntityTypesRequest].
 pub mod import_entity_types_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5425,7 +5425,7 @@ impl wkt::message::Message for ImportEntityTypesResponse {
     }
 }
 
-/// Defines additional types related to ImportEntityTypesResponse
+/// Defines additional types related to [ImportEntityTypesResponse].
 pub mod import_entity_types_response {
     #[allow(unused_imports)]
     use super::*;
@@ -6010,7 +6010,7 @@ impl wkt::message::Message for Environment {
     }
 }
 
-/// Defines additional types related to Environment
+/// Defines additional types related to [Environment].
 pub mod environment {
     #[allow(unused_imports)]
     use super::*;
@@ -6638,7 +6638,7 @@ impl wkt::message::Message for ContinuousTestResult {
     }
 }
 
-/// Defines additional types related to ContinuousTestResult
+/// Defines additional types related to [ContinuousTestResult].
 pub mod continuous_test_result {
     #[allow(unused_imports)]
     use super::*;
@@ -7286,7 +7286,7 @@ impl wkt::message::Message for Experiment {
     }
 }
 
-/// Defines additional types related to Experiment
+/// Defines additional types related to [Experiment].
 pub mod experiment {
     #[allow(unused_imports)]
     use super::*;
@@ -7371,7 +7371,7 @@ pub mod experiment {
         }
     }
 
-    /// Defines additional types related to Definition
+    /// Defines additional types related to [Definition].
     pub mod definition {
         #[allow(unused_imports)]
         use super::*;
@@ -7436,7 +7436,7 @@ pub mod experiment {
         }
     }
 
-    /// Defines additional types related to Result
+    /// Defines additional types related to [Result].
     pub mod result {
         #[allow(unused_imports)]
         use super::*;
@@ -7633,7 +7633,7 @@ pub mod experiment {
             }
         }
 
-        /// Defines additional types related to Metric
+        /// Defines additional types related to [Metric].
         pub mod metric {
             #[allow(unused_imports)]
             use super::*;
@@ -7956,7 +7956,7 @@ impl wkt::message::Message for VersionVariants {
     }
 }
 
-/// Defines additional types related to VersionVariants
+/// Defines additional types related to [VersionVariants].
 pub mod version_variants {
     #[allow(unused_imports)]
     use super::*;
@@ -8092,7 +8092,7 @@ impl wkt::message::Message for VariantsHistory {
     }
 }
 
-/// Defines additional types related to VariantsHistory
+/// Defines additional types related to [VariantsHistory].
 pub mod variants_history {
     #[allow(unused_imports)]
     use super::*;
@@ -8176,7 +8176,7 @@ impl wkt::message::Message for RolloutConfig {
     }
 }
 
-/// Defines additional types related to RolloutConfig
+/// Defines additional types related to [RolloutConfig].
 pub mod rollout_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8708,7 +8708,7 @@ impl wkt::message::Message for NluSettings {
     }
 }
 
-/// Defines additional types related to NluSettings
+/// Defines additional types related to [NluSettings].
 pub mod nlu_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -9063,7 +9063,7 @@ impl wkt::message::Message for Flow {
     }
 }
 
-/// Defines additional types related to Flow
+/// Defines additional types related to [Flow].
 pub mod flow {
     #[allow(unused_imports)]
     use super::*;
@@ -9821,7 +9821,7 @@ impl wkt::message::Message for ImportFlowRequest {
     }
 }
 
-/// Defines additional types related to ImportFlowRequest
+/// Defines additional types related to [ImportFlowRequest].
 pub mod import_flow_request {
     #[allow(unused_imports)]
     use super::*;
@@ -10126,7 +10126,7 @@ impl wkt::message::Message for ExportFlowResponse {
     }
 }
 
-/// Defines additional types related to ExportFlowResponse
+/// Defines additional types related to [ExportFlowResponse].
 pub mod export_flow_response {
     #[allow(unused_imports)]
     use super::*;
@@ -10310,7 +10310,7 @@ impl wkt::message::Message for Fulfillment {
     }
 }
 
-/// Defines additional types related to Fulfillment
+/// Defines additional types related to [Fulfillment].
 pub mod fulfillment {
     #[allow(unused_imports)]
     use super::*;
@@ -10392,7 +10392,7 @@ pub mod fulfillment {
         }
     }
 
-    /// Defines additional types related to ConditionalCases
+    /// Defines additional types related to [ConditionalCases].
     pub mod conditional_cases {
         #[allow(unused_imports)]
         use super::*;
@@ -10457,7 +10457,7 @@ pub mod fulfillment {
             }
         }
 
-        /// Defines additional types related to Case
+        /// Defines additional types related to [Case].
         pub mod case {
             #[allow(unused_imports)]
             use super::*;
@@ -10562,7 +10562,7 @@ pub mod fulfillment {
                 }
             }
 
-            /// Defines additional types related to CaseContent
+            /// Defines additional types related to [CaseContent].
             pub mod case_content {
                 #[allow(unused_imports)]
                 use super::*;
@@ -10704,7 +10704,7 @@ impl wkt::message::Message for GenerativeSettings {
     }
 }
 
-/// Defines additional types related to GenerativeSettings
+/// Defines additional types related to [GenerativeSettings].
 pub mod generative_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -10760,7 +10760,7 @@ pub mod generative_settings {
         }
     }
 
-    /// Defines additional types related to FallbackSettings
+    /// Defines additional types related to [FallbackSettings].
     pub mod fallback_settings {
         #[allow(unused_imports)]
         use super::*;
@@ -11014,7 +11014,7 @@ impl wkt::message::Message for Generator {
     }
 }
 
-/// Defines additional types related to Generator
+/// Defines additional types related to [Generator].
 pub mod generator {
     #[allow(unused_imports)]
     use super::*;
@@ -11722,7 +11722,7 @@ impl wkt::message::Message for Intent {
     }
 }
 
-/// Defines additional types related to Intent
+/// Defines additional types related to [Intent].
 pub mod intent {
     #[allow(unused_imports)]
     use super::*;
@@ -11801,7 +11801,7 @@ pub mod intent {
         }
     }
 
-    /// Defines additional types related to TrainingPhrase
+    /// Defines additional types related to [TrainingPhrase].
     pub mod training_phrase {
         #[allow(unused_imports)]
         use super::*;
@@ -12413,7 +12413,7 @@ impl wkt::message::Message for ImportIntentsRequest {
     }
 }
 
-/// Defines additional types related to ImportIntentsRequest
+/// Defines additional types related to [ImportIntentsRequest].
 pub mod import_intents_request {
     #[allow(unused_imports)]
     use super::*;
@@ -12584,7 +12584,7 @@ impl wkt::message::Message for ImportIntentsResponse {
     }
 }
 
-/// Defines additional types related to ImportIntentsResponse
+/// Defines additional types related to [ImportIntentsResponse].
 pub mod import_intents_response {
     #[allow(unused_imports)]
     use super::*;
@@ -12794,7 +12794,7 @@ impl wkt::message::Message for ExportIntentsRequest {
     }
 }
 
-/// Defines additional types related to ExportIntentsRequest
+/// Defines additional types related to [ExportIntentsRequest].
 pub mod export_intents_request {
     #[allow(unused_imports)]
     use super::*;
@@ -12978,7 +12978,7 @@ impl wkt::message::Message for ExportIntentsResponse {
     }
 }
 
-/// Defines additional types related to ExportIntentsResponse
+/// Defines additional types related to [ExportIntentsResponse].
 pub mod export_intents_response {
     #[allow(unused_imports)]
     use super::*;
@@ -13291,7 +13291,7 @@ impl wkt::message::Message for Form {
     }
 }
 
-/// Defines additional types related to Form
+/// Defines additional types related to [Form].
 pub mod form {
     #[allow(unused_imports)]
     use super::*;
@@ -13426,7 +13426,7 @@ pub mod form {
         }
     }
 
-    /// Defines additional types related to Parameter
+    /// Defines additional types related to [Parameter].
     pub mod parameter {
         #[allow(unused_imports)]
         use super::*;
@@ -13656,7 +13656,7 @@ impl wkt::message::Message for EventHandler {
     }
 }
 
-/// Defines additional types related to EventHandler
+/// Defines additional types related to [EventHandler].
 pub mod event_handler {
     #[allow(unused_imports)]
     use super::*;
@@ -13863,7 +13863,7 @@ impl wkt::message::Message for TransitionRoute {
     }
 }
 
-/// Defines additional types related to TransitionRoute
+/// Defines additional types related to [TransitionRoute].
 pub mod transition_route {
     #[allow(unused_imports)]
     use super::*;
@@ -14452,7 +14452,7 @@ impl wkt::message::Message for KnowledgeConnectorSettings {
     }
 }
 
-/// Defines additional types related to KnowledgeConnectorSettings
+/// Defines additional types related to [KnowledgeConnectorSettings].
 pub mod knowledge_connector_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -14867,7 +14867,7 @@ impl wkt::message::Message for ResponseMessage {
     }
 }
 
-/// Defines additional types related to ResponseMessage
+/// Defines additional types related to [ResponseMessage].
 pub mod response_message {
     #[allow(unused_imports)]
     use super::*;
@@ -15124,7 +15124,7 @@ pub mod response_message {
         }
     }
 
-    /// Defines additional types related to OutputAudioText
+    /// Defines additional types related to [OutputAudioText].
     pub mod output_audio_text {
         #[allow(unused_imports)]
         use super::*;
@@ -15249,7 +15249,7 @@ pub mod response_message {
         }
     }
 
-    /// Defines additional types related to MixedAudio
+    /// Defines additional types related to [MixedAudio].
     pub mod mixed_audio {
         #[allow(unused_imports)]
         use super::*;
@@ -15357,7 +15357,7 @@ pub mod response_message {
             }
         }
 
-        /// Defines additional types related to Segment
+        /// Defines additional types related to [Segment].
         pub mod segment {
             #[allow(unused_imports)]
             use super::*;
@@ -15447,7 +15447,7 @@ pub mod response_message {
         }
     }
 
-    /// Defines additional types related to TelephonyTransferCall
+    /// Defines additional types related to [TelephonyTransferCall].
     pub mod telephony_transfer_call {
         #[allow(unused_imports)]
         use super::*;
@@ -15647,7 +15647,7 @@ impl wkt::message::Message for SafetySettings {
     }
 }
 
-/// Defines additional types related to SafetySettings
+/// Defines additional types related to [SafetySettings].
 pub mod safety_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -16262,7 +16262,7 @@ impl wkt::message::Message for SecuritySettings {
     }
 }
 
-/// Defines additional types related to SecuritySettings
+/// Defines additional types related to [SecuritySettings].
 pub mod security_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -16349,7 +16349,7 @@ pub mod security_settings {
         }
     }
 
-    /// Defines additional types related to AudioExportSettings
+    /// Defines additional types related to [AudioExportSettings].
     pub mod audio_export_settings {
         #[allow(unused_imports)]
         use super::*;
@@ -16756,7 +16756,7 @@ impl wkt::message::Message for AnswerFeedback {
     }
 }
 
-/// Defines additional types related to AnswerFeedback
+/// Defines additional types related to [AnswerFeedback].
 pub mod answer_feedback {
     #[allow(unused_imports)]
     use super::*;
@@ -17131,7 +17131,7 @@ impl wkt::message::Message for DetectIntentResponse {
     }
 }
 
-/// Defines additional types related to DetectIntentResponse
+/// Defines additional types related to [DetectIntentResponse].
 pub mod detect_intent_response {
     #[allow(unused_imports)]
     use super::*;
@@ -17744,7 +17744,7 @@ impl wkt::message::Message for StreamingDetectIntentResponse {
     }
 }
 
-/// Defines additional types related to StreamingDetectIntentResponse
+/// Defines additional types related to [StreamingDetectIntentResponse].
 pub mod streaming_detect_intent_response {
     #[allow(unused_imports)]
     use super::*;
@@ -17929,7 +17929,7 @@ impl wkt::message::Message for StreamingRecognitionResult {
     }
 }
 
-/// Defines additional types related to StreamingRecognitionResult
+/// Defines additional types related to [StreamingRecognitionResult].
 pub mod streaming_recognition_result {
     #[allow(unused_imports)]
     use super::*;
@@ -18416,7 +18416,7 @@ impl wkt::message::Message for BoostSpec {
     }
 }
 
-/// Defines additional types related to BoostSpec
+/// Defines additional types related to [BoostSpec].
 pub mod boost_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -18503,7 +18503,7 @@ pub mod boost_spec {
         }
     }
 
-    /// Defines additional types related to ConditionBoostSpec
+    /// Defines additional types related to [ConditionBoostSpec].
     pub mod condition_boost_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -18584,7 +18584,7 @@ pub mod boost_spec {
             }
         }
 
-        /// Defines additional types related to BoostControlSpec
+        /// Defines additional types related to [BoostControlSpec].
         pub mod boost_control_spec {
             #[allow(unused_imports)]
             use super::*;
@@ -19048,7 +19048,7 @@ impl wkt::message::Message for QueryInput {
     }
 }
 
-/// Defines additional types related to QueryInput
+/// Defines additional types related to [QueryInput].
 pub mod query_input {
     #[allow(unused_imports)]
     use super::*;
@@ -19551,7 +19551,7 @@ impl wkt::message::Message for QueryResult {
     }
 }
 
-/// Defines additional types related to QueryResult
+/// Defines additional types related to [QueryResult].
 pub mod query_result {
     #[allow(unused_imports)]
     use super::*;
@@ -19896,7 +19896,7 @@ impl wkt::message::Message for Match {
     }
 }
 
-/// Defines additional types related to Match
+/// Defines additional types related to [Match].
 pub mod r#match {
     #[allow(unused_imports)]
     use super::*;
@@ -20231,7 +20231,7 @@ impl wkt::message::Message for MatchIntentResponse {
     }
 }
 
-/// Defines additional types related to MatchIntentResponse
+/// Defines additional types related to [MatchIntentResponse].
 pub mod match_intent_response {
     #[allow(unused_imports)]
     use super::*;
@@ -20534,7 +20534,7 @@ impl wkt::message::Message for SessionEntityType {
     }
 }
 
-/// Defines additional types related to SessionEntityType
+/// Defines additional types related to [SessionEntityType].
 pub mod session_entity_type {
     #[allow(unused_imports)]
     use super::*;
@@ -21253,7 +21253,7 @@ impl wkt::message::Message for ConversationTurn {
     }
 }
 
-/// Defines additional types related to ConversationTurn
+/// Defines additional types related to [ConversationTurn].
 pub mod conversation_turn {
     #[allow(unused_imports)]
     use super::*;
@@ -21506,7 +21506,7 @@ impl wkt::message::Message for TestRunDifference {
     }
 }
 
-/// Defines additional types related to TestRunDifference
+/// Defines additional types related to [TestRunDifference].
 pub mod test_run_difference {
     #[allow(unused_imports)]
     use super::*;
@@ -21629,7 +21629,7 @@ impl wkt::message::Message for TransitionCoverage {
     }
 }
 
-/// Defines additional types related to TransitionCoverage
+/// Defines additional types related to [TransitionCoverage].
 pub mod transition_coverage {
     #[allow(unused_imports)]
     use super::*;
@@ -21726,7 +21726,7 @@ pub mod transition_coverage {
         }
     }
 
-    /// Defines additional types related to TransitionNode
+    /// Defines additional types related to [TransitionNode].
     pub mod transition_node {
         #[allow(unused_imports)]
         use super::*;
@@ -21902,7 +21902,7 @@ pub mod transition_coverage {
         }
     }
 
-    /// Defines additional types related to Transition
+    /// Defines additional types related to [Transition].
     pub mod transition {
         #[allow(unused_imports)]
         use super::*;
@@ -21966,7 +21966,7 @@ impl wkt::message::Message for TransitionRouteGroupCoverage {
     }
 }
 
-/// Defines additional types related to TransitionRouteGroupCoverage
+/// Defines additional types related to [TransitionRouteGroupCoverage].
 pub mod transition_route_group_coverage {
     #[allow(unused_imports)]
     use super::*;
@@ -22033,7 +22033,7 @@ pub mod transition_route_group_coverage {
         }
     }
 
-    /// Defines additional types related to Coverage
+    /// Defines additional types related to [Coverage].
     pub mod coverage {
         #[allow(unused_imports)]
         use super::*;
@@ -22128,7 +22128,7 @@ impl wkt::message::Message for IntentCoverage {
     }
 }
 
-/// Defines additional types related to IntentCoverage
+/// Defines additional types related to [IntentCoverage].
 pub mod intent_coverage {
     #[allow(unused_imports)]
     use super::*;
@@ -22221,7 +22221,7 @@ impl wkt::message::Message for CalculateCoverageRequest {
     }
 }
 
-/// Defines additional types related to CalculateCoverageRequest
+/// Defines additional types related to [CalculateCoverageRequest].
 pub mod calculate_coverage_request {
     #[allow(unused_imports)]
     use super::*;
@@ -22437,7 +22437,7 @@ impl wkt::message::Message for CalculateCoverageResponse {
     }
 }
 
-/// Defines additional types related to CalculateCoverageResponse
+/// Defines additional types related to [CalculateCoverageResponse].
 pub mod calculate_coverage_response {
     #[allow(unused_imports)]
     use super::*;
@@ -22522,7 +22522,7 @@ impl wkt::message::Message for ListTestCasesRequest {
     }
 }
 
-/// Defines additional types related to ListTestCasesRequest
+/// Defines additional types related to [ListTestCasesRequest].
 pub mod list_test_cases_request {
     #[allow(unused_imports)]
     use super::*;
@@ -23230,7 +23230,7 @@ impl wkt::message::Message for ImportTestCasesRequest {
     }
 }
 
-/// Defines additional types related to ImportTestCasesRequest
+/// Defines additional types related to [ImportTestCasesRequest].
 pub mod import_test_cases_request {
     #[allow(unused_imports)]
     use super::*;
@@ -23486,7 +23486,7 @@ impl wkt::message::Message for ExportTestCasesRequest {
     }
 }
 
-/// Defines additional types related to ExportTestCasesRequest
+/// Defines additional types related to [ExportTestCasesRequest].
 pub mod export_test_cases_request {
     #[allow(unused_imports)]
     use super::*;
@@ -23658,7 +23658,7 @@ impl wkt::message::Message for ExportTestCasesResponse {
     }
 }
 
-/// Defines additional types related to ExportTestCasesResponse
+/// Defines additional types related to [ExportTestCasesResponse].
 pub mod export_test_cases_response {
     #[allow(unused_imports)]
     use super::*;
@@ -24439,7 +24439,7 @@ impl wkt::message::Message for ValidationMessage {
     }
 }
 
-/// Defines additional types related to ValidationMessage
+/// Defines additional types related to [ValidationMessage].
 pub mod validation_message {
     #[allow(unused_imports)]
     use super::*;
@@ -24794,7 +24794,7 @@ impl wkt::message::Message for Version {
     }
 }
 
-/// Defines additional types related to Version
+/// Defines additional types related to [Version].
 pub mod version {
     #[allow(unused_imports)]
     use super::*;
@@ -25474,7 +25474,7 @@ impl wkt::message::Message for Webhook {
     }
 }
 
-/// Defines additional types related to Webhook
+/// Defines additional types related to [Webhook].
 pub mod webhook {
     #[allow(unused_imports)]
     use super::*;
@@ -25673,7 +25673,7 @@ pub mod webhook {
         }
     }
 
-    /// Defines additional types related to GenericWebService
+    /// Defines additional types related to [GenericWebService].
     pub mod generic_web_service {
         #[allow(unused_imports)]
         use super::*;
@@ -26639,7 +26639,7 @@ impl wkt::message::Message for WebhookRequest {
     }
 }
 
-/// Defines additional types related to WebhookRequest
+/// Defines additional types related to [WebhookRequest].
 pub mod webhook_request {
     #[allow(unused_imports)]
     use super::*;
@@ -26766,7 +26766,7 @@ pub mod webhook_request {
         }
     }
 
-    /// Defines additional types related to IntentInfo
+    /// Defines additional types related to [IntentInfo].
     pub mod intent_info {
         #[allow(unused_imports)]
         use super::*;
@@ -27044,7 +27044,7 @@ impl wkt::message::Message for WebhookResponse {
     }
 }
 
-/// Defines additional types related to WebhookResponse
+/// Defines additional types related to [WebhookResponse].
 pub mod webhook_response {
     #[allow(unused_imports)]
     use super::*;
@@ -27097,7 +27097,7 @@ pub mod webhook_response {
         }
     }
 
-    /// Defines additional types related to FulfillmentResponse
+    /// Defines additional types related to [FulfillmentResponse].
     pub mod fulfillment_response {
         #[allow(unused_imports)]
         use super::*;
@@ -27255,7 +27255,7 @@ impl wkt::message::Message for PageInfo {
     }
 }
 
-/// Defines additional types related to PageInfo
+/// Defines additional types related to [PageInfo].
 pub mod page_info {
     #[allow(unused_imports)]
     use super::*;
@@ -27301,7 +27301,7 @@ pub mod page_info {
         }
     }
 
-    /// Defines additional types related to FormInfo
+    /// Defines additional types related to [FormInfo].
     pub mod form_info {
         #[allow(unused_imports)]
         use super::*;
@@ -27426,7 +27426,7 @@ pub mod page_info {
             }
         }
 
-        /// Defines additional types related to ParameterInfo
+        /// Defines additional types related to [ParameterInfo].
         pub mod parameter_info {
             #[allow(unused_imports)]
             use super::*;

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -213,7 +213,7 @@ impl wkt::message::Message for Agent {
     }
 }
 
-/// Defines additional types related to Agent
+/// Defines additional types related to [Agent].
 pub mod agent {
     #[allow(unused_imports)]
     use super::*;
@@ -804,7 +804,7 @@ impl wkt::message::Message for ExportAgentResponse {
     }
 }
 
-/// Defines additional types related to ExportAgentResponse
+/// Defines additional types related to [ExportAgentResponse].
 pub mod export_agent_response {
     #[allow(unused_imports)]
     use super::*;
@@ -918,7 +918,7 @@ impl wkt::message::Message for ImportAgentRequest {
     }
 }
 
-/// Defines additional types related to ImportAgentRequest
+/// Defines additional types related to [ImportAgentRequest].
 pub mod import_agent_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1038,7 +1038,7 @@ impl wkt::message::Message for RestoreAgentRequest {
     }
 }
 
-/// Defines additional types related to RestoreAgentRequest
+/// Defines additional types related to [RestoreAgentRequest].
 pub mod restore_agent_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1237,7 +1237,7 @@ impl wkt::message::Message for AnswerRecord {
     }
 }
 
-/// Defines additional types related to AnswerRecord
+/// Defines additional types related to [AnswerRecord].
 pub mod answer_record {
     #[allow(unused_imports)]
     use super::*;
@@ -1586,7 +1586,7 @@ impl wkt::message::Message for AnswerFeedback {
     }
 }
 
-/// Defines additional types related to AnswerFeedback
+/// Defines additional types related to [AnswerFeedback].
 pub mod answer_feedback {
     #[allow(unused_imports)]
     use super::*;
@@ -1813,7 +1813,7 @@ impl wkt::message::Message for AgentAssistantFeedback {
     }
 }
 
-/// Defines additional types related to AgentAssistantFeedback
+/// Defines additional types related to [AgentAssistantFeedback].
 pub mod agent_assistant_feedback {
     #[allow(unused_imports)]
     use super::*;
@@ -2306,7 +2306,7 @@ impl wkt::message::Message for AgentAssistantRecord {
     }
 }
 
-/// Defines additional types related to AgentAssistantRecord
+/// Defines additional types related to [AgentAssistantRecord].
 pub mod agent_assistant_record {
     #[allow(unused_imports)]
     use super::*;
@@ -3679,7 +3679,7 @@ impl wkt::message::Message for Conversation {
     }
 }
 
-/// Defines additional types related to Conversation
+/// Defines additional types related to [Conversation].
 pub mod conversation {
     #[allow(unused_imports)]
     use super::*;
@@ -3762,7 +3762,7 @@ pub mod conversation {
         }
     }
 
-    /// Defines additional types related to TelephonyConnectionInfo
+    /// Defines additional types related to [TelephonyConnectionInfo].
     pub mod telephony_connection_info {
         #[allow(unused_imports)]
         use super::*;
@@ -3926,7 +3926,7 @@ pub mod conversation {
         }
     }
 
-    /// Defines additional types related to ContextReference
+    /// Defines additional types related to [ContextReference].
     pub mod context_reference {
         #[allow(unused_imports)]
         use super::*;
@@ -3986,7 +3986,7 @@ pub mod conversation {
             }
         }
 
-        /// Defines additional types related to ContextContent
+        /// Defines additional types related to [ContextContent].
         pub mod context_content {
             #[allow(unused_imports)]
             use super::*;
@@ -4914,7 +4914,7 @@ impl wkt::message::Message for SuggestConversationSummaryResponse {
     }
 }
 
-/// Defines additional types related to SuggestConversationSummaryResponse
+/// Defines additional types related to [SuggestConversationSummaryResponse].
 pub mod suggest_conversation_summary_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5079,7 +5079,7 @@ impl wkt::message::Message for GenerateStatelessSummaryRequest {
     }
 }
 
-/// Defines additional types related to GenerateStatelessSummaryRequest
+/// Defines additional types related to [GenerateStatelessSummaryRequest].
 pub mod generate_stateless_summary_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5203,7 +5203,7 @@ impl wkt::message::Message for GenerateStatelessSummaryResponse {
     }
 }
 
-/// Defines additional types related to GenerateStatelessSummaryResponse
+/// Defines additional types related to [GenerateStatelessSummaryResponse].
 pub mod generate_stateless_summary_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5431,7 +5431,7 @@ impl wkt::message::Message for GenerateStatelessSuggestionRequest {
     }
 }
 
-/// Defines additional types related to GenerateStatelessSuggestionRequest
+/// Defines additional types related to [GenerateStatelessSuggestionRequest].
 pub mod generate_stateless_suggestion_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5659,7 +5659,7 @@ impl wkt::message::Message for SearchKnowledgeRequest {
     }
 }
 
-/// Defines additional types related to SearchKnowledgeRequest
+/// Defines additional types related to [SearchKnowledgeRequest].
 pub mod search_knowledge_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5728,7 +5728,7 @@ pub mod search_knowledge_request {
         }
     }
 
-    /// Defines additional types related to SearchConfig
+    /// Defines additional types related to [SearchConfig].
     pub mod search_config {
         #[allow(unused_imports)]
         use super::*;
@@ -5787,7 +5787,7 @@ pub mod search_knowledge_request {
             }
         }
 
-        /// Defines additional types related to BoostSpecs
+        /// Defines additional types related to [BoostSpecs].
         pub mod boost_specs {
             #[allow(unused_imports)]
             use super::*;
@@ -5833,7 +5833,7 @@ pub mod search_knowledge_request {
                 }
             }
 
-            /// Defines additional types related to BoostSpec
+            /// Defines additional types related to [BoostSpec].
             pub mod boost_spec {
                 #[allow(unused_imports)]
                 use super::*;
@@ -5917,7 +5917,7 @@ pub mod search_knowledge_request {
                     }
                 }
 
-                /// Defines additional types related to ConditionBoostSpec
+                /// Defines additional types related to [ConditionBoostSpec].
                 pub mod condition_boost_spec {
                     #[allow(unused_imports)]
                     use super::*;
@@ -6002,7 +6002,7 @@ pub mod search_knowledge_request {
                         }
                     }
 
-                    /// Defines additional types related to BoostControlSpec
+                    /// Defines additional types related to [BoostControlSpec].
                     pub mod boost_control_spec {
                         #[allow(unused_imports)]
                         use super::*;
@@ -6440,7 +6440,7 @@ impl wkt::message::Message for SearchKnowledgeAnswer {
     }
 }
 
-/// Defines additional types related to SearchKnowledgeAnswer
+/// Defines additional types related to [SearchKnowledgeAnswer].
 pub mod search_knowledge_answer {
     #[allow(unused_imports)]
     use super::*;
@@ -6730,7 +6730,7 @@ impl wkt::message::Message for InputConfig {
     }
 }
 
-/// Defines additional types related to InputConfig
+/// Defines additional types related to [InputConfig].
 pub mod input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7468,7 +7468,7 @@ impl wkt::message::Message for ConversationEvent {
     }
 }
 
-/// Defines additional types related to ConversationEvent
+/// Defines additional types related to [ConversationEvent].
 pub mod conversation_event {
     #[allow(unused_imports)]
     use super::*;
@@ -7789,7 +7789,7 @@ impl wkt::message::Message for ConversationModel {
     }
 }
 
-/// Defines additional types related to ConversationModel
+/// Defines additional types related to [ConversationModel].
 pub mod conversation_model {
     #[allow(unused_imports)]
     use super::*;
@@ -8103,7 +8103,7 @@ impl wkt::message::Message for ConversationModelEvaluation {
     }
 }
 
-/// Defines additional types related to ConversationModelEvaluation
+/// Defines additional types related to [ConversationModelEvaluation].
 pub mod conversation_model_evaluation {
     #[allow(unused_imports)]
     use super::*;
@@ -8236,7 +8236,7 @@ impl wkt::message::Message for EvaluationConfig {
     }
 }
 
-/// Defines additional types related to EvaluationConfig
+/// Defines additional types related to [EvaluationConfig].
 pub mod evaluation_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8500,7 +8500,7 @@ impl wkt::message::Message for SmartReplyMetrics {
     }
 }
 
-/// Defines additional types related to SmartReplyMetrics
+/// Defines additional types related to [SmartReplyMetrics].
 pub mod smart_reply_metrics {
     #[allow(unused_imports)]
     use super::*;
@@ -9105,7 +9105,7 @@ impl wkt::message::Message for CreateConversationModelOperationMetadata {
     }
 }
 
-/// Defines additional types related to CreateConversationModelOperationMetadata
+/// Defines additional types related to [CreateConversationModelOperationMetadata].
 pub mod create_conversation_model_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -9426,7 +9426,7 @@ impl wkt::message::Message for CreateConversationModelEvaluationOperationMetadat
     }
 }
 
-/// Defines additional types related to CreateConversationModelEvaluationOperationMetadata
+/// Defines additional types related to [CreateConversationModelEvaluationOperationMetadata].
 pub mod create_conversation_model_evaluation_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -10208,7 +10208,7 @@ impl wkt::message::Message for HumanAgentAssistantConfig {
     }
 }
 
-/// Defines additional types related to HumanAgentAssistantConfig
+/// Defines additional types related to [HumanAgentAssistantConfig].
 pub mod human_agent_assistant_config {
     #[allow(unused_imports)]
     use super::*;
@@ -10707,7 +10707,7 @@ pub mod human_agent_assistant_config {
         }
     }
 
-    /// Defines additional types related to SuggestionQueryConfig
+    /// Defines additional types related to [SuggestionQueryConfig].
     pub mod suggestion_query_config {
         #[allow(unused_imports)]
         use super::*;
@@ -10835,7 +10835,7 @@ pub mod human_agent_assistant_config {
             }
         }
 
-        /// Defines additional types related to DialogflowQuerySource
+        /// Defines additional types related to [DialogflowQuerySource].
         pub mod dialogflow_query_source {
             #[allow(unused_imports)]
             use super::*;
@@ -10969,7 +10969,7 @@ pub mod human_agent_assistant_config {
             }
         }
 
-        /// Defines additional types related to Sections
+        /// Defines additional types related to [Sections].
         pub mod sections {
             #[allow(unused_imports)]
             use super::*;
@@ -11354,7 +11354,7 @@ impl wkt::message::Message for HumanAgentHandoffConfig {
     }
 }
 
-/// Defines additional types related to HumanAgentHandoffConfig
+/// Defines additional types related to [HumanAgentHandoffConfig].
 pub mod human_agent_handoff_config {
     #[allow(unused_imports)]
     use super::*;
@@ -11540,7 +11540,7 @@ impl wkt::message::Message for NotificationConfig {
     }
 }
 
-/// Defines additional types related to NotificationConfig
+/// Defines additional types related to [NotificationConfig].
 pub mod notification_config {
     #[allow(unused_imports)]
     use super::*;
@@ -11673,7 +11673,7 @@ impl wkt::message::Message for SuggestionFeature {
     }
 }
 
-/// Defines additional types related to SuggestionFeature
+/// Defines additional types related to [SuggestionFeature].
 pub mod suggestion_feature {
     #[allow(unused_imports)]
     use super::*;
@@ -12253,7 +12253,7 @@ impl wkt::message::Message for Document {
     }
 }
 
-/// Defines additional types related to Document
+/// Defines additional types related to [Document].
 pub mod document {
     #[allow(unused_imports)]
     use super::*;
@@ -12814,7 +12814,7 @@ impl wkt::message::Message for ImportDocumentsRequest {
     }
 }
 
-/// Defines additional types related to ImportDocumentsRequest
+/// Defines additional types related to [ImportDocumentsRequest].
 pub mod import_documents_request {
     #[allow(unused_imports)]
     use super::*;
@@ -13126,7 +13126,7 @@ impl wkt::message::Message for ReloadDocumentRequest {
     }
 }
 
-/// Defines additional types related to ReloadDocumentRequest
+/// Defines additional types related to [ReloadDocumentRequest].
 pub mod reload_document_request {
     #[allow(unused_imports)]
     use super::*;
@@ -13253,7 +13253,7 @@ impl wkt::message::Message for ExportDocumentRequest {
     }
 }
 
-/// Defines additional types related to ExportDocumentRequest
+/// Defines additional types related to [ExportDocumentRequest].
 pub mod export_document_request {
     #[allow(unused_imports)]
     use super::*;
@@ -13393,7 +13393,7 @@ impl wkt::message::Message for KnowledgeOperationMetadata {
     }
 }
 
-/// Defines additional types related to KnowledgeOperationMetadata
+/// Defines additional types related to [KnowledgeOperationMetadata].
 pub mod knowledge_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -13745,7 +13745,7 @@ impl wkt::message::Message for EntityType {
     }
 }
 
-/// Defines additional types related to EntityType
+/// Defines additional types related to [EntityType].
 pub mod entity_type {
     #[allow(unused_imports)]
     use super::*;
@@ -14413,7 +14413,7 @@ impl wkt::message::Message for BatchUpdateEntityTypesRequest {
     }
 }
 
-/// Defines additional types related to BatchUpdateEntityTypesRequest
+/// Defines additional types related to [BatchUpdateEntityTypesRequest].
 pub mod batch_update_entity_types_request {
     #[allow(unused_imports)]
     use super::*;
@@ -14895,7 +14895,7 @@ impl wkt::message::Message for Environment {
     }
 }
 
-/// Defines additional types related to Environment
+/// Defines additional types related to [Environment].
 pub mod environment {
     #[allow(unused_imports)]
     use super::*;
@@ -15500,7 +15500,7 @@ impl gax::paginator::PageableResponse for EnvironmentHistory {
     }
 }
 
-/// Defines additional types related to EnvironmentHistory
+/// Defines additional types related to [EnvironmentHistory].
 pub mod environment_history {
     #[allow(unused_imports)]
     use super::*;
@@ -15690,7 +15690,7 @@ impl wkt::message::Message for Fulfillment {
     }
 }
 
-/// Defines additional types related to Fulfillment
+/// Defines additional types related to [Fulfillment].
 pub mod fulfillment {
     #[allow(unused_imports)]
     use super::*;
@@ -15814,7 +15814,7 @@ pub mod fulfillment {
         }
     }
 
-    /// Defines additional types related to Feature
+    /// Defines additional types related to [Feature].
     pub mod feature {
         #[allow(unused_imports)]
         use super::*;
@@ -16378,7 +16378,7 @@ impl wkt::message::Message for MessageEntry {
     }
 }
 
-/// Defines additional types related to MessageEntry
+/// Defines additional types related to [MessageEntry].
 pub mod message_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -16630,7 +16630,7 @@ impl wkt::message::Message for FewShotExample {
     }
 }
 
-/// Defines additional types related to FewShotExample
+/// Defines additional types related to [FewShotExample].
 pub mod few_shot_example {
     #[allow(unused_imports)]
     use super::*;
@@ -16780,7 +16780,7 @@ impl wkt::message::Message for SummarizationSection {
     }
 }
 
-/// Defines additional types related to SummarizationSection
+/// Defines additional types related to [SummarizationSection].
 pub mod summarization_section {
     #[allow(unused_imports)]
     use super::*;
@@ -17209,7 +17209,7 @@ impl wkt::message::Message for Generator {
     }
 }
 
-/// Defines additional types related to Generator
+/// Defines additional types related to [Generator].
 pub mod generator {
     #[allow(unused_imports)]
     use super::*;
@@ -17305,7 +17305,7 @@ impl wkt::message::Message for SummarySuggestion {
     }
 }
 
-/// Defines additional types related to SummarySuggestion
+/// Defines additional types related to [SummarySuggestion].
 pub mod summary_suggestion {
     #[allow(unused_imports)]
     use super::*;
@@ -17448,7 +17448,7 @@ impl wkt::message::Message for GeneratorSuggestion {
     }
 }
 
-/// Defines additional types related to GeneratorSuggestion
+/// Defines additional types related to [GeneratorSuggestion].
 pub mod generator_suggestion {
     #[allow(unused_imports)]
     use super::*;
@@ -17847,7 +17847,7 @@ impl wkt::message::Message for Intent {
     }
 }
 
-/// Defines additional types related to Intent
+/// Defines additional types related to [Intent].
 pub mod intent {
     #[allow(unused_imports)]
     use super::*;
@@ -17942,7 +17942,7 @@ pub mod intent {
         }
     }
 
-    /// Defines additional types related to TrainingPhrase
+    /// Defines additional types related to [TrainingPhrase].
     pub mod training_phrase {
         #[allow(unused_imports)]
         use super::*;
@@ -18696,7 +18696,7 @@ pub mod intent {
         }
     }
 
-    /// Defines additional types related to Message
+    /// Defines additional types related to [Message].
     pub mod message {
         #[allow(unused_imports)]
         use super::*;
@@ -18895,7 +18895,7 @@ pub mod intent {
             }
         }
 
-        /// Defines additional types related to Card
+        /// Defines additional types related to [Card].
         pub mod card {
             #[allow(unused_imports)]
             use super::*;
@@ -19127,7 +19127,7 @@ pub mod intent {
             }
         }
 
-        /// Defines additional types related to BasicCard
+        /// Defines additional types related to [BasicCard].
         pub mod basic_card {
             #[allow(unused_imports)]
             use super::*;
@@ -19185,7 +19185,7 @@ pub mod intent {
                 }
             }
 
-            /// Defines additional types related to Button
+            /// Defines additional types related to [Button].
             pub mod button {
                 #[allow(unused_imports)]
                 use super::*;
@@ -19391,7 +19391,7 @@ pub mod intent {
             }
         }
 
-        /// Defines additional types related to ListSelect
+        /// Defines additional types related to [ListSelect].
         pub mod list_select {
             #[allow(unused_imports)]
             use super::*;
@@ -19508,7 +19508,7 @@ pub mod intent {
             }
         }
 
-        /// Defines additional types related to CarouselSelect
+        /// Defines additional types related to [CarouselSelect].
         pub mod carousel_select {
             #[allow(unused_imports)]
             use super::*;
@@ -19689,7 +19689,7 @@ pub mod intent {
             }
         }
 
-        /// Defines additional types related to MediaContent
+        /// Defines additional types related to [MediaContent].
         pub mod media_content {
             #[allow(unused_imports)]
             use super::*;
@@ -19831,7 +19831,7 @@ pub mod intent {
                 }
             }
 
-            /// Defines additional types related to ResponseMediaObject
+            /// Defines additional types related to [ResponseMediaObject].
             pub mod response_media_object {
                 #[allow(unused_imports)]
                 use super::*;
@@ -19964,7 +19964,7 @@ pub mod intent {
             }
         }
 
-        /// Defines additional types related to BrowseCarouselCard
+        /// Defines additional types related to [BrowseCarouselCard].
         pub mod browse_carousel_card {
             #[allow(unused_imports)]
             use super::*;
@@ -20055,7 +20055,7 @@ pub mod intent {
                 }
             }
 
-            /// Defines additional types related to BrowseCarouselCardItem
+            /// Defines additional types related to [BrowseCarouselCardItem].
             pub mod browse_carousel_card_item {
                 #[allow(unused_imports)]
                 use super::*;
@@ -20105,7 +20105,7 @@ pub mod intent {
                     }
                 }
 
-                /// Defines additional types related to OpenUrlAction
+                /// Defines additional types related to [OpenUrlAction].
                 pub mod open_url_action {
                     #[allow(unused_imports)]
                     use super::*;
@@ -20408,7 +20408,7 @@ pub mod intent {
             }
         }
 
-        /// Defines additional types related to ColumnProperties
+        /// Defines additional types related to [ColumnProperties].
         pub mod column_properties {
             #[allow(unused_imports)]
             use super::*;
@@ -21330,7 +21330,7 @@ impl wkt::message::Message for BatchUpdateIntentsRequest {
     }
 }
 
-/// Defines additional types related to BatchUpdateIntentsRequest
+/// Defines additional types related to [BatchUpdateIntentsRequest].
 pub mod batch_update_intents_request {
     #[allow(unused_imports)]
     use super::*;
@@ -22009,7 +22009,7 @@ impl wkt::message::Message for Participant {
     }
 }
 
-/// Defines additional types related to Participant
+/// Defines additional types related to [Participant].
 pub mod participant {
     #[allow(unused_imports)]
     use super::*;
@@ -22707,7 +22707,7 @@ impl wkt::message::Message for AnalyzeContentRequest {
     }
 }
 
-/// Defines additional types related to AnalyzeContentRequest
+/// Defines additional types related to [AnalyzeContentRequest].
 pub mod analyze_content_request {
     #[allow(unused_imports)]
     use super::*;
@@ -23301,7 +23301,7 @@ impl wkt::message::Message for StreamingAnalyzeContentRequest {
     }
 }
 
-/// Defines additional types related to StreamingAnalyzeContentRequest
+/// Defines additional types related to [StreamingAnalyzeContentRequest].
 pub mod streaming_analyze_content_request {
     #[allow(unused_imports)]
     use super::*;
@@ -23890,7 +23890,7 @@ impl wkt::message::Message for GenerateSuggestionsResponse {
     }
 }
 
-/// Defines additional types related to GenerateSuggestionsResponse
+/// Defines additional types related to [GenerateSuggestionsResponse].
 pub mod generate_suggestions_response {
     #[allow(unused_imports)]
     use super::*;
@@ -24274,7 +24274,7 @@ impl wkt::message::Message for AutomatedAgentReply {
     }
 }
 
-/// Defines additional types related to AutomatedAgentReply
+/// Defines additional types related to [AutomatedAgentReply].
 pub mod automated_agent_reply {
     #[allow(unused_imports)]
     use super::*;
@@ -24659,7 +24659,7 @@ impl wkt::message::Message for IntentSuggestion {
     }
 }
 
-/// Defines additional types related to IntentSuggestion
+/// Defines additional types related to [IntentSuggestion].
 pub mod intent_suggestion {
     #[allow(unused_imports)]
     use super::*;
@@ -24786,7 +24786,7 @@ impl wkt::message::Message for DialogflowAssistAnswer {
     }
 }
 
-/// Defines additional types related to DialogflowAssistAnswer
+/// Defines additional types related to [DialogflowAssistAnswer].
 pub mod dialogflow_assist_answer {
     #[allow(unused_imports)]
     use super::*;
@@ -25045,7 +25045,7 @@ impl wkt::message::Message for SuggestionResult {
     }
 }
 
-/// Defines additional types related to SuggestionResult
+/// Defines additional types related to [SuggestionResult].
 pub mod suggestion_result {
     #[allow(unused_imports)]
     use super::*;
@@ -25509,7 +25509,7 @@ impl wkt::message::Message for KnowledgeAssistAnswer {
     }
 }
 
-/// Defines additional types related to KnowledgeAssistAnswer
+/// Defines additional types related to [KnowledgeAssistAnswer].
 pub mod knowledge_assist_answer {
     #[allow(unused_imports)]
     use super::*;
@@ -25673,7 +25673,7 @@ pub mod knowledge_assist_answer {
         }
     }
 
-    /// Defines additional types related to KnowledgeAnswer
+    /// Defines additional types related to [KnowledgeAnswer].
     pub mod knowledge_answer {
         #[allow(unused_imports)]
         use super::*;
@@ -25747,7 +25747,7 @@ pub mod knowledge_assist_answer {
             }
         }
 
-        /// Defines additional types related to GenerativeSource
+        /// Defines additional types related to [GenerativeSource].
         pub mod generative_source {
             #[allow(unused_imports)]
             use super::*;
@@ -26350,7 +26350,7 @@ impl wkt::message::Message for QueryInput {
     }
 }
 
-/// Defines additional types related to QueryInput
+/// Defines additional types related to [QueryInput].
 pub mod query_input {
     #[allow(unused_imports)]
     use super::*;
@@ -27390,7 +27390,7 @@ impl wkt::message::Message for StreamingRecognitionResult {
     }
 }
 
-/// Defines additional types related to StreamingRecognitionResult
+/// Defines additional types related to [StreamingRecognitionResult].
 pub mod streaming_recognition_result {
     #[allow(unused_imports)]
     use super::*;
@@ -27787,7 +27787,7 @@ impl wkt::message::Message for SessionEntityType {
     }
 }
 
-/// Defines additional types related to SessionEntityType
+/// Defines additional types related to [SessionEntityType].
 pub mod session_entity_type {
     #[allow(unused_imports)]
     use super::*;
@@ -28234,7 +28234,7 @@ impl wkt::message::Message for ValidationError {
     }
 }
 
-/// Defines additional types related to ValidationError
+/// Defines additional types related to [ValidationError].
 pub mod validation_error {
     #[allow(unused_imports)]
     use super::*;
@@ -28439,7 +28439,7 @@ impl wkt::message::Message for Version {
     }
 }
 
-/// Defines additional types related to Version
+/// Defines additional types related to [Version].
 pub mod version {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -201,7 +201,7 @@ impl wkt::message::Message for Answer {
     }
 }
 
-/// Defines additional types related to Answer
+/// Defines additional types related to [Answer].
 pub mod answer {
     #[allow(unused_imports)]
     use super::*;
@@ -432,7 +432,7 @@ pub mod answer {
         }
     }
 
-    /// Defines additional types related to Reference
+    /// Defines additional types related to [Reference].
     pub mod reference {
         #[allow(unused_imports)]
         use super::*;
@@ -522,7 +522,7 @@ pub mod answer {
             }
         }
 
-        /// Defines additional types related to UnstructuredDocumentInfo
+        /// Defines additional types related to [UnstructuredDocumentInfo].
         pub mod unstructured_document_info {
             #[allow(unused_imports)]
             use super::*;
@@ -666,7 +666,7 @@ pub mod answer {
             }
         }
 
-        /// Defines additional types related to ChunkInfo
+        /// Defines additional types related to [ChunkInfo].
         pub mod chunk_info {
             #[allow(unused_imports)]
             use super::*;
@@ -883,7 +883,7 @@ pub mod answer {
         }
     }
 
-    /// Defines additional types related to Step
+    /// Defines additional types related to [Step].
     pub mod step {
         #[allow(unused_imports)]
         use super::*;
@@ -975,7 +975,7 @@ pub mod answer {
             }
         }
 
-        /// Defines additional types related to Action
+        /// Defines additional types related to [Action].
         pub mod action {
             #[allow(unused_imports)]
             use super::*;
@@ -1050,7 +1050,7 @@ pub mod answer {
                 }
             }
 
-            /// Defines additional types related to Observation
+            /// Defines additional types related to [Observation].
             pub mod observation {
                 #[allow(unused_imports)]
                 use super::*;
@@ -1168,7 +1168,7 @@ pub mod answer {
                     }
                 }
 
-                /// Defines additional types related to SearchResult
+                /// Defines additional types related to [SearchResult].
                 pub mod search_result {
                     #[allow(unused_imports)]
                     use super::*;
@@ -1398,7 +1398,7 @@ pub mod answer {
         }
     }
 
-    /// Defines additional types related to QueryUnderstandingInfo
+    /// Defines additional types related to [QueryUnderstandingInfo].
     pub mod query_understanding_info {
         #[allow(unused_imports)]
         use super::*;
@@ -1442,7 +1442,7 @@ pub mod answer {
             }
         }
 
-        /// Defines additional types related to QueryClassificationInfo
+        /// Defines additional types related to [QueryClassificationInfo].
         pub mod query_classification_info {
             #[allow(unused_imports)]
             use super::*;
@@ -1850,7 +1850,7 @@ impl wkt::message::Message for Chunk {
     }
 }
 
-/// Defines additional types related to Chunk
+/// Defines additional types related to [Chunk].
 pub mod chunk {
     #[allow(unused_imports)]
     use super::*;
@@ -2157,7 +2157,7 @@ impl wkt::message::Message for Interval {
     }
 }
 
-/// Defines additional types related to Interval
+/// Defines additional types related to [Interval].
 pub mod interval {
     #[allow(unused_imports)]
     use super::*;
@@ -2376,7 +2376,7 @@ impl wkt::message::Message for SuggestionDenyListEntry {
     }
 }
 
-/// Defines additional types related to SuggestionDenyListEntry
+/// Defines additional types related to [SuggestionDenyListEntry].
 pub mod suggestion_deny_list_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -2581,7 +2581,7 @@ impl wkt::message::Message for CompletionSuggestion {
     }
 }
 
-/// Defines additional types related to CompletionSuggestion
+/// Defines additional types related to [CompletionSuggestion].
 pub mod completion_suggestion {
     #[allow(unused_imports)]
     use super::*;
@@ -2763,7 +2763,7 @@ impl wkt::message::Message for CompleteQueryResponse {
     }
 }
 
-/// Defines additional types related to CompleteQueryResponse
+/// Defines additional types related to [CompleteQueryResponse].
 pub mod complete_query_response {
     #[allow(unused_imports)]
     use super::*;
@@ -2890,7 +2890,7 @@ impl wkt::message::Message for Condition {
     }
 }
 
-/// Defines additional types related to Condition
+/// Defines additional types related to [Condition].
 pub mod condition {
     #[allow(unused_imports)]
     use super::*;
@@ -3240,7 +3240,7 @@ impl wkt::message::Message for Control {
     }
 }
 
-/// Defines additional types related to Control
+/// Defines additional types related to [Control].
 pub mod control {
     #[allow(unused_imports)]
     use super::*;
@@ -3841,7 +3841,7 @@ impl wkt::message::Message for Conversation {
     }
 }
 
-/// Defines additional types related to Conversation
+/// Defines additional types related to [Conversation].
 pub mod conversation {
     #[allow(unused_imports)]
     use super::*;
@@ -4127,7 +4127,7 @@ impl wkt::message::Message for ConversationMessage {
     }
 }
 
-/// Defines additional types related to ConversationMessage
+/// Defines additional types related to [ConversationMessage].
 pub mod conversation_message {
     #[allow(unused_imports)]
     use super::*;
@@ -4916,7 +4916,7 @@ impl wkt::message::Message for AnswerQueryRequest {
     }
 }
 
-/// Defines additional types related to AnswerQueryRequest
+/// Defines additional types related to [AnswerQueryRequest].
 pub mod answer_query_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5137,7 +5137,7 @@ pub mod answer_query_request {
         }
     }
 
-    /// Defines additional types related to AnswerGenerationSpec
+    /// Defines additional types related to [AnswerGenerationSpec].
     pub mod answer_generation_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -5319,7 +5319,7 @@ pub mod answer_query_request {
         }
     }
 
-    /// Defines additional types related to SearchSpec
+    /// Defines additional types related to [SearchSpec].
     pub mod search_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -5491,7 +5491,7 @@ pub mod answer_query_request {
             }
         }
 
-        /// Defines additional types related to SearchResultList
+        /// Defines additional types related to [SearchResultList].
         pub mod search_result_list {
             #[allow(unused_imports)]
             use super::*;
@@ -5577,7 +5577,7 @@ pub mod answer_query_request {
                 }
             }
 
-            /// Defines additional types related to SearchResult
+            /// Defines additional types related to [SearchResult].
             pub mod search_result {
                 #[allow(unused_imports)]
                 use super::*;
@@ -5693,7 +5693,7 @@ pub mod answer_query_request {
                     }
                 }
 
-                /// Defines additional types related to UnstructuredDocumentInfo
+                /// Defines additional types related to [UnstructuredDocumentInfo].
                 pub mod unstructured_document_info {
                     #[allow(unused_imports)]
                     use super::*;
@@ -5902,7 +5902,7 @@ pub mod answer_query_request {
                     }
                 }
 
-                /// Defines additional types related to ChunkInfo
+                /// Defines additional types related to [ChunkInfo].
                 pub mod chunk_info {
                     #[allow(unused_imports)]
                     use super::*;
@@ -6029,7 +6029,7 @@ pub mod answer_query_request {
         }
     }
 
-    /// Defines additional types related to QueryUnderstandingSpec
+    /// Defines additional types related to [QueryUnderstandingSpec].
     pub mod query_understanding_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -6069,7 +6069,7 @@ pub mod answer_query_request {
             }
         }
 
-        /// Defines additional types related to QueryClassificationSpec
+        /// Defines additional types related to [QueryClassificationSpec].
         pub mod query_classification_spec {
             #[allow(unused_imports)]
             use super::*;
@@ -6715,7 +6715,7 @@ impl wkt::message::Message for CustomTuningModel {
     }
 }
 
-/// Defines additional types related to CustomTuningModel
+/// Defines additional types related to [CustomTuningModel].
 pub mod custom_tuning_model {
     #[allow(unused_imports)]
     use super::*;
@@ -7018,7 +7018,7 @@ impl wkt::message::Message for DataStore {
     }
 }
 
-/// Defines additional types related to DataStore
+/// Defines additional types related to [DataStore].
 pub mod data_store {
     #[allow(unused_imports)]
     use super::*;
@@ -7272,7 +7272,7 @@ impl wkt::message::Message for WorkspaceConfig {
     }
 }
 
-/// Defines additional types related to WorkspaceConfig
+/// Defines additional types related to [WorkspaceConfig].
 pub mod workspace_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8077,7 +8077,7 @@ impl wkt::message::Message for Document {
     }
 }
 
-/// Defines additional types related to Document
+/// Defines additional types related to [Document].
 pub mod document {
     #[allow(unused_imports)]
     use super::*;
@@ -8180,7 +8180,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to Content
+    /// Defines additional types related to [Content].
     pub mod content {
         #[allow(unused_imports)]
         use super::*;
@@ -8391,7 +8391,7 @@ impl wkt::message::Message for DocumentProcessingConfig {
     }
 }
 
-/// Defines additional types related to DocumentProcessingConfig
+/// Defines additional types related to [DocumentProcessingConfig].
 pub mod document_processing_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8461,7 +8461,7 @@ pub mod document_processing_config {
         }
     }
 
-    /// Defines additional types related to ChunkingConfig
+    /// Defines additional types related to [ChunkingConfig].
     pub mod chunking_config {
         #[allow(unused_imports)]
         use super::*;
@@ -8656,7 +8656,7 @@ pub mod document_processing_config {
         }
     }
 
-    /// Defines additional types related to ParsingConfig
+    /// Defines additional types related to [ParsingConfig].
     pub mod parsing_config {
         #[allow(unused_imports)]
         use super::*;
@@ -9217,7 +9217,7 @@ impl wkt::message::Message for BatchGetDocumentsMetadataRequest {
     }
 }
 
-/// Defines additional types related to BatchGetDocumentsMetadataRequest
+/// Defines additional types related to [BatchGetDocumentsMetadataRequest].
 pub mod batch_get_documents_metadata_request {
     #[allow(unused_imports)]
     use super::*;
@@ -9419,7 +9419,7 @@ pub mod batch_get_documents_metadata_request {
         }
     }
 
-    /// Defines additional types related to Matcher
+    /// Defines additional types related to [Matcher].
     pub mod matcher {
         #[allow(unused_imports)]
         use super::*;
@@ -9486,7 +9486,7 @@ impl wkt::message::Message for BatchGetDocumentsMetadataResponse {
     }
 }
 
-/// Defines additional types related to BatchGetDocumentsMetadataResponse
+/// Defines additional types related to [BatchGetDocumentsMetadataResponse].
 pub mod batch_get_documents_metadata_response {
     #[allow(unused_imports)]
     use super::*;
@@ -9580,7 +9580,7 @@ pub mod batch_get_documents_metadata_response {
         }
     }
 
-    /// Defines additional types related to DocumentMetadata
+    /// Defines additional types related to [DocumentMetadata].
     pub mod document_metadata {
         #[allow(unused_imports)]
         use super::*;
@@ -9675,7 +9675,7 @@ pub mod batch_get_documents_metadata_response {
             }
         }
 
-        /// Defines additional types related to MatcherValue
+        /// Defines additional types related to [MatcherValue].
         pub mod matcher_value {
             #[allow(unused_imports)]
             use super::*;
@@ -10069,7 +10069,7 @@ impl wkt::message::Message for Engine {
     }
 }
 
-/// Defines additional types related to Engine
+/// Defines additional types related to [Engine].
 pub mod engine {
     #[allow(unused_imports)]
     use super::*;
@@ -10210,7 +10210,7 @@ pub mod engine {
         }
     }
 
-    /// Defines additional types related to ChatEngineConfig
+    /// Defines additional types related to [ChatEngineConfig].
     pub mod chat_engine_config {
         #[allow(unused_imports)]
         use super::*;
@@ -10902,7 +10902,7 @@ impl wkt::message::Message for GroundedGenerationContent {
     }
 }
 
-/// Defines additional types related to GroundedGenerationContent
+/// Defines additional types related to [GroundedGenerationContent].
 pub mod grounded_generation_content {
     #[allow(unused_imports)]
     use super::*;
@@ -10968,7 +10968,7 @@ pub mod grounded_generation_content {
         }
     }
 
-    /// Defines additional types related to Part
+    /// Defines additional types related to [Part].
     pub mod part {
         #[allow(unused_imports)]
         use super::*;
@@ -11125,7 +11125,7 @@ impl wkt::message::Message for GenerateGroundedContentRequest {
     }
 }
 
-/// Defines additional types related to GenerateGroundedContentRequest
+/// Defines additional types related to [GenerateGroundedContentRequest].
 pub mod generate_grounded_content_request {
     #[allow(unused_imports)]
     use super::*;
@@ -11275,7 +11275,7 @@ pub mod generate_grounded_content_request {
         }
     }
 
-    /// Defines additional types related to DynamicRetrievalConfiguration
+    /// Defines additional types related to [DynamicRetrievalConfiguration].
     pub mod dynamic_retrieval_configuration {
         #[allow(unused_imports)]
         use super::*;
@@ -11323,7 +11323,7 @@ pub mod generate_grounded_content_request {
             }
         }
 
-        /// Defines additional types related to DynamicRetrievalPredictor
+        /// Defines additional types related to [DynamicRetrievalPredictor].
         pub mod dynamic_retrieval_predictor {
             #[allow(unused_imports)]
             use super::*;
@@ -11511,7 +11511,7 @@ pub mod generate_grounded_content_request {
         }
     }
 
-    /// Defines additional types related to GroundingSource
+    /// Defines additional types related to [GroundingSource].
     pub mod grounding_source {
         #[allow(unused_imports)]
         use super::*;
@@ -11754,7 +11754,7 @@ impl wkt::message::Message for GenerateGroundedContentResponse {
     }
 }
 
-/// Defines additional types related to GenerateGroundedContentResponse
+/// Defines additional types related to [GenerateGroundedContentResponse].
 pub mod generate_grounded_content_response {
     #[allow(unused_imports)]
     use super::*;
@@ -11827,7 +11827,7 @@ pub mod generate_grounded_content_response {
         }
     }
 
-    /// Defines additional types related to Candidate
+    /// Defines additional types related to [Candidate].
     pub mod candidate {
         #[allow(unused_imports)]
         use super::*;
@@ -11928,7 +11928,7 @@ pub mod generate_grounded_content_response {
             }
         }
 
-        /// Defines additional types related to GroundingMetadata
+        /// Defines additional types related to [GroundingMetadata].
         pub mod grounding_metadata {
             #[allow(unused_imports)]
             use super::*;
@@ -11972,7 +11972,7 @@ pub mod generate_grounded_content_response {
                 }
             }
 
-            /// Defines additional types related to RetrievalMetadata
+            /// Defines additional types related to [RetrievalMetadata].
             pub mod retrieval_metadata {
                 #[allow(unused_imports)]
                 use super::*;
@@ -12123,7 +12123,7 @@ pub mod generate_grounded_content_response {
                 }
             }
 
-            /// Defines additional types related to DynamicRetrievalPredictorMetadata
+            /// Defines additional types related to [DynamicRetrievalPredictorMetadata].
             pub mod dynamic_retrieval_predictor_metadata {
                 #[allow(unused_imports)]
                 use super::*;
@@ -12515,7 +12515,7 @@ impl wkt::message::Message for CheckGroundingResponse {
     }
 }
 
-/// Defines additional types related to CheckGroundingResponse
+/// Defines additional types related to [CheckGroundingResponse].
 pub mod check_grounding_response {
     #[allow(unused_imports)]
     use super::*;
@@ -12957,7 +12957,7 @@ impl wkt::message::Message for BigQuerySource {
     }
 }
 
-/// Defines additional types related to BigQuerySource
+/// Defines additional types related to [BigQuerySource].
 pub mod big_query_source {
     #[allow(unused_imports)]
     use super::*;
@@ -13097,7 +13097,7 @@ impl wkt::message::Message for BigtableOptions {
     }
 }
 
-/// Defines additional types related to BigtableOptions
+/// Defines additional types related to [BigtableOptions].
 pub mod bigtable_options {
     #[allow(unused_imports)]
     use super::*;
@@ -13841,7 +13841,7 @@ impl wkt::message::Message for ImportErrorConfig {
     }
 }
 
-/// Defines additional types related to ImportErrorConfig
+/// Defines additional types related to [ImportErrorConfig].
 pub mod import_error_config {
     #[allow(unused_imports)]
     use super::*;
@@ -14013,7 +14013,7 @@ impl wkt::message::Message for ImportUserEventsRequest {
     }
 }
 
-/// Defines additional types related to ImportUserEventsRequest
+/// Defines additional types related to [ImportUserEventsRequest].
 pub mod import_user_events_request {
     #[allow(unused_imports)]
     use super::*;
@@ -14760,7 +14760,7 @@ impl wkt::message::Message for ImportDocumentsRequest {
     }
 }
 
-/// Defines additional types related to ImportDocumentsRequest
+/// Defines additional types related to [ImportDocumentsRequest].
 pub mod import_documents_request {
     #[allow(unused_imports)]
     use super::*;
@@ -15066,7 +15066,7 @@ impl wkt::message::Message for ImportSuggestionDenyListEntriesRequest {
     }
 }
 
-/// Defines additional types related to ImportSuggestionDenyListEntriesRequest
+/// Defines additional types related to [ImportSuggestionDenyListEntriesRequest].
 pub mod import_suggestion_deny_list_entries_request {
     #[allow(unused_imports)]
     use super::*;
@@ -15398,7 +15398,7 @@ impl wkt::message::Message for ImportCompletionSuggestionsRequest {
     }
 }
 
-/// Defines additional types related to ImportCompletionSuggestionsRequest
+/// Defines additional types related to [ImportCompletionSuggestionsRequest].
 pub mod import_completion_suggestions_request {
     #[allow(unused_imports)]
     use super::*;
@@ -15666,7 +15666,7 @@ impl wkt::message::Message for Project {
     }
 }
 
-/// Defines additional types related to Project
+/// Defines additional types related to [Project].
 pub mod project {
     #[allow(unused_imports)]
     use super::*;
@@ -15763,7 +15763,7 @@ pub mod project {
         }
     }
 
-    /// Defines additional types related to ServiceTerms
+    /// Defines additional types related to [ServiceTerms].
     pub mod service_terms {
         #[allow(unused_imports)]
         use super::*;
@@ -16154,7 +16154,7 @@ impl wkt::message::Message for PurgeErrorConfig {
     }
 }
 
-/// Defines additional types related to PurgeErrorConfig
+/// Defines additional types related to [PurgeErrorConfig].
 pub mod purge_error_config {
     #[allow(unused_imports)]
     use super::*;
@@ -16319,7 +16319,7 @@ impl wkt::message::Message for PurgeDocumentsRequest {
     }
 }
 
-/// Defines additional types related to PurgeDocumentsRequest
+/// Defines additional types related to [PurgeDocumentsRequest].
 pub mod purge_documents_request {
     #[allow(unused_imports)]
     use super::*;
@@ -17307,7 +17307,7 @@ impl wkt::message::Message for RecommendResponse {
     }
 }
 
-/// Defines additional types related to RecommendResponse
+/// Defines additional types related to [RecommendResponse].
 pub mod recommend_response {
     #[allow(unused_imports)]
     use super::*;
@@ -17481,7 +17481,7 @@ impl wkt::message::Message for Schema {
     }
 }
 
-/// Defines additional types related to Schema
+/// Defines additional types related to [Schema].
 pub mod schema {
     #[allow(unused_imports)]
     use super::*;
@@ -18491,7 +18491,7 @@ impl wkt::message::Message for SearchRequest {
     }
 }
 
-/// Defines additional types related to SearchRequest
+/// Defines additional types related to [SearchRequest].
 pub mod search_request {
     #[allow(unused_imports)]
     use super::*;
@@ -18556,7 +18556,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to ImageQuery
+    /// Defines additional types related to [ImageQuery].
     pub mod image_query {
         #[allow(unused_imports)]
         use super::*;
@@ -18750,7 +18750,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to FacetSpec
+    /// Defines additional types related to [FacetSpec].
     pub mod facet_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -18946,7 +18946,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to BoostSpec
+    /// Defines additional types related to [BoostSpec].
     pub mod boost_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -19034,7 +19034,7 @@ pub mod search_request {
             }
         }
 
-        /// Defines additional types related to ConditionBoostSpec
+        /// Defines additional types related to [ConditionBoostSpec].
         pub mod condition_boost_spec {
             #[allow(unused_imports)]
             use super::*;
@@ -19115,7 +19115,7 @@ pub mod search_request {
                 }
             }
 
-            /// Defines additional types related to BoostControlSpec
+            /// Defines additional types related to [BoostControlSpec].
             pub mod boost_control_spec {
                 #[allow(unused_imports)]
                 use super::*;
@@ -19348,7 +19348,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to QueryExpansionSpec
+    /// Defines additional types related to [QueryExpansionSpec].
     pub mod query_expansion_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -19458,7 +19458,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to SpellCorrectionSpec
+    /// Defines additional types related to [SpellCorrectionSpec].
     pub mod spell_correction_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -19656,7 +19656,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to ContentSearchSpec
+    /// Defines additional types related to [ContentSearchSpec].
     pub mod content_search_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -19914,7 +19914,7 @@ pub mod search_request {
             }
         }
 
-        /// Defines additional types related to SummarySpec
+        /// Defines additional types related to [SummarySpec].
         pub mod summary_spec {
             #[allow(unused_imports)]
             use super::*;
@@ -20259,7 +20259,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to SearchAsYouTypeSpec
+    /// Defines additional types related to [SearchAsYouTypeSpec].
     pub mod search_as_you_type_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -20611,7 +20611,7 @@ impl gax::paginator::PageableResponse for SearchResponse {
     }
 }
 
-/// Defines additional types related to SearchResponse
+/// Defines additional types related to [SearchResponse].
 pub mod search_response {
     #[allow(unused_imports)]
     use super::*;
@@ -20738,7 +20738,7 @@ pub mod search_response {
         }
     }
 
-    /// Defines additional types related to Facet
+    /// Defines additional types related to [Facet].
     pub mod facet {
         #[allow(unused_imports)]
         use super::*;
@@ -20849,7 +20849,7 @@ pub mod search_response {
             }
         }
 
-        /// Defines additional types related to FacetValue
+        /// Defines additional types related to [FacetValue].
         pub mod facet_value {
             #[allow(unused_imports)]
             use super::*;
@@ -20959,7 +20959,7 @@ pub mod search_response {
         }
     }
 
-    /// Defines additional types related to Summary
+    /// Defines additional types related to [Summary].
     pub mod summary {
         #[allow(unused_imports)]
         use super::*;
@@ -21209,7 +21209,7 @@ pub mod search_response {
             }
         }
 
-        /// Defines additional types related to Reference
+        /// Defines additional types related to [Reference].
         pub mod reference {
             #[allow(unused_imports)]
             use super::*;
@@ -21776,7 +21776,7 @@ impl wkt::message::Message for TrainCustomModelRequest {
     }
 }
 
-/// Defines additional types related to TrainCustomModelRequest
+/// Defines additional types related to [TrainCustomModelRequest].
 pub mod train_custom_model_request {
     #[allow(unused_imports)]
     use super::*;
@@ -22119,7 +22119,7 @@ impl wkt::message::Message for Session {
     }
 }
 
-/// Defines additional types related to Session
+/// Defines additional types related to [Session].
 pub mod session {
     #[allow(unused_imports)]
     use super::*;
@@ -22286,7 +22286,7 @@ impl wkt::message::Message for Query {
     }
 }
 
-/// Defines additional types related to Query
+/// Defines additional types related to [Query].
 pub mod query {
     #[allow(unused_imports)]
     use super::*;
@@ -22483,7 +22483,7 @@ impl wkt::message::Message for TargetSite {
     }
 }
 
-/// Defines additional types related to TargetSite
+/// Defines additional types related to [TargetSite].
 pub mod target_site {
     #[allow(unused_imports)]
     use super::*;
@@ -22560,7 +22560,7 @@ pub mod target_site {
         }
     }
 
-    /// Defines additional types related to FailureReason
+    /// Defines additional types related to [FailureReason].
     pub mod failure_reason {
         #[allow(unused_imports)]
         use super::*;
@@ -22786,7 +22786,7 @@ impl wkt::message::Message for SiteVerificationInfo {
     }
 }
 
-/// Defines additional types related to SiteVerificationInfo
+/// Defines additional types related to [SiteVerificationInfo].
 pub mod site_verification_info {
     #[allow(unused_imports)]
     use super::*;
@@ -23873,7 +23873,7 @@ impl wkt::message::Message for RecrawlUrisResponse {
     }
 }
 
-/// Defines additional types related to RecrawlUrisResponse
+/// Defines additional types related to [RecrawlUrisResponse].
 pub mod recrawl_uris_response {
     #[allow(unused_imports)]
     use super::*;
@@ -23924,7 +23924,7 @@ pub mod recrawl_uris_response {
         }
     }
 
-    /// Defines additional types related to FailureInfo
+    /// Defines additional types related to [FailureInfo].
     pub mod failure_info {
         #[allow(unused_imports)]
         use super::*;
@@ -23972,7 +23972,7 @@ pub mod recrawl_uris_response {
             }
         }
 
-        /// Defines additional types related to FailureReason
+        /// Defines additional types related to [FailureReason].
         pub mod failure_reason {
             #[allow(unused_imports)]
             use super::*;
@@ -25361,7 +25361,7 @@ impl wkt::message::Message for DocumentInfo {
     }
 }
 
-/// Defines additional types related to DocumentInfo
+/// Defines additional types related to [DocumentInfo].
 pub mod document_info {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -382,7 +382,7 @@ impl wkt::message::Message for Document {
     }
 }
 
-/// Defines additional types related to Document
+/// Defines additional types related to [Document].
 pub mod document {
     #[allow(unused_imports)]
     use super::*;
@@ -572,7 +572,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to Style
+    /// Defines additional types related to [Style].
     pub mod style {
         #[allow(unused_imports)]
         use super::*;
@@ -909,7 +909,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to Page
+    /// Defines additional types related to [Page].
     pub mod page {
         #[allow(unused_imports)]
         use super::*;
@@ -1173,7 +1173,7 @@ pub mod document {
             }
         }
 
-        /// Defines additional types related to Layout
+        /// Defines additional types related to [Layout].
         pub mod layout {
             #[allow(unused_imports)]
             use super::*;
@@ -1563,7 +1563,7 @@ pub mod document {
             }
         }
 
-        /// Defines additional types related to Token
+        /// Defines additional types related to [Token].
         pub mod token {
             #[allow(unused_imports)]
             use super::*;
@@ -1605,7 +1605,7 @@ pub mod document {
                 }
             }
 
-            /// Defines additional types related to DetectedBreak
+            /// Defines additional types related to [DetectedBreak].
             pub mod detected_break {
                 #[allow(unused_imports)]
                 use super::*;
@@ -2073,7 +2073,7 @@ pub mod document {
             }
         }
 
-        /// Defines additional types related to Table
+        /// Defines additional types related to [Table].
         pub mod table {
             #[allow(unused_imports)]
             use super::*;
@@ -2483,7 +2483,7 @@ pub mod document {
             }
         }
 
-        /// Defines additional types related to ImageQualityScores
+        /// Defines additional types related to [ImageQualityScores].
         pub mod image_quality_scores {
             #[allow(unused_imports)]
             use super::*;
@@ -2713,7 +2713,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to Entity
+    /// Defines additional types related to [Entity].
     pub mod entity {
         #[allow(unused_imports)]
         use super::*;
@@ -2980,7 +2980,7 @@ pub mod document {
             }
         }
 
-        /// Defines additional types related to NormalizedValue
+        /// Defines additional types related to [NormalizedValue].
         pub mod normalized_value {
             #[allow(unused_imports)]
             use super::*;
@@ -3120,7 +3120,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to TextAnchor
+    /// Defines additional types related to [TextAnchor].
     pub mod text_anchor {
         #[allow(unused_imports)]
         use super::*;
@@ -3221,7 +3221,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to PageAnchor
+    /// Defines additional types related to [PageAnchor].
     pub mod page_anchor {
         #[allow(unused_imports)]
         use super::*;
@@ -3321,7 +3321,7 @@ pub mod document {
             }
         }
 
-        /// Defines additional types related to PageRef
+        /// Defines additional types related to [PageRef].
         pub mod page_ref {
             #[allow(unused_imports)]
             use super::*;
@@ -3508,7 +3508,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to Provenance
+    /// Defines additional types related to [Provenance].
     pub mod provenance {
         #[allow(unused_imports)]
         use super::*;
@@ -3808,7 +3808,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to Revision
+    /// Defines additional types related to [Revision].
     pub mod revision {
         #[allow(unused_imports)]
         use super::*;
@@ -3974,7 +3974,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to DocumentLayout
+    /// Defines additional types related to [DocumentLayout].
     pub mod document_layout {
         #[allow(unused_imports)]
         use super::*;
@@ -4131,7 +4131,7 @@ pub mod document {
             }
         }
 
-        /// Defines additional types related to DocumentLayoutBlock
+        /// Defines additional types related to [DocumentLayoutBlock].
         pub mod document_layout_block {
             #[allow(unused_imports)]
             use super::*;
@@ -4535,7 +4535,7 @@ pub mod document {
         }
     }
 
-    /// Defines additional types related to ChunkedDocument
+    /// Defines additional types related to [ChunkedDocument].
     pub mod chunked_document {
         #[allow(unused_imports)]
         use super::*;
@@ -4653,7 +4653,7 @@ pub mod document {
             }
         }
 
-        /// Defines additional types related to Chunk
+        /// Defines additional types related to [Chunk].
         pub mod chunk {
             #[allow(unused_imports)]
             use super::*;
@@ -5072,7 +5072,7 @@ impl wkt::message::Message for BatchDocumentsInputConfig {
     }
 }
 
-/// Defines additional types related to BatchDocumentsInputConfig
+/// Defines additional types related to [BatchDocumentsInputConfig].
 pub mod batch_documents_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5158,7 +5158,7 @@ impl wkt::message::Message for DocumentOutputConfig {
     }
 }
 
-/// Defines additional types related to DocumentOutputConfig
+/// Defines additional types related to [DocumentOutputConfig].
 pub mod document_output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5228,7 +5228,7 @@ pub mod document_output_config {
         }
     }
 
-    /// Defines additional types related to GcsOutputConfig
+    /// Defines additional types related to [GcsOutputConfig].
     pub mod gcs_output_config {
         #[allow(unused_imports)]
         use super::*;
@@ -5408,7 +5408,7 @@ impl wkt::message::Message for OcrConfig {
     }
 }
 
-/// Defines additional types related to OcrConfig
+/// Defines additional types related to [OcrConfig].
 pub mod ocr_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5675,7 +5675,7 @@ impl wkt::message::Message for ProcessOptions {
     }
 }
 
-/// Defines additional types related to ProcessOptions
+/// Defines additional types related to [ProcessOptions].
 pub mod process_options {
     #[allow(unused_imports)]
     use super::*;
@@ -5719,7 +5719,7 @@ pub mod process_options {
         }
     }
 
-    /// Defines additional types related to LayoutConfig
+    /// Defines additional types related to [LayoutConfig].
     pub mod layout_config {
         #[allow(unused_imports)]
         use super::*;
@@ -6044,7 +6044,7 @@ impl wkt::message::Message for ProcessRequest {
     }
 }
 
-/// Defines additional types related to ProcessRequest
+/// Defines additional types related to [ProcessRequest].
 pub mod process_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6125,7 +6125,7 @@ impl wkt::message::Message for HumanReviewStatus {
     }
 }
 
-/// Defines additional types related to HumanReviewStatus
+/// Defines additional types related to [HumanReviewStatus].
 pub mod human_review_status {
     #[allow(unused_imports)]
     use super::*;
@@ -6489,7 +6489,7 @@ impl wkt::message::Message for BatchProcessMetadata {
     }
 }
 
-/// Defines additional types related to BatchProcessMetadata
+/// Defines additional types related to [BatchProcessMetadata].
 pub mod batch_process_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -8059,7 +8059,7 @@ impl wkt::message::Message for TrainProcessorVersionRequest {
     }
 }
 
-/// Defines additional types related to TrainProcessorVersionRequest
+/// Defines additional types related to [TrainProcessorVersionRequest].
 pub mod train_processor_version_request {
     #[allow(unused_imports)]
     use super::*;
@@ -8146,7 +8146,7 @@ pub mod train_processor_version_request {
         }
     }
 
-    /// Defines additional types related to CustomDocumentExtractionOptions
+    /// Defines additional types related to [CustomDocumentExtractionOptions].
     pub mod custom_document_extraction_options {
         #[allow(unused_imports)]
         use super::*;
@@ -8377,7 +8377,7 @@ impl wkt::message::Message for TrainProcessorVersionMetadata {
     }
 }
 
-/// Defines additional types related to TrainProcessorVersionMetadata
+/// Defines additional types related to [TrainProcessorVersionMetadata].
 pub mod train_processor_version_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -8574,7 +8574,7 @@ impl wkt::message::Message for ReviewDocumentRequest {
     }
 }
 
-/// Defines additional types related to ReviewDocumentRequest
+/// Defines additional types related to [ReviewDocumentRequest].
 pub mod review_document_request {
     #[allow(unused_imports)]
     use super::*;
@@ -8701,7 +8701,7 @@ impl wkt::message::Message for ReviewDocumentResponse {
     }
 }
 
-/// Defines additional types related to ReviewDocumentResponse
+/// Defines additional types related to [ReviewDocumentResponse].
 pub mod review_document_response {
     #[allow(unused_imports)]
     use super::*;
@@ -9159,7 +9159,7 @@ impl wkt::message::Message for DocumentSchema {
     }
 }
 
-/// Defines additional types related to DocumentSchema
+/// Defines additional types related to [DocumentSchema].
 pub mod document_schema {
     #[allow(unused_imports)]
     use super::*;
@@ -9304,7 +9304,7 @@ pub mod document_schema {
         }
     }
 
-    /// Defines additional types related to EntityType
+    /// Defines additional types related to [EntityType].
     pub mod entity_type {
         #[allow(unused_imports)]
         use super::*;
@@ -9418,7 +9418,7 @@ pub mod document_schema {
             }
         }
 
-        /// Defines additional types related to Property
+        /// Defines additional types related to [Property].
         pub mod property {
             #[allow(unused_imports)]
             use super::*;
@@ -9768,7 +9768,7 @@ impl wkt::message::Message for Evaluation {
     }
 }
 
-/// Defines additional types related to Evaluation
+/// Defines additional types related to [Evaluation].
 pub mod evaluation {
     #[allow(unused_imports)]
     use super::*;
@@ -10102,7 +10102,7 @@ pub mod evaluation {
         }
     }
 
-    /// Defines additional types related to MultiConfidenceMetrics
+    /// Defines additional types related to [MultiConfidenceMetrics].
     pub mod multi_confidence_metrics {
         #[allow(unused_imports)]
         use super::*;
@@ -10372,7 +10372,7 @@ impl wkt::message::Message for CommonOperationMetadata {
     }
 }
 
-/// Defines additional types related to CommonOperationMetadata
+/// Defines additional types related to [CommonOperationMetadata].
 pub mod common_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -10642,7 +10642,7 @@ impl wkt::message::Message for ProcessorVersion {
     }
 }
 
-/// Defines additional types related to ProcessorVersion
+/// Defines additional types related to [ProcessorVersion].
 pub mod processor_version {
     #[allow(unused_imports)]
     use super::*;
@@ -10803,7 +10803,7 @@ pub mod processor_version {
         }
     }
 
-    /// Defines additional types related to GenAiModelInfo
+    /// Defines additional types related to [GenAiModelInfo].
     pub mod gen_ai_model_info {
         #[allow(unused_imports)]
         use super::*;
@@ -10893,7 +10893,7 @@ pub mod processor_version {
             }
         }
 
-        /// Defines additional types related to CustomGenAiModelInfo
+        /// Defines additional types related to [CustomGenAiModelInfo].
         pub mod custom_gen_ai_model_info {
             #[allow(unused_imports)]
             use super::*;
@@ -11320,7 +11320,7 @@ impl wkt::message::Message for Processor {
     }
 }
 
-/// Defines additional types related to Processor
+/// Defines additional types related to [Processor].
 pub mod processor {
     #[allow(unused_imports)]
     use super::*;
@@ -11520,7 +11520,7 @@ impl wkt::message::Message for ProcessorType {
     }
 }
 
-/// Defines additional types related to ProcessorType
+/// Defines additional types related to [ProcessorType].
 pub mod processor_type {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/domains/v1/src/model.rs
+++ b/src/generated/cloud/domains/v1/src/model.rs
@@ -246,7 +246,7 @@ impl wkt::message::Message for Registration {
     }
 }
 
-/// Defines additional types related to Registration
+/// Defines additional types related to [Registration].
 pub mod registration {
     #[allow(unused_imports)]
     use super::*;
@@ -452,7 +452,7 @@ impl wkt::message::Message for ManagementSettings {
     }
 }
 
-/// Defines additional types related to ManagementSettings
+/// Defines additional types related to [ManagementSettings].
 pub mod management_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -636,7 +636,7 @@ impl wkt::message::Message for DnsSettings {
     }
 }
 
-/// Defines additional types related to DnsSettings
+/// Defines additional types related to [DnsSettings].
 pub mod dns_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -832,7 +832,7 @@ pub mod dns_settings {
         }
     }
 
-    /// Defines additional types related to DsRecord
+    /// Defines additional types related to [DsRecord].
     pub mod ds_record {
         #[allow(unused_imports)]
         use super::*;
@@ -1272,7 +1272,7 @@ impl wkt::message::Message for ContactSettings {
     }
 }
 
-/// Defines additional types related to ContactSettings
+/// Defines additional types related to [ContactSettings].
 pub mod contact_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -2418,7 +2418,7 @@ impl wkt::message::Message for RegisterParameters {
     }
 }
 
-/// Defines additional types related to RegisterParameters
+/// Defines additional types related to [RegisterParameters].
 pub mod register_parameters {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -392,7 +392,7 @@ impl wkt::message::Message for Cluster {
     }
 }
 
-/// Defines additional types related to Cluster
+/// Defines additional types related to [Cluster].
 pub mod cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -496,7 +496,7 @@ pub mod cluster {
         }
     }
 
-    /// Defines additional types related to ControlPlane
+    /// Defines additional types related to [ControlPlane].
     pub mod control_plane {
         #[allow(unused_imports)]
         use super::*;
@@ -753,7 +753,7 @@ pub mod cluster {
         }
     }
 
-    /// Defines additional types related to SystemAddonsConfig
+    /// Defines additional types related to [SystemAddonsConfig].
     pub mod system_addons_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1070,7 +1070,7 @@ pub mod cluster {
         }
     }
 
-    /// Defines additional types related to MaintenanceEvent
+    /// Defines additional types related to [MaintenanceEvent].
     pub mod maintenance_event {
         #[allow(unused_imports)]
         use super::*;
@@ -1331,7 +1331,7 @@ pub mod cluster {
         }
     }
 
-    /// Defines additional types related to ConnectionState
+    /// Defines additional types related to [ConnectionState].
     pub mod connection_state {
         #[allow(unused_imports)]
         use super::*;
@@ -1849,7 +1849,7 @@ impl wkt::message::Message for NodePool {
     }
 }
 
-/// Defines additional types related to NodePool
+/// Defines additional types related to [NodePool].
 pub mod node_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -2284,7 +2284,7 @@ impl wkt::message::Message for VpnConnection {
     }
 }
 
-/// Defines additional types related to VpnConnection
+/// Defines additional types related to [VpnConnection].
 pub mod vpn_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -2405,7 +2405,7 @@ pub mod vpn_connection {
         }
     }
 
-    /// Defines additional types related to Details
+    /// Defines additional types related to [Details].
     pub mod details {
         #[allow(unused_imports)]
         use super::*;
@@ -2694,7 +2694,7 @@ impl wkt::message::Message for ZoneMetadata {
     }
 }
 
-/// Defines additional types related to ZoneMetadata
+/// Defines additional types related to [ZoneMetadata].
 pub mod zone_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -3320,7 +3320,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -3738,7 +3738,7 @@ impl wkt::message::Message for UpgradeClusterRequest {
     }
 }
 
-/// Defines additional types related to UpgradeClusterRequest
+/// Defines additional types related to [UpgradeClusterRequest].
 pub mod upgrade_cluster_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -366,7 +366,7 @@ impl wkt::message::Message for Subnet {
     }
 }
 
-/// Defines additional types related to Subnet
+/// Defines additional types related to [Subnet].
 pub mod subnet {
     #[allow(unused_imports)]
     use super::*;
@@ -571,7 +571,7 @@ impl wkt::message::Message for Interconnect {
     }
 }
 
-/// Defines additional types related to Interconnect
+/// Defines additional types related to [Interconnect].
 pub mod interconnect {
     #[allow(unused_imports)]
     use super::*;
@@ -927,7 +927,7 @@ impl wkt::message::Message for Router {
     }
 }
 
-/// Defines additional types related to Router
+/// Defines additional types related to [Router].
 pub mod router {
     #[allow(unused_imports)]
     use super::*;
@@ -1334,7 +1334,7 @@ impl wkt::message::Message for InterconnectDiagnostics {
     }
 }
 
-/// Defines additional types related to InterconnectDiagnostics
+/// Defines additional types related to [InterconnectDiagnostics].
 pub mod interconnect_diagnostics {
     #[allow(unused_imports)]
     use super::*;
@@ -1592,7 +1592,7 @@ pub mod interconnect_diagnostics {
         }
     }
 
-    /// Defines additional types related to LinkLACPStatus
+    /// Defines additional types related to [LinkLACPStatus].
     pub mod link_lacp_status {
         #[allow(unused_imports)]
         use super::*;
@@ -1802,7 +1802,7 @@ impl wkt::message::Message for RouterStatus {
     }
 }
 
-/// Defines additional types related to RouterStatus
+/// Defines additional types related to [RouterStatus].
 pub mod router_status {
     #[allow(unused_imports)]
     use super::*;
@@ -1920,7 +1920,7 @@ pub mod router_status {
         }
     }
 
-    /// Defines additional types related to BgpPeerStatus
+    /// Defines additional types related to [BgpPeerStatus].
     pub mod bgp_peer_status {
         #[allow(unused_imports)]
         use super::*;
@@ -3919,7 +3919,7 @@ impl wkt::message::Message for DiagnoseNetworkResponse {
     }
 }
 
-/// Defines additional types related to DiagnoseNetworkResponse
+/// Defines additional types related to [DiagnoseNetworkResponse].
 pub mod diagnose_network_response {
     #[allow(unused_imports)]
     use super::*;
@@ -3976,7 +3976,7 @@ pub mod diagnose_network_response {
         }
     }
 
-    /// Defines additional types related to NetworkStatus
+    /// Defines additional types related to [NetworkStatus].
     pub mod network_status {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -203,7 +203,7 @@ impl wkt::message::Message for Channel {
     }
 }
 
-/// Defines additional types related to Channel
+/// Defines additional types related to [Channel].
 pub mod channel {
     #[allow(unused_imports)]
     use super::*;
@@ -3898,7 +3898,7 @@ impl wkt::message::Message for LoggingConfig {
     }
 }
 
-/// Defines additional types related to LoggingConfig
+/// Defines additional types related to [LoggingConfig].
 pub mod logging_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4424,7 +4424,7 @@ impl wkt::message::Message for Pipeline {
     }
 }
 
-/// Defines additional types related to Pipeline
+/// Defines additional types related to [Pipeline].
 pub mod pipeline {
     #[allow(unused_imports)]
     use super::*;
@@ -4576,7 +4576,7 @@ pub mod pipeline {
         }
     }
 
-    /// Defines additional types related to MessagePayloadFormat
+    /// Defines additional types related to [MessagePayloadFormat].
     pub mod message_payload_format {
         #[allow(unused_imports)]
         use super::*;
@@ -4887,7 +4887,7 @@ pub mod pipeline {
         }
     }
 
-    /// Defines additional types related to Destination
+    /// Defines additional types related to [Destination].
     pub mod destination {
         #[allow(unused_imports)]
         use super::*;
@@ -5252,7 +5252,7 @@ pub mod pipeline {
             }
         }
 
-        /// Defines additional types related to AuthenticationConfig
+        /// Defines additional types related to [AuthenticationConfig].
         pub mod authentication_config {
             #[allow(unused_imports)]
             use super::*;
@@ -5495,7 +5495,7 @@ pub mod pipeline {
         }
     }
 
-    /// Defines additional types related to Mediation
+    /// Defines additional types related to [Mediation].
     pub mod mediation {
         #[allow(unused_imports)]
         use super::*;
@@ -6170,7 +6170,7 @@ impl wkt::message::Message for Destination {
     }
 }
 
-/// Defines additional types related to Destination
+/// Defines additional types related to [Destination].
 pub mod destination {
     #[allow(unused_imports)]
     use super::*;
@@ -6262,7 +6262,7 @@ impl wkt::message::Message for Transport {
     }
 }
 
-/// Defines additional types related to Transport
+/// Defines additional types related to [Transport].
 pub mod transport {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -142,7 +142,7 @@ impl wkt::message::Message for NetworkConfig {
     }
 }
 
-/// Defines additional types related to NetworkConfig
+/// Defines additional types related to [NetworkConfig].
 pub mod network_config {
     #[allow(unused_imports)]
     use super::*;
@@ -363,7 +363,7 @@ impl wkt::message::Message for FileShareConfig {
     }
 }
 
-/// Defines additional types related to FileShareConfig
+/// Defines additional types related to [FileShareConfig].
 pub mod file_share_config {
     #[allow(unused_imports)]
     use super::*;
@@ -476,7 +476,7 @@ impl wkt::message::Message for NfsExportOptions {
     }
 }
 
-/// Defines additional types related to NfsExportOptions
+/// Defines additional types related to [NfsExportOptions].
 pub mod nfs_export_options {
     #[allow(unused_imports)]
     use super::*;
@@ -671,7 +671,7 @@ impl wkt::message::Message for ReplicaConfig {
     }
 }
 
-/// Defines additional types related to ReplicaConfig
+/// Defines additional types related to [ReplicaConfig].
 pub mod replica_config {
     #[allow(unused_imports)]
     use super::*;
@@ -854,7 +854,7 @@ impl wkt::message::Message for Replication {
     }
 }
 
-/// Defines additional types related to Replication
+/// Defines additional types related to [Replication].
 pub mod replication {
     #[allow(unused_imports)]
     use super::*;
@@ -1225,7 +1225,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -1394,7 +1394,7 @@ pub mod instance {
         }
     }
 
-    /// Defines additional types related to PerformanceConfig
+    /// Defines additional types related to [PerformanceConfig].
     pub mod performance_config {
         #[allow(unused_imports)]
         use super::*;
@@ -2037,7 +2037,7 @@ impl wkt::message::Message for RestoreInstanceRequest {
     }
 }
 
-/// Defines additional types related to RestoreInstanceRequest
+/// Defines additional types related to [RestoreInstanceRequest].
 pub mod restore_instance_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2406,7 +2406,7 @@ impl wkt::message::Message for Snapshot {
     }
 }
 
-/// Defines additional types related to Snapshot
+/// Defines additional types related to [Snapshot].
 pub mod snapshot {
     #[allow(unused_imports)]
     use super::*;
@@ -3013,7 +3013,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/financialservices/v1/src/model.rs
+++ b/src/generated/cloud/financialservices/v1/src/model.rs
@@ -198,7 +198,7 @@ impl wkt::message::Message for BacktestResult {
     }
 }
 
-/// Defines additional types related to BacktestResult
+/// Defines additional types related to [BacktestResult].
 pub mod backtest_result {
     #[allow(unused_imports)]
     use super::*;
@@ -802,7 +802,7 @@ impl wkt::message::Message for BigQueryDestination {
     }
 }
 
-/// Defines additional types related to BigQueryDestination
+/// Defines additional types related to [BigQueryDestination].
 pub mod big_query_destination {
     #[allow(unused_imports)]
     use super::*;
@@ -1002,7 +1002,7 @@ impl wkt::message::Message for Dataset {
     }
 }
 
-/// Defines additional types related to Dataset
+/// Defines additional types related to [Dataset].
 pub mod dataset {
     #[allow(unused_imports)]
     use super::*;
@@ -1625,7 +1625,7 @@ impl wkt::message::Message for EngineConfig {
     }
 }
 
-/// Defines additional types related to EngineConfig
+/// Defines additional types related to [EngineConfig].
 pub mod engine_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2432,7 +2432,7 @@ impl wkt::message::Message for EngineVersion {
     }
 }
 
-/// Defines additional types related to EngineVersion
+/// Defines additional types related to [EngineVersion].
 pub mod engine_version {
     #[allow(unused_imports)]
     use super::*;
@@ -2782,7 +2782,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -3317,7 +3317,7 @@ impl wkt::message::Message for ImportRegisteredPartiesRequest {
     }
 }
 
-/// Defines additional types related to ImportRegisteredPartiesRequest
+/// Defines additional types related to [ImportRegisteredPartiesRequest].
 pub mod import_registered_parties_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3693,7 +3693,7 @@ impl wkt::message::Message for Model {
     }
 }
 
-/// Defines additional types related to Model
+/// Defines additional types related to [Model].
 pub mod model {
     #[allow(unused_imports)]
     use super::*;
@@ -4372,7 +4372,7 @@ impl wkt::message::Message for PredictionResult {
     }
 }
 
-/// Defines additional types related to PredictionResult
+/// Defines additional types related to [PredictionResult].
 pub mod prediction_result {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -236,7 +236,7 @@ impl wkt::message::Message for Function {
     }
 }
 
-/// Defines additional types related to Function
+/// Defines additional types related to [Function].
 pub mod function {
     #[allow(unused_imports)]
     use super::*;
@@ -367,7 +367,7 @@ impl wkt::message::Message for StateMessage {
     }
 }
 
-/// Defines additional types related to StateMessage
+/// Defines additional types related to [StateMessage].
 pub mod state_message {
     #[allow(unused_imports)]
     use super::*;
@@ -651,7 +651,7 @@ impl wkt::message::Message for RepoSource {
     }
 }
 
-/// Defines additional types related to RepoSource
+/// Defines additional types related to [RepoSource].
 pub mod repo_source {
     #[allow(unused_imports)]
     use super::*;
@@ -786,7 +786,7 @@ impl wkt::message::Message for Source {
     }
 }
 
-/// Defines additional types related to Source
+/// Defines additional types related to [Source].
 pub mod source {
     #[allow(unused_imports)]
     use super::*;
@@ -1131,7 +1131,7 @@ impl wkt::message::Message for BuildConfig {
     }
 }
 
-/// Defines additional types related to BuildConfig
+/// Defines additional types related to [BuildConfig].
 pub mod build_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1500,7 +1500,7 @@ impl wkt::message::Message for ServiceConfig {
     }
 }
 
-/// Defines additional types related to ServiceConfig
+/// Defines additional types related to [ServiceConfig].
 pub mod service_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1849,7 +1849,7 @@ impl wkt::message::Message for SecretVolume {
     }
 }
 
-/// Defines additional types related to SecretVolume
+/// Defines additional types related to [SecretVolume].
 pub mod secret_volume {
     #[allow(unused_imports)]
     use super::*;
@@ -2045,7 +2045,7 @@ impl wkt::message::Message for EventTrigger {
     }
 }
 
-/// Defines additional types related to EventTrigger
+/// Defines additional types related to [EventTrigger].
 pub mod event_trigger {
     #[allow(unused_imports)]
     use super::*;
@@ -2755,7 +2755,7 @@ impl wkt::message::Message for ListRuntimesResponse {
     }
 }
 
-/// Defines additional types related to ListRuntimesResponse
+/// Defines additional types related to [ListRuntimesResponse].
 pub mod list_runtimes_response {
     #[allow(unused_imports)]
     use super::*;
@@ -3283,7 +3283,7 @@ impl wkt::message::Message for Stage {
     }
 }
 
-/// Defines additional types related to Stage
+/// Defines additional types related to [Stage].
 pub mod stage {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -509,7 +509,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -652,7 +652,7 @@ pub mod backup {
         }
     }
 
-    /// Defines additional types related to ClusterMetadata
+    /// Defines additional types related to [ClusterMetadata].
     pub mod cluster_metadata {
         #[allow(unused_imports)]
         use super::*;
@@ -1011,7 +1011,7 @@ impl wkt::message::Message for BackupPlan {
     }
 }
 
-/// Defines additional types related to BackupPlan
+/// Defines additional types related to [BackupPlan].
 pub mod backup_plan {
     #[allow(unused_imports)]
     use super::*;
@@ -1382,7 +1382,7 @@ pub mod backup_plan {
         }
     }
 
-    /// Defines additional types related to BackupConfig
+    /// Defines additional types related to [BackupConfig].
     pub mod backup_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1697,7 +1697,7 @@ impl wkt::message::Message for ExclusionWindow {
     }
 }
 
-/// Defines additional types related to ExclusionWindow
+/// Defines additional types related to [ExclusionWindow].
 pub mod exclusion_window {
     #[allow(unused_imports)]
     use super::*;
@@ -1913,7 +1913,7 @@ impl wkt::message::Message for VolumeTypeEnum {
     }
 }
 
-/// Defines additional types related to VolumeTypeEnum
+/// Defines additional types related to [VolumeTypeEnum].
 pub mod volume_type_enum {
     #[allow(unused_imports)]
     use super::*;
@@ -4174,7 +4174,7 @@ impl wkt::message::Message for Restore {
     }
 }
 
-/// Defines additional types related to Restore
+/// Defines additional types related to [Restore].
 pub mod restore {
     #[allow(unused_imports)]
     use super::*;
@@ -4656,7 +4656,7 @@ impl wkt::message::Message for RestoreConfig {
     }
 }
 
-/// Defines additional types related to RestoreConfig
+/// Defines additional types related to [RestoreConfig].
 pub mod restore_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4986,7 +4986,7 @@ pub mod restore_config {
         }
     }
 
-    /// Defines additional types related to TransformationRuleAction
+    /// Defines additional types related to [TransformationRuleAction].
     pub mod transformation_rule_action {
         #[allow(unused_imports)]
         use super::*;
@@ -5309,7 +5309,7 @@ pub mod restore_config {
         }
     }
 
-    /// Defines additional types related to VolumeDataRestorePolicyBinding
+    /// Defines additional types related to [VolumeDataRestorePolicyBinding].
     pub mod volume_data_restore_policy_binding {
         #[allow(unused_imports)]
         use super::*;
@@ -5362,7 +5362,7 @@ pub mod restore_config {
         }
     }
 
-    /// Defines additional types related to RestoreOrder
+    /// Defines additional types related to [RestoreOrder].
     pub mod restore_order {
         #[allow(unused_imports)]
         use super::*;
@@ -5889,7 +5889,7 @@ impl wkt::message::Message for VolumeDataRestorePolicyOverride {
     }
 }
 
-/// Defines additional types related to VolumeDataRestorePolicyOverride
+/// Defines additional types related to [VolumeDataRestorePolicyOverride].
 pub mod volume_data_restore_policy_override {
     #[allow(unused_imports)]
     use super::*;
@@ -6086,7 +6086,7 @@ impl wkt::message::Message for RestorePlan {
     }
 }
 
-/// Defines additional types related to RestorePlan
+/// Defines additional types related to [RestorePlan].
 pub mod restore_plan {
     #[allow(unused_imports)]
     use super::*;
@@ -6348,7 +6348,7 @@ impl wkt::message::Message for VolumeBackup {
     }
 }
 
-/// Defines additional types related to VolumeBackup
+/// Defines additional types related to [VolumeBackup].
 pub mod volume_backup {
     #[allow(unused_imports)]
     use super::*;
@@ -6661,7 +6661,7 @@ impl wkt::message::Message for VolumeRestore {
     }
 }
 
-/// Defines additional types related to VolumeRestore
+/// Defines additional types related to [VolumeRestore].
 pub mod volume_restore {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
@@ -116,7 +116,7 @@ impl wkt::message::Message for GenerateCredentialsRequest {
     }
 }
 
-/// Defines additional types related to GenerateCredentialsRequest
+/// Defines additional types related to [GenerateCredentialsRequest].
 pub mod generate_credentials_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
@@ -231,7 +231,7 @@ impl wkt::message::Message for MembershipSpec {
     }
 }
 
-/// Defines additional types related to MembershipSpec
+/// Defines additional types related to [MembershipSpec].
 pub mod membership_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -1046,7 +1046,7 @@ impl wkt::message::Message for ConfigSyncState {
     }
 }
 
-/// Defines additional types related to ConfigSyncState
+/// Defines additional types related to [ConfigSyncState].
 pub mod config_sync_state {
     #[allow(unused_imports)]
     use super::*;
@@ -1517,7 +1517,7 @@ impl wkt::message::Message for SyncState {
     }
 }
 
-/// Defines additional types related to SyncState
+/// Defines additional types related to [SyncState].
 pub mod sync_state {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -259,7 +259,7 @@ impl wkt::message::Message for FeatureResourceState {
     }
 }
 
-/// Defines additional types related to FeatureResourceState
+/// Defines additional types related to [FeatureResourceState].
 pub mod feature_resource_state {
     #[allow(unused_imports)]
     use super::*;
@@ -396,7 +396,7 @@ impl wkt::message::Message for FeatureState {
     }
 }
 
-/// Defines additional types related to FeatureState
+/// Defines additional types related to [FeatureState].
 pub mod feature_state {
     #[allow(unused_imports)]
     use super::*;
@@ -536,7 +536,7 @@ impl wkt::message::Message for CommonFeatureSpec {
     }
 }
 
-/// Defines additional types related to CommonFeatureSpec
+/// Defines additional types related to [CommonFeatureSpec].
 pub mod common_feature_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -649,7 +649,7 @@ impl wkt::message::Message for MembershipFeatureSpec {
     }
 }
 
-/// Defines additional types related to MembershipFeatureSpec
+/// Defines additional types related to [MembershipFeatureSpec].
 pub mod membership_feature_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -745,7 +745,7 @@ impl wkt::message::Message for MembershipFeatureState {
     }
 }
 
-/// Defines additional types related to MembershipFeatureState
+/// Defines additional types related to [MembershipFeatureState].
 pub mod membership_feature_state {
     #[allow(unused_imports)]
     use super::*;
@@ -996,7 +996,7 @@ impl wkt::message::Message for Membership {
     }
 }
 
-/// Defines additional types related to Membership
+/// Defines additional types related to [Membership].
 pub mod membership {
     #[allow(unused_imports)]
     use super::*;
@@ -1540,7 +1540,7 @@ impl wkt::message::Message for MembershipState {
     }
 }
 
-/// Defines additional types related to MembershipState
+/// Defines additional types related to [MembershipState].
 pub mod membership_state {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -407,7 +407,7 @@ impl wkt::message::Message for AttachedCluster {
     }
 }
 
-/// Defines additional types related to AttachedCluster
+/// Defines additional types related to [AttachedCluster].
 pub mod attached_cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -2034,7 +2034,7 @@ impl wkt::message::Message for AwsCluster {
     }
 }
 
-/// Defines additional types related to AwsCluster
+/// Defines additional types related to [AwsCluster].
 pub mod aws_cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -2646,7 +2646,7 @@ impl wkt::message::Message for AwsVolumeTemplate {
     }
 }
 
-/// Defines additional types related to AwsVolumeTemplate
+/// Defines additional types related to [AwsVolumeTemplate].
 pub mod aws_volume_template {
     #[allow(unused_imports)]
     use super::*;
@@ -3061,7 +3061,7 @@ impl wkt::message::Message for AwsNodePool {
     }
 }
 
-/// Defines additional types related to AwsNodePool
+/// Defines additional types related to [AwsNodePool].
 pub mod aws_node_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -3991,7 +3991,7 @@ impl wkt::message::Message for AwsInstancePlacement {
     }
 }
 
-/// Defines additional types related to AwsInstancePlacement
+/// Defines additional types related to [AwsInstancePlacement].
 pub mod aws_instance_placement {
     #[allow(unused_imports)]
     use super::*;
@@ -5861,7 +5861,7 @@ impl wkt::message::Message for AzureCluster {
     }
 }
 
-/// Defines additional types related to AzureCluster
+/// Defines additional types related to [AzureCluster].
 pub mod azure_cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -7031,7 +7031,7 @@ impl wkt::message::Message for AzureNodePool {
     }
 }
 
-/// Defines additional types related to AzureNodePool
+/// Defines additional types related to [AzureNodePool].
 pub mod azure_node_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -9675,7 +9675,7 @@ impl wkt::message::Message for NodeTaint {
     }
 }
 
-/// Defines additional types related to NodeTaint
+/// Defines additional types related to [NodeTaint].
 pub mod node_taint {
     #[allow(unused_imports)]
     use super::*;
@@ -9991,7 +9991,7 @@ impl wkt::message::Message for LoggingComponentConfig {
     }
 }
 
-/// Defines additional types related to LoggingComponentConfig
+/// Defines additional types related to [LoggingComponentConfig].
 pub mod logging_component_config {
     #[allow(unused_imports)]
     use super::*;
@@ -10199,7 +10199,7 @@ impl wkt::message::Message for BinaryAuthorization {
     }
 }
 
-/// Defines additional types related to BinaryAuthorization
+/// Defines additional types related to [BinaryAuthorization].
 pub mod binary_authorization {
     #[allow(unused_imports)]
     use super::*;
@@ -10301,7 +10301,7 @@ impl wkt::message::Message for SecurityPostureConfig {
     }
 }
 
-/// Defines additional types related to SecurityPostureConfig
+/// Defines additional types related to [SecurityPostureConfig].
 pub mod security_posture_config {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/iap/v1/src/model.rs
+++ b/src/generated/cloud/iap/v1/src/model.rs
@@ -819,7 +819,7 @@ impl wkt::message::Message for ReauthSettings {
     }
 }
 
-/// Defines additional types related to ReauthSettings
+/// Defines additional types related to [ReauthSettings].
 pub mod reauth_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -1273,7 +1273,7 @@ impl wkt::message::Message for AttributePropagationSettings {
     }
 }
 
-/// Defines additional types related to AttributePropagationSettings
+/// Defines additional types related to [AttributePropagationSettings].
 pub mod attribute_propagation_settings {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/ids/v1/src/model.rs
+++ b/src/generated/cloud/ids/v1/src/model.rs
@@ -178,7 +178,7 @@ impl wkt::message::Message for Endpoint {
     }
 }
 
-/// Defines additional types related to Endpoint
+/// Defines additional types related to [Endpoint].
 pub mod endpoint {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -543,7 +543,7 @@ impl wkt::message::Message for AutokeyConfig {
     }
 }
 
-/// Defines additional types related to AutokeyConfig
+/// Defines additional types related to [AutokeyConfig].
 pub mod autokey_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1377,7 +1377,7 @@ impl wkt::message::Message for EkmConnection {
     }
 }
 
-/// Defines additional types related to EkmConnection
+/// Defines additional types related to [EkmConnection].
 pub mod ekm_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -2048,7 +2048,7 @@ impl wkt::message::Message for CryptoKey {
     }
 }
 
-/// Defines additional types related to CryptoKey
+/// Defines additional types related to [CryptoKey].
 pub mod crypto_key {
     #[allow(unused_imports)]
     use super::*;
@@ -2334,7 +2334,7 @@ impl wkt::message::Message for KeyOperationAttestation {
     }
 }
 
-/// Defines additional types related to KeyOperationAttestation
+/// Defines additional types related to [KeyOperationAttestation].
 pub mod key_operation_attestation {
     #[allow(unused_imports)]
     use super::*;
@@ -2791,7 +2791,7 @@ impl wkt::message::Message for CryptoKeyVersion {
     }
 }
 
-/// Defines additional types related to CryptoKeyVersion
+/// Defines additional types related to [CryptoKeyVersion].
 pub mod crypto_key_version {
     #[allow(unused_imports)]
     use super::*;
@@ -3616,7 +3616,7 @@ impl wkt::message::Message for PublicKey {
     }
 }
 
-/// Defines additional types related to PublicKey
+/// Defines additional types related to [PublicKey].
 pub mod public_key {
     #[allow(unused_imports)]
     use super::*;
@@ -3938,7 +3938,7 @@ impl wkt::message::Message for ImportJob {
     }
 }
 
-/// Defines additional types related to ImportJob
+/// Defines additional types related to [ImportJob].
 pub mod import_job {
     #[allow(unused_imports)]
     use super::*;
@@ -5620,7 +5620,7 @@ impl wkt::message::Message for ImportCryptoKeyVersionRequest {
     }
 }
 
-/// Defines additional types related to ImportCryptoKeyVersionRequest
+/// Defines additional types related to [ImportCryptoKeyVersionRequest].
 pub mod import_crypto_key_version_request {
     #[allow(unused_imports)]
     use super::*;
@@ -8488,7 +8488,7 @@ impl wkt::message::Message for Digest {
     }
 }
 
-/// Defines additional types related to Digest
+/// Defines additional types related to [Digest].
 pub mod digest {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -136,7 +136,7 @@ impl wkt::message::Message for Document {
     }
 }
 
-/// Defines additional types related to Document
+/// Defines additional types related to [Document].
 pub mod document {
     #[allow(unused_imports)]
     use super::*;
@@ -356,7 +356,7 @@ impl wkt::message::Message for Entity {
     }
 }
 
-/// Defines additional types related to Entity
+/// Defines additional types related to [Entity].
 pub mod entity {
     #[allow(unused_imports)]
     use super::*;
@@ -620,7 +620,7 @@ impl wkt::message::Message for EntityMention {
     }
 }
 
-/// Defines additional types related to EntityMention
+/// Defines additional types related to [EntityMention].
 pub mod entity_mention {
     #[allow(unused_imports)]
     use super::*;
@@ -1128,7 +1128,7 @@ impl wkt::message::Message for ModerateTextRequest {
     }
 }
 
-/// Defines additional types related to ModerateTextRequest
+/// Defines additional types related to [ModerateTextRequest].
 pub mod moderate_text_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1314,7 +1314,7 @@ impl wkt::message::Message for AnnotateTextRequest {
     }
 }
 
-/// Defines additional types related to AnnotateTextRequest
+/// Defines additional types related to [AnnotateTextRequest].
 pub mod annotate_text_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/managedidentities/v1/src/model.rs
+++ b/src/generated/cloud/managedidentities/v1/src/model.rs
@@ -898,7 +898,7 @@ impl wkt::message::Message for Domain {
     }
 }
 
-/// Defines additional types related to Domain
+/// Defines additional types related to [Domain].
 pub mod domain {
     #[allow(unused_imports)]
     use super::*;
@@ -1150,7 +1150,7 @@ impl wkt::message::Message for Trust {
     }
 }
 
-/// Defines additional types related to Trust
+/// Defines additional types related to [Trust].
 pub mod trust {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/memcache/v1/src/model.rs
+++ b/src/generated/cloud/memcache/v1/src/model.rs
@@ -320,7 +320,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -448,7 +448,7 @@ pub mod instance {
         }
     }
 
-    /// Defines additional types related to Node
+    /// Defines additional types related to [Node].
     pub mod node {
         #[allow(unused_imports)]
         use super::*;
@@ -561,7 +561,7 @@ pub mod instance {
         }
     }
 
-    /// Defines additional types related to InstanceMessage
+    /// Defines additional types related to [InstanceMessage].
     pub mod instance_message {
         #[allow(unused_imports)]
         use super::*;
@@ -944,7 +944,7 @@ impl wkt::message::Message for RescheduleMaintenanceRequest {
     }
 }
 
-/// Defines additional types related to RescheduleMaintenanceRequest
+/// Defines additional types related to [RescheduleMaintenanceRequest].
 pub mod reschedule_maintenance_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -341,7 +341,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -412,7 +412,7 @@ pub mod instance {
         }
     }
 
-    /// Defines additional types related to StateInfo
+    /// Defines additional types related to [StateInfo].
     pub mod state_info {
         #[allow(unused_imports)]
         use super::*;
@@ -610,7 +610,7 @@ pub mod instance {
         }
     }
 
-    /// Defines additional types related to ConnectionDetail
+    /// Defines additional types related to [ConnectionDetail].
     pub mod connection_detail {
         #[allow(unused_imports)]
         use super::*;
@@ -1108,7 +1108,7 @@ impl wkt::message::Message for PscAutoConnection {
     }
 }
 
-/// Defines additional types related to PscAutoConnection
+/// Defines additional types related to [PscAutoConnection].
 pub mod psc_auto_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -1355,7 +1355,7 @@ impl wkt::message::Message for PersistenceConfig {
     }
 }
 
-/// Defines additional types related to PersistenceConfig
+/// Defines additional types related to [PersistenceConfig].
 pub mod persistence_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1410,7 +1410,7 @@ pub mod persistence_config {
         }
     }
 
-    /// Defines additional types related to RDBConfig
+    /// Defines additional types related to [RDBConfig].
     pub mod rdb_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1518,7 +1518,7 @@ pub mod persistence_config {
         }
     }
 
-    /// Defines additional types related to AOFConfig
+    /// Defines additional types related to [AOFConfig].
     pub mod aof_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1728,7 +1728,7 @@ impl wkt::message::Message for ZoneDistributionConfig {
     }
 }
 
-/// Defines additional types related to ZoneDistributionConfig
+/// Defines additional types related to [ZoneDistributionConfig].
 pub mod zone_distribution_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2288,7 +2288,7 @@ impl wkt::message::Message for CertificateAuthority {
     }
 }
 
-/// Defines additional types related to CertificateAuthority
+/// Defines additional types related to [CertificateAuthority].
 pub mod certificate_authority {
     #[allow(unused_imports)]
     use super::*;
@@ -2331,7 +2331,7 @@ pub mod certificate_authority {
         }
     }
 
-    /// Defines additional types related to ManagedCertificateAuthority
+    /// Defines additional types related to [ManagedCertificateAuthority].
     pub mod managed_certificate_authority {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -364,7 +364,7 @@ impl wkt::message::Message for Service {
     }
 }
 
-/// Defines additional types related to Service
+/// Defines additional types related to [Service].
 pub mod service {
     #[allow(unused_imports)]
     use super::*;
@@ -798,7 +798,7 @@ impl wkt::message::Message for HiveMetastoreConfig {
     }
 }
 
-/// Defines additional types related to HiveMetastoreConfig
+/// Defines additional types related to [HiveMetastoreConfig].
 pub mod hive_metastore_config {
     #[allow(unused_imports)]
     use super::*;
@@ -975,7 +975,7 @@ impl wkt::message::Message for Secret {
     }
 }
 
-/// Defines additional types related to Secret
+/// Defines additional types related to [Secret].
 pub mod secret {
     #[allow(unused_imports)]
     use super::*;
@@ -1127,7 +1127,7 @@ impl wkt::message::Message for NetworkConfig {
     }
 }
 
-/// Defines additional types related to NetworkConfig
+/// Defines additional types related to [NetworkConfig].
 pub mod network_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1222,7 +1222,7 @@ pub mod network_config {
         }
     }
 
-    /// Defines additional types related to Consumer
+    /// Defines additional types related to [Consumer].
     pub mod consumer {
         #[allow(unused_imports)]
         use super::*;
@@ -1275,7 +1275,7 @@ impl wkt::message::Message for TelemetryConfig {
     }
 }
 
-/// Defines additional types related to TelemetryConfig
+/// Defines additional types related to [TelemetryConfig].
 pub mod telemetry_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1525,7 +1525,7 @@ impl wkt::message::Message for MetadataImport {
     }
 }
 
-/// Defines additional types related to MetadataImport
+/// Defines additional types related to [MetadataImport].
 pub mod metadata_import {
     #[allow(unused_imports)]
     use super::*;
@@ -1602,7 +1602,7 @@ pub mod metadata_import {
         }
     }
 
-    /// Defines additional types related to DatabaseDump
+    /// Defines additional types related to [DatabaseDump].
     pub mod database_dump {
         #[allow(unused_imports)]
         use super::*;
@@ -1851,7 +1851,7 @@ impl wkt::message::Message for MetadataExport {
     }
 }
 
-/// Defines additional types related to MetadataExport
+/// Defines additional types related to [MetadataExport].
 pub mod metadata_export {
     #[allow(unused_imports)]
     use super::*;
@@ -2041,7 +2041,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -2210,7 +2210,7 @@ impl wkt::message::Message for Restore {
     }
 }
 
-/// Defines additional types related to Restore
+/// Defines additional types related to [Restore].
 pub mod restore {
     #[allow(unused_imports)]
     use super::*;
@@ -2432,7 +2432,7 @@ impl wkt::message::Message for ScalingConfig {
     }
 }
 
-/// Defines additional types related to ScalingConfig
+/// Defines additional types related to [ScalingConfig].
 pub mod scaling_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3764,7 +3764,7 @@ impl wkt::message::Message for ExportMetadataRequest {
     }
 }
 
-/// Defines additional types related to ExportMetadataRequest
+/// Defines additional types related to [ExportMetadataRequest].
 pub mod export_metadata_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3996,7 +3996,7 @@ impl wkt::message::Message for LocationMetadata {
     }
 }
 
-/// Defines additional types related to LocationMetadata
+/// Defines additional types related to [LocationMetadata].
 pub mod location_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -4060,7 +4060,7 @@ impl wkt::message::Message for DatabaseDumpSpec {
     }
 }
 
-/// Defines additional types related to DatabaseDumpSpec
+/// Defines additional types related to [DatabaseDumpSpec].
 pub mod database_dump_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -4570,7 +4570,7 @@ impl wkt::message::Message for Federation {
     }
 }
 
-/// Defines additional types related to Federation
+/// Defines additional types related to [Federation].
 pub mod federation {
     #[allow(unused_imports)]
     use super::*;
@@ -4700,7 +4700,7 @@ impl wkt::message::Message for BackendMetastore {
     }
 }
 
-/// Defines additional types related to BackendMetastore
+/// Defines additional types related to [BackendMetastore].
 pub mod backend_metastore {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -227,7 +227,7 @@ impl wkt::message::Message for Asset {
     }
 }
 
-/// Defines additional types related to Asset
+/// Defines additional types related to [Asset].
 pub mod asset {
     #[allow(unused_imports)]
     use super::*;
@@ -523,7 +523,7 @@ impl wkt::message::Message for ImportJob {
     }
 }
 
-/// Defines additional types related to ImportJob
+/// Defines additional types related to [ImportJob].
 pub mod import_job {
     #[allow(unused_imports)]
     use super::*;
@@ -758,7 +758,7 @@ impl wkt::message::Message for ImportDataFile {
     }
 }
 
-/// Defines additional types related to ImportDataFile
+/// Defines additional types related to [ImportDataFile].
 pub mod import_data_file {
     #[allow(unused_imports)]
     use super::*;
@@ -1131,7 +1131,7 @@ impl wkt::message::Message for Source {
     }
 }
 
-/// Defines additional types related to Source
+/// Defines additional types related to [Source].
 pub mod source {
     #[allow(unused_imports)]
     use super::*;
@@ -1362,7 +1362,7 @@ impl wkt::message::Message for ReportConfig {
     }
 }
 
-/// Defines additional types related to ReportConfig
+/// Defines additional types related to [ReportConfig].
 pub mod report_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1517,7 +1517,7 @@ impl wkt::message::Message for Report {
     }
 }
 
-/// Defines additional types related to Report
+/// Defines additional types related to [Report].
 pub mod report {
     #[allow(unused_imports)]
     use super::*;
@@ -5499,7 +5499,7 @@ impl wkt::message::Message for AssetFrame {
     }
 }
 
-/// Defines additional types related to AssetFrame
+/// Defines additional types related to [AssetFrame].
 pub mod asset_frame {
     #[allow(unused_imports)]
     use super::*;
@@ -5672,7 +5672,7 @@ impl wkt::message::Message for MachineDetails {
     }
 }
 
-/// Defines additional types related to MachineDetails
+/// Defines additional types related to [MachineDetails].
 pub mod machine_details {
     #[allow(unused_imports)]
     use super::*;
@@ -5870,7 +5870,7 @@ impl wkt::message::Message for MachineArchitectureDetails {
     }
 }
 
-/// Defines additional types related to MachineArchitectureDetails
+/// Defines additional types related to [MachineArchitectureDetails].
 pub mod machine_architecture_details {
     #[allow(unused_imports)]
     use super::*;
@@ -6346,7 +6346,7 @@ impl wkt::message::Message for NetworkAddress {
     }
 }
 
-/// Defines additional types related to NetworkAddress
+/// Defines additional types related to [NetworkAddress].
 pub mod network_address {
     #[allow(unused_imports)]
     use super::*;
@@ -6639,7 +6639,7 @@ impl wkt::message::Message for DiskEntry {
     }
 }
 
-/// Defines additional types related to DiskEntry
+/// Defines additional types related to [DiskEntry].
 pub mod disk_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -6935,7 +6935,7 @@ impl wkt::message::Message for VmwareDiskConfig {
     }
 }
 
-/// Defines additional types related to VmwareDiskConfig
+/// Defines additional types related to [VmwareDiskConfig].
 pub mod vmware_disk_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7322,7 +7322,7 @@ impl wkt::message::Message for GuestConfigDetails {
     }
 }
 
-/// Defines additional types related to GuestConfigDetails
+/// Defines additional types related to [GuestConfigDetails].
 pub mod guest_config_details {
     #[allow(unused_imports)]
     use super::*;
@@ -7911,7 +7911,7 @@ impl wkt::message::Message for RunningService {
     }
 }
 
-/// Defines additional types related to RunningService
+/// Defines additional types related to [RunningService].
 pub mod running_service {
     #[allow(unused_imports)]
     use super::*;
@@ -8345,7 +8345,7 @@ impl wkt::message::Message for NetworkConnection {
     }
 }
 
-/// Defines additional types related to NetworkConnection
+/// Defines additional types related to [NetworkConnection].
 pub mod network_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -8818,7 +8818,7 @@ impl wkt::message::Message for PlatformDetails {
     }
 }
 
-/// Defines additional types related to PlatformDetails
+/// Defines additional types related to [PlatformDetails].
 pub mod platform_details {
     #[allow(unused_imports)]
     use super::*;
@@ -9429,7 +9429,7 @@ impl wkt::message::Message for DailyResourceUsageAggregation {
     }
 }
 
-/// Defines additional types related to DailyResourceUsageAggregation
+/// Defines additional types related to [DailyResourceUsageAggregation].
 pub mod daily_resource_usage_aggregation {
     #[allow(unused_imports)]
     use super::*;
@@ -9791,7 +9791,7 @@ impl wkt::message::Message for Insight {
     }
 }
 
-/// Defines additional types related to Insight
+/// Defines additional types related to [Insight].
 pub mod insight {
     #[allow(unused_imports)]
     use super::*;
@@ -9946,7 +9946,7 @@ impl wkt::message::Message for MigrationInsight {
     }
 }
 
-/// Defines additional types related to MigrationInsight
+/// Defines additional types related to [MigrationInsight].
 pub mod migration_insight {
     #[allow(unused_imports)]
     use super::*;
@@ -10148,7 +10148,7 @@ impl wkt::message::Message for FitDescriptor {
     }
 }
 
-/// Defines additional types related to FitDescriptor
+/// Defines additional types related to [FitDescriptor].
 pub mod fit_descriptor {
     #[allow(unused_imports)]
     use super::*;
@@ -10380,7 +10380,7 @@ impl wkt::message::Message for Aggregation {
     }
 }
 
-/// Defines additional types related to Aggregation
+/// Defines additional types related to [Aggregation].
 pub mod aggregation {
     #[allow(unused_imports)]
     use super::*;
@@ -10659,7 +10659,7 @@ impl wkt::message::Message for AggregationResult {
     }
 }
 
-/// Defines additional types related to AggregationResult
+/// Defines additional types related to [AggregationResult].
 pub mod aggregation_result {
     #[allow(unused_imports)]
     use super::*;
@@ -10757,7 +10757,7 @@ pub mod aggregation_result {
         }
     }
 
-    /// Defines additional types related to Histogram
+    /// Defines additional types related to [Histogram].
     pub mod histogram {
         #[allow(unused_imports)]
         use super::*;
@@ -11071,7 +11071,7 @@ impl wkt::message::Message for ImportError {
     }
 }
 
-/// Defines additional types related to ImportError
+/// Defines additional types related to [ImportError].
 pub mod import_error {
     #[allow(unused_imports)]
     use super::*;
@@ -11656,7 +11656,7 @@ impl wkt::message::Message for VmwareEnginePreferences {
     }
 }
 
-/// Defines additional types related to VmwareEnginePreferences
+/// Defines additional types related to [VmwareEnginePreferences].
 pub mod vmware_engine_preferences {
     #[allow(unused_imports)]
     use super::*;
@@ -11820,7 +11820,7 @@ impl wkt::message::Message for SoleTenancyPreferences {
     }
 }
 
-/// Defines additional types related to SoleTenancyPreferences
+/// Defines additional types related to [SoleTenancyPreferences].
 pub mod sole_tenancy_preferences {
     #[allow(unused_imports)]
     use super::*;
@@ -12123,7 +12123,7 @@ impl wkt::message::Message for ReportSummary {
     }
 }
 
-/// Defines additional types related to ReportSummary
+/// Defines additional types related to [ReportSummary].
 pub mod report_summary {
     #[allow(unused_imports)]
     use super::*;
@@ -12164,7 +12164,7 @@ pub mod report_summary {
         }
     }
 
-    /// Defines additional types related to ChartData
+    /// Defines additional types related to [ChartData].
     pub mod chart_data {
         #[allow(unused_imports)]
         use super::*;
@@ -12287,7 +12287,7 @@ pub mod report_summary {
         }
     }
 
-    /// Defines additional types related to HistogramChartData
+    /// Defines additional types related to [HistogramChartData].
     pub mod histogram_chart_data {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -132,7 +132,7 @@ impl wkt::message::Message for Template {
     }
 }
 
-/// Defines additional types related to Template
+/// Defines additional types related to [Template].
 pub mod template {
     #[allow(unused_imports)]
     use super::*;
@@ -914,7 +914,7 @@ impl wkt::message::Message for PiAndJailbreakFilterSettings {
     }
 }
 
-/// Defines additional types related to PiAndJailbreakFilterSettings
+/// Defines additional types related to [PiAndJailbreakFilterSettings].
 pub mod pi_and_jailbreak_filter_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -1019,7 +1019,7 @@ impl wkt::message::Message for MaliciousUriFilterSettings {
     }
 }
 
-/// Defines additional types related to MaliciousUriFilterSettings
+/// Defines additional types related to [MaliciousUriFilterSettings].
 pub mod malicious_uri_filter_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -1119,7 +1119,7 @@ impl wkt::message::Message for RaiFilterSettings {
     }
 }
 
-/// Defines additional types related to RaiFilterSettings
+/// Defines additional types related to [RaiFilterSettings].
 pub mod rai_filter_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -1274,7 +1274,7 @@ impl wkt::message::Message for SdpFilterSettings {
     }
 }
 
-/// Defines additional types related to SdpFilterSettings
+/// Defines additional types related to [SdpFilterSettings].
 pub mod sdp_filter_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -1331,7 +1331,7 @@ impl wkt::message::Message for SdpBasicConfig {
     }
 }
 
-/// Defines additional types related to SdpBasicConfig
+/// Defines additional types related to [SdpBasicConfig].
 pub mod sdp_basic_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1718,7 +1718,7 @@ impl wkt::message::Message for SanitizationResult {
     }
 }
 
-/// Defines additional types related to SanitizationResult
+/// Defines additional types related to [SanitizationResult].
 pub mod sanitization_result {
     #[allow(unused_imports)]
     use super::*;
@@ -1994,7 +1994,7 @@ impl wkt::message::Message for FilterResult {
     }
 }
 
-/// Defines additional types related to FilterResult
+/// Defines additional types related to [FilterResult].
 pub mod filter_result {
     #[allow(unused_imports)]
     use super::*;
@@ -2105,7 +2105,7 @@ impl wkt::message::Message for RaiFilterResult {
     }
 }
 
-/// Defines additional types related to RaiFilterResult
+/// Defines additional types related to [RaiFilterResult].
 pub mod rai_filter_result {
     #[allow(unused_imports)]
     use super::*;
@@ -2266,7 +2266,7 @@ impl wkt::message::Message for SdpFilterResult {
     }
 }
 
-/// Defines additional types related to SdpFilterResult
+/// Defines additional types related to [SdpFilterResult].
 pub mod sdp_filter_result {
     #[allow(unused_imports)]
     use super::*;
@@ -2459,7 +2459,7 @@ impl wkt::message::Message for DataItem {
     }
 }
 
-/// Defines additional types related to DataItem
+/// Defines additional types related to [DataItem].
 pub mod data_item {
     #[allow(unused_imports)]
     use super::*;
@@ -2518,7 +2518,7 @@ impl wkt::message::Message for ByteDataItem {
     }
 }
 
-/// Defines additional types related to ByteDataItem
+/// Defines additional types related to [ByteDataItem].
 pub mod byte_data_item {
     #[allow(unused_imports)]
     use super::*;
@@ -2740,7 +2740,7 @@ impl wkt::message::Message for SdpFinding {
     }
 }
 
-/// Defines additional types related to SdpFinding
+/// Defines additional types related to [SdpFinding].
 pub mod sdp_finding {
     #[allow(unused_imports)]
     use super::*;
@@ -2953,7 +2953,7 @@ impl wkt::message::Message for MaliciousUriFilterResult {
     }
 }
 
-/// Defines additional types related to MaliciousUriFilterResult
+/// Defines additional types related to [MaliciousUriFilterResult].
 pub mod malicious_uri_filter_result {
     #[allow(unused_imports)]
     use super::*;
@@ -3112,7 +3112,7 @@ impl wkt::message::Message for VirusScanFilterResult {
     }
 }
 
-/// Defines additional types related to VirusScanFilterResult
+/// Defines additional types related to [VirusScanFilterResult].
 pub mod virus_scan_filter_result {
     #[allow(unused_imports)]
     use super::*;
@@ -3239,7 +3239,7 @@ impl wkt::message::Message for VirusDetail {
     }
 }
 
-/// Defines additional types related to VirusDetail
+/// Defines additional types related to [VirusDetail].
 pub mod virus_detail {
     #[allow(unused_imports)]
     use super::*;
@@ -3426,7 +3426,7 @@ impl wkt::message::Message for MessageItem {
     }
 }
 
-/// Defines additional types related to MessageItem
+/// Defines additional types related to [MessageItem].
 pub mod message_item {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -616,7 +616,7 @@ impl wkt::message::Message for ActiveDirectory {
     }
 }
 
-/// Defines additional types related to ActiveDirectory
+/// Defines additional types related to [ActiveDirectory].
 pub mod active_directory {
     #[allow(unused_imports)]
     use super::*;
@@ -866,7 +866,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -1483,7 +1483,7 @@ impl wkt::message::Message for BackupPolicy {
     }
 }
 
-/// Defines additional types related to BackupPolicy
+/// Defines additional types related to [BackupPolicy].
 pub mod backup_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -1956,7 +1956,7 @@ impl wkt::message::Message for BackupVault {
     }
 }
 
-/// Defines additional types related to BackupVault
+/// Defines additional types related to [BackupVault].
 pub mod backup_vault {
     #[allow(unused_imports)]
     use super::*;
@@ -3035,7 +3035,7 @@ impl wkt::message::Message for KmsConfig {
     }
 }
 
-/// Defines additional types related to KmsConfig
+/// Defines additional types related to [KmsConfig].
 pub mod kms_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3571,7 +3571,7 @@ impl wkt::message::Message for QuotaRule {
     }
 }
 
-/// Defines additional types related to QuotaRule
+/// Defines additional types related to [QuotaRule].
 pub mod quota_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -4097,7 +4097,7 @@ impl wkt::message::Message for Replication {
     }
 }
 
-/// Defines additional types related to Replication
+/// Defines additional types related to [Replication].
 pub mod replication {
     #[allow(unused_imports)]
     use super::*;
@@ -5576,7 +5576,7 @@ impl wkt::message::Message for Snapshot {
     }
 }
 
-/// Defines additional types related to Snapshot
+/// Defines additional types related to [Snapshot].
 pub mod snapshot {
     #[allow(unused_imports)]
     use super::*;
@@ -6260,7 +6260,7 @@ impl wkt::message::Message for StoragePool {
     }
 }
 
-/// Defines additional types related to StoragePool
+/// Defines additional types related to [StoragePool].
 pub mod storage_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -7221,7 +7221,7 @@ impl wkt::message::Message for Volume {
     }
 }
 
-/// Defines additional types related to Volume
+/// Defines additional types related to [Volume].
 pub mod volume {
     #[allow(unused_imports)]
     use super::*;
@@ -8003,7 +8003,7 @@ impl wkt::message::Message for RestoreParameters {
     }
 }
 
-/// Defines additional types related to RestoreParameters
+/// Defines additional types related to [RestoreParameters].
 pub mod restore_parameters {
     #[allow(unused_imports)]
     use super::*;
@@ -8149,7 +8149,7 @@ impl wkt::message::Message for TieringPolicy {
     }
 }
 
-/// Defines additional types related to TieringPolicy
+/// Defines additional types related to [TieringPolicy].
 pub mod tiering_policy {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -631,7 +631,7 @@ impl wkt::message::Message for Spoke {
     }
 }
 
-/// Defines additional types related to Spoke
+/// Defines additional types related to [Spoke].
 pub mod spoke {
     #[allow(unused_imports)]
     use super::*;
@@ -690,7 +690,7 @@ pub mod spoke {
         }
     }
 
-    /// Defines additional types related to StateReason
+    /// Defines additional types related to [StateReason].
     pub mod state_reason {
         #[allow(unused_imports)]
         use super::*;
@@ -1772,7 +1772,7 @@ impl wkt::message::Message for ListHubSpokesRequest {
     }
 }
 
-/// Defines additional types related to ListHubSpokesRequest
+/// Defines additional types related to [ListHubSpokesRequest].
 pub mod list_hub_spokes_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2241,7 +2241,7 @@ impl wkt::message::Message for PscPropagationStatus {
     }
 }
 
-/// Defines additional types related to PscPropagationStatus
+/// Defines additional types related to [PscPropagationStatus].
 pub mod psc_propagation_status {
     #[allow(unused_imports)]
     use super::*;
@@ -4184,7 +4184,7 @@ impl wkt::message::Message for SpokeSummary {
     }
 }
 
-/// Defines additional types related to SpokeSummary
+/// Defines additional types related to [SpokeSummary].
 pub mod spoke_summary {
     #[allow(unused_imports)]
     use super::*;
@@ -4746,7 +4746,7 @@ impl wkt::message::Message for PolicyBasedRoute {
     }
 }
 
-/// Defines additional types related to PolicyBasedRoute
+/// Defines additional types related to [PolicyBasedRoute].
 pub mod policy_based_route {
     #[allow(unused_imports)]
     use super::*;
@@ -4885,7 +4885,7 @@ pub mod policy_based_route {
         }
     }
 
-    /// Defines additional types related to Filter
+    /// Defines additional types related to [Filter].
     pub mod filter {
         #[allow(unused_imports)]
         use super::*;
@@ -5010,7 +5010,7 @@ pub mod policy_based_route {
         }
     }
 
-    /// Defines additional types related to Warnings
+    /// Defines additional types related to [Warnings].
     pub mod warnings {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -530,7 +530,7 @@ impl wkt::message::Message for Endpoint {
     }
 }
 
-/// Defines additional types related to Endpoint
+/// Defines additional types related to [Endpoint].
 pub mod endpoint {
     #[allow(unused_imports)]
     use super::*;
@@ -837,7 +837,7 @@ impl wkt::message::Message for ReachabilityDetails {
     }
 }
 
-/// Defines additional types related to ReachabilityDetails
+/// Defines additional types related to [ReachabilityDetails].
 pub mod reachability_details {
     #[allow(unused_imports)]
     use super::*;
@@ -1144,7 +1144,7 @@ impl wkt::message::Message for ProbingDetails {
     }
 }
 
-/// Defines additional types related to ProbingDetails
+/// Defines additional types related to [ProbingDetails].
 pub mod probing_details {
     #[allow(unused_imports)]
     use super::*;
@@ -2671,7 +2671,7 @@ impl wkt::message::Message for Step {
     }
 }
 
-/// Defines additional types related to Step
+/// Defines additional types related to [Step].
 pub mod step {
     #[allow(unused_imports)]
     use super::*;
@@ -3362,7 +3362,7 @@ impl wkt::message::Message for FirewallInfo {
     }
 }
 
-/// Defines additional types related to FirewallInfo
+/// Defines additional types related to [FirewallInfo].
 pub mod firewall_info {
     #[allow(unused_imports)]
     use super::*;
@@ -3744,7 +3744,7 @@ impl wkt::message::Message for RouteInfo {
     }
 }
 
-/// Defines additional types related to RouteInfo
+/// Defines additional types related to [RouteInfo].
 pub mod route_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4064,7 +4064,7 @@ impl wkt::message::Message for GoogleServiceInfo {
     }
 }
 
-/// Defines additional types related to GoogleServiceInfo
+/// Defines additional types related to [GoogleServiceInfo].
 pub mod google_service_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4394,7 +4394,7 @@ impl wkt::message::Message for LoadBalancerInfo {
     }
 }
 
-/// Defines additional types related to LoadBalancerInfo
+/// Defines additional types related to [LoadBalancerInfo].
 pub mod load_balancer_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4621,7 +4621,7 @@ impl wkt::message::Message for LoadBalancerBackend {
     }
 }
 
-/// Defines additional types related to LoadBalancerBackend
+/// Defines additional types related to [LoadBalancerBackend].
 pub mod load_balancer_backend {
     #[allow(unused_imports)]
     use super::*;
@@ -4890,7 +4890,7 @@ impl wkt::message::Message for VpnTunnelInfo {
     }
 }
 
-/// Defines additional types related to VpnTunnelInfo
+/// Defines additional types related to [VpnTunnelInfo].
 pub mod vpn_tunnel_info {
     #[allow(unused_imports)]
     use super::*;
@@ -5144,7 +5144,7 @@ impl wkt::message::Message for DeliverInfo {
     }
 }
 
-/// Defines additional types related to DeliverInfo
+/// Defines additional types related to [DeliverInfo].
 pub mod deliver_info {
     #[allow(unused_imports)]
     use super::*;
@@ -5336,7 +5336,7 @@ impl wkt::message::Message for ForwardInfo {
     }
 }
 
-/// Defines additional types related to ForwardInfo
+/// Defines additional types related to [ForwardInfo].
 pub mod forward_info {
     #[allow(unused_imports)]
     use super::*;
@@ -5503,7 +5503,7 @@ impl wkt::message::Message for AbortInfo {
     }
 }
 
-/// Defines additional types related to AbortInfo
+/// Defines additional types related to [AbortInfo].
 pub mod abort_info {
     #[allow(unused_imports)]
     use super::*;
@@ -5879,7 +5879,7 @@ impl wkt::message::Message for DropInfo {
     }
 }
 
-/// Defines additional types related to DropInfo
+/// Defines additional types related to [DropInfo].
 pub mod drop_info {
     #[allow(unused_imports)]
     use super::*;
@@ -7293,7 +7293,7 @@ impl wkt::message::Message for NatInfo {
     }
 }
 
-/// Defines additional types related to NatInfo
+/// Defines additional types related to [NatInfo].
 pub mod nat_info {
     #[allow(unused_imports)]
     use super::*;
@@ -7658,7 +7658,7 @@ impl wkt::message::Message for LoadBalancerBackendInfo {
     }
 }
 
-/// Defines additional types related to LoadBalancerBackendInfo
+/// Defines additional types related to [LoadBalancerBackendInfo].
 pub mod load_balancer_backend_info {
     #[allow(unused_imports)]
     use super::*;
@@ -8392,7 +8392,7 @@ impl wkt::message::Message for VpcFlowLogsConfig {
     }
 }
 
-/// Defines additional types related to VpcFlowLogsConfig
+/// Defines additional types related to [VpcFlowLogsConfig].
 pub mod vpc_flow_logs_config {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/networksecurity/v1/src/model.rs
+++ b/src/generated/cloud/networksecurity/v1/src/model.rs
@@ -150,7 +150,7 @@ impl wkt::message::Message for AuthorizationPolicy {
     }
 }
 
-/// Defines additional types related to AuthorizationPolicy
+/// Defines additional types related to [AuthorizationPolicy].
 pub mod authorization_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -211,7 +211,7 @@ pub mod authorization_policy {
         }
     }
 
-    /// Defines additional types related to Rule
+    /// Defines additional types related to [Rule].
     pub mod rule {
         #[allow(unused_imports)]
         use super::*;
@@ -367,7 +367,7 @@ pub mod authorization_policy {
             }
         }
 
-        /// Defines additional types related to Destination
+        /// Defines additional types related to [Destination].
         pub mod destination {
             #[allow(unused_imports)]
             use super::*;
@@ -447,7 +447,7 @@ pub mod authorization_policy {
                 }
             }
 
-            /// Defines additional types related to HttpHeaderMatch
+            /// Defines additional types related to [HttpHeaderMatch].
             pub mod http_header_match {
                 #[allow(unused_imports)]
                 use super::*;
@@ -1460,7 +1460,7 @@ impl wkt::message::Message for ServerTlsPolicy {
     }
 }
 
-/// Defines additional types related to ServerTlsPolicy
+/// Defines additional types related to [ServerTlsPolicy].
 pub mod server_tls_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -1908,7 +1908,7 @@ impl wkt::message::Message for ValidationCA {
     }
 }
 
-/// Defines additional types related to ValidationCA
+/// Defines additional types related to [ValidationCA].
 pub mod validation_ca {
     #[allow(unused_imports)]
     use super::*;
@@ -2060,7 +2060,7 @@ impl wkt::message::Message for CertificateProvider {
     }
 }
 
-/// Defines additional types related to CertificateProvider
+/// Defines additional types related to [CertificateProvider].
 pub mod certificate_provider {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/networkservices/v1/src/model.rs
+++ b/src/generated/cloud/networkservices/v1/src/model.rs
@@ -239,7 +239,7 @@ impl wkt::message::Message for EndpointMatcher {
     }
 }
 
-/// Defines additional types related to EndpointMatcher
+/// Defines additional types related to [EndpointMatcher].
 pub mod endpoint_matcher {
     #[allow(unused_imports)]
     use super::*;
@@ -320,7 +320,7 @@ pub mod endpoint_matcher {
         }
     }
 
-    /// Defines additional types related to MetadataLabelMatcher
+    /// Defines additional types related to [MetadataLabelMatcher].
     pub mod metadata_label_matcher {
         #[allow(unused_imports)]
         use super::*;
@@ -513,7 +513,7 @@ impl wkt::message::Message for ExtensionChain {
     }
 }
 
-/// Defines additional types related to ExtensionChain
+/// Defines additional types related to [ExtensionChain].
 pub mod extension_chain {
     #[allow(unused_imports)]
     use super::*;
@@ -1967,7 +1967,7 @@ impl wkt::message::Message for EndpointPolicy {
     }
 }
 
-/// Defines additional types related to EndpointPolicy
+/// Defines additional types related to [EndpointPolicy].
 pub mod endpoint_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -2468,7 +2468,7 @@ impl wkt::message::Message for Gateway {
     }
 }
 
-/// Defines additional types related to Gateway
+/// Defines additional types related to [Gateway].
 pub mod gateway {
     #[allow(unused_imports)]
     use super::*;
@@ -3006,7 +3006,7 @@ impl wkt::message::Message for GrpcRoute {
     }
 }
 
-/// Defines additional types related to GrpcRoute
+/// Defines additional types related to [GrpcRoute].
 pub mod grpc_route {
     #[allow(unused_imports)]
     use super::*;
@@ -3084,7 +3084,7 @@ pub mod grpc_route {
         }
     }
 
-    /// Defines additional types related to MethodMatch
+    /// Defines additional types related to [MethodMatch].
     pub mod method_match {
         #[allow(unused_imports)]
         use super::*;
@@ -3201,7 +3201,7 @@ pub mod grpc_route {
         }
     }
 
-    /// Defines additional types related to HeaderMatch
+    /// Defines additional types related to [HeaderMatch].
     pub mod header_match {
         #[allow(unused_imports)]
         use super::*;
@@ -3405,7 +3405,7 @@ pub mod grpc_route {
         }
     }
 
-    /// Defines additional types related to Destination
+    /// Defines additional types related to [Destination].
     pub mod destination {
         #[allow(unused_imports)]
         use super::*;
@@ -3479,7 +3479,7 @@ pub mod grpc_route {
         }
     }
 
-    /// Defines additional types related to FaultInjectionPolicy
+    /// Defines additional types related to [FaultInjectionPolicy].
     pub mod fault_injection_policy {
         #[allow(unused_imports)]
         use super::*;
@@ -4250,7 +4250,7 @@ impl wkt::message::Message for HttpRoute {
     }
 }
 
-/// Defines additional types related to HttpRoute
+/// Defines additional types related to [HttpRoute].
 pub mod http_route {
     #[allow(unused_imports)]
     use super::*;
@@ -4477,7 +4477,7 @@ pub mod http_route {
         }
     }
 
-    /// Defines additional types related to HeaderMatch
+    /// Defines additional types related to [HeaderMatch].
     pub mod header_match {
         #[allow(unused_imports)]
         use super::*;
@@ -4667,7 +4667,7 @@ pub mod http_route {
         }
     }
 
-    /// Defines additional types related to QueryParameterMatch
+    /// Defines additional types related to [QueryParameterMatch].
     pub mod query_parameter_match {
         #[allow(unused_imports)]
         use super::*;
@@ -4856,7 +4856,7 @@ pub mod http_route {
         }
     }
 
-    /// Defines additional types related to RouteMatch
+    /// Defines additional types related to [RouteMatch].
     pub mod route_match {
         #[allow(unused_imports)]
         use super::*;
@@ -5057,7 +5057,7 @@ pub mod http_route {
         }
     }
 
-    /// Defines additional types related to Redirect
+    /// Defines additional types related to [Redirect].
     pub mod redirect {
         #[allow(unused_imports)]
         use super::*;
@@ -5197,7 +5197,7 @@ pub mod http_route {
         }
     }
 
-    /// Defines additional types related to FaultInjectionPolicy
+    /// Defines additional types related to [FaultInjectionPolicy].
     pub mod fault_injection_policy {
         #[allow(unused_imports)]
         use super::*;
@@ -7030,7 +7030,7 @@ impl wkt::message::Message for TcpRoute {
     }
 }
 
-/// Defines additional types related to TcpRoute
+/// Defines additional types related to [TcpRoute].
 pub mod tcp_route {
     #[allow(unused_imports)]
     use super::*;
@@ -7648,7 +7648,7 @@ impl wkt::message::Message for TlsRoute {
     }
 }
 
-/// Defines additional types related to TlsRoute
+/// Defines additional types related to [TlsRoute].
 pub mod tls_route {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -175,7 +175,7 @@ impl wkt::message::Message for Event {
     }
 }
 
-/// Defines additional types related to Event
+/// Defines additional types related to [Event].
 pub mod event {
     #[allow(unused_imports)]
     use super::*;
@@ -317,7 +317,7 @@ impl wkt::message::Message for NetworkInterface {
     }
 }
 
-/// Defines additional types related to NetworkInterface
+/// Defines additional types related to [NetworkInterface].
 pub mod network_interface {
     #[allow(unused_imports)]
     use super::*;
@@ -467,7 +467,7 @@ impl wkt::message::Message for VmImage {
     }
 }
 
-/// Defines additional types related to VmImage
+/// Defines additional types related to [VmImage].
 pub mod vm_image {
     #[allow(unused_imports)]
     use super::*;
@@ -574,7 +574,7 @@ impl wkt::message::Message for AcceleratorConfig {
     }
 }
 
-/// Defines additional types related to AcceleratorConfig
+/// Defines additional types related to [AcceleratorConfig].
 pub mod accelerator_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1222,7 +1222,7 @@ impl wkt::message::Message for GceSetup {
     }
 }
 
-/// Defines additional types related to GceSetup
+/// Defines additional types related to [GceSetup].
 pub mod gce_setup {
     #[allow(unused_imports)]
     use super::*;
@@ -1356,7 +1356,7 @@ impl wkt::message::Message for UpgradeHistoryEntry {
     }
 }
 
-/// Defines additional types related to UpgradeHistoryEntry
+/// Defines additional types related to [UpgradeHistoryEntry].
 pub mod upgrade_history_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -1718,7 +1718,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -105,7 +105,7 @@ impl wkt::message::Message for InputConfig {
     }
 }
 
-/// Defines additional types related to InputConfig
+/// Defines additional types related to [InputConfig].
 pub mod input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -201,7 +201,7 @@ impl wkt::message::Message for OutputConfig {
     }
 }
 
-/// Defines additional types related to OutputConfig
+/// Defines additional types related to [OutputConfig].
 pub mod output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -343,7 +343,7 @@ impl wkt::message::Message for AsyncModelMetadata {
     }
 }
 
-/// Defines additional types related to AsyncModelMetadata
+/// Defines additional types related to [AsyncModelMetadata].
 pub mod async_model_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -828,7 +828,7 @@ impl wkt::message::Message for OptimizeToursRequest {
     }
 }
 
-/// Defines additional types related to OptimizeToursRequest
+/// Defines additional types related to [OptimizeToursRequest].
 pub mod optimize_tours_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1098,7 +1098,7 @@ impl wkt::message::Message for OptimizeToursResponse {
     }
 }
 
-/// Defines additional types related to OptimizeToursResponse
+/// Defines additional types related to [OptimizeToursResponse].
 pub mod optimize_tours_response {
     #[allow(unused_imports)]
     use super::*;
@@ -1292,7 +1292,7 @@ impl wkt::message::Message for BatchOptimizeToursRequest {
     }
 }
 
-/// Defines additional types related to BatchOptimizeToursRequest
+/// Defines additional types related to [BatchOptimizeToursRequest].
 pub mod batch_optimize_tours_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1767,7 +1767,7 @@ impl wkt::message::Message for ShipmentModel {
     }
 }
 
-/// Defines additional types related to ShipmentModel
+/// Defines additional types related to [ShipmentModel].
 pub mod shipment_model {
     #[allow(unused_imports)]
     use super::*;
@@ -1832,7 +1832,7 @@ pub mod shipment_model {
         }
     }
 
-    /// Defines additional types related to DurationDistanceMatrix
+    /// Defines additional types related to [DurationDistanceMatrix].
     pub mod duration_distance_matrix {
         #[allow(unused_imports)]
         use super::*;
@@ -2042,7 +2042,7 @@ pub mod shipment_model {
         }
     }
 
-    /// Defines additional types related to BreakRule
+    /// Defines additional types related to [BreakRule].
     pub mod break_rule {
         #[allow(unused_imports)]
         use super::*;
@@ -2506,7 +2506,7 @@ impl wkt::message::Message for Shipment {
     }
 }
 
-/// Defines additional types related to Shipment
+/// Defines additional types related to [Shipment].
 pub mod shipment {
     #[allow(unused_imports)]
     use super::*;
@@ -2845,7 +2845,7 @@ impl wkt::message::Message for ShipmentTypeIncompatibility {
     }
 }
 
-/// Defines additional types related to ShipmentTypeIncompatibility
+/// Defines additional types related to [ShipmentTypeIncompatibility].
 pub mod shipment_type_incompatibility {
     #[allow(unused_imports)]
     use super::*;
@@ -2995,7 +2995,7 @@ impl wkt::message::Message for ShipmentTypeRequirement {
     }
 }
 
-/// Defines additional types related to ShipmentTypeRequirement
+/// Defines additional types related to [ShipmentTypeRequirement].
 pub mod shipment_type_requirement {
     #[allow(unused_imports)]
     use super::*;
@@ -3705,7 +3705,7 @@ impl wkt::message::Message for Vehicle {
     }
 }
 
-/// Defines additional types related to Vehicle
+/// Defines additional types related to [Vehicle].
 pub mod vehicle {
     #[allow(unused_imports)]
     use super::*;
@@ -3814,7 +3814,7 @@ pub mod vehicle {
         }
     }
 
-    /// Defines additional types related to LoadLimit
+    /// Defines additional types related to [LoadLimit].
     pub mod load_limit {
         #[allow(unused_imports)]
         use super::*;
@@ -4715,7 +4715,7 @@ impl wkt::message::Message for Waypoint {
     }
 }
 
-/// Defines additional types related to Waypoint
+/// Defines additional types related to [Waypoint].
 pub mod waypoint {
     #[allow(unused_imports)]
     use super::*;
@@ -4837,7 +4837,7 @@ impl wkt::message::Message for BreakRule {
     }
 }
 
-/// Defines additional types related to BreakRule
+/// Defines additional types related to [BreakRule].
 pub mod break_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -5385,7 +5385,7 @@ impl wkt::message::Message for ShipmentRoute {
     }
 }
 
-/// Defines additional types related to ShipmentRoute
+/// Defines additional types related to [ShipmentRoute].
 pub mod shipment_route {
     #[allow(unused_imports)]
     use super::*;
@@ -6137,7 +6137,7 @@ impl wkt::message::Message for SkippedShipment {
     }
 }
 
-/// Defines additional types related to SkippedShipment
+/// Defines additional types related to [SkippedShipment].
 pub mod skipped_shipment {
     #[allow(unused_imports)]
     use super::*;
@@ -6228,7 +6228,7 @@ pub mod skipped_shipment {
         }
     }
 
-    /// Defines additional types related to Reason
+    /// Defines additional types related to [Reason].
     pub mod reason {
         #[allow(unused_imports)]
         use super::*;
@@ -6628,7 +6628,7 @@ impl wkt::message::Message for InjectedSolutionConstraint {
     }
 }
 
-/// Defines additional types related to InjectedSolutionConstraint
+/// Defines additional types related to [InjectedSolutionConstraint].
 pub mod injected_solution_constraint {
     #[allow(unused_imports)]
     use super::*;
@@ -6703,7 +6703,7 @@ pub mod injected_solution_constraint {
         }
     }
 
-    /// Defines additional types related to ConstraintRelaxation
+    /// Defines additional types related to [ConstraintRelaxation].
     pub mod constraint_relaxation {
         #[allow(unused_imports)]
         use super::*;
@@ -6803,7 +6803,7 @@ pub mod injected_solution_constraint {
             }
         }
 
-        /// Defines additional types related to Relaxation
+        /// Defines additional types related to [Relaxation].
         pub mod relaxation {
             #[allow(unused_imports)]
             use super::*;
@@ -7254,7 +7254,7 @@ impl wkt::message::Message for OptimizeToursValidationError {
     }
 }
 
-/// Defines additional types related to OptimizeToursValidationError
+/// Defines additional types related to [OptimizeToursValidationError].
 pub mod optimize_tours_validation_error {
     #[allow(unused_imports)]
     use super::*;
@@ -7393,7 +7393,7 @@ pub mod optimize_tours_validation_error {
         }
     }
 
-    /// Defines additional types related to FieldReference
+    /// Defines additional types related to [FieldReference].
     pub mod field_reference {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/oracledatabase/v1/src/model.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/model.rs
@@ -933,7 +933,7 @@ impl wkt::message::Message for AutonomousDatabaseProperties {
     }
 }
 
-/// Defines additional types related to AutonomousDatabaseProperties
+/// Defines additional types related to [AutonomousDatabaseProperties].
 pub mod autonomous_database_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -1913,7 +1913,7 @@ impl wkt::message::Message for DatabaseConnectionStringProfile {
     }
 }
 
-/// Defines additional types related to DatabaseConnectionStringProfile
+/// Defines additional types related to [DatabaseConnectionStringProfile].
 pub mod database_connection_string_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -2663,7 +2663,7 @@ impl wkt::message::Message for AutonomousDatabaseCharacterSet {
     }
 }
 
-/// Defines additional types related to AutonomousDatabaseCharacterSet
+/// Defines additional types related to [AutonomousDatabaseCharacterSet].
 pub mod autonomous_database_character_set {
     #[allow(unused_imports)]
     use super::*;
@@ -3065,7 +3065,7 @@ impl wkt::message::Message for AutonomousDatabaseBackupProperties {
     }
 }
 
-/// Defines additional types related to AutonomousDatabaseBackupProperties
+/// Defines additional types related to [AutonomousDatabaseBackupProperties].
 pub mod autonomous_database_backup_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -3449,7 +3449,7 @@ impl wkt::message::Message for DbNodeProperties {
     }
 }
 
-/// Defines additional types related to DbNodeProperties
+/// Defines additional types related to [DbNodeProperties].
 pub mod db_node_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -3722,7 +3722,7 @@ impl wkt::message::Message for DbServerProperties {
     }
 }
 
-/// Defines additional types related to DbServerProperties
+/// Defines additional types related to [DbServerProperties].
 pub mod db_server_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -3998,7 +3998,7 @@ impl wkt::message::Message for Entitlement {
     }
 }
 
-/// Defines additional types related to Entitlement
+/// Defines additional types related to [Entitlement].
 pub mod entitlement {
     #[allow(unused_imports)]
     use super::*;
@@ -4582,7 +4582,7 @@ impl wkt::message::Message for CloudExadataInfrastructureProperties {
     }
 }
 
-/// Defines additional types related to CloudExadataInfrastructureProperties
+/// Defines additional types related to [CloudExadataInfrastructureProperties].
 pub mod cloud_exadata_infrastructure_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -4825,7 +4825,7 @@ impl wkt::message::Message for MaintenanceWindow {
     }
 }
 
-/// Defines additional types related to MaintenanceWindow
+/// Defines additional types related to [MaintenanceWindow].
 pub mod maintenance_window {
     #[allow(unused_imports)]
     use super::*;
@@ -7527,7 +7527,7 @@ impl wkt::message::Message for CloudVmClusterProperties {
     }
 }
 
-/// Defines additional types related to CloudVmClusterProperties
+/// Defines additional types related to [CloudVmClusterProperties].
 pub mod cloud_vm_cluster_properties {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -801,7 +801,7 @@ impl wkt::message::Message for PollAirflowCommandResponse {
     }
 }
 
-/// Defines additional types related to PollAirflowCommandResponse
+/// Defines additional types related to [PollAirflowCommandResponse].
 pub mod poll_airflow_command_response {
     #[allow(unused_imports)]
     use super::*;
@@ -1610,7 +1610,7 @@ impl gax::paginator::PageableResponse for ListWorkloadsResponse {
     }
 }
 
-/// Defines additional types related to ListWorkloadsResponse
+/// Defines additional types related to [ListWorkloadsResponse].
 pub mod list_workloads_response {
     #[allow(unused_imports)]
     use super::*;
@@ -2593,7 +2593,7 @@ impl wkt::message::Message for EnvironmentConfig {
     }
 }
 
-/// Defines additional types related to EnvironmentConfig
+/// Defines additional types related to [EnvironmentConfig].
 pub mod environment_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2754,7 +2754,7 @@ impl wkt::message::Message for WebServerNetworkAccessControl {
     }
 }
 
-/// Defines additional types related to WebServerNetworkAccessControl
+/// Defines additional types related to [WebServerNetworkAccessControl].
 pub mod web_server_network_access_control {
     #[allow(unused_imports)]
     use super::*;
@@ -3203,7 +3203,7 @@ impl wkt::message::Message for SoftwareConfig {
     }
 }
 
-/// Defines additional types related to SoftwareConfig
+/// Defines additional types related to [SoftwareConfig].
 pub mod software_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3455,7 +3455,7 @@ impl wkt::message::Message for IPAllocationPolicy {
     }
 }
 
-/// Defines additional types related to IPAllocationPolicy
+/// Defines additional types related to [IPAllocationPolicy].
 pub mod ip_allocation_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -3871,7 +3871,7 @@ impl wkt::message::Message for NetworkingConfig {
     }
 }
 
-/// Defines additional types related to NetworkingConfig
+/// Defines additional types related to [NetworkingConfig].
 pub mod networking_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4245,7 +4245,7 @@ impl wkt::message::Message for WorkloadsConfig {
     }
 }
 
-/// Defines additional types related to WorkloadsConfig
+/// Defines additional types related to [WorkloadsConfig].
 pub mod workloads_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4678,7 +4678,7 @@ impl wkt::message::Message for MasterAuthorizedNetworksConfig {
     }
 }
 
-/// Defines additional types related to MasterAuthorizedNetworksConfig
+/// Defines additional types related to [MasterAuthorizedNetworksConfig].
 pub mod master_authorized_networks_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4907,7 +4907,7 @@ impl wkt::message::Message for Environment {
     }
 }
 
-/// Defines additional types related to Environment
+/// Defines additional types related to [Environment].
 pub mod environment {
     #[allow(unused_imports)]
     use super::*;
@@ -5135,7 +5135,7 @@ impl wkt::message::Message for CheckUpgradeResponse {
     }
 }
 
-/// Defines additional types related to CheckUpgradeResponse
+/// Defines additional types related to [CheckUpgradeResponse].
 pub mod check_upgrade_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5283,7 +5283,7 @@ impl wkt::message::Message for TaskLogsRetentionConfig {
     }
 }
 
-/// Defines additional types related to TaskLogsRetentionConfig
+/// Defines additional types related to [TaskLogsRetentionConfig].
 pub mod task_logs_retention_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5395,7 +5395,7 @@ impl wkt::message::Message for AirflowMetadataRetentionPolicyConfig {
     }
 }
 
-/// Defines additional types related to AirflowMetadataRetentionPolicyConfig
+/// Defines additional types related to [AirflowMetadataRetentionPolicyConfig].
 pub mod airflow_metadata_retention_policy_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5758,7 +5758,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/orgpolicy/v1/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v1/src/model.rs
@@ -219,7 +219,7 @@ impl wkt::message::Message for Policy {
     }
 }
 
-/// Defines additional types related to Policy
+/// Defines additional types related to [Policy].
 pub mod policy {
     #[allow(unused_imports)]
     use super::*;
@@ -430,7 +430,7 @@ pub mod policy {
         }
     }
 
-    /// Defines additional types related to ListPolicy
+    /// Defines additional types related to [ListPolicy].
     pub mod list_policy {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -209,7 +209,7 @@ impl wkt::message::Message for Constraint {
     }
 }
 
-/// Defines additional types related to Constraint
+/// Defines additional types related to [Constraint].
 pub mod constraint {
     #[allow(unused_imports)]
     use super::*;
@@ -497,7 +497,7 @@ impl wkt::message::Message for CustomConstraint {
     }
 }
 
-/// Defines additional types related to CustomConstraint
+/// Defines additional types related to [CustomConstraint].
 pub mod custom_constraint {
     #[allow(unused_imports)]
     use super::*;
@@ -893,7 +893,7 @@ impl wkt::message::Message for PolicySpec {
     }
 }
 
-/// Defines additional types related to PolicySpec
+/// Defines additional types related to [PolicySpec].
 pub mod policy_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -1066,7 +1066,7 @@ pub mod policy_spec {
         }
     }
 
-    /// Defines additional types related to PolicyRule
+    /// Defines additional types related to [PolicyRule].
     pub mod policy_rule {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -120,7 +120,7 @@ impl wkt::message::Message for Inventory {
     }
 }
 
-/// Defines additional types related to Inventory
+/// Defines additional types related to [Inventory].
 pub mod inventory {
     #[allow(unused_imports)]
     use super::*;
@@ -400,7 +400,7 @@ pub mod inventory {
         }
     }
 
-    /// Defines additional types related to Item
+    /// Defines additional types related to [Item].
     pub mod item {
         #[allow(unused_imports)]
         use super::*;
@@ -864,7 +864,7 @@ pub mod inventory {
         }
     }
 
-    /// Defines additional types related to SoftwarePackage
+    /// Defines additional types related to [SoftwarePackage].
     pub mod software_package {
         #[allow(unused_imports)]
         use super::*;
@@ -1163,7 +1163,7 @@ pub mod inventory {
         }
     }
 
-    /// Defines additional types related to WindowsUpdatePackage
+    /// Defines additional types related to [WindowsUpdatePackage].
     pub mod windows_update_package {
         #[allow(unused_imports)]
         use super::*;
@@ -1625,7 +1625,7 @@ impl wkt::message::Message for OSPolicy {
     }
 }
 
-/// Defines additional types related to OSPolicy
+/// Defines additional types related to [OSPolicy].
 pub mod os_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -1870,7 +1870,7 @@ pub mod os_policy {
         }
     }
 
-    /// Defines additional types related to Resource
+    /// Defines additional types related to [Resource].
     pub mod resource {
         #[allow(unused_imports)]
         use super::*;
@@ -2021,7 +2021,7 @@ pub mod os_policy {
             }
         }
 
-        /// Defines additional types related to File
+        /// Defines additional types related to [File].
         pub mod file {
             #[allow(unused_imports)]
             use super::*;
@@ -2464,7 +2464,7 @@ pub mod os_policy {
             }
         }
 
-        /// Defines additional types related to PackageResource
+        /// Defines additional types related to [PackageResource].
         pub mod package_resource {
             #[allow(unused_imports)]
             use super::*;
@@ -3046,7 +3046,7 @@ pub mod os_policy {
             }
         }
 
-        /// Defines additional types related to RepositoryResource
+        /// Defines additional types related to [RepositoryResource].
         pub mod repository_resource {
             #[allow(unused_imports)]
             use super::*;
@@ -3135,7 +3135,7 @@ pub mod os_policy {
                 }
             }
 
-            /// Defines additional types related to AptRepository
+            /// Defines additional types related to [AptRepository].
             pub mod apt_repository {
                 #[allow(unused_imports)]
                 use super::*;
@@ -3511,7 +3511,7 @@ pub mod os_policy {
             }
         }
 
-        /// Defines additional types related to ExecResource
+        /// Defines additional types related to [ExecResource].
         pub mod exec_resource {
             #[allow(unused_imports)]
             use super::*;
@@ -3671,7 +3671,7 @@ pub mod os_policy {
                 }
             }
 
-            /// Defines additional types related to Exec
+            /// Defines additional types related to [Exec].
             pub mod exec {
                 #[allow(unused_imports)]
                 use super::*;
@@ -3905,7 +3905,7 @@ pub mod os_policy {
             }
         }
 
-        /// Defines additional types related to FileResource
+        /// Defines additional types related to [FileResource].
         pub mod file_resource {
             #[allow(unused_imports)]
             use super::*;
@@ -4415,7 +4415,7 @@ impl wkt::message::Message for OSPolicyAssignmentReport {
     }
 }
 
-/// Defines additional types related to OSPolicyAssignmentReport
+/// Defines additional types related to [OSPolicyAssignmentReport].
 pub mod os_policy_assignment_report {
     #[allow(unused_imports)]
     use super::*;
@@ -4510,7 +4510,7 @@ pub mod os_policy_assignment_report {
         }
     }
 
-    /// Defines additional types related to OSPolicyCompliance
+    /// Defines additional types related to [OSPolicyCompliance].
     pub mod os_policy_compliance {
         #[allow(unused_imports)]
         use super::*;
@@ -4635,7 +4635,7 @@ pub mod os_policy_assignment_report {
             }
         }
 
-        /// Defines additional types related to OSPolicyResourceCompliance
+        /// Defines additional types related to [OSPolicyResourceCompliance].
         pub mod os_policy_resource_compliance {
             #[allow(unused_imports)]
             use super::*;
@@ -4685,7 +4685,7 @@ pub mod os_policy_assignment_report {
                 }
             }
 
-            /// Defines additional types related to OSPolicyResourceConfigStep
+            /// Defines additional types related to [OSPolicyResourceConfigStep].
             pub mod os_policy_resource_config_step {
                 #[allow(unused_imports)]
                 use super::*;
@@ -5147,7 +5147,7 @@ impl wkt::message::Message for OSPolicyAssignment {
     }
 }
 
-/// Defines additional types related to OSPolicyAssignment
+/// Defines additional types related to [OSPolicyAssignment].
 pub mod os_policy_assignment {
     #[allow(unused_imports)]
     use super::*;
@@ -5285,7 +5285,7 @@ pub mod os_policy_assignment {
         }
     }
 
-    /// Defines additional types related to InstanceFilter
+    /// Defines additional types related to [InstanceFilter].
     pub mod instance_filter {
         #[allow(unused_imports)]
         use super::*;
@@ -5555,7 +5555,7 @@ impl wkt::message::Message for OSPolicyAssignmentOperationMetadata {
     }
 }
 
-/// Defines additional types related to OSPolicyAssignmentOperationMetadata
+/// Defines additional types related to [OSPolicyAssignmentOperationMetadata].
 pub mod os_policy_assignment_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -6160,7 +6160,7 @@ impl wkt::message::Message for FixedOrPercent {
     }
 }
 
-/// Defines additional types related to FixedOrPercent
+/// Defines additional types related to [FixedOrPercent].
 pub mod fixed_or_percent {
     #[allow(unused_imports)]
     use super::*;
@@ -6416,7 +6416,7 @@ impl wkt::message::Message for PatchDeployment {
     }
 }
 
-/// Defines additional types related to PatchDeployment
+/// Defines additional types related to [PatchDeployment].
 pub mod patch_deployment {
     #[allow(unused_imports)]
     use super::*;
@@ -6712,7 +6712,7 @@ impl wkt::message::Message for RecurringSchedule {
     }
 }
 
-/// Defines additional types related to RecurringSchedule
+/// Defines additional types related to [RecurringSchedule].
 pub mod recurring_schedule {
     #[allow(unused_imports)]
     use super::*;
@@ -6913,7 +6913,7 @@ impl wkt::message::Message for MonthlySchedule {
     }
 }
 
-/// Defines additional types related to MonthlySchedule
+/// Defines additional types related to [MonthlySchedule].
 pub mod monthly_schedule {
     #[allow(unused_imports)]
     use super::*;
@@ -8006,7 +8006,7 @@ impl wkt::message::Message for PatchJob {
     }
 }
 
-/// Defines additional types related to PatchJob
+/// Defines additional types related to [PatchJob].
 pub mod patch_job {
     #[allow(unused_imports)]
     use super::*;
@@ -8425,7 +8425,7 @@ impl wkt::message::Message for PatchConfig {
     }
 }
 
-/// Defines additional types related to PatchConfig
+/// Defines additional types related to [PatchConfig].
 pub mod patch_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8517,7 +8517,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -8749,7 +8749,7 @@ impl wkt::message::Message for AptSettings {
     }
 }
 
-/// Defines additional types related to AptSettings
+/// Defines additional types related to [AptSettings].
 pub mod apt_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -9075,7 +9075,7 @@ impl wkt::message::Message for WindowsUpdateSettings {
     }
 }
 
-/// Defines additional types related to WindowsUpdateSettings
+/// Defines additional types related to [WindowsUpdateSettings].
 pub mod windows_update_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -9361,7 +9361,7 @@ impl wkt::message::Message for ExecStepConfig {
     }
 }
 
-/// Defines additional types related to ExecStepConfig
+/// Defines additional types related to [ExecStepConfig].
 pub mod exec_step_config {
     #[allow(unused_imports)]
     use super::*;
@@ -9590,7 +9590,7 @@ impl wkt::message::Message for PatchInstanceFilter {
     }
 }
 
-/// Defines additional types related to PatchInstanceFilter
+/// Defines additional types related to [PatchInstanceFilter].
 pub mod patch_instance_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -9708,7 +9708,7 @@ impl wkt::message::Message for PatchRollout {
     }
 }
 
-/// Defines additional types related to PatchRollout
+/// Defines additional types related to [PatchRollout].
 pub mod patch_rollout {
     #[allow(unused_imports)]
     use super::*;
@@ -9841,7 +9841,7 @@ impl wkt::message::Message for VulnerabilityReport {
     }
 }
 
-/// Defines additional types related to VulnerabilityReport
+/// Defines additional types related to [VulnerabilityReport].
 pub mod vulnerability_report {
     #[allow(unused_imports)]
     use super::*;
@@ -9964,7 +9964,7 @@ pub mod vulnerability_report {
         }
     }
 
-    /// Defines additional types related to Vulnerability
+    /// Defines additional types related to [Vulnerability].
     pub mod vulnerability {
         #[allow(unused_imports)]
         use super::*;
@@ -10069,7 +10069,7 @@ pub mod vulnerability_report {
             }
         }
 
-        /// Defines additional types related to Details
+        /// Defines additional types related to [Details].
         pub mod details {
             #[allow(unused_imports)]
             use super::*;
@@ -10519,7 +10519,7 @@ impl wkt::message::Message for CVSSv3 {
     }
 }
 
-/// Defines additional types related to CVSSv3
+/// Defines additional types related to [CVSSv3].
 pub mod cvs_sv_3 {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -262,7 +262,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -1115,7 +1115,7 @@ impl wkt::message::Message for ImportDataRequest {
     }
 }
 
-/// Defines additional types related to ImportDataRequest
+/// Defines additional types related to [ImportDataRequest].
 pub mod import_data_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1303,7 +1303,7 @@ impl wkt::message::Message for ExportDataRequest {
     }
 }
 
-/// Defines additional types related to ExportDataRequest
+/// Defines additional types related to [ExportDataRequest].
 pub mod export_data_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1920,7 +1920,7 @@ impl wkt::message::Message for TransferOperationMetadata {
     }
 }
 
-/// Defines additional types related to TransferOperationMetadata
+/// Defines additional types related to [TransferOperationMetadata].
 pub mod transfer_operation_metadata {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/policysimulator/v1/src/model.rs
+++ b/src/generated/cloud/policysimulator/v1/src/model.rs
@@ -373,7 +373,7 @@ impl wkt::message::Message for BindingExplanation {
     }
 }
 
-/// Defines additional types related to BindingExplanation
+/// Defines additional types related to [BindingExplanation].
 pub mod binding_explanation {
     #[allow(unused_imports)]
     use super::*;
@@ -657,7 +657,7 @@ impl wkt::message::Message for Replay {
     }
 }
 
-/// Defines additional types related to Replay
+/// Defines additional types related to [Replay].
 pub mod replay {
     #[allow(unused_imports)]
     use super::*;
@@ -961,7 +961,7 @@ impl wkt::message::Message for ReplayResult {
     }
 }
 
-/// Defines additional types related to ReplayResult
+/// Defines additional types related to [ReplayResult].
 pub mod replay_result {
     #[allow(unused_imports)]
     use super::*;
@@ -1322,7 +1322,7 @@ impl wkt::message::Message for ReplayConfig {
     }
 }
 
-/// Defines additional types related to ReplayConfig
+/// Defines additional types related to [ReplayConfig].
 pub mod replay_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1508,7 +1508,7 @@ impl wkt::message::Message for AccessStateDiff {
     }
 }
 
-/// Defines additional types related to AccessStateDiff
+/// Defines additional types related to [AccessStateDiff].
 pub mod access_state_diff {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
@@ -158,7 +158,7 @@ impl wkt::message::Message for TroubleshootIamPolicyResponse {
     }
 }
 
-/// Defines additional types related to TroubleshootIamPolicyResponse
+/// Defines additional types related to [TroubleshootIamPolicyResponse].
 pub mod troubleshoot_iam_policy_response {
     #[allow(unused_imports)]
     use super::*;
@@ -420,7 +420,7 @@ impl wkt::message::Message for ConditionContext {
     }
 }
 
-/// Defines additional types related to ConditionContext
+/// Defines additional types related to [ConditionContext].
 pub mod condition_context {
     #[allow(unused_imports)]
     use super::*;
@@ -1044,7 +1044,7 @@ impl wkt::message::Message for AllowBindingExplanation {
     }
 }
 
-/// Defines additional types related to AllowBindingExplanation
+/// Defines additional types related to [AllowBindingExplanation].
 pub mod allow_binding_explanation {
     #[allow(unused_imports)]
     use super::*;
@@ -1638,7 +1638,7 @@ impl wkt::message::Message for DenyRuleExplanation {
     }
 }
 
-/// Defines additional types related to DenyRuleExplanation
+/// Defines additional types related to [DenyRuleExplanation].
 pub mod deny_rule_explanation {
     #[allow(unused_imports)]
     use super::*;
@@ -1803,7 +1803,7 @@ impl wkt::message::Message for ConditionExplanation {
     }
 }
 
-/// Defines additional types related to ConditionExplanation
+/// Defines additional types related to [ConditionExplanation].
 pub mod condition_explanation {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/policytroubleshooter/v1/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/model.rs
@@ -468,7 +468,7 @@ impl wkt::message::Message for BindingExplanation {
     }
 }
 
-/// Defines additional types related to BindingExplanation
+/// Defines additional types related to [BindingExplanation].
 pub mod binding_explanation {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
@@ -114,7 +114,7 @@ impl wkt::message::Message for CheckOnboardingStatusResponse {
     }
 }
 
-/// Defines additional types related to CheckOnboardingStatusResponse
+/// Defines additional types related to [CheckOnboardingStatusResponse].
 pub mod check_onboarding_status_response {
     #[allow(unused_imports)]
     use super::*;
@@ -199,7 +199,7 @@ pub mod check_onboarding_status_response {
         }
     }
 
-    /// Defines additional types related to Finding
+    /// Defines additional types related to [Finding].
     pub mod finding {
         #[allow(unused_imports)]
         use super::*;
@@ -442,7 +442,7 @@ impl wkt::message::Message for Entitlement {
     }
 }
 
-/// Defines additional types related to Entitlement
+/// Defines additional types related to [Entitlement].
 pub mod entitlement {
     #[allow(unused_imports)]
     use super::*;
@@ -561,7 +561,7 @@ pub mod entitlement {
         }
     }
 
-    /// Defines additional types related to RequesterJustificationConfig
+    /// Defines additional types related to [RequesterJustificationConfig].
     pub mod requester_justification_config {
         #[allow(unused_imports)]
         use super::*;
@@ -855,7 +855,7 @@ impl wkt::message::Message for ApprovalWorkflow {
     }
 }
 
-/// Defines additional types related to ApprovalWorkflow
+/// Defines additional types related to [ApprovalWorkflow].
 pub mod approval_workflow {
     #[allow(unused_imports)]
     use super::*;
@@ -929,7 +929,7 @@ impl wkt::message::Message for ManualApprovals {
     }
 }
 
-/// Defines additional types related to ManualApprovals
+/// Defines additional types related to [ManualApprovals].
 pub mod manual_approvals {
     #[allow(unused_imports)]
     use super::*;
@@ -1062,7 +1062,7 @@ impl wkt::message::Message for PrivilegedAccess {
     }
 }
 
-/// Defines additional types related to PrivilegedAccess
+/// Defines additional types related to [PrivilegedAccess].
 pub mod privileged_access {
     #[allow(unused_imports)]
     use super::*;
@@ -1127,7 +1127,7 @@ pub mod privileged_access {
         }
     }
 
-    /// Defines additional types related to GcpIamAccess
+    /// Defines additional types related to [GcpIamAccess].
     pub mod gcp_iam_access {
         #[allow(unused_imports)]
         use super::*;
@@ -1408,7 +1408,7 @@ impl wkt::message::Message for SearchEntitlementsRequest {
     }
 }
 
-/// Defines additional types related to SearchEntitlementsRequest
+/// Defines additional types related to [SearchEntitlementsRequest].
 pub mod search_entitlements_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1952,7 +1952,7 @@ impl wkt::message::Message for Grant {
     }
 }
 
-/// Defines additional types related to Grant
+/// Defines additional types related to [Grant].
 pub mod grant {
     #[allow(unused_imports)]
     use super::*;
@@ -1994,7 +1994,7 @@ pub mod grant {
         }
     }
 
-    /// Defines additional types related to Timeline
+    /// Defines additional types related to [Timeline].
     pub mod timeline {
         #[allow(unused_imports)]
         use super::*;
@@ -2392,7 +2392,7 @@ pub mod grant {
             }
         }
 
-        /// Defines additional types related to Event
+        /// Defines additional types related to [Event].
         pub mod event {
             #[allow(unused_imports)]
             use super::*;
@@ -2963,7 +2963,7 @@ impl wkt::message::Message for Justification {
     }
 }
 
-/// Defines additional types related to Justification
+/// Defines additional types related to [Justification].
 pub mod justification {
     #[allow(unused_imports)]
     use super::*;
@@ -3193,7 +3193,7 @@ impl wkt::message::Message for SearchGrantsRequest {
     }
 }
 
-/// Defines additional types related to SearchGrantsRequest
+/// Defines additional types related to [SearchGrantsRequest].
 pub mod search_grants_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
@@ -284,7 +284,7 @@ impl wkt::message::Message for Collector {
     }
 }
 
-/// Defines additional types related to Collector
+/// Defines additional types related to [Collector].
 pub mod collector {
     #[allow(unused_imports)]
     use super::*;
@@ -465,7 +465,7 @@ impl wkt::message::Message for Annotation {
     }
 }
 
-/// Defines additional types related to Annotation
+/// Defines additional types related to [Annotation].
 pub mod annotation {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -144,7 +144,7 @@ impl wkt::message::Message for TransactionEvent {
     }
 }
 
-/// Defines additional types related to TransactionEvent
+/// Defines additional types related to [TransactionEvent].
 pub mod transaction_event {
     #[allow(unused_imports)]
     use super::*;
@@ -435,7 +435,7 @@ impl wkt::message::Message for AnnotateAssessmentRequest {
     }
 }
 
-/// Defines additional types related to AnnotateAssessmentRequest
+/// Defines additional types related to [AnnotateAssessmentRequest].
 pub mod annotate_assessment_request {
     #[allow(unused_imports)]
     use super::*;
@@ -775,7 +775,7 @@ impl wkt::message::Message for EndpointVerificationInfo {
     }
 }
 
-/// Defines additional types related to EndpointVerificationInfo
+/// Defines additional types related to [EndpointVerificationInfo].
 pub mod endpoint_verification_info {
     #[allow(unused_imports)]
     use super::*;
@@ -862,7 +862,7 @@ impl wkt::message::Message for AccountVerificationInfo {
     }
 }
 
-/// Defines additional types related to AccountVerificationInfo
+/// Defines additional types related to [AccountVerificationInfo].
 pub mod account_verification_info {
     #[allow(unused_imports)]
     use super::*;
@@ -1483,7 +1483,7 @@ impl wkt::message::Message for Event {
     }
 }
 
-/// Defines additional types related to Event
+/// Defines additional types related to [Event].
 pub mod event {
     #[allow(unused_imports)]
     use super::*;
@@ -1747,7 +1747,7 @@ impl wkt::message::Message for TransactionData {
     }
 }
 
-/// Defines additional types related to TransactionData
+/// Defines additional types related to [TransactionData].
 pub mod transaction_data {
     #[allow(unused_imports)]
     use super::*;
@@ -2223,7 +2223,7 @@ impl wkt::message::Message for UserId {
     }
 }
 
-/// Defines additional types related to UserId
+/// Defines additional types related to [UserId].
 pub mod user_id {
     #[allow(unused_imports)]
     use super::*;
@@ -2317,7 +2317,7 @@ impl wkt::message::Message for RiskAnalysis {
     }
 }
 
-/// Defines additional types related to RiskAnalysis
+/// Defines additional types related to [RiskAnalysis].
 pub mod risk_analysis {
     #[allow(unused_imports)]
     use super::*;
@@ -2580,7 +2580,7 @@ impl wkt::message::Message for TokenProperties {
     }
 }
 
-/// Defines additional types related to TokenProperties
+/// Defines additional types related to [TokenProperties].
 pub mod token_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -2756,7 +2756,7 @@ impl wkt::message::Message for FraudPreventionAssessment {
     }
 }
 
-/// Defines additional types related to FraudPreventionAssessment
+/// Defines additional types related to [FraudPreventionAssessment].
 pub mod fraud_prevention_assessment {
     #[allow(unused_imports)]
     use super::*;
@@ -2902,7 +2902,7 @@ impl wkt::message::Message for FraudSignals {
     }
 }
 
-/// Defines additional types related to FraudSignals
+/// Defines additional types related to [FraudSignals].
 pub mod fraud_signals {
     #[allow(unused_imports)]
     use super::*;
@@ -2981,7 +2981,7 @@ pub mod fraud_signals {
         }
     }
 
-    /// Defines additional types related to CardSignals
+    /// Defines additional types related to [CardSignals].
     pub mod card_signals {
         #[allow(unused_imports)]
         use super::*;
@@ -3099,7 +3099,7 @@ impl wkt::message::Message for SmsTollFraudVerdict {
     }
 }
 
-/// Defines additional types related to SmsTollFraudVerdict
+/// Defines additional types related to [SmsTollFraudVerdict].
 pub mod sms_toll_fraud_verdict {
     #[allow(unused_imports)]
     use super::*;
@@ -3228,7 +3228,7 @@ impl wkt::message::Message for AccountDefenderAssessment {
     }
 }
 
-/// Defines additional types related to AccountDefenderAssessment
+/// Defines additional types related to [AccountDefenderAssessment].
 pub mod account_defender_assessment {
     #[allow(unused_imports)]
     use super::*;
@@ -4353,7 +4353,7 @@ impl wkt::message::Message for Key {
     }
 }
 
-/// Defines additional types related to Key
+/// Defines additional types related to [Key].
 pub mod key {
     #[allow(unused_imports)]
     use super::*;
@@ -4420,7 +4420,7 @@ impl wkt::message::Message for TestingOptions {
     }
 }
 
-/// Defines additional types related to TestingOptions
+/// Defines additional types related to [TestingOptions].
 pub mod testing_options {
     #[allow(unused_imports)]
     use super::*;
@@ -4575,7 +4575,7 @@ impl wkt::message::Message for WebKeySettings {
     }
 }
 
-/// Defines additional types related to WebKeySettings
+/// Defines additional types related to [WebKeySettings].
 pub mod web_key_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -5343,7 +5343,7 @@ impl wkt::message::Message for FirewallAction {
     }
 }
 
-/// Defines additional types related to FirewallAction
+/// Defines additional types related to [FirewallAction].
 pub mod firewall_action {
     #[allow(unused_imports)]
     use super::*;
@@ -6367,7 +6367,7 @@ impl wkt::message::Message for WafSettings {
     }
 }
 
-/// Defines additional types related to WafSettings
+/// Defines additional types related to [WafSettings].
 pub mod waf_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -6610,7 +6610,7 @@ impl wkt::message::Message for IpOverrideData {
     }
 }
 
-/// Defines additional types related to IpOverrideData
+/// Defines additional types related to [IpOverrideData].
 pub mod ip_override_data {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/recommender/v1/src/model.rs
+++ b/src/generated/cloud/recommender/v1/src/model.rs
@@ -204,7 +204,7 @@ impl wkt::message::Message for Insight {
     }
 }
 
-/// Defines additional types related to Insight
+/// Defines additional types related to [Insight].
 pub mod insight {
     #[allow(unused_imports)]
     use super::*;
@@ -434,7 +434,7 @@ impl wkt::message::Message for InsightStateInfo {
     }
 }
 
-/// Defines additional types related to InsightStateInfo
+/// Defines additional types related to [InsightStateInfo].
 pub mod insight_state_info {
     #[allow(unused_imports)]
     use super::*;
@@ -849,7 +849,7 @@ impl wkt::message::Message for Recommendation {
     }
 }
 
-/// Defines additional types related to Recommendation
+/// Defines additional types related to [Recommendation].
 pub mod recommendation {
     #[allow(unused_imports)]
     use super::*;
@@ -1270,7 +1270,7 @@ impl wkt::message::Message for Operation {
     }
 }
 
-/// Defines additional types related to Operation
+/// Defines additional types related to [Operation].
 pub mod operation {
     #[allow(unused_imports)]
     use super::*;
@@ -1349,7 +1349,7 @@ impl wkt::message::Message for ValueMatcher {
     }
 }
 
-/// Defines additional types related to ValueMatcher
+/// Defines additional types related to [ValueMatcher].
 pub mod value_matcher {
     #[allow(unused_imports)]
     use super::*;
@@ -1553,7 +1553,7 @@ impl wkt::message::Message for ReliabilityProjection {
     }
 }
 
-/// Defines additional types related to ReliabilityProjection
+/// Defines additional types related to [ReliabilityProjection].
 pub mod reliability_projection {
     #[allow(unused_imports)]
     use super::*;
@@ -1791,7 +1791,7 @@ impl wkt::message::Message for Impact {
     }
 }
 
-/// Defines additional types related to Impact
+/// Defines additional types related to [Impact].
 pub mod impact {
     #[allow(unused_imports)]
     use super::*;
@@ -1936,7 +1936,7 @@ impl wkt::message::Message for RecommendationStateInfo {
     }
 }
 
-/// Defines additional types related to RecommendationStateInfo
+/// Defines additional types related to [RecommendationStateInfo].
 pub mod recommendation_state_info {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -858,7 +858,7 @@ impl wkt::message::Message for ExportBackupRequest {
     }
 }
 
-/// Defines additional types related to ExportBackupRequest
+/// Defines additional types related to [ExportBackupRequest].
 pub mod export_backup_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1422,7 +1422,7 @@ impl wkt::message::Message for Cluster {
     }
 }
 
-/// Defines additional types related to Cluster
+/// Defines additional types related to [Cluster].
 pub mod cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -1493,7 +1493,7 @@ pub mod cluster {
         }
     }
 
-    /// Defines additional types related to StateInfo
+    /// Defines additional types related to [StateInfo].
     pub mod state_info {
         #[allow(unused_imports)]
         use super::*;
@@ -1804,7 +1804,7 @@ impl wkt::message::Message for AutomatedBackupConfig {
     }
 }
 
-/// Defines additional types related to AutomatedBackupConfig
+/// Defines additional types related to [AutomatedBackupConfig].
 pub mod automated_backup_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2175,7 +2175,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -2517,7 +2517,7 @@ impl wkt::message::Message for CrossClusterReplicationConfig {
     }
 }
 
-/// Defines additional types related to CrossClusterReplicationConfig
+/// Defines additional types related to [CrossClusterReplicationConfig].
 pub mod cross_cluster_replication_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3183,7 +3183,7 @@ impl wkt::message::Message for ConnectionDetail {
     }
 }
 
-/// Defines additional types related to ConnectionDetail
+/// Defines additional types related to [ConnectionDetail].
 pub mod connection_detail {
     #[allow(unused_imports)]
     use super::*;
@@ -3507,7 +3507,7 @@ impl wkt::message::Message for CertificateAuthority {
     }
 }
 
-/// Defines additional types related to CertificateAuthority
+/// Defines additional types related to [CertificateAuthority].
 pub mod certificate_authority {
     #[allow(unused_imports)]
     use super::*;
@@ -3550,7 +3550,7 @@ pub mod certificate_authority {
         }
     }
 
-    /// Defines additional types related to ManagedCertificateAuthority
+    /// Defines additional types related to [ManagedCertificateAuthority].
     pub mod managed_certificate_authority {
         #[allow(unused_imports)]
         use super::*;
@@ -3667,7 +3667,7 @@ impl wkt::message::Message for ClusterPersistenceConfig {
     }
 }
 
-/// Defines additional types related to ClusterPersistenceConfig
+/// Defines additional types related to [ClusterPersistenceConfig].
 pub mod cluster_persistence_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3725,7 +3725,7 @@ pub mod cluster_persistence_config {
         }
     }
 
-    /// Defines additional types related to RDBConfig
+    /// Defines additional types related to [RDBConfig].
     pub mod rdb_config {
         #[allow(unused_imports)]
         use super::*;
@@ -3833,7 +3833,7 @@ pub mod cluster_persistence_config {
         }
     }
 
-    /// Defines additional types related to AOFConfig
+    /// Defines additional types related to [AOFConfig].
     pub mod aof_config {
         #[allow(unused_imports)]
         use super::*;
@@ -4017,7 +4017,7 @@ impl wkt::message::Message for ZoneDistributionConfig {
     }
 }
 
-/// Defines additional types related to ZoneDistributionConfig
+/// Defines additional types related to [ZoneDistributionConfig].
 pub mod zone_distribution_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4146,7 +4146,7 @@ impl wkt::message::Message for RescheduleClusterMaintenanceRequest {
     }
 }
 
-/// Defines additional types related to RescheduleClusterMaintenanceRequest
+/// Defines additional types related to [RescheduleClusterMaintenanceRequest].
 pub mod reschedule_cluster_maintenance_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4286,7 +4286,7 @@ impl wkt::message::Message for EncryptionInfo {
     }
 }
 
-/// Defines additional types related to EncryptionInfo
+/// Defines additional types related to [EncryptionInfo].
 pub mod encryption_info {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -606,7 +606,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -1082,7 +1082,7 @@ impl wkt::message::Message for PersistenceConfig {
     }
 }
 
-/// Defines additional types related to PersistenceConfig
+/// Defines additional types related to [PersistenceConfig].
 pub mod persistence_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1281,7 +1281,7 @@ impl wkt::message::Message for RescheduleMaintenanceRequest {
     }
 }
 
-/// Defines additional types related to RescheduleMaintenanceRequest
+/// Defines additional types related to [RescheduleMaintenanceRequest].
 pub mod reschedule_maintenance_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2088,7 +2088,7 @@ impl wkt::message::Message for InputConfig {
     }
 }
 
-/// Defines additional types related to InputConfig
+/// Defines additional types related to [InputConfig].
 pub mod input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2247,7 +2247,7 @@ impl wkt::message::Message for OutputConfig {
     }
 }
 
-/// Defines additional types related to OutputConfig
+/// Defines additional types related to [OutputConfig].
 pub mod output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2358,7 +2358,7 @@ impl wkt::message::Message for FailoverInstanceRequest {
     }
 }
 
-/// Defines additional types related to FailoverInstanceRequest
+/// Defines additional types related to [FailoverInstanceRequest].
 pub mod failover_instance_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/resourcemanager/v3/src/model.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/model.rs
@@ -160,7 +160,7 @@ impl wkt::message::Message for Folder {
     }
 }
 
-/// Defines additional types related to Folder
+/// Defines additional types related to [Folder].
 pub mod folder {
     #[allow(unused_imports)]
     use super::*;
@@ -1026,7 +1026,7 @@ impl wkt::message::Message for Organization {
     }
 }
 
-/// Defines additional types related to Organization
+/// Defines additional types related to [Organization].
 pub mod organization {
     #[allow(unused_imports)]
     use super::*;
@@ -1469,7 +1469,7 @@ impl wkt::message::Message for Project {
     }
 }
 
-/// Defines additional types related to Project
+/// Defines additional types related to [Project].
 pub mod project {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -356,7 +356,7 @@ impl wkt::message::Message for CatalogAttribute {
     }
 }
 
-/// Defines additional types related to CatalogAttribute
+/// Defines additional types related to [CatalogAttribute].
 pub mod catalog_attribute {
     #[allow(unused_imports)]
     use super::*;
@@ -497,7 +497,7 @@ pub mod catalog_attribute {
         }
     }
 
-    /// Defines additional types related to FacetConfig
+    /// Defines additional types related to [FacetConfig].
     pub mod facet_config {
         #[allow(unused_imports)]
         use super::*;
@@ -2264,7 +2264,7 @@ impl wkt::message::Message for Condition {
     }
 }
 
-/// Defines additional types related to Condition
+/// Defines additional types related to [Condition].
 pub mod condition {
     #[allow(unused_imports)]
     use super::*;
@@ -2700,7 +2700,7 @@ impl wkt::message::Message for Rule {
     }
 }
 
-/// Defines additional types related to Rule
+/// Defines additional types related to [Rule].
 pub mod rule {
     #[allow(unused_imports)]
     use super::*;
@@ -3227,7 +3227,7 @@ pub mod rule {
         }
     }
 
-    /// Defines additional types related to ForceReturnFacetAction
+    /// Defines additional types related to [ForceReturnFacetAction].
     pub mod force_return_facet_action {
         #[allow(unused_imports)]
         use super::*;
@@ -3928,7 +3928,7 @@ impl wkt::message::Message for Interval {
     }
 }
 
-/// Defines additional types related to Interval
+/// Defines additional types related to [Interval].
 pub mod interval {
     #[allow(unused_imports)]
     use super::*;
@@ -4146,7 +4146,7 @@ impl wkt::message::Message for PriceInfo {
     }
 }
 
-/// Defines additional types related to PriceInfo
+/// Defines additional types related to [PriceInfo].
 pub mod price_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4824,7 +4824,7 @@ impl wkt::message::Message for CompleteQueryResponse {
     }
 }
 
-/// Defines additional types related to CompleteQueryResponse
+/// Defines additional types related to [CompleteQueryResponse].
 pub mod complete_query_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5112,7 +5112,7 @@ impl wkt::message::Message for Control {
     }
 }
 
-/// Defines additional types related to Control
+/// Defines additional types related to [Control].
 pub mod control {
     #[allow(unused_imports)]
     use super::*;
@@ -5528,7 +5528,7 @@ impl wkt::message::Message for OutputConfig {
     }
 }
 
-/// Defines additional types related to OutputConfig
+/// Defines additional types related to [OutputConfig].
 pub mod output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5697,7 +5697,7 @@ impl wkt::message::Message for ExportErrorsConfig {
     }
 }
 
-/// Defines additional types related to ExportErrorsConfig
+/// Defines additional types related to [ExportErrorsConfig].
 pub mod export_errors_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6677,7 +6677,7 @@ impl wkt::message::Message for BigQuerySource {
     }
 }
 
-/// Defines additional types related to BigQuerySource
+/// Defines additional types related to [BigQuerySource].
 pub mod big_query_source {
     #[allow(unused_imports)]
     use super::*;
@@ -6829,7 +6829,7 @@ impl wkt::message::Message for ImportErrorsConfig {
     }
 }
 
-/// Defines additional types related to ImportErrorsConfig
+/// Defines additional types related to [ImportErrorsConfig].
 pub mod import_errors_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6985,7 +6985,7 @@ impl wkt::message::Message for ImportProductsRequest {
     }
 }
 
-/// Defines additional types related to ImportProductsRequest
+/// Defines additional types related to [ImportProductsRequest].
 pub mod import_products_request {
     #[allow(unused_imports)]
     use super::*;
@@ -7303,7 +7303,7 @@ impl wkt::message::Message for ProductInputConfig {
     }
 }
 
-/// Defines additional types related to ProductInputConfig
+/// Defines additional types related to [ProductInputConfig].
 pub mod product_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7448,7 +7448,7 @@ impl wkt::message::Message for UserEventInputConfig {
     }
 }
 
-/// Defines additional types related to UserEventInputConfig
+/// Defines additional types related to [UserEventInputConfig].
 pub mod user_event_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7543,7 +7543,7 @@ impl wkt::message::Message for CompletionDataInputConfig {
     }
 }
 
-/// Defines additional types related to CompletionDataInputConfig
+/// Defines additional types related to [CompletionDataInputConfig].
 pub mod completion_data_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8159,7 +8159,7 @@ impl wkt::message::Message for Model {
     }
 }
 
-/// Defines additional types related to Model
+/// Defines additional types related to [Model].
 pub mod model {
     #[allow(unused_imports)]
     use super::*;
@@ -8312,7 +8312,7 @@ pub mod model {
         }
     }
 
-    /// Defines additional types related to ModelFeaturesConfig
+    /// Defines additional types related to [ModelFeaturesConfig].
     pub mod model_features_config {
         #[allow(unused_imports)]
         use super::*;
@@ -9419,7 +9419,7 @@ impl wkt::message::Message for PredictResponse {
     }
 }
 
-/// Defines additional types related to PredictResponse
+/// Defines additional types related to [PredictResponse].
 pub mod predict_response {
     #[allow(unused_imports)]
     use super::*;
@@ -10394,7 +10394,7 @@ impl wkt::message::Message for Product {
     }
 }
 
-/// Defines additional types related to Product
+/// Defines additional types related to [Product].
 pub mod product {
     #[allow(unused_imports)]
     use super::*;
@@ -12578,7 +12578,7 @@ impl wkt::message::Message for Tile {
     }
 }
 
-/// Defines additional types related to Tile
+/// Defines additional types related to [Tile].
 pub mod tile {
     #[allow(unused_imports)]
     use super::*;
@@ -13155,7 +13155,7 @@ impl wkt::message::Message for SearchRequest {
     }
 }
 
-/// Defines additional types related to SearchRequest
+/// Defines additional types related to [SearchRequest].
 pub mod search_request {
     #[allow(unused_imports)]
     use super::*;
@@ -13289,7 +13289,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to FacetSpec
+    /// Defines additional types related to [FacetSpec].
     pub mod facet_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -13609,7 +13609,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to DynamicFacetSpec
+    /// Defines additional types related to [DynamicFacetSpec].
     pub mod dynamic_facet_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -13730,7 +13730,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to BoostSpec
+    /// Defines additional types related to [BoostSpec].
     pub mod boost_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -13854,7 +13854,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to QueryExpansionSpec
+    /// Defines additional types related to [QueryExpansionSpec].
     pub mod query_expansion_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -13963,7 +13963,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to PersonalizationSpec
+    /// Defines additional types related to [PersonalizationSpec].
     pub mod personalization_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -14067,7 +14067,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to SpellCorrectionSpec
+    /// Defines additional types related to [SpellCorrectionSpec].
     pub mod spell_correction_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -14214,7 +14214,7 @@ pub mod search_request {
         }
     }
 
-    /// Defines additional types related to ConversationalSearchSpec
+    /// Defines additional types related to [ConversationalSearchSpec].
     pub mod conversational_search_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -14306,7 +14306,7 @@ pub mod search_request {
             }
         }
 
-        /// Defines additional types related to UserAnswer
+        /// Defines additional types related to [UserAnswer].
         pub mod user_answer {
             #[allow(unused_imports)]
             use super::*;
@@ -14775,7 +14775,7 @@ impl gax::paginator::PageableResponse for SearchResponse {
     }
 }
 
-/// Defines additional types related to SearchResponse
+/// Defines additional types related to [SearchResponse].
 pub mod search_response {
     #[allow(unused_imports)]
     use super::*;
@@ -15031,7 +15031,7 @@ pub mod search_response {
         }
     }
 
-    /// Defines additional types related to Facet
+    /// Defines additional types related to [Facet].
     pub mod facet {
         #[allow(unused_imports)]
         use super::*;
@@ -15174,7 +15174,7 @@ pub mod search_response {
             }
         }
 
-        /// Defines additional types related to FacetValue
+        /// Defines additional types related to [FacetValue].
         pub mod facet_value {
             #[allow(unused_imports)]
             use super::*;
@@ -15369,7 +15369,7 @@ pub mod search_response {
         }
     }
 
-    /// Defines additional types related to ConversationalSearchResult
+    /// Defines additional types related to [ConversationalSearchResult].
     pub mod conversational_search_result {
         #[allow(unused_imports)]
         use super::*;
@@ -15561,7 +15561,7 @@ impl wkt::message::Message for ExperimentInfo {
     }
 }
 
-/// Defines additional types related to ExperimentInfo
+/// Defines additional types related to [ExperimentInfo].
 pub mod experiment_info {
     #[allow(unused_imports)]
     use super::*;
@@ -16121,7 +16121,7 @@ impl wkt::message::Message for ServingConfig {
     }
 }
 
-/// Defines additional types related to ServingConfig
+/// Defines additional types related to [ServingConfig].
 pub mod serving_config {
     #[allow(unused_imports)]
     use super::*;
@@ -17417,7 +17417,7 @@ impl wkt::message::Message for CollectUserEventRequest {
     }
 }
 
-/// Defines additional types related to CollectUserEventRequest
+/// Defines additional types related to [CollectUserEventRequest].
 pub mod collect_user_event_request {
     #[allow(unused_imports)]
     use super::*;
@@ -17481,7 +17481,7 @@ impl wkt::message::Message for RejoinUserEventsRequest {
     }
 }
 
-/// Defines additional types related to RejoinUserEventsRequest
+/// Defines additional types related to [RejoinUserEventsRequest].
 pub mod rejoin_user_events_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -246,7 +246,7 @@ impl wkt::message::Message for SubmitBuildRequest {
     }
 }
 
-/// Defines additional types related to SubmitBuildRequest
+/// Defines additional types related to [SubmitBuildRequest].
 pub mod submit_build_request {
     #[allow(unused_imports)]
     use super::*;
@@ -695,7 +695,7 @@ impl wkt::message::Message for Condition {
     }
 }
 
-/// Defines additional types related to Condition
+/// Defines additional types related to [Condition].
 pub mod condition {
     #[allow(unused_imports)]
     use super::*;
@@ -2296,7 +2296,7 @@ impl wkt::message::Message for RunJobRequest {
     }
 }
 
-/// Defines additional types related to RunJobRequest
+/// Defines additional types related to [RunJobRequest].
 pub mod run_job_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2361,7 +2361,7 @@ pub mod run_job_request {
         }
     }
 
-    /// Defines additional types related to Overrides
+    /// Defines additional types related to [Overrides].
     pub mod overrides {
         #[allow(unused_imports)]
         use super::*;
@@ -2868,7 +2868,7 @@ impl wkt::message::Message for Job {
     }
 }
 
-/// Defines additional types related to Job
+/// Defines additional types related to [Job].
 pub mod job {
     #[allow(unused_imports)]
     use super::*;
@@ -2972,7 +2972,7 @@ impl wkt::message::Message for ExecutionReference {
     }
 }
 
-/// Defines additional types related to ExecutionReference
+/// Defines additional types related to [ExecutionReference].
 pub mod execution_reference {
     #[allow(unused_imports)]
     use super::*;
@@ -3422,7 +3422,7 @@ impl wkt::message::Message for EnvVar {
     }
 }
 
-/// Defines additional types related to EnvVar
+/// Defines additional types related to [EnvVar].
 pub mod env_var {
     #[allow(unused_imports)]
     use super::*;
@@ -3779,7 +3779,7 @@ impl wkt::message::Message for Volume {
     }
 }
 
-/// Defines additional types related to Volume
+/// Defines additional types related to [Volume].
 pub mod volume {
     #[allow(unused_imports)]
     use super::*;
@@ -4039,7 +4039,7 @@ impl wkt::message::Message for EmptyDirVolumeSource {
     }
 }
 
-/// Defines additional types related to EmptyDirVolumeSource
+/// Defines additional types related to [EmptyDirVolumeSource].
 pub mod empty_dir_volume_source {
     #[allow(unused_imports)]
     use super::*;
@@ -4357,7 +4357,7 @@ impl wkt::message::Message for Probe {
     }
 }
 
-/// Defines additional types related to Probe
+/// Defines additional types related to [Probe].
 pub mod probe {
     #[allow(unused_imports)]
     use super::*;
@@ -7181,7 +7181,7 @@ impl wkt::message::Message for TaskTemplate {
     }
 }
 
-/// Defines additional types related to TaskTemplate
+/// Defines additional types related to [TaskTemplate].
 pub mod task_template {
     #[allow(unused_imports)]
     use super::*;
@@ -7395,7 +7395,7 @@ impl wkt::message::Message for VpcAccess {
     }
 }
 
-/// Defines additional types related to VpcAccess
+/// Defines additional types related to [VpcAccess].
 pub mod vpc_access {
     #[allow(unused_imports)]
     use super::*;
@@ -7619,7 +7619,7 @@ impl wkt::message::Message for BinaryAuthorization {
     }
 }
 
-/// Defines additional types related to BinaryAuthorization
+/// Defines additional types related to [BinaryAuthorization].
 pub mod binary_authorization {
     #[allow(unused_imports)]
     use super::*;
@@ -7768,7 +7768,7 @@ impl wkt::message::Message for ServiceScaling {
     }
 }
 
-/// Defines additional types related to ServiceScaling
+/// Defines additional types related to [ServiceScaling].
 pub mod service_scaling {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -781,7 +781,7 @@ impl wkt::message::Message for Job {
     }
 }
 
-/// Defines additional types related to Job
+/// Defines additional types related to [Job].
 pub mod job {
     #[allow(unused_imports)]
     use super::*;
@@ -1225,7 +1225,7 @@ impl wkt::message::Message for HttpTarget {
     }
 }
 
-/// Defines additional types related to HttpTarget
+/// Defines additional types related to [HttpTarget].
 pub mod http_target {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -354,7 +354,7 @@ impl wkt::message::Message for Secret {
     }
 }
 
-/// Defines additional types related to Secret
+/// Defines additional types related to [Secret].
 pub mod secret {
     #[allow(unused_imports)]
     use super::*;
@@ -574,7 +574,7 @@ impl wkt::message::Message for SecretVersion {
     }
 }
 
-/// Defines additional types related to SecretVersion
+/// Defines additional types related to [SecretVersion].
 pub mod secret_version {
     #[allow(unused_imports)]
     use super::*;
@@ -753,7 +753,7 @@ impl wkt::message::Message for Replication {
     }
 }
 
-/// Defines additional types related to Replication
+/// Defines additional types related to [Replication].
 pub mod replication {
     #[allow(unused_imports)]
     use super::*;
@@ -853,7 +853,7 @@ pub mod replication {
         }
     }
 
-    /// Defines additional types related to UserManaged
+    /// Defines additional types related to [UserManaged].
     pub mod user_managed {
         #[allow(unused_imports)]
         use super::*;
@@ -1095,7 +1095,7 @@ impl wkt::message::Message for ReplicationStatus {
     }
 }
 
-/// Defines additional types related to ReplicationStatus
+/// Defines additional types related to [ReplicationStatus].
 pub mod replication_status {
     #[allow(unused_imports)]
     use super::*;
@@ -1195,7 +1195,7 @@ pub mod replication_status {
         }
     }
 
-    /// Defines additional types related to UserManagedStatus
+    /// Defines additional types related to [UserManagedStatus].
     pub mod user_managed_status {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/securesourcemanager/v1/src/model.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/model.rs
@@ -179,7 +179,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -595,7 +595,7 @@ impl wkt::message::Message for Repository {
     }
 }
 
-/// Defines additional types related to Repository
+/// Defines additional types related to [Repository].
 pub mod repository {
     #[allow(unused_imports)]
     use super::*;
@@ -1036,7 +1036,7 @@ impl wkt::message::Message for BranchRule {
     }
 }
 
-/// Defines additional types related to BranchRule
+/// Defines additional types related to [BranchRule].
 pub mod branch_rule {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -374,7 +374,7 @@ impl wkt::message::Message for CertificateAuthority {
     }
 }
 
-/// Defines additional types related to CertificateAuthority
+/// Defines additional types related to [CertificateAuthority].
 pub mod certificate_authority {
     #[allow(unused_imports)]
     use super::*;
@@ -544,7 +544,7 @@ pub mod certificate_authority {
         }
     }
 
-    /// Defines additional types related to KeyVersionSpec
+    /// Defines additional types related to [KeyVersionSpec].
     pub mod key_version_spec {
         #[allow(unused_imports)]
         use super::*;
@@ -963,7 +963,7 @@ impl wkt::message::Message for CaPool {
     }
 }
 
-/// Defines additional types related to CaPool
+/// Defines additional types related to [CaPool].
 pub mod ca_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -1054,7 +1054,7 @@ pub mod ca_pool {
         }
     }
 
-    /// Defines additional types related to PublishingOptions
+    /// Defines additional types related to [PublishingOptions].
     pub mod publishing_options {
         #[allow(unused_imports)]
         use super::*;
@@ -1304,7 +1304,7 @@ pub mod ca_pool {
         }
     }
 
-    /// Defines additional types related to IssuancePolicy
+    /// Defines additional types related to [IssuancePolicy].
     pub mod issuance_policy {
         #[allow(unused_imports)]
         use super::*;
@@ -1439,7 +1439,7 @@ pub mod ca_pool {
             }
         }
 
-        /// Defines additional types related to AllowedKeyType
+        /// Defines additional types related to [AllowedKeyType].
         pub mod allowed_key_type {
             #[allow(unused_imports)]
             use super::*;
@@ -1527,7 +1527,7 @@ pub mod ca_pool {
                 }
             }
 
-            /// Defines additional types related to EcKeyType
+            /// Defines additional types related to [EcKeyType].
             pub mod ec_key_type {
                 #[allow(unused_imports)]
                 use super::*;
@@ -1916,7 +1916,7 @@ impl wkt::message::Message for CertificateRevocationList {
     }
 }
 
-/// Defines additional types related to CertificateRevocationList
+/// Defines additional types related to [CertificateRevocationList].
 pub mod certificate_revocation_list {
     #[allow(unused_imports)]
     use super::*;
@@ -2345,7 +2345,7 @@ impl wkt::message::Message for Certificate {
     }
 }
 
-/// Defines additional types related to Certificate
+/// Defines additional types related to [Certificate].
 pub mod certificate {
     #[allow(unused_imports)]
     use super::*;
@@ -2755,7 +2755,7 @@ impl wkt::message::Message for X509Parameters {
     }
 }
 
-/// Defines additional types related to X509Parameters
+/// Defines additional types related to [X509Parameters].
 pub mod x_509_parameters {
     #[allow(unused_imports)]
     use super::*;
@@ -3088,7 +3088,7 @@ impl wkt::message::Message for SubordinateConfig {
     }
 }
 
-/// Defines additional types related to SubordinateConfig
+/// Defines additional types related to [SubordinateConfig].
 pub mod subordinate_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3197,7 +3197,7 @@ impl wkt::message::Message for PublicKey {
     }
 }
 
-/// Defines additional types related to PublicKey
+/// Defines additional types related to [PublicKey].
 pub mod public_key {
     #[allow(unused_imports)]
     use super::*;
@@ -3364,7 +3364,7 @@ impl wkt::message::Message for CertificateConfig {
     }
 }
 
-/// Defines additional types related to CertificateConfig
+/// Defines additional types related to [CertificateConfig].
 pub mod certificate_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3604,7 +3604,7 @@ impl wkt::message::Message for CertificateDescription {
     }
 }
 
-/// Defines additional types related to CertificateDescription
+/// Defines additional types related to [CertificateDescription].
 pub mod certificate_description {
     #[allow(unused_imports)]
     use super::*;
@@ -3942,7 +3942,7 @@ impl wkt::message::Message for KeyUsage {
     }
 }
 
-/// Defines additional types related to KeyUsage
+/// Defines additional types related to [KeyUsage].
 pub mod key_usage {
     #[allow(unused_imports)]
     use super::*;
@@ -4488,7 +4488,7 @@ impl wkt::message::Message for CertificateExtensionConstraints {
     }
 }
 
-/// Defines additional types related to CertificateExtensionConstraints
+/// Defines additional types related to [CertificateExtensionConstraints].
 pub mod certificate_extension_constraints {
     #[allow(unused_imports)]
     use super::*;
@@ -6266,7 +6266,7 @@ impl wkt::message::Message for FetchCaCertsResponse {
     }
 }
 
-/// Defines additional types related to FetchCaCertsResponse
+/// Defines additional types related to [FetchCaCertsResponse].
 pub mod fetch_ca_certs_response {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -439,7 +439,7 @@ impl wkt::message::Message for AttackExposure {
     }
 }
 
-/// Defines additional types related to AttackExposure
+/// Defines additional types related to [AttackExposure].
 pub mod attack_exposure {
     #[allow(unused_imports)]
     use super::*;
@@ -562,7 +562,7 @@ impl wkt::message::Message for AttackPath {
     }
 }
 
-/// Defines additional types related to AttackPath
+/// Defines additional types related to [AttackPath].
 pub mod attack_path {
     #[allow(unused_imports)]
     use super::*;
@@ -670,7 +670,7 @@ pub mod attack_path {
         }
     }
 
-    /// Defines additional types related to AttackPathNode
+    /// Defines additional types related to [AttackPathNode].
     pub mod attack_path_node {
         #[allow(unused_imports)]
         use super::*;
@@ -1607,7 +1607,7 @@ impl wkt::message::Message for CloudDlpDataProfile {
     }
 }
 
-/// Defines additional types related to CloudDlpDataProfile
+/// Defines additional types related to [CloudDlpDataProfile].
 pub mod cloud_dlp_data_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -1863,7 +1863,7 @@ impl wkt::message::Message for Connection {
     }
 }
 
-/// Defines additional types related to Connection
+/// Defines additional types related to [Connection].
 pub mod connection {
     #[allow(unused_imports)]
     use super::*;
@@ -2149,7 +2149,7 @@ impl wkt::message::Message for DataAccessEvent {
     }
 }
 
-/// Defines additional types related to DataAccessEvent
+/// Defines additional types related to [DataAccessEvent].
 pub mod data_access_event {
     #[allow(unused_imports)]
     use super::*;
@@ -2297,7 +2297,7 @@ impl wkt::message::Message for DataFlowEvent {
     }
 }
 
-/// Defines additional types related to DataFlowEvent
+/// Defines additional types related to [DataFlowEvent].
 pub mod data_flow_event {
     #[allow(unused_imports)]
     use super::*;
@@ -2450,7 +2450,7 @@ impl wkt::message::Message for DataRetentionDeletionEvent {
     }
 }
 
-/// Defines additional types related to DataRetentionDeletionEvent
+/// Defines additional types related to [DataRetentionDeletionEvent].
 pub mod data_retention_deletion_event {
     #[allow(unused_imports)]
     use super::*;
@@ -2925,7 +2925,7 @@ impl wkt::message::Message for ExternalSystem {
     }
 }
 
-/// Defines additional types related to ExternalSystem
+/// Defines additional types related to [ExternalSystem].
 pub mod external_system {
     #[allow(unused_imports)]
     use super::*;
@@ -3113,7 +3113,7 @@ impl wkt::message::Message for File {
     }
 }
 
-/// Defines additional types related to File
+/// Defines additional types related to [File].
 pub mod file {
     #[allow(unused_imports)]
     use super::*;
@@ -4024,7 +4024,7 @@ impl wkt::message::Message for Finding {
     }
 }
 
-/// Defines additional types related to Finding
+/// Defines additional types related to [Finding].
 pub mod finding {
     #[allow(unused_imports)]
     use super::*;
@@ -4081,7 +4081,7 @@ pub mod finding {
         }
     }
 
-    /// Defines additional types related to MuteInfo
+    /// Defines additional types related to [MuteInfo].
     pub mod mute_info {
         #[allow(unused_imports)]
         use super::*;
@@ -4592,7 +4592,7 @@ impl wkt::message::Message for GroupMembership {
     }
 }
 
-/// Defines additional types related to GroupMembership
+/// Defines additional types related to [GroupMembership].
 pub mod group_membership {
     #[allow(unused_imports)]
     use super::*;
@@ -4706,7 +4706,7 @@ impl wkt::message::Message for IamBinding {
     }
 }
 
-/// Defines additional types related to IamBinding
+/// Defines additional types related to [IamBinding].
 pub mod iam_binding {
     #[allow(unused_imports)]
     use super::*;
@@ -4853,7 +4853,7 @@ impl wkt::message::Message for Indicator {
     }
 }
 
-/// Defines additional types related to Indicator
+/// Defines additional types related to [Indicator].
 pub mod indicator {
     #[allow(unused_imports)]
     use super::*;
@@ -4983,7 +4983,7 @@ pub mod indicator {
         }
     }
 
-    /// Defines additional types related to ProcessSignature
+    /// Defines additional types related to [ProcessSignature].
     pub mod process_signature {
         #[allow(unused_imports)]
         use super::*;
@@ -5038,7 +5038,7 @@ pub mod indicator {
             }
         }
 
-        /// Defines additional types related to MemoryHashSignature
+        /// Defines additional types related to [MemoryHashSignature].
         pub mod memory_hash_signature {
             #[allow(unused_imports)]
             use super::*;
@@ -5449,7 +5449,7 @@ impl wkt::message::Message for Kubernetes {
     }
 }
 
-/// Defines additional types related to Kubernetes
+/// Defines additional types related to [Kubernetes].
 pub mod kubernetes {
     #[allow(unused_imports)]
     use super::*;
@@ -5649,7 +5649,7 @@ pub mod kubernetes {
         }
     }
 
-    /// Defines additional types related to Role
+    /// Defines additional types related to [Role].
     pub mod role {
         #[allow(unused_imports)]
         use super::*;
@@ -5833,7 +5833,7 @@ pub mod kubernetes {
         }
     }
 
-    /// Defines additional types related to Subject
+    /// Defines additional types related to [Subject].
     pub mod subject {
         #[allow(unused_imports)]
         use super::*;
@@ -6213,7 +6213,7 @@ impl wkt::message::Message for LogEntry {
     }
 }
 
-/// Defines additional types related to LogEntry
+/// Defines additional types related to [LogEntry].
 pub mod log_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -6390,7 +6390,7 @@ impl wkt::message::Message for MitreAttack {
     }
 }
 
-/// Defines additional types related to MitreAttack
+/// Defines additional types related to [MitreAttack].
 pub mod mitre_attack {
     #[allow(unused_imports)]
     use super::*;
@@ -7109,7 +7109,7 @@ impl wkt::message::Message for MuteConfig {
     }
 }
 
-/// Defines additional types related to MuteConfig
+/// Defines additional types related to [MuteConfig].
 pub mod mute_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7365,7 +7365,7 @@ impl wkt::message::Message for NotificationConfig {
     }
 }
 
-/// Defines additional types related to NotificationConfig
+/// Defines additional types related to [NotificationConfig].
 pub mod notification_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7515,7 +7515,7 @@ impl wkt::message::Message for NotificationMessage {
     }
 }
 
-/// Defines additional types related to NotificationMessage
+/// Defines additional types related to [NotificationMessage].
 pub mod notification_message {
     #[allow(unused_imports)]
     use super::*;
@@ -7970,7 +7970,7 @@ impl wkt::message::Message for Resource {
     }
 }
 
-/// Defines additional types related to Resource
+/// Defines additional types related to [Resource].
 pub mod resource {
     #[allow(unused_imports)]
     use super::*;
@@ -8147,7 +8147,7 @@ impl wkt::message::Message for AwsMetadata {
     }
 }
 
-/// Defines additional types related to AwsMetadata
+/// Defines additional types related to [AwsMetadata].
 pub mod aws_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -8351,7 +8351,7 @@ impl wkt::message::Message for AzureMetadata {
     }
 }
 
-/// Defines additional types related to AzureMetadata
+/// Defines additional types related to [AzureMetadata].
 pub mod azure_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -8561,7 +8561,7 @@ impl wkt::message::Message for ResourcePath {
     }
 }
 
-/// Defines additional types related to ResourcePath
+/// Defines additional types related to [ResourcePath].
 pub mod resource_path {
     #[allow(unused_imports)]
     use super::*;
@@ -8901,7 +8901,7 @@ impl wkt::message::Message for ResourceValueConfig {
     }
 }
 
-/// Defines additional types related to ResourceValueConfig
+/// Defines additional types related to [ResourceValueConfig].
 pub mod resource_value_config {
     #[allow(unused_imports)]
     use super::*;
@@ -9165,7 +9165,7 @@ impl wkt::message::Message for SecurityPosture {
     }
 }
 
-/// Defines additional types related to SecurityPosture
+/// Defines additional types related to [SecurityPosture].
 pub mod security_posture {
     #[allow(unused_imports)]
     use super::*;
@@ -9399,7 +9399,7 @@ impl wkt::message::Message for BulkMuteFindingsRequest {
     }
 }
 
-/// Defines additional types related to BulkMuteFindingsRequest
+/// Defines additional types related to [BulkMuteFindingsRequest].
 pub mod bulk_mute_findings_request {
     #[allow(unused_imports)]
     use super::*;
@@ -10949,7 +10949,7 @@ impl gax::paginator::PageableResponse for ListFindingsResponse {
     }
 }
 
-/// Defines additional types related to ListFindingsResponse
+/// Defines additional types related to [ListFindingsResponse].
 pub mod list_findings_response {
     #[allow(unused_imports)]
     use super::*;
@@ -11007,7 +11007,7 @@ pub mod list_findings_response {
         }
     }
 
-    /// Defines additional types related to ListFindingsResult
+    /// Defines additional types related to [ListFindingsResult].
     pub mod list_findings_result {
         #[allow(unused_imports)]
         use super::*;
@@ -11246,7 +11246,7 @@ pub mod list_findings_response {
             }
         }
 
-        /// Defines additional types related to Resource
+        /// Defines additional types related to [Resource].
         pub mod resource {
             #[allow(unused_imports)]
             use super::*;
@@ -12705,7 +12705,7 @@ impl wkt::message::Message for ValuedResource {
     }
 }
 
-/// Defines additional types related to ValuedResource
+/// Defines additional types related to [ValuedResource].
 pub mod valued_resource {
     #[allow(unused_imports)]
     use super::*;
@@ -13024,7 +13024,7 @@ impl wkt::message::Message for Cve {
     }
 }
 
-/// Defines additional types related to Cve
+/// Defines additional types related to [Cve].
 pub mod cve {
     #[allow(unused_imports)]
     use super::*;
@@ -13357,7 +13357,7 @@ impl wkt::message::Message for Cvssv3 {
     }
 }
 
-/// Defines additional types related to Cvssv3
+/// Defines additional types related to [Cvssv3].
 pub mod cvssv_3 {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/securityposture/v1/src/model.rs
+++ b/src/generated/cloud/securityposture/v1/src/model.rs
@@ -180,7 +180,7 @@ impl wkt::message::Message for PolicyRule {
     }
 }
 
-/// Defines additional types related to PolicyRule
+/// Defines additional types related to [PolicyRule].
 pub mod policy_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -409,7 +409,7 @@ impl wkt::message::Message for CustomConstraint {
     }
 }
 
-/// Defines additional types related to CustomConstraint
+/// Defines additional types related to [CustomConstraint].
 pub mod custom_constraint {
     #[allow(unused_imports)]
     use super::*;
@@ -903,7 +903,7 @@ impl wkt::message::Message for Posture {
     }
 }
 
-/// Defines additional types related to Posture
+/// Defines additional types related to [Posture].
 pub mod posture {
     #[allow(unused_imports)]
     use super::*;
@@ -1093,7 +1093,7 @@ impl wkt::message::Message for Policy {
     }
 }
 
-/// Defines additional types related to Policy
+/// Defines additional types related to [Policy].
 pub mod policy {
     #[allow(unused_imports)]
     use super::*;
@@ -1300,7 +1300,7 @@ impl wkt::message::Message for Constraint {
     }
 }
 
-/// Defines additional types related to Constraint
+/// Defines additional types related to [Constraint].
 pub mod constraint {
     #[allow(unused_imports)]
     use super::*;
@@ -2003,7 +2003,7 @@ impl wkt::message::Message for PostureDeployment {
     }
 }
 
-/// Defines additional types related to PostureDeployment
+/// Defines additional types related to [PostureDeployment].
 pub mod posture_deployment {
     #[allow(unused_imports)]
     use super::*;
@@ -2480,7 +2480,7 @@ impl wkt::message::Message for PostureTemplate {
     }
 }
 
-/// Defines additional types related to PostureTemplate
+/// Defines additional types related to [PostureTemplate].
 pub mod posture_template {
     #[allow(unused_imports)]
     use super::*;
@@ -2918,7 +2918,7 @@ impl wkt::message::Message for CustomConfig {
     }
 }
 
-/// Defines additional types related to CustomConfig
+/// Defines additional types related to [CustomConfig].
 pub mod custom_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2960,7 +2960,7 @@ pub mod custom_config {
         }
     }
 
-    /// Defines additional types related to CustomOutputSpec
+    /// Defines additional types related to [CustomOutputSpec].
     pub mod custom_output_spec {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/servicehealth/v1/src/model.rs
+++ b/src/generated/cloud/servicehealth/v1/src/model.rs
@@ -236,7 +236,7 @@ impl wkt::message::Message for Event {
     }
 }
 
-/// Defines additional types related to Event
+/// Defines additional types related to [Event].
 pub mod event {
     #[allow(unused_imports)]
     use super::*;
@@ -795,7 +795,7 @@ impl wkt::message::Message for OrganizationEvent {
     }
 }
 
-/// Defines additional types related to OrganizationEvent
+/// Defines additional types related to [OrganizationEvent].
 pub mod organization_event {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/shell/v1/src/model.rs
+++ b/src/generated/cloud/shell/v1/src/model.rs
@@ -164,7 +164,7 @@ impl wkt::message::Message for Environment {
     }
 }
 
-/// Defines additional types related to Environment
+/// Defines additional types related to [Environment].
 pub mod environment {
     #[allow(unused_imports)]
     use super::*;
@@ -522,7 +522,7 @@ impl wkt::message::Message for StartEnvironmentMetadata {
     }
 }
 
-/// Defines additional types related to StartEnvironmentMetadata
+/// Defines additional types related to [StartEnvironmentMetadata].
 pub mod start_environment_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -870,7 +870,7 @@ impl wkt::message::Message for CloudShellErrorDetails {
     }
 }
 
-/// Defines additional types related to CloudShellErrorDetails
+/// Defines additional types related to [CloudShellErrorDetails].
 pub mod cloud_shell_error_details {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -718,7 +718,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -1383,7 +1383,7 @@ impl wkt::message::Message for Recognizer {
     }
 }
 
-/// Defines additional types related to Recognizer
+/// Defines additional types related to [Recognizer].
 pub mod recognizer {
     #[allow(unused_imports)]
     use super::*;
@@ -1551,7 +1551,7 @@ impl wkt::message::Message for ExplicitDecodingConfig {
     }
 }
 
-/// Defines additional types related to ExplicitDecodingConfig
+/// Defines additional types related to [ExplicitDecodingConfig].
 pub mod explicit_decoding_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1848,7 +1848,7 @@ impl wkt::message::Message for RecognitionFeatures {
     }
 }
 
-/// Defines additional types related to RecognitionFeatures
+/// Defines additional types related to [RecognitionFeatures].
 pub mod recognition_features {
     #[allow(unused_imports)]
     use super::*;
@@ -1956,7 +1956,7 @@ impl wkt::message::Message for TranscriptNormalization {
     }
 }
 
-/// Defines additional types related to TranscriptNormalization
+/// Defines additional types related to [TranscriptNormalization].
 pub mod transcript_normalization {
     #[allow(unused_imports)]
     use super::*;
@@ -2092,7 +2092,7 @@ impl wkt::message::Message for SpeechAdaptation {
     }
 }
 
-/// Defines additional types related to SpeechAdaptation
+/// Defines additional types related to [SpeechAdaptation].
 pub mod speech_adaptation {
     #[allow(unused_imports)]
     use super::*;
@@ -2195,7 +2195,7 @@ pub mod speech_adaptation {
         }
     }
 
-    /// Defines additional types related to AdaptationPhraseSet
+    /// Defines additional types related to [AdaptationPhraseSet].
     pub mod adaptation_phrase_set {
         #[allow(unused_imports)]
         use super::*;
@@ -2420,7 +2420,7 @@ impl wkt::message::Message for RecognitionConfig {
     }
 }
 
-/// Defines additional types related to RecognitionConfig
+/// Defines additional types related to [RecognitionConfig].
 pub mod recognition_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2591,7 +2591,7 @@ impl wkt::message::Message for RecognizeRequest {
     }
 }
 
-/// Defines additional types related to RecognizeRequest
+/// Defines additional types related to [RecognizeRequest].
 pub mod recognize_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3024,7 +3024,7 @@ impl wkt::message::Message for StreamingRecognitionFeatures {
     }
 }
 
-/// Defines additional types related to StreamingRecognitionFeatures
+/// Defines additional types related to [StreamingRecognitionFeatures].
 pub mod streaming_recognition_features {
     #[allow(unused_imports)]
     use super::*;
@@ -3298,7 +3298,7 @@ impl wkt::message::Message for StreamingRecognizeRequest {
     }
 }
 
-/// Defines additional types related to StreamingRecognizeRequest
+/// Defines additional types related to [StreamingRecognizeRequest].
 pub mod streaming_recognize_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3449,7 +3449,7 @@ impl wkt::message::Message for BatchRecognizeRequest {
     }
 }
 
-/// Defines additional types related to BatchRecognizeRequest
+/// Defines additional types related to [BatchRecognizeRequest].
 pub mod batch_recognize_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3801,7 +3801,7 @@ impl wkt::message::Message for RecognitionOutputConfig {
     }
 }
 
-/// Defines additional types related to RecognitionOutputConfig
+/// Defines additional types related to [RecognitionOutputConfig].
 pub mod recognition_output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4185,7 +4185,7 @@ impl wkt::message::Message for BatchRecognizeFileResult {
     }
 }
 
-/// Defines additional types related to BatchRecognizeFileResult
+/// Defines additional types related to [BatchRecognizeFileResult].
 pub mod batch_recognize_file_result {
     #[allow(unused_imports)]
     use super::*;
@@ -4420,7 +4420,7 @@ impl wkt::message::Message for BatchRecognizeFileMetadata {
     }
 }
 
-/// Defines additional types related to BatchRecognizeFileMetadata
+/// Defines additional types related to [BatchRecognizeFileMetadata].
 pub mod batch_recognize_file_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -4675,7 +4675,7 @@ impl wkt::message::Message for StreamingRecognizeResponse {
     }
 }
 
-/// Defines additional types related to StreamingRecognizeResponse
+/// Defines additional types related to [StreamingRecognizeResponse].
 pub mod streaming_recognize_response {
     #[allow(unused_imports)]
     use super::*;
@@ -5108,7 +5108,7 @@ impl wkt::message::Message for CustomClass {
     }
 }
 
-/// Defines additional types related to CustomClass
+/// Defines additional types related to [CustomClass].
 pub mod custom_class {
     #[allow(unused_imports)]
     use super::*;
@@ -5416,7 +5416,7 @@ impl wkt::message::Message for PhraseSet {
     }
 }
 
-/// Defines additional types related to PhraseSet
+/// Defines additional types related to [PhraseSet].
 pub mod phrase_set {
     #[allow(unused_imports)]
     use super::*;
@@ -6566,7 +6566,7 @@ impl wkt::message::Message for AccessMetadata {
     }
 }
 
-/// Defines additional types related to AccessMetadata
+/// Defines additional types related to [AccessMetadata].
 pub mod access_metadata {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -686,7 +686,7 @@ impl wkt::message::Message for ConnectSettings {
     }
 }
 
-/// Defines additional types related to ConnectSettings
+/// Defines additional types related to [ConnectSettings].
 pub mod connect_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -2684,7 +2684,7 @@ impl wkt::message::Message for BackupReencryptionConfig {
     }
 }
 
-/// Defines additional types related to BackupReencryptionConfig
+/// Defines additional types related to [BackupReencryptionConfig].
 pub mod backup_reencryption_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2912,7 +2912,7 @@ impl wkt::message::Message for SqlInstancesVerifyExternalSyncSettingsRequest {
     }
 }
 
-/// Defines additional types related to SqlInstancesVerifyExternalSyncSettingsRequest
+/// Defines additional types related to [SqlInstancesVerifyExternalSyncSettingsRequest].
 pub mod sql_instances_verify_external_sync_settings_request {
     #[allow(unused_imports)]
     use super::*;
@@ -3159,7 +3159,7 @@ impl wkt::message::Message for SqlInstancesStartExternalSyncRequest {
     }
 }
 
-/// Defines additional types related to SqlInstancesStartExternalSyncRequest
+/// Defines additional types related to [SqlInstancesStartExternalSyncRequest].
 pub mod sql_instances_start_external_sync_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4638,7 +4638,7 @@ impl wkt::message::Message for DatabaseInstance {
     }
 }
 
-/// Defines additional types related to DatabaseInstance
+/// Defines additional types related to [DatabaseInstance].
 pub mod database_instance {
     #[allow(unused_imports)]
     use super::*;
@@ -4795,7 +4795,7 @@ pub mod database_instance {
         }
     }
 
-    /// Defines additional types related to SqlOutOfDiskReport
+    /// Defines additional types related to [SqlOutOfDiskReport].
     pub mod sql_out_of_disk_report {
         #[allow(unused_imports)]
         use super::*;
@@ -5228,7 +5228,7 @@ impl wkt::message::Message for SqlInstancesRescheduleMaintenanceRequestBody {
     }
 }
 
-/// Defines additional types related to SqlInstancesRescheduleMaintenanceRequestBody
+/// Defines additional types related to [SqlInstancesRescheduleMaintenanceRequestBody].
 pub mod sql_instances_reschedule_maintenance_request_body {
     #[allow(unused_imports)]
     use super::*;
@@ -5692,7 +5692,7 @@ impl wkt::message::Message for SqlExternalSyncSettingError {
     }
 }
 
-/// Defines additional types related to SqlExternalSyncSettingError
+/// Defines additional types related to [SqlExternalSyncSettingError].
 pub mod sql_external_sync_setting_error {
     #[allow(unused_imports)]
     use super::*;
@@ -6653,7 +6653,7 @@ impl wkt::message::Message for ApiWarning {
     }
 }
 
-/// Defines additional types related to ApiWarning
+/// Defines additional types related to [ApiWarning].
 pub mod api_warning {
     #[allow(unused_imports)]
     use super::*;
@@ -6773,7 +6773,7 @@ impl wkt::message::Message for BackupRetentionSettings {
     }
 }
 
-/// Defines additional types related to BackupRetentionSettings
+/// Defines additional types related to [BackupRetentionSettings].
 pub mod backup_retention_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -6957,7 +6957,7 @@ impl wkt::message::Message for BackupConfiguration {
     }
 }
 
-/// Defines additional types related to BackupConfiguration
+/// Defines additional types related to [BackupConfiguration].
 pub mod backup_configuration {
     #[allow(unused_imports)]
     use super::*;
@@ -7247,7 +7247,7 @@ impl wkt::message::Message for Database {
     }
 }
 
-/// Defines additional types related to Database
+/// Defines additional types related to [Database].
 pub mod database {
     #[allow(unused_imports)]
     use super::*;
@@ -7723,7 +7723,7 @@ impl wkt::message::Message for ExportContext {
     }
 }
 
-/// Defines additional types related to ExportContext
+/// Defines additional types related to [ExportContext].
 pub mod export_context {
     #[allow(unused_imports)]
     use super::*;
@@ -7886,7 +7886,7 @@ pub mod export_context {
         }
     }
 
-    /// Defines additional types related to SqlExportOptions
+    /// Defines additional types related to [SqlExportOptions].
     pub mod sql_export_options {
         #[allow(unused_imports)]
         use super::*;
@@ -8150,7 +8150,7 @@ impl wkt::message::Message for ImportContext {
     }
 }
 
-/// Defines additional types related to ImportContext
+/// Defines additional types related to [ImportContext].
 pub mod import_context {
     #[allow(unused_imports)]
     use super::*;
@@ -8205,7 +8205,7 @@ pub mod import_context {
         }
     }
 
-    /// Defines additional types related to SqlImportOptions
+    /// Defines additional types related to [SqlImportOptions].
     pub mod sql_import_options {
         #[allow(unused_imports)]
         use super::*;
@@ -8439,7 +8439,7 @@ pub mod import_context {
         }
     }
 
-    /// Defines additional types related to SqlBakImportOptions
+    /// Defines additional types related to [SqlBakImportOptions].
     pub mod sql_bak_import_options {
         #[allow(unused_imports)]
         use super::*;
@@ -8654,7 +8654,7 @@ impl wkt::message::Message for IpConfiguration {
     }
 }
 
-/// Defines additional types related to IpConfiguration
+/// Defines additional types related to [IpConfiguration].
 pub mod ip_configuration {
     #[allow(unused_imports)]
     use super::*;
@@ -9613,7 +9613,7 @@ impl wkt::message::Message for Operation {
     }
 }
 
-/// Defines additional types related to Operation
+/// Defines additional types related to [Operation].
 pub mod operation {
     #[allow(unused_imports)]
     use super::*;
@@ -10156,7 +10156,7 @@ impl wkt::message::Message for PasswordValidationPolicy {
     }
 }
 
-/// Defines additional types related to PasswordValidationPolicy
+/// Defines additional types related to [PasswordValidationPolicy].
 pub mod password_validation_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -10674,7 +10674,7 @@ impl wkt::message::Message for Settings {
     }
 }
 
-/// Defines additional types related to Settings
+/// Defines additional types related to [Settings].
 pub mod settings {
     #[allow(unused_imports)]
     use super::*;
@@ -12232,7 +12232,7 @@ impl wkt::message::Message for User {
     }
 }
 
-/// Defines additional types related to User
+/// Defines additional types related to [User].
 pub mod user {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -538,7 +538,7 @@ impl wkt::message::Message for ReportDetail {
     }
 }
 
-/// Defines additional types related to ReportDetail
+/// Defines additional types related to [ReportDetail].
 pub mod report_detail {
     #[allow(unused_imports)]
     use super::*;
@@ -904,7 +904,7 @@ impl wkt::message::Message for FrequencyOptions {
     }
 }
 
-/// Defines additional types related to FrequencyOptions
+/// Defines additional types related to [FrequencyOptions].
 pub mod frequency_options {
     #[allow(unused_imports)]
     use super::*;
@@ -1247,7 +1247,7 @@ impl wkt::message::Message for ObjectMetadataReportOptions {
     }
 }
 
-/// Defines additional types related to ObjectMetadataReportOptions
+/// Defines additional types related to [ObjectMetadataReportOptions].
 pub mod object_metadata_report_options {
     #[allow(unused_imports)]
     use super::*;
@@ -1498,7 +1498,7 @@ impl wkt::message::Message for ReportConfig {
     }
 }
 
-/// Defines additional types related to ReportConfig
+/// Defines additional types related to [ReportConfig].
 pub mod report_config {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/support/v2/src/model.rs
+++ b/src/generated/cloud/support/v2/src/model.rs
@@ -485,7 +485,7 @@ impl wkt::message::Message for Case {
     }
 }
 
-/// Defines additional types related to Case
+/// Defines additional types related to [Case].
 pub mod case {
     #[allow(unused_imports)]
     use super::*;
@@ -1547,7 +1547,7 @@ impl wkt::message::Message for Escalation {
     }
 }
 
-/// Defines additional types related to Escalation
+/// Defines additional types related to [Escalation].
 pub mod escalation {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -165,7 +165,7 @@ impl wkt::message::Message for Location {
     }
 }
 
-/// Defines additional types related to Location
+/// Defines additional types related to [Location].
 pub mod location {
     #[allow(unused_imports)]
     use super::*;
@@ -484,7 +484,7 @@ impl wkt::message::Message for DeviceInfo {
     }
 }
 
-/// Defines additional types related to DeviceInfo
+/// Defines additional types related to [DeviceInfo].
 pub mod device_info {
     #[allow(unused_imports)]
     use super::*;
@@ -829,7 +829,7 @@ impl wkt::message::Message for CompensationInfo {
     }
 }
 
-/// Defines additional types related to CompensationInfo
+/// Defines additional types related to [CompensationInfo].
 pub mod compensation_info {
     #[allow(unused_imports)]
     use super::*;
@@ -1038,7 +1038,7 @@ pub mod compensation_info {
         }
     }
 
-    /// Defines additional types related to CompensationEntry
+    /// Defines additional types related to [CompensationEntry].
     pub mod compensation_entry {
         #[allow(unused_imports)]
         use super::*;
@@ -1447,7 +1447,7 @@ impl wkt::message::Message for BatchOperationMetadata {
     }
 }
 
-/// Defines additional types related to BatchOperationMetadata
+/// Defines additional types related to [BatchOperationMetadata].
 pub mod batch_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -1738,7 +1738,7 @@ impl wkt::message::Message for Company {
     }
 }
 
-/// Defines additional types related to Company
+/// Defines additional types related to [Company].
 pub mod company {
     #[allow(unused_imports)]
     use super::*;
@@ -2216,7 +2216,7 @@ impl wkt::message::Message for CompleteQueryRequest {
     }
 }
 
-/// Defines additional types related to CompleteQueryRequest
+/// Defines additional types related to [CompleteQueryRequest].
 pub mod complete_query_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2425,7 +2425,7 @@ impl wkt::message::Message for CompleteQueryResponse {
     }
 }
 
-/// Defines additional types related to CompleteQueryResponse
+/// Defines additional types related to [CompleteQueryResponse].
 pub mod complete_query_response {
     #[allow(unused_imports)]
     use super::*;
@@ -2602,7 +2602,7 @@ impl wkt::message::Message for ClientEvent {
     }
 }
 
-/// Defines additional types related to ClientEvent
+/// Defines additional types related to [ClientEvent].
 pub mod client_event {
     #[allow(unused_imports)]
     use super::*;
@@ -2685,7 +2685,7 @@ impl wkt::message::Message for JobEvent {
     }
 }
 
-/// Defines additional types related to JobEvent
+/// Defines additional types related to [JobEvent].
 pub mod job_event {
     #[allow(unused_imports)]
     use super::*;
@@ -3411,7 +3411,7 @@ impl wkt::message::Message for LocationFilter {
     }
 }
 
-/// Defines additional types related to LocationFilter
+/// Defines additional types related to [LocationFilter].
 pub mod location_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -3563,7 +3563,7 @@ impl wkt::message::Message for CompensationFilter {
     }
 }
 
-/// Defines additional types related to CompensationFilter
+/// Defines additional types related to [CompensationFilter].
 pub mod compensation_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -3830,7 +3830,7 @@ impl wkt::message::Message for CommuteFilter {
     }
 }
 
-/// Defines additional types related to CommuteFilter
+/// Defines additional types related to [CommuteFilter].
 pub mod commute_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -4633,7 +4633,7 @@ impl wkt::message::Message for Job {
     }
 }
 
-/// Defines additional types related to Job
+/// Defines additional types related to [Job].
 pub mod job {
     #[allow(unused_imports)]
     use super::*;
@@ -5678,7 +5678,7 @@ impl wkt::message::Message for SearchJobsRequest {
     }
 }
 
-/// Defines additional types related to SearchJobsRequest
+/// Defines additional types related to [SearchJobsRequest].
 pub mod search_jobs_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5765,7 +5765,7 @@ pub mod search_jobs_request {
         }
     }
 
-    /// Defines additional types related to CustomRankingInfo
+    /// Defines additional types related to [CustomRankingInfo].
     pub mod custom_ranking_info {
         #[allow(unused_imports)]
         use super::*;
@@ -6359,7 +6359,7 @@ impl wkt::message::Message for SearchJobsResponse {
     }
 }
 
-/// Defines additional types related to SearchJobsResponse
+/// Defines additional types related to [SearchJobsResponse].
 pub mod search_jobs_response {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/tasks/v2/src/model.rs
+++ b/src/generated/cloud/tasks/v2/src/model.rs
@@ -1120,7 +1120,7 @@ impl wkt::message::Message for Queue {
     }
 }
 
-/// Defines additional types related to Queue
+/// Defines additional types related to [Queue].
 pub mod queue {
     #[allow(unused_imports)]
     use super::*;
@@ -1759,7 +1759,7 @@ impl wkt::message::Message for HttpRequest {
     }
 }
 
-/// Defines additional types related to HttpRequest
+/// Defines additional types related to [HttpRequest].
 pub mod http_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2546,7 +2546,7 @@ impl wkt::message::Message for Task {
     }
 }
 
-/// Defines additional types related to Task
+/// Defines additional types related to [Task].
 pub mod task {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -143,7 +143,7 @@ impl wkt::message::Message for OrchestrationCluster {
     }
 }
 
-/// Defines additional types related to OrchestrationCluster
+/// Defines additional types related to [OrchestrationCluster].
 pub mod orchestration_cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -340,7 +340,7 @@ impl wkt::message::Message for EdgeSlm {
     }
 }
 
-/// Defines additional types related to EdgeSlm
+/// Defines additional types related to [EdgeSlm].
 pub mod edge_slm {
     #[allow(unused_imports)]
     use super::*;
@@ -677,7 +677,7 @@ impl wkt::message::Message for Blueprint {
     }
 }
 
-/// Defines additional types related to Blueprint
+/// Defines additional types related to [Blueprint].
 pub mod blueprint {
     #[allow(unused_imports)]
     use super::*;
@@ -1053,7 +1053,7 @@ impl wkt::message::Message for Deployment {
     }
 }
 
-/// Defines additional types related to Deployment
+/// Defines additional types related to [Deployment].
 pub mod deployment {
     #[allow(unused_imports)]
     use super::*;
@@ -1204,7 +1204,7 @@ impl wkt::message::Message for HydratedDeployment {
     }
 }
 
-/// Defines additional types related to HydratedDeployment
+/// Defines additional types related to [HydratedDeployment].
 pub mod hydrated_deployment {
     #[allow(unused_imports)]
     use super::*;
@@ -3819,7 +3819,7 @@ impl wkt::message::Message for ManagementConfig {
     }
 }
 
-/// Defines additional types related to ManagementConfig
+/// Defines additional types related to [ManagementConfig].
 pub mod management_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4148,7 +4148,7 @@ impl wkt::message::Message for MasterAuthorizedNetworksConfig {
     }
 }
 
-/// Defines additional types related to MasterAuthorizedNetworksConfig
+/// Defines additional types related to [MasterAuthorizedNetworksConfig].
 pub mod master_authorized_networks_config {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/texttospeech/v1/src/model.rs
+++ b/src/generated/cloud/texttospeech/v1/src/model.rs
@@ -345,7 +345,7 @@ impl wkt::message::Message for CustomPronunciationParams {
     }
 }
 
-/// Defines additional types related to CustomPronunciationParams
+/// Defines additional types related to [CustomPronunciationParams].
 pub mod custom_pronunciation_params {
     #[allow(unused_imports)]
     use super::*;
@@ -482,7 +482,7 @@ impl wkt::message::Message for MultiSpeakerMarkup {
     }
 }
 
-/// Defines additional types related to MultiSpeakerMarkup
+/// Defines additional types related to [MultiSpeakerMarkup].
 pub mod multi_speaker_markup {
     #[allow(unused_imports)]
     use super::*;
@@ -667,7 +667,7 @@ impl wkt::message::Message for SynthesisInput {
     }
 }
 
-/// Defines additional types related to SynthesisInput
+/// Defines additional types related to [SynthesisInput].
 pub mod synthesis_input {
     #[allow(unused_imports)]
     use super::*;
@@ -940,7 +940,7 @@ impl wkt::message::Message for CustomVoiceParams {
     }
 }
 
-/// Defines additional types related to CustomVoiceParams
+/// Defines additional types related to [CustomVoiceParams].
 pub mod custom_voice_params {
     #[allow(unused_imports)]
     use super::*;
@@ -1226,7 +1226,7 @@ impl wkt::message::Message for StreamingSynthesisInput {
     }
 }
 
-/// Defines additional types related to StreamingSynthesisInput
+/// Defines additional types related to [StreamingSynthesisInput].
 pub mod streaming_synthesis_input {
     #[allow(unused_imports)]
     use super::*;
@@ -1349,7 +1349,7 @@ impl wkt::message::Message for StreamingSynthesizeRequest {
     }
 }
 
-/// Defines additional types related to StreamingSynthesizeRequest
+/// Defines additional types related to [StreamingSynthesizeRequest].
 pub mod streaming_synthesize_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -253,7 +253,7 @@ impl wkt::message::Message for DataSet {
     }
 }
 
-/// Defines additional types related to DataSet
+/// Defines additional types related to [DataSet].
 pub mod data_set {
     #[allow(unused_imports)]
     use super::*;
@@ -481,7 +481,7 @@ impl wkt::message::Message for EventDimension {
     }
 }
 
-/// Defines additional types related to EventDimension
+/// Defines additional types related to [EventDimension].
 pub mod event_dimension {
     #[allow(unused_imports)]
     use super::*;
@@ -956,7 +956,7 @@ impl wkt::message::Message for PinnedDimension {
     }
 }
 
-/// Defines additional types related to PinnedDimension
+/// Defines additional types related to [PinnedDimension].
 pub mod pinned_dimension {
     #[allow(unused_imports)]
     use super::*;
@@ -1083,7 +1083,7 @@ impl wkt::message::Message for ForecastParams {
     }
 }
 
-/// Defines additional types related to ForecastParams
+/// Defines additional types related to [ForecastParams].
 pub mod forecast_params {
     #[allow(unused_imports)]
     use super::*;
@@ -1741,7 +1741,7 @@ impl wkt::message::Message for TimeseriesParams {
     }
 }
 
-/// Defines additional types related to TimeseriesParams
+/// Defines additional types related to [TimeseriesParams].
 pub mod timeseries_params {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -209,7 +209,7 @@ impl wkt::message::Message for AttachedDisk {
     }
 }
 
-/// Defines additional types related to AttachedDisk
+/// Defines additional types related to [AttachedDisk].
 pub mod attached_disk {
     #[allow(unused_imports)]
     use super::*;
@@ -880,7 +880,7 @@ impl wkt::message::Message for Node {
     }
 }
 
-/// Defines additional types related to Node
+/// Defines additional types related to [Node].
 pub mod node {
     #[allow(unused_imports)]
     use super::*;
@@ -1348,7 +1348,7 @@ impl wkt::message::Message for QueuedResource {
     }
 }
 
-/// Defines additional types related to QueuedResource
+/// Defines additional types related to [QueuedResource].
 pub mod queued_resource {
     #[allow(unused_imports)]
     use super::*;
@@ -1387,7 +1387,7 @@ pub mod queued_resource {
         }
     }
 
-    /// Defines additional types related to Tpu
+    /// Defines additional types related to [Tpu].
     pub mod tpu {
         #[allow(unused_imports)]
         use super::*;
@@ -1519,7 +1519,7 @@ pub mod queued_resource {
             }
         }
 
-        /// Defines additional types related to NodeSpec
+        /// Defines additional types related to [NodeSpec].
         pub mod node_spec {
             #[allow(unused_imports)]
             use super::*;
@@ -1838,7 +1838,7 @@ pub mod queued_resource {
         }
     }
 
-    /// Defines additional types related to QueueingPolicy
+    /// Defines additional types related to [QueueingPolicy].
     pub mod queueing_policy {
         #[allow(unused_imports)]
         use super::*;
@@ -2213,7 +2213,7 @@ impl wkt::message::Message for QueuedResourceState {
     }
 }
 
-/// Defines additional types related to QueuedResourceState
+/// Defines additional types related to [QueuedResourceState].
 pub mod queued_resource_state {
     #[allow(unused_imports)]
     use super::*;
@@ -3952,7 +3952,7 @@ impl wkt::message::Message for Symptom {
     }
 }
 
-/// Defines additional types related to Symptom
+/// Defines additional types related to [Symptom].
 pub mod symptom {
     #[allow(unused_imports)]
     use super::*;
@@ -4175,7 +4175,7 @@ impl wkt::message::Message for AcceleratorConfig {
     }
 }
 
-/// Defines additional types related to AcceleratorConfig
+/// Defines additional types related to [AcceleratorConfig].
 pub mod accelerator_config {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -464,7 +464,7 @@ impl wkt::message::Message for AdaptiveMtTranslateRequest {
     }
 }
 
-/// Defines additional types related to AdaptiveMtTranslateRequest
+/// Defines additional types related to [AdaptiveMtTranslateRequest].
 pub mod adaptive_mt_translate_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1012,7 +1012,7 @@ impl wkt::message::Message for ImportAdaptiveMtFileRequest {
     }
 }
 
-/// Defines additional types related to ImportAdaptiveMtFileRequest
+/// Defines additional types related to [ImportAdaptiveMtFileRequest].
 pub mod import_adaptive_mt_file_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1443,7 +1443,7 @@ impl wkt::message::Message for DatasetInputConfig {
     }
 }
 
-/// Defines additional types related to DatasetInputConfig
+/// Defines additional types related to [DatasetInputConfig].
 pub mod dataset_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1529,7 +1529,7 @@ pub mod dataset_input_config {
         }
     }
 
-    /// Defines additional types related to InputFile
+    /// Defines additional types related to [InputFile].
     pub mod input_file {
         #[allow(unused_imports)]
         use super::*;
@@ -1725,7 +1725,7 @@ impl wkt::message::Message for DatasetOutputConfig {
     }
 }
 
-/// Defines additional types related to DatasetOutputConfig
+/// Defines additional types related to [DatasetOutputConfig].
 pub mod dataset_output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2373,7 +2373,7 @@ impl wkt::message::Message for BatchTransferResourcesResponse {
     }
 }
 
-/// Defines additional types related to BatchTransferResourcesResponse
+/// Defines additional types related to [BatchTransferResourcesResponse].
 pub mod batch_transfer_resources_response {
     #[allow(unused_imports)]
     use super::*;
@@ -3284,7 +3284,7 @@ impl wkt::message::Message for GlossaryEntry {
     }
 }
 
-/// Defines additional types related to GlossaryEntry
+/// Defines additional types related to [GlossaryEntry].
 pub mod glossary_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -4063,7 +4063,7 @@ impl wkt::message::Message for DetectLanguageRequest {
     }
 }
 
-/// Defines additional types related to DetectLanguageRequest
+/// Defines additional types related to [DetectLanguageRequest].
 pub mod detect_language_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4428,7 +4428,7 @@ impl wkt::message::Message for InputConfig {
     }
 }
 
-/// Defines additional types related to InputConfig
+/// Defines additional types related to [InputConfig].
 pub mod input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4562,7 +4562,7 @@ impl wkt::message::Message for OutputConfig {
     }
 }
 
-/// Defines additional types related to OutputConfig
+/// Defines additional types related to [OutputConfig].
 pub mod output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4759,7 +4759,7 @@ impl wkt::message::Message for DocumentInputConfig {
     }
 }
 
-/// Defines additional types related to DocumentInputConfig
+/// Defines additional types related to [DocumentInputConfig].
 pub mod document_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4874,7 +4874,7 @@ impl wkt::message::Message for DocumentOutputConfig {
     }
 }
 
-/// Defines additional types related to DocumentOutputConfig
+/// Defines additional types related to [DocumentOutputConfig].
 pub mod document_output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5553,7 +5553,7 @@ impl wkt::message::Message for BatchTranslateMetadata {
     }
 }
 
-/// Defines additional types related to BatchTranslateMetadata
+/// Defines additional types related to [BatchTranslateMetadata].
 pub mod batch_translate_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -5781,7 +5781,7 @@ impl wkt::message::Message for GlossaryInputConfig {
     }
 }
 
-/// Defines additional types related to GlossaryInputConfig
+/// Defines additional types related to [GlossaryInputConfig].
 pub mod glossary_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5982,7 +5982,7 @@ impl wkt::message::Message for Glossary {
     }
 }
 
-/// Defines additional types related to Glossary
+/// Defines additional types related to [Glossary].
 pub mod glossary {
     #[allow(unused_imports)]
     use super::*;
@@ -6669,7 +6669,7 @@ impl wkt::message::Message for CreateGlossaryMetadata {
     }
 }
 
-/// Defines additional types related to CreateGlossaryMetadata
+/// Defines additional types related to [CreateGlossaryMetadata].
 pub mod create_glossary_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -6810,7 +6810,7 @@ impl wkt::message::Message for UpdateGlossaryMetadata {
     }
 }
 
-/// Defines additional types related to UpdateGlossaryMetadata
+/// Defines additional types related to [UpdateGlossaryMetadata].
 pub mod update_glossary_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -6947,7 +6947,7 @@ impl wkt::message::Message for DeleteGlossaryMetadata {
     }
 }
 
-/// Defines additional types related to DeleteGlossaryMetadata
+/// Defines additional types related to [DeleteGlossaryMetadata].
 pub mod delete_glossary_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -7367,7 +7367,7 @@ impl wkt::message::Message for BatchDocumentInputConfig {
     }
 }
 
-/// Defines additional types related to BatchDocumentInputConfig
+/// Defines additional types related to [BatchDocumentInputConfig].
 pub mod batch_document_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7470,7 +7470,7 @@ impl wkt::message::Message for BatchDocumentOutputConfig {
     }
 }
 
-/// Defines additional types related to BatchDocumentOutputConfig
+/// Defines additional types related to [BatchDocumentOutputConfig].
 pub mod batch_document_output_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7804,7 +7804,7 @@ impl wkt::message::Message for BatchTranslateDocumentMetadata {
     }
 }
 
-/// Defines additional types related to BatchTranslateDocumentMetadata
+/// Defines additional types related to [BatchTranslateDocumentMetadata].
 pub mod batch_translate_document_metadata {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -173,7 +173,7 @@ impl wkt::message::Message for ElementaryStream {
     }
 }
 
-/// Defines additional types related to ElementaryStream
+/// Defines additional types related to [ElementaryStream].
 pub mod elementary_stream {
     #[allow(unused_imports)]
     use super::*;
@@ -420,7 +420,7 @@ impl wkt::message::Message for Manifest {
     }
 }
 
-/// Defines additional types related to Manifest
+/// Defines additional types related to [Manifest].
 pub mod manifest {
     #[allow(unused_imports)]
     use super::*;
@@ -661,7 +661,7 @@ impl wkt::message::Message for PreprocessingConfig {
     }
 }
 
-/// Defines additional types related to PreprocessingConfig
+/// Defines additional types related to [PreprocessingConfig].
 pub mod preprocessing_config {
     #[allow(unused_imports)]
     use super::*;
@@ -880,7 +880,7 @@ impl wkt::message::Message for VideoStream {
     }
 }
 
-/// Defines additional types related to VideoStream
+/// Defines additional types related to [VideoStream].
 pub mod video_stream {
     #[allow(unused_imports)]
     use super::*;
@@ -1153,7 +1153,7 @@ pub mod video_stream {
         }
     }
 
-    /// Defines additional types related to H264CodecSettings
+    /// Defines additional types related to [H264CodecSettings].
     pub mod h_264_codec_settings {
         #[allow(unused_imports)]
         use super::*;
@@ -1306,7 +1306,7 @@ impl wkt::message::Message for AudioStream {
     }
 }
 
-/// Defines additional types related to AudioStream
+/// Defines additional types related to [AudioStream].
 pub mod audio_stream {
     #[allow(unused_imports)]
     use super::*;
@@ -1573,7 +1573,7 @@ impl wkt::message::Message for TimecodeConfig {
     }
 }
 
-/// Defines additional types related to TimecodeConfig
+/// Defines additional types related to [TimecodeConfig].
 pub mod timecode_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1809,7 +1809,7 @@ impl wkt::message::Message for Input {
     }
 }
 
-/// Defines additional types related to Input
+/// Defines additional types related to [Input].
 pub mod input {
     #[allow(unused_imports)]
     use super::*;
@@ -2282,7 +2282,7 @@ impl wkt::message::Message for Channel {
     }
 }
 
-/// Defines additional types related to Channel
+/// Defines additional types related to [Channel].
 pub mod channel {
     #[allow(unused_imports)]
     use super::*;
@@ -2592,7 +2592,7 @@ impl wkt::message::Message for InputConfig {
     }
 }
 
-/// Defines additional types related to InputConfig
+/// Defines additional types related to [InputConfig].
 pub mod input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2706,7 +2706,7 @@ impl wkt::message::Message for LogConfig {
     }
 }
 
-/// Defines additional types related to LogConfig
+/// Defines additional types related to [LogConfig].
 pub mod log_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3160,7 +3160,7 @@ impl wkt::message::Message for InputAttachment {
     }
 }
 
-/// Defines additional types related to InputAttachment
+/// Defines additional types related to [InputAttachment].
 pub mod input_attachment {
     #[allow(unused_imports)]
     use super::*;
@@ -3510,7 +3510,7 @@ impl wkt::message::Message for Event {
     }
 }
 
-/// Defines additional types related to Event
+/// Defines additional types related to [Event].
 pub mod event {
     #[allow(unused_imports)]
     use super::*;
@@ -3958,7 +3958,7 @@ impl wkt::message::Message for Clip {
     }
 }
 
-/// Defines additional types related to Clip
+/// Defines additional types related to [Clip].
 pub mod clip {
     #[allow(unused_imports)]
     use super::*;
@@ -4072,7 +4072,7 @@ pub mod clip {
         }
     }
 
-    /// Defines additional types related to Slice
+    /// Defines additional types related to [Slice].
     pub mod slice {
         #[allow(unused_imports)]
         use super::*;
@@ -4394,7 +4394,7 @@ impl wkt::message::Message for Asset {
     }
 }
 
-/// Defines additional types related to Asset
+/// Defines additional types related to [Asset].
 pub mod asset {
     #[allow(unused_imports)]
     use super::*;
@@ -4736,7 +4736,7 @@ impl wkt::message::Message for Encryption {
     }
 }
 
-/// Defines additional types related to Encryption
+/// Defines additional types related to [Encryption].
 pub mod encryption {
     #[allow(unused_imports)]
     use super::*;
@@ -5113,7 +5113,7 @@ impl wkt::message::Message for Pool {
     }
 }
 
-/// Defines additional types related to Pool
+/// Defines additional types related to [Pool].
 pub mod pool {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -444,7 +444,7 @@ impl wkt::message::Message for CdnKey {
     }
 }
 
-/// Defines additional types related to CdnKey
+/// Defines additional types related to [CdnKey].
 pub mod cdn_key {
     #[allow(unused_imports)]
     use super::*;
@@ -589,7 +589,7 @@ impl wkt::message::Message for MediaCdnKey {
     }
 }
 
-/// Defines additional types related to MediaCdnKey
+/// Defines additional types related to [MediaCdnKey].
 pub mod media_cdn_key {
     #[allow(unused_imports)]
     use super::*;
@@ -682,7 +682,7 @@ impl wkt::message::Message for CompanionAds {
     }
 }
 
-/// Defines additional types related to CompanionAds
+/// Defines additional types related to [CompanionAds].
 pub mod companion_ads {
     #[allow(unused_imports)]
     use super::*;
@@ -971,7 +971,7 @@ impl wkt::message::Message for Companion {
     }
 }
 
-/// Defines additional types related to Companion
+/// Defines additional types related to [Companion].
 pub mod companion {
     #[allow(unused_imports)]
     use super::*;
@@ -1149,7 +1149,7 @@ impl wkt::message::Message for Event {
     }
 }
 
-/// Defines additional types related to Event
+/// Defines additional types related to [Event].
 pub mod event {
     #[allow(unused_imports)]
     use super::*;
@@ -1560,7 +1560,7 @@ impl wkt::message::Message for LiveConfig {
     }
 }
 
-/// Defines additional types related to LiveConfig
+/// Defines additional types related to [LiveConfig].
 pub mod live_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1964,7 +1964,7 @@ impl wkt::message::Message for VodSession {
     }
 }
 
-/// Defines additional types related to VodSession
+/// Defines additional types related to [VodSession].
 pub mod vod_session {
     #[allow(unused_imports)]
     use super::*;
@@ -2360,7 +2360,7 @@ impl wkt::message::Message for LiveSession {
     }
 }
 
-/// Defines additional types related to LiveSession
+/// Defines additional types related to [LiveSession].
 pub mod live_session {
     #[allow(unused_imports)]
     use super::*;
@@ -2464,7 +2464,7 @@ impl wkt::message::Message for ManifestOptions {
     }
 }
 
-/// Defines additional types related to ManifestOptions
+/// Defines additional types related to [ManifestOptions].
 pub mod manifest_options {
     #[allow(unused_imports)]
     use super::*;
@@ -2625,7 +2625,7 @@ impl wkt::message::Message for Slate {
     }
 }
 
-/// Defines additional types related to Slate
+/// Defines additional types related to [Slate].
 pub mod slate {
     #[allow(unused_imports)]
     use super::*;
@@ -4802,7 +4802,7 @@ impl wkt::message::Message for VodConfig {
     }
 }
 
-/// Defines additional types related to VodConfig
+/// Defines additional types related to [VodConfig].
 pub mod vod_config {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/video/transcoder/v1/src/model.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/model.rs
@@ -285,7 +285,7 @@ impl wkt::message::Message for Job {
     }
 }
 
-/// Defines additional types related to Job
+/// Defines additional types related to [Job].
 pub mod job {
     #[allow(unused_imports)]
     use super::*;
@@ -1088,7 +1088,7 @@ impl wkt::message::Message for ElementaryStream {
     }
 }
 
-/// Defines additional types related to ElementaryStream
+/// Defines additional types related to [ElementaryStream].
 pub mod elementary_stream {
     #[allow(unused_imports)]
     use super::*;
@@ -1318,7 +1318,7 @@ impl wkt::message::Message for Manifest {
     }
 }
 
-/// Defines additional types related to Manifest
+/// Defines additional types related to [Manifest].
 pub mod manifest {
     #[allow(unused_imports)]
     use super::*;
@@ -1357,7 +1357,7 @@ pub mod manifest {
         }
     }
 
-    /// Defines additional types related to DashConfig
+    /// Defines additional types related to [DashConfig].
     pub mod dash_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1747,7 +1747,7 @@ impl wkt::message::Message for SpriteSheet {
     }
 }
 
-/// Defines additional types related to SpriteSheet
+/// Defines additional types related to [SpriteSheet].
 pub mod sprite_sheet {
     #[allow(unused_imports)]
     use super::*;
@@ -1815,7 +1815,7 @@ impl wkt::message::Message for Overlay {
     }
 }
 
-/// Defines additional types related to Overlay
+/// Defines additional types related to [Overlay].
 pub mod overlay {
     #[allow(unused_imports)]
     use super::*;
@@ -2209,7 +2209,7 @@ pub mod overlay {
         }
     }
 
-    /// Defines additional types related to Animation
+    /// Defines additional types related to [Animation].
     pub mod animation {
         #[allow(unused_imports)]
         use super::*;
@@ -2410,7 +2410,7 @@ impl wkt::message::Message for PreprocessingConfig {
     }
 }
 
-/// Defines additional types related to PreprocessingConfig
+/// Defines additional types related to [PreprocessingConfig].
 pub mod preprocessing_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2844,7 +2844,7 @@ pub mod preprocessing_config {
         }
     }
 
-    /// Defines additional types related to Deinterlace
+    /// Defines additional types related to [Deinterlace].
     pub mod deinterlace {
         #[allow(unused_imports)]
         use super::*;
@@ -3116,7 +3116,7 @@ impl wkt::message::Message for VideoStream {
     }
 }
 
-/// Defines additional types related to VideoStream
+/// Defines additional types related to [VideoStream].
 pub mod video_stream {
     #[allow(unused_imports)]
     use super::*;
@@ -3462,7 +3462,7 @@ pub mod video_stream {
         }
     }
 
-    /// Defines additional types related to H264CodecSettings
+    /// Defines additional types related to [H264CodecSettings].
     pub mod h_264_codec_settings {
         #[allow(unused_imports)]
         use super::*;
@@ -3822,7 +3822,7 @@ pub mod video_stream {
         }
     }
 
-    /// Defines additional types related to H265CodecSettings
+    /// Defines additional types related to [H265CodecSettings].
     pub mod h_265_codec_settings {
         #[allow(unused_imports)]
         use super::*;
@@ -4066,7 +4066,7 @@ pub mod video_stream {
         }
     }
 
-    /// Defines additional types related to Vp9CodecSettings
+    /// Defines additional types related to [Vp9CodecSettings].
     pub mod vp_9_codec_settings {
         #[allow(unused_imports)]
         use super::*;
@@ -4233,7 +4233,7 @@ impl wkt::message::Message for AudioStream {
     }
 }
 
-/// Defines additional types related to AudioStream
+/// Defines additional types related to [AudioStream].
 pub mod audio_stream {
     #[allow(unused_imports)]
     use super::*;
@@ -4392,7 +4392,7 @@ impl wkt::message::Message for TextStream {
     }
 }
 
-/// Defines additional types related to TextStream
+/// Defines additional types related to [TextStream].
 pub mod text_stream {
     #[allow(unused_imports)]
     use super::*;
@@ -4686,7 +4686,7 @@ impl wkt::message::Message for Encryption {
     }
 }
 
-/// Defines additional types related to Encryption
+/// Defines additional types related to [Encryption].
 pub mod encryption {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -2803,7 +2803,7 @@ impl wkt::message::Message for ObjectTrackingAnnotation {
     }
 }
 
-/// Defines additional types related to ObjectTrackingAnnotation
+/// Defines additional types related to [ObjectTrackingAnnotation].
 pub mod object_tracking_annotation {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -262,7 +262,7 @@ impl wkt::message::Message for Feature {
     }
 }
 
-/// Defines additional types related to Feature
+/// Defines additional types related to [Feature].
 pub mod feature {
     #[allow(unused_imports)]
     use super::*;
@@ -702,7 +702,7 @@ impl wkt::message::Message for FaceAnnotation {
     }
 }
 
-/// Defines additional types related to FaceAnnotation
+/// Defines additional types related to [FaceAnnotation].
 pub mod face_annotation {
     #[allow(unused_imports)]
     use super::*;
@@ -752,7 +752,7 @@ pub mod face_annotation {
         }
     }
 
-    /// Defines additional types related to Landmark
+    /// Defines additional types related to [Landmark].
     pub mod landmark {
         #[allow(unused_imports)]
         use super::*;
@@ -3200,7 +3200,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -3429,7 +3429,7 @@ impl wkt::message::Message for ProductSearchResults {
     }
 }
 
-/// Defines additional types related to ProductSearchResults
+/// Defines additional types related to [ProductSearchResults].
 pub mod product_search_results {
     #[allow(unused_imports)]
     use super::*;
@@ -3717,7 +3717,7 @@ impl wkt::message::Message for Product {
     }
 }
 
-/// Defines additional types related to Product
+/// Defines additional types related to [Product].
 pub mod product {
     #[allow(unused_imports)]
     use super::*;
@@ -5091,7 +5091,7 @@ impl wkt::message::Message for ImportProductSetsInputConfig {
     }
 }
 
-/// Defines additional types related to ImportProductSetsInputConfig
+/// Defines additional types related to [ImportProductSetsInputConfig].
 pub mod import_product_sets_input_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5279,7 +5279,7 @@ impl wkt::message::Message for BatchOperationMetadata {
     }
 }
 
-/// Defines additional types related to BatchOperationMetadata
+/// Defines additional types related to [BatchOperationMetadata].
 pub mod batch_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -5499,7 +5499,7 @@ impl wkt::message::Message for PurgeProductsRequest {
     }
 }
 
-/// Defines additional types related to PurgeProductsRequest
+/// Defines additional types related to [PurgeProductsRequest].
 pub mod purge_products_request {
     #[allow(unused_imports)]
     use super::*;
@@ -5570,7 +5570,7 @@ impl wkt::message::Message for TextAnnotation {
     }
 }
 
-/// Defines additional types related to TextAnnotation
+/// Defines additional types related to [TextAnnotation].
 pub mod text_annotation {
     #[allow(unused_imports)]
     use super::*;
@@ -5661,7 +5661,7 @@ pub mod text_annotation {
         }
     }
 
-    /// Defines additional types related to DetectedBreak
+    /// Defines additional types related to [DetectedBreak].
     pub mod detected_break {
         #[allow(unused_imports)]
         use super::*;
@@ -5977,7 +5977,7 @@ impl wkt::message::Message for Block {
     }
 }
 
-/// Defines additional types related to Block
+/// Defines additional types related to [Block].
 pub mod block {
     #[allow(unused_imports)]
     use super::*;
@@ -6428,7 +6428,7 @@ impl wkt::message::Message for WebDetection {
     }
 }
 
-/// Defines additional types related to WebDetection
+/// Defines additional types related to [WebDetection].
 pub mod web_detection {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -163,7 +163,7 @@ impl wkt::message::Message for ReplicationCycle {
     }
 }
 
-/// Defines additional types related to ReplicationCycle
+/// Defines additional types related to [ReplicationCycle].
 pub mod replication_cycle {
     #[allow(unused_imports)]
     use super::*;
@@ -384,7 +384,7 @@ impl wkt::message::Message for CycleStep {
     }
 }
 
-/// Defines additional types related to CycleStep
+/// Defines additional types related to [CycleStep].
 pub mod cycle_step {
     #[allow(unused_imports)]
     use super::*;
@@ -878,7 +878,7 @@ impl wkt::message::Message for MigratingVm {
     }
 }
 
-/// Defines additional types related to MigratingVm
+/// Defines additional types related to [MigratingVm].
 pub mod migrating_vm {
     #[allow(unused_imports)]
     use super::*;
@@ -1179,7 +1179,7 @@ impl wkt::message::Message for CloneJob {
     }
 }
 
-/// Defines additional types related to CloneJob
+/// Defines additional types related to [CloneJob].
 pub mod clone_job {
     #[allow(unused_imports)]
     use super::*;
@@ -1421,7 +1421,7 @@ impl wkt::message::Message for CloneStep {
     }
 }
 
-/// Defines additional types related to CloneStep
+/// Defines additional types related to [CloneStep].
 pub mod clone_step {
     #[allow(unused_imports)]
     use super::*;
@@ -1675,7 +1675,7 @@ impl wkt::message::Message for CutoverJob {
     }
 }
 
-/// Defines additional types related to CutoverJob
+/// Defines additional types related to [CutoverJob].
 pub mod cutover_job {
     #[allow(unused_imports)]
     use super::*;
@@ -1986,7 +1986,7 @@ impl wkt::message::Message for CutoverStep {
     }
 }
 
-/// Defines additional types related to CutoverStep
+/// Defines additional types related to [CutoverStep].
 pub mod cutover_step {
     #[allow(unused_imports)]
     use super::*;
@@ -2474,7 +2474,7 @@ impl wkt::message::Message for Source {
     }
 }
 
-/// Defines additional types related to Source
+/// Defines additional types related to [Source].
 pub mod source {
     #[allow(unused_imports)]
     use super::*;
@@ -2717,7 +2717,7 @@ impl wkt::message::Message for AwsSourceDetails {
     }
 }
 
-/// Defines additional types related to AwsSourceDetails
+/// Defines additional types related to [AwsSourceDetails].
 pub mod aws_source_details {
     #[allow(unused_imports)]
     use super::*;
@@ -3084,7 +3084,7 @@ impl wkt::message::Message for DatacenterConnector {
     }
 }
 
-/// Defines additional types related to DatacenterConnector
+/// Defines additional types related to [DatacenterConnector].
 pub mod datacenter_connector {
     #[allow(unused_imports)]
     use super::*;
@@ -3240,7 +3240,7 @@ impl wkt::message::Message for UpgradeStatus {
     }
 }
 
-/// Defines additional types related to UpgradeStatus
+/// Defines additional types related to [UpgradeStatus].
 pub mod upgrade_status {
     #[allow(unused_imports)]
     use super::*;
@@ -3986,7 +3986,7 @@ impl wkt::message::Message for VmwareVmDetails {
     }
 }
 
-/// Defines additional types related to VmwareVmDetails
+/// Defines additional types related to [VmwareVmDetails].
 pub mod vmware_vm_details {
     #[allow(unused_imports)]
     use super::*;
@@ -4335,7 +4335,7 @@ impl wkt::message::Message for AwsVmDetails {
     }
 }
 
-/// Defines additional types related to AwsVmDetails
+/// Defines additional types related to [AwsVmDetails].
 pub mod aws_vm_details {
     #[allow(unused_imports)]
     use super::*;
@@ -4818,7 +4818,7 @@ impl wkt::message::Message for FetchInventoryResponse {
     }
 }
 
-/// Defines additional types related to FetchInventoryResponse
+/// Defines additional types related to [FetchInventoryResponse].
 pub mod fetch_inventory_response {
     #[allow(unused_imports)]
     use super::*;
@@ -4982,7 +4982,7 @@ impl wkt::message::Message for UtilizationReport {
     }
 }
 
-/// Defines additional types related to UtilizationReport
+/// Defines additional types related to [UtilizationReport].
 pub mod utilization_report {
     #[allow(unused_imports)]
     use super::*;
@@ -5202,7 +5202,7 @@ impl wkt::message::Message for VmUtilizationInfo {
     }
 }
 
-/// Defines additional types related to VmUtilizationInfo
+/// Defines additional types related to [VmUtilizationInfo].
 pub mod vm_utilization_info {
     #[allow(unused_imports)]
     use super::*;
@@ -6631,7 +6631,7 @@ impl wkt::message::Message for AppliedLicense {
     }
 }
 
-/// Defines additional types related to AppliedLicense
+/// Defines additional types related to [AppliedLicense].
 pub mod applied_license {
     #[allow(unused_imports)]
     use super::*;
@@ -6758,7 +6758,7 @@ impl wkt::message::Message for SchedulingNodeAffinity {
     }
 }
 
-/// Defines additional types related to SchedulingNodeAffinity
+/// Defines additional types related to [SchedulingNodeAffinity].
 pub mod scheduling_node_affinity {
     #[allow(unused_imports)]
     use super::*;
@@ -6903,7 +6903,7 @@ impl wkt::message::Message for ComputeScheduling {
     }
 }
 
-/// Defines additional types related to ComputeScheduling
+/// Defines additional types related to [ComputeScheduling].
 pub mod compute_scheduling {
     #[allow(unused_imports)]
     use super::*;
@@ -9150,7 +9150,7 @@ impl wkt::message::Message for MigrationError {
     }
 }
 
-/// Defines additional types related to MigrationError
+/// Defines additional types related to [MigrationError].
 pub mod migration_error {
     #[allow(unused_imports)]
     use super::*;
@@ -9301,7 +9301,7 @@ impl wkt::message::Message for AwsSourceVmDetails {
     }
 }
 
-/// Defines additional types related to AwsSourceVmDetails
+/// Defines additional types related to [AwsSourceVmDetails].
 pub mod aws_source_vm_details {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -6991,7 +6991,7 @@ impl wkt::message::Message for PrivateCloud {
     }
 }
 
-/// Defines additional types related to PrivateCloud
+/// Defines additional types related to [PrivateCloud].
 pub mod private_cloud {
     #[allow(unused_imports)]
     use super::*;
@@ -7346,7 +7346,7 @@ impl wkt::message::Message for Cluster {
     }
 }
 
-/// Defines additional types related to Cluster
+/// Defines additional types related to [Cluster].
 pub mod cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -7521,7 +7521,7 @@ impl wkt::message::Message for Node {
     }
 }
 
-/// Defines additional types related to Node
+/// Defines additional types related to [Node].
 pub mod node {
     #[allow(unused_imports)]
     use super::*;
@@ -7706,7 +7706,7 @@ impl wkt::message::Message for ExternalAddress {
     }
 }
 
-/// Defines additional types related to ExternalAddress
+/// Defines additional types related to [ExternalAddress].
 pub mod external_address {
     #[allow(unused_imports)]
     use super::*;
@@ -7864,7 +7864,7 @@ impl wkt::message::Message for Subnet {
     }
 }
 
-/// Defines additional types related to Subnet
+/// Defines additional types related to [Subnet].
 pub mod subnet {
     #[allow(unused_imports)]
     use super::*;
@@ -8158,7 +8158,7 @@ impl wkt::message::Message for ExternalAccessRule {
     }
 }
 
-/// Defines additional types related to ExternalAccessRule
+/// Defines additional types related to [ExternalAccessRule].
 pub mod external_access_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -8279,7 +8279,7 @@ pub mod external_access_rule {
         }
     }
 
-    /// Defines additional types related to IpRange
+    /// Defines additional types related to [IpRange].
     pub mod ip_range {
         #[allow(unused_imports)]
         use super::*;
@@ -8542,7 +8542,7 @@ impl wkt::message::Message for LoggingServer {
     }
 }
 
-/// Defines additional types related to LoggingServer
+/// Defines additional types related to [LoggingServer].
 pub mod logging_server {
     #[allow(unused_imports)]
     use super::*;
@@ -8827,7 +8827,7 @@ impl wkt::message::Message for NodeType {
     }
 }
 
-/// Defines additional types related to NodeType
+/// Defines additional types related to [NodeType].
 pub mod node_type {
     #[allow(unused_imports)]
     use super::*;
@@ -9070,7 +9070,7 @@ impl wkt::message::Message for HcxActivationKey {
     }
 }
 
-/// Defines additional types related to HcxActivationKey
+/// Defines additional types related to [HcxActivationKey].
 pub mod hcx_activation_key {
     #[allow(unused_imports)]
     use super::*;
@@ -9196,7 +9196,7 @@ impl wkt::message::Message for Hcx {
     }
 }
 
-/// Defines additional types related to Hcx
+/// Defines additional types related to [Hcx].
 pub mod hcx {
     #[allow(unused_imports)]
     use super::*;
@@ -9322,7 +9322,7 @@ impl wkt::message::Message for Nsx {
     }
 }
 
-/// Defines additional types related to Nsx
+/// Defines additional types related to [Nsx].
 pub mod nsx {
     #[allow(unused_imports)]
     use super::*;
@@ -9443,7 +9443,7 @@ impl wkt::message::Message for Vcenter {
     }
 }
 
-/// Defines additional types related to Vcenter
+/// Defines additional types related to [Vcenter].
 pub mod vcenter {
     #[allow(unused_imports)]
     use super::*;
@@ -9593,7 +9593,7 @@ impl wkt::message::Message for AutoscalingSettings {
     }
 }
 
-/// Defines additional types related to AutoscalingSettings
+/// Defines additional types related to [AutoscalingSettings].
 pub mod autoscaling_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -9826,7 +9826,7 @@ impl wkt::message::Message for DnsForwarding {
     }
 }
 
-/// Defines additional types related to DnsForwarding
+/// Defines additional types related to [DnsForwarding].
 pub mod dns_forwarding {
     #[allow(unused_imports)]
     use super::*;
@@ -10123,7 +10123,7 @@ impl wkt::message::Message for NetworkPeering {
     }
 }
 
-/// Defines additional types related to NetworkPeering
+/// Defines additional types related to [NetworkPeering].
 pub mod network_peering {
     #[allow(unused_imports)]
     use super::*;
@@ -10382,7 +10382,7 @@ impl wkt::message::Message for PeeringRoute {
     }
 }
 
-/// Defines additional types related to PeeringRoute
+/// Defines additional types related to [PeeringRoute].
 pub mod peering_route {
     #[allow(unused_imports)]
     use super::*;
@@ -10670,7 +10670,7 @@ impl wkt::message::Message for NetworkPolicy {
     }
 }
 
-/// Defines additional types related to NetworkPolicy
+/// Defines additional types related to [NetworkPolicy].
 pub mod network_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -10722,7 +10722,7 @@ pub mod network_policy {
         }
     }
 
-    /// Defines additional types related to NetworkService
+    /// Defines additional types related to [NetworkService].
     pub mod network_service {
         #[allow(unused_imports)]
         use super::*;
@@ -10959,7 +10959,7 @@ impl wkt::message::Message for ManagementDnsZoneBinding {
     }
 }
 
-/// Defines additional types related to ManagementDnsZoneBinding
+/// Defines additional types related to [ManagementDnsZoneBinding].
 pub mod management_dns_zone_binding {
     #[allow(unused_imports)]
     use super::*;
@@ -11192,7 +11192,7 @@ impl wkt::message::Message for VmwareEngineNetwork {
     }
 }
 
-/// Defines additional types related to VmwareEngineNetwork
+/// Defines additional types related to [VmwareEngineNetwork].
 pub mod vmware_engine_network {
     #[allow(unused_imports)]
     use super::*;
@@ -11245,7 +11245,7 @@ pub mod vmware_engine_network {
         }
     }
 
-    /// Defines additional types related to VpcNetwork
+    /// Defines additional types related to [VpcNetwork].
     pub mod vpc_network {
         #[allow(unused_imports)]
         use super::*;
@@ -11647,7 +11647,7 @@ impl wkt::message::Message for PrivateConnection {
     }
 }
 
-/// Defines additional types related to PrivateConnection
+/// Defines additional types related to [PrivateConnection].
 pub mod private_connection {
     #[allow(unused_imports)]
     use super::*;
@@ -11957,7 +11957,7 @@ impl wkt::message::Message for LocationMetadata {
     }
 }
 
-/// Defines additional types related to LocationMetadata
+/// Defines additional types related to [LocationMetadata].
 pub mod location_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -12149,7 +12149,7 @@ impl wkt::message::Message for Principal {
     }
 }
 
-/// Defines additional types related to Principal
+/// Defines additional types related to [Principal].
 pub mod principal {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/vpcaccess/v1/src/model.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/model.rs
@@ -171,7 +171,7 @@ impl wkt::message::Message for Connector {
     }
 }
 
-/// Defines additional types related to Connector
+/// Defines additional types related to [Connector].
 pub mod connector {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -98,7 +98,7 @@ impl wkt::message::Message for ComputeThreatListDiffRequest {
     }
 }
 
-/// Defines additional types related to ComputeThreatListDiffRequest
+/// Defines additional types related to [ComputeThreatListDiffRequest].
 pub mod compute_threat_list_diff_request {
     #[allow(unused_imports)]
     use super::*;
@@ -273,7 +273,7 @@ impl wkt::message::Message for ComputeThreatListDiffResponse {
     }
 }
 
-/// Defines additional types related to ComputeThreatListDiffResponse
+/// Defines additional types related to [ComputeThreatListDiffResponse].
 pub mod compute_threat_list_diff_response {
     #[allow(unused_imports)]
     use super::*;
@@ -449,7 +449,7 @@ impl wkt::message::Message for SearchUrisResponse {
     }
 }
 
-/// Defines additional types related to SearchUrisResponse
+/// Defines additional types related to [SearchUrisResponse].
 pub mod search_uris_response {
     #[allow(unused_imports)]
     use super::*;
@@ -600,7 +600,7 @@ impl wkt::message::Message for SearchHashesResponse {
     }
 }
 
-/// Defines additional types related to SearchHashesResponse
+/// Defines additional types related to [SearchHashesResponse].
 pub mod search_hashes_response {
     #[allow(unused_imports)]
     use super::*;
@@ -1028,7 +1028,7 @@ impl wkt::message::Message for ThreatInfo {
     }
 }
 
-/// Defines additional types related to ThreatInfo
+/// Defines additional types related to [ThreatInfo].
 pub mod threat_info {
     #[allow(unused_imports)]
     use super::*;
@@ -1123,7 +1123,7 @@ pub mod threat_info {
         }
     }
 
-    /// Defines additional types related to Confidence
+    /// Defines additional types related to [Confidence].
     pub mod confidence {
         #[allow(unused_imports)]
         use super::*;
@@ -1257,7 +1257,7 @@ pub mod threat_info {
         }
     }
 
-    /// Defines additional types related to ThreatJustification
+    /// Defines additional types related to [ThreatJustification].
     pub mod threat_justification {
         #[allow(unused_imports)]
         use super::*;
@@ -1438,7 +1438,7 @@ impl wkt::message::Message for ThreatDiscovery {
     }
 }
 
-/// Defines additional types related to ThreatDiscovery
+/// Defines additional types related to [ThreatDiscovery].
 pub mod threat_discovery {
     #[allow(unused_imports)]
     use super::*;
@@ -1683,7 +1683,7 @@ impl wkt::message::Message for SubmitUriMetadata {
     }
 }
 
-/// Defines additional types related to SubmitUriMetadata
+/// Defines additional types related to [SubmitUriMetadata].
 pub mod submit_uri_metadata {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -328,7 +328,7 @@ impl wkt::message::Message for Finding {
     }
 }
 
-/// Defines additional types related to Finding
+/// Defines additional types related to [Finding].
 pub mod finding {
     #[allow(unused_imports)]
     use super::*;
@@ -622,7 +622,7 @@ impl wkt::message::Message for VulnerableHeaders {
     }
 }
 
-/// Defines additional types related to VulnerableHeaders
+/// Defines additional types related to [VulnerableHeaders].
 pub mod vulnerable_headers {
     #[allow(unused_imports)]
     use super::*;
@@ -736,7 +736,7 @@ impl wkt::message::Message for Xss {
     }
 }
 
-/// Defines additional types related to Xss
+/// Defines additional types related to [Xss].
 pub mod xss {
     #[allow(unused_imports)]
     use super::*;
@@ -909,7 +909,7 @@ impl wkt::message::Message for Xxe {
     }
 }
 
-/// Defines additional types related to Xxe
+/// Defines additional types related to [Xxe].
 pub mod xxe {
     #[allow(unused_imports)]
     use super::*;
@@ -1189,7 +1189,7 @@ impl wkt::message::Message for ScanConfig {
     }
 }
 
-/// Defines additional types related to ScanConfig
+/// Defines additional types related to [ScanConfig].
 pub mod scan_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1340,7 +1340,7 @@ pub mod scan_config {
         }
     }
 
-    /// Defines additional types related to Authentication
+    /// Defines additional types related to [Authentication].
     pub mod authentication {
         #[allow(unused_imports)]
         use super::*;
@@ -1507,7 +1507,7 @@ pub mod scan_config {
             }
         }
 
-        /// Defines additional types related to IapCredential
+        /// Defines additional types related to [IapCredential].
         pub mod iap_credential {
             #[allow(unused_imports)]
             use super::*;
@@ -1852,7 +1852,7 @@ impl wkt::message::Message for ScanConfigError {
     }
 }
 
-/// Defines additional types related to ScanConfigError
+/// Defines additional types related to [ScanConfigError].
 pub mod scan_config_error {
     #[allow(unused_imports)]
     use super::*;
@@ -2345,7 +2345,7 @@ impl wkt::message::Message for ScanRun {
     }
 }
 
-/// Defines additional types related to ScanRun
+/// Defines additional types related to [ScanRun].
 pub mod scan_run {
     #[allow(unused_imports)]
     use super::*;
@@ -2541,7 +2541,7 @@ impl wkt::message::Message for ScanRunErrorTrace {
     }
 }
 
-/// Defines additional types related to ScanRunErrorTrace
+/// Defines additional types related to [ScanRunErrorTrace].
 pub mod scan_run_error_trace {
     #[allow(unused_imports)]
     use super::*;
@@ -2775,7 +2775,7 @@ impl wkt::message::Message for ScanRunWarningTrace {
     }
 }
 
-/// Defines additional types related to ScanRunWarningTrace
+/// Defines additional types related to [ScanRunWarningTrace].
 pub mod scan_run_warning_trace {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/cloud/workflows/executions/v1/src/model.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/model.rs
@@ -234,7 +234,7 @@ impl wkt::message::Message for Execution {
     }
 }
 
-/// Defines additional types related to Execution
+/// Defines additional types related to [Execution].
 pub mod execution {
     #[allow(unused_imports)]
     use super::*;
@@ -295,7 +295,7 @@ pub mod execution {
         }
     }
 
-    /// Defines additional types related to StackTraceElement
+    /// Defines additional types related to [StackTraceElement].
     pub mod stack_trace_element {
         #[allow(unused_imports)]
         use super::*;
@@ -481,7 +481,7 @@ pub mod execution {
         }
     }
 
-    /// Defines additional types related to Status
+    /// Defines additional types related to [Status].
     pub mod status {
         #[allow(unused_imports)]
         use super::*;
@@ -568,7 +568,7 @@ pub mod execution {
         }
     }
 
-    /// Defines additional types related to StateError
+    /// Defines additional types related to [StateError].
     pub mod state_error {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -383,7 +383,7 @@ impl wkt::message::Message for Workflow {
     }
 }
 
-/// Defines additional types related to Workflow
+/// Defines additional types related to [Workflow].
 pub mod workflow {
     #[allow(unused_imports)]
     use super::*;
@@ -430,7 +430,7 @@ pub mod workflow {
         }
     }
 
-    /// Defines additional types related to StateError
+    /// Defines additional types related to [StateError].
     pub mod state_error {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/cloud/workstations/v1/src/model.rs
+++ b/src/generated/cloud/workstations/v1/src/model.rs
@@ -270,7 +270,7 @@ impl wkt::message::Message for WorkstationCluster {
     }
 }
 
-/// Defines additional types related to WorkstationCluster
+/// Defines additional types related to [WorkstationCluster].
 pub mod workstation_cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -718,7 +718,7 @@ impl wkt::message::Message for WorkstationConfig {
     }
 }
 
-/// Defines additional types related to WorkstationConfig
+/// Defines additional types related to [WorkstationConfig].
 pub mod workstation_config {
     #[allow(unused_imports)]
     use super::*;
@@ -793,7 +793,7 @@ pub mod workstation_config {
         }
     }
 
-    /// Defines additional types related to Host
+    /// Defines additional types related to [Host].
     pub mod host {
         #[allow(unused_imports)]
         use super::*;
@@ -1025,7 +1025,7 @@ pub mod workstation_config {
             }
         }
 
-        /// Defines additional types related to GceInstance
+        /// Defines additional types related to [GceInstance].
         pub mod gce_instance {
             #[allow(unused_imports)]
             use super::*;
@@ -1204,7 +1204,7 @@ pub mod workstation_config {
         }
     }
 
-    /// Defines additional types related to PersistentDirectory
+    /// Defines additional types related to [PersistentDirectory].
     pub mod persistent_directory {
         #[allow(unused_imports)]
         use super::*;
@@ -1324,7 +1324,7 @@ pub mod workstation_config {
             }
         }
 
-        /// Defines additional types related to GceRegionalPersistentDisk
+        /// Defines additional types related to [GceRegionalPersistentDisk].
         pub mod gce_regional_persistent_disk {
             #[allow(unused_imports)]
             use super::*;
@@ -1787,7 +1787,7 @@ impl wkt::message::Message for Workstation {
     }
 }
 
-/// Defines additional types related to Workstation
+/// Defines additional types related to [Workstation].
 pub mod workstation {
     #[allow(unused_imports)]
     use super::*;
@@ -3336,7 +3336,7 @@ impl wkt::message::Message for GenerateAccessTokenRequest {
     }
 }
 
-/// Defines additional types related to GenerateAccessTokenRequest
+/// Defines additional types related to [GenerateAccessTokenRequest].
 pub mod generate_access_token_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -111,7 +111,7 @@ impl wkt::message::Message for LinuxNodeConfig {
     }
 }
 
-/// Defines additional types related to LinuxNodeConfig
+/// Defines additional types related to [LinuxNodeConfig].
 pub mod linux_node_config {
     #[allow(unused_imports)]
     use super::*;
@@ -259,7 +259,7 @@ impl wkt::message::Message for WindowsNodeConfig {
     }
 }
 
-/// Defines additional types related to WindowsNodeConfig
+/// Defines additional types related to [WindowsNodeConfig].
 pub mod windows_node_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1135,7 +1135,7 @@ impl wkt::message::Message for NodeConfig {
     }
 }
 
-/// Defines additional types related to NodeConfig
+/// Defines additional types related to [NodeConfig].
 pub mod node_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1512,7 +1512,7 @@ impl wkt::message::Message for NodeNetworkConfig {
     }
 }
 
-/// Defines additional types related to NodeNetworkConfig
+/// Defines additional types related to [NodeNetworkConfig].
 pub mod node_network_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1557,7 +1557,7 @@ pub mod node_network_config {
         }
     }
 
-    /// Defines additional types related to NetworkPerformanceConfig
+    /// Defines additional types related to [NetworkPerformanceConfig].
     pub mod network_performance_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1793,7 +1793,7 @@ impl wkt::message::Message for SandboxConfig {
     }
 }
 
-/// Defines additional types related to SandboxConfig
+/// Defines additional types related to [SandboxConfig].
 pub mod sandbox_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1943,7 +1943,7 @@ impl wkt::message::Message for ReservationAffinity {
     }
 }
 
-/// Defines additional types related to ReservationAffinity
+/// Defines additional types related to [ReservationAffinity].
 pub mod reservation_affinity {
     #[allow(unused_imports)]
     use super::*;
@@ -2047,7 +2047,7 @@ impl wkt::message::Message for SoleTenantConfig {
     }
 }
 
-/// Defines additional types related to SoleTenantConfig
+/// Defines additional types related to [SoleTenantConfig].
 pub mod sole_tenant_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2112,7 +2112,7 @@ pub mod sole_tenant_config {
         }
     }
 
-    /// Defines additional types related to NodeAffinity
+    /// Defines additional types related to [NodeAffinity].
     pub mod node_affinity {
         #[allow(unused_imports)]
         use super::*;
@@ -2215,7 +2215,7 @@ impl wkt::message::Message for ContainerdConfig {
     }
 }
 
-/// Defines additional types related to ContainerdConfig
+/// Defines additional types related to [ContainerdConfig].
 pub mod containerd_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2265,7 +2265,7 @@ pub mod containerd_config {
         }
     }
 
-    /// Defines additional types related to PrivateRegistryAccessConfig
+    /// Defines additional types related to [PrivateRegistryAccessConfig].
     pub mod private_registry_access_config {
         #[allow(unused_imports)]
         use super::*;
@@ -2350,7 +2350,7 @@ pub mod containerd_config {
             }
         }
 
-        /// Defines additional types related to CertificateAuthorityDomainConfig
+        /// Defines additional types related to [CertificateAuthorityDomainConfig].
         pub mod certificate_authority_domain_config {
             #[allow(unused_imports)]
             use super::*;
@@ -2460,7 +2460,7 @@ impl wkt::message::Message for NodeTaint {
     }
 }
 
-/// Defines additional types related to NodeTaint
+/// Defines additional types related to [NodeTaint].
 pub mod node_taint {
     #[allow(unused_imports)]
     use super::*;
@@ -3469,7 +3469,7 @@ impl wkt::message::Message for CloudRunConfig {
     }
 }
 
-/// Defines additional types related to CloudRunConfig
+/// Defines additional types related to [CloudRunConfig].
 pub mod cloud_run_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3869,7 +3869,7 @@ impl wkt::message::Message for MasterAuthorizedNetworksConfig {
     }
 }
 
-/// Defines additional types related to MasterAuthorizedNetworksConfig
+/// Defines additional types related to [MasterAuthorizedNetworksConfig].
 pub mod master_authorized_networks_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3990,7 +3990,7 @@ impl wkt::message::Message for NetworkPolicy {
     }
 }
 
-/// Defines additional types related to NetworkPolicy
+/// Defines additional types related to [NetworkPolicy].
 pub mod network_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -4093,7 +4093,7 @@ impl wkt::message::Message for BinaryAuthorization {
     }
 }
 
-/// Defines additional types related to BinaryAuthorization
+/// Defines additional types related to [BinaryAuthorization].
 pub mod binary_authorization {
     #[allow(unused_imports)]
     use super::*;
@@ -5683,7 +5683,7 @@ impl wkt::message::Message for Cluster {
     }
 }
 
-/// Defines additional types related to Cluster
+/// Defines additional types related to [Cluster].
 pub mod cluster {
     #[allow(unused_imports)]
     use super::*;
@@ -6004,7 +6004,7 @@ impl wkt::message::Message for CompliancePostureConfig {
     }
 }
 
-/// Defines additional types related to CompliancePostureConfig
+/// Defines additional types related to [CompliancePostureConfig].
 pub mod compliance_posture_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6186,7 +6186,7 @@ impl wkt::message::Message for SecurityPostureConfig {
     }
 }
 
-/// Defines additional types related to SecurityPostureConfig
+/// Defines additional types related to [SecurityPostureConfig].
 pub mod security_posture_config {
     #[allow(unused_imports)]
     use super::*;
@@ -7927,7 +7927,7 @@ impl wkt::message::Message for Operation {
     }
 }
 
-/// Defines additional types related to Operation
+/// Defines additional types related to [Operation].
 pub mod operation {
     #[allow(unused_imports)]
     use super::*;
@@ -8303,7 +8303,7 @@ impl wkt::message::Message for OperationProgress {
     }
 }
 
-/// Defines additional types related to OperationProgress
+/// Defines additional types related to [OperationProgress].
 pub mod operation_progress {
     #[allow(unused_imports)]
     use super::*;
@@ -8432,7 +8432,7 @@ pub mod operation_progress {
         }
     }
 
-    /// Defines additional types related to Metric
+    /// Defines additional types related to [Metric].
     pub mod metric {
         #[allow(unused_imports)]
         use super::*;
@@ -9762,7 +9762,7 @@ impl wkt::message::Message for SetMasterAuthRequest {
     }
 }
 
-/// Defines additional types related to SetMasterAuthRequest
+/// Defines additional types related to [SetMasterAuthRequest].
 pub mod set_master_auth_request {
     #[allow(unused_imports)]
     use super::*;
@@ -10404,7 +10404,7 @@ impl wkt::message::Message for ServerConfig {
     }
 }
 
-/// Defines additional types related to ServerConfig
+/// Defines additional types related to [ServerConfig].
 pub mod server_config {
     #[allow(unused_imports)]
     use super::*;
@@ -10870,7 +10870,7 @@ impl wkt::message::Message for BlueGreenSettings {
     }
 }
 
-/// Defines additional types related to BlueGreenSettings
+/// Defines additional types related to [BlueGreenSettings].
 pub mod blue_green_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -10980,7 +10980,7 @@ pub mod blue_green_settings {
         }
     }
 
-    /// Defines additional types related to StandardRolloutPolicy
+    /// Defines additional types related to [StandardRolloutPolicy].
     pub mod standard_rollout_policy {
         #[allow(unused_imports)]
         use super::*;
@@ -11333,7 +11333,7 @@ impl wkt::message::Message for NodePool {
     }
 }
 
-/// Defines additional types related to NodePool
+/// Defines additional types related to [NodePool].
 pub mod node_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -11493,7 +11493,7 @@ pub mod node_pool {
         }
     }
 
-    /// Defines additional types related to UpdateInfo
+    /// Defines additional types related to [UpdateInfo].
     pub mod update_info {
         #[allow(unused_imports)]
         use super::*;
@@ -11592,7 +11592,7 @@ pub mod node_pool {
             }
         }
 
-        /// Defines additional types related to BlueGreenInfo
+        /// Defines additional types related to [BlueGreenInfo].
         pub mod blue_green_info {
             #[allow(unused_imports)]
             use super::*;
@@ -11743,7 +11743,7 @@ pub mod node_pool {
         }
     }
 
-    /// Defines additional types related to PlacementPolicy
+    /// Defines additional types related to [PlacementPolicy].
     pub mod placement_policy {
         #[allow(unused_imports)]
         use super::*;
@@ -12229,7 +12229,7 @@ impl wkt::message::Message for MaintenanceWindow {
     }
 }
 
-/// Defines additional types related to MaintenanceWindow
+/// Defines additional types related to [MaintenanceWindow].
 pub mod maintenance_window {
     #[allow(unused_imports)]
     use super::*;
@@ -12339,7 +12339,7 @@ impl wkt::message::Message for TimeWindow {
     }
 }
 
-/// Defines additional types related to TimeWindow
+/// Defines additional types related to [TimeWindow].
 pub mod time_window {
     #[allow(unused_imports)]
     use super::*;
@@ -12386,7 +12386,7 @@ impl wkt::message::Message for MaintenanceExclusionOptions {
     }
 }
 
-/// Defines additional types related to MaintenanceExclusionOptions
+/// Defines additional types related to [MaintenanceExclusionOptions].
 pub mod maintenance_exclusion_options {
     #[allow(unused_imports)]
     use super::*;
@@ -13007,7 +13007,7 @@ impl wkt::message::Message for ClusterAutoscaling {
     }
 }
 
-/// Defines additional types related to ClusterAutoscaling
+/// Defines additional types related to [ClusterAutoscaling].
 pub mod cluster_autoscaling {
     #[allow(unused_imports)]
     use super::*;
@@ -13399,7 +13399,7 @@ impl wkt::message::Message for NodePoolAutoscaling {
     }
 }
 
-/// Defines additional types related to NodePoolAutoscaling
+/// Defines additional types related to [NodePoolAutoscaling].
 pub mod node_pool_autoscaling {
     #[allow(unused_imports)]
     use super::*;
@@ -13923,7 +13923,7 @@ impl wkt::message::Message for GPUSharingConfig {
     }
 }
 
-/// Defines additional types related to GPUSharingConfig
+/// Defines additional types related to [GPUSharingConfig].
 pub mod gpu_sharing_config {
     #[allow(unused_imports)]
     use super::*;
@@ -14026,7 +14026,7 @@ impl wkt::message::Message for GPUDriverInstallationConfig {
     }
 }
 
-/// Defines additional types related to GPUDriverInstallationConfig
+/// Defines additional types related to [GPUDriverInstallationConfig].
 pub mod gpu_driver_installation_config {
     #[allow(unused_imports)]
     use super::*;
@@ -14129,7 +14129,7 @@ impl wkt::message::Message for WorkloadMetadataConfig {
     }
 }
 
-/// Defines additional types related to WorkloadMetadataConfig
+/// Defines additional types related to [WorkloadMetadataConfig].
 pub mod workload_metadata_config {
     #[allow(unused_imports)]
     use super::*;
@@ -14410,7 +14410,7 @@ impl wkt::message::Message for StatusCondition {
     }
 }
 
-/// Defines additional types related to StatusCondition
+/// Defines additional types related to [StatusCondition].
 pub mod status_condition {
     #[allow(unused_imports)]
     use super::*;
@@ -14745,7 +14745,7 @@ impl wkt::message::Message for NetworkConfig {
     }
 }
 
-/// Defines additional types related to NetworkConfig
+/// Defines additional types related to [NetworkConfig].
 pub mod network_config {
     #[allow(unused_imports)]
     use super::*;
@@ -14790,7 +14790,7 @@ pub mod network_config {
         }
     }
 
-    /// Defines additional types related to ClusterNetworkPerformanceConfig
+    /// Defines additional types related to [ClusterNetworkPerformanceConfig].
     pub mod cluster_network_performance_config {
         #[allow(unused_imports)]
         use super::*;
@@ -14880,7 +14880,7 @@ impl wkt::message::Message for GatewayAPIConfig {
     }
 }
 
-/// Defines additional types related to GatewayAPIConfig
+/// Defines additional types related to [GatewayAPIConfig].
 pub mod gateway_api_config {
     #[allow(unused_imports)]
     use super::*;
@@ -15428,7 +15428,7 @@ impl wkt::message::Message for AutopilotCompatibilityIssue {
     }
 }
 
-/// Defines additional types related to AutopilotCompatibilityIssue
+/// Defines additional types related to [AutopilotCompatibilityIssue].
 pub mod autopilot_compatibility_issue {
     #[allow(unused_imports)]
     use super::*;
@@ -15584,7 +15584,7 @@ impl wkt::message::Message for ReleaseChannel {
     }
 }
 
-/// Defines additional types related to ReleaseChannel
+/// Defines additional types related to [ReleaseChannel].
 pub mod release_channel {
     #[allow(unused_imports)]
     use super::*;
@@ -15821,7 +15821,7 @@ impl wkt::message::Message for DNSConfig {
     }
 }
 
-/// Defines additional types related to DNSConfig
+/// Defines additional types related to [DNSConfig].
 pub mod dns_config {
     #[allow(unused_imports)]
     use super::*;
@@ -16167,7 +16167,7 @@ impl wkt::message::Message for DatabaseEncryption {
     }
 }
 
-/// Defines additional types related to DatabaseEncryption
+/// Defines additional types related to [DatabaseEncryption].
 pub mod database_encryption {
     #[allow(unused_imports)]
     use super::*;
@@ -16563,7 +16563,7 @@ impl wkt::message::Message for UsableSubnetworkSecondaryRange {
     }
 }
 
-/// Defines additional types related to UsableSubnetworkSecondaryRange
+/// Defines additional types related to [UsableSubnetworkSecondaryRange].
 pub mod usable_subnetwork_secondary_range {
     #[allow(unused_imports)]
     use super::*;
@@ -16790,7 +16790,7 @@ impl wkt::message::Message for ResourceUsageExportConfig {
     }
 }
 
-/// Defines additional types related to ResourceUsageExportConfig
+/// Defines additional types related to [ResourceUsageExportConfig].
 pub mod resource_usage_export_config {
     #[allow(unused_imports)]
     use super::*;
@@ -17032,7 +17032,7 @@ impl wkt::message::Message for NotificationConfig {
     }
 }
 
-/// Defines additional types related to NotificationConfig
+/// Defines additional types related to [NotificationConfig].
 pub mod notification_config {
     #[allow(unused_imports)]
     use super::*;
@@ -17434,7 +17434,7 @@ impl wkt::message::Message for UpgradeInfoEvent {
     }
 }
 
-/// Defines additional types related to UpgradeInfoEvent
+/// Defines additional types related to [UpgradeInfoEvent].
 pub mod upgrade_info_event {
     #[allow(unused_imports)]
     use super::*;
@@ -17871,7 +17871,7 @@ impl wkt::message::Message for LoggingComponentConfig {
     }
 }
 
-/// Defines additional types related to LoggingComponentConfig
+/// Defines additional types related to [LoggingComponentConfig].
 pub mod logging_component_config {
     #[allow(unused_imports)]
     use super::*;
@@ -18109,7 +18109,7 @@ impl wkt::message::Message for AdvancedDatapathObservabilityConfig {
     }
 }
 
-/// Defines additional types related to AdvancedDatapathObservabilityConfig
+/// Defines additional types related to [AdvancedDatapathObservabilityConfig].
 pub mod advanced_datapath_observability_config {
     #[allow(unused_imports)]
     use super::*;
@@ -18271,7 +18271,7 @@ impl wkt::message::Message for LoggingVariantConfig {
     }
 }
 
-/// Defines additional types related to LoggingVariantConfig
+/// Defines additional types related to [LoggingVariantConfig].
 pub mod logging_variant_config {
     #[allow(unused_imports)]
     use super::*;
@@ -18369,7 +18369,7 @@ impl wkt::message::Message for MonitoringComponentConfig {
     }
 }
 
-/// Defines additional types related to MonitoringComponentConfig
+/// Defines additional types related to [MonitoringComponentConfig].
 pub mod monitoring_component_config {
     #[allow(unused_imports)]
     use super::*;
@@ -18628,7 +18628,7 @@ impl wkt::message::Message for ControlPlaneEndpointsConfig {
     }
 }
 
-/// Defines additional types related to ControlPlaneEndpointsConfig
+/// Defines additional types related to [ControlPlaneEndpointsConfig].
 pub mod control_plane_endpoints_config {
     #[allow(unused_imports)]
     use super::*;
@@ -18994,7 +18994,7 @@ impl wkt::message::Message for EnterpriseConfig {
     }
 }
 
-/// Defines additional types related to EnterpriseConfig
+/// Defines additional types related to [EnterpriseConfig].
 pub mod enterprise_config {
     #[allow(unused_imports)]
     use super::*;
@@ -19130,7 +19130,7 @@ impl wkt::message::Message for SecondaryBootDisk {
     }
 }
 
-/// Defines additional types related to SecondaryBootDisk
+/// Defines additional types related to [SecondaryBootDisk].
 pub mod secondary_boot_disk {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -119,7 +119,7 @@ impl wkt::message::Message for CommonMetadata {
     }
 }
 
-/// Defines additional types related to CommonMetadata
+/// Defines additional types related to [CommonMetadata].
 pub mod common_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -1185,7 +1185,7 @@ impl wkt::message::Message for Index {
     }
 }
 
-/// Defines additional types related to Index
+/// Defines additional types related to [Index].
 pub mod index {
     #[allow(unused_imports)]
     use super::*;
@@ -1586,7 +1586,7 @@ impl wkt::message::Message for MigrationProgressEvent {
     }
 }
 
-/// Defines additional types related to MigrationProgressEvent
+/// Defines additional types related to [MigrationProgressEvent].
 pub mod migration_progress_event {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -120,7 +120,7 @@ impl wkt::message::Message for AptArtifact {
     }
 }
 
-/// Defines additional types related to AptArtifact
+/// Defines additional types related to [AptArtifact].
 pub mod apt_artifact {
     #[allow(unused_imports)]
     use super::*;
@@ -304,7 +304,7 @@ impl wkt::message::Message for ImportAptArtifactsRequest {
     }
 }
 
-/// Defines additional types related to ImportAptArtifactsRequest
+/// Defines additional types related to [ImportAptArtifactsRequest].
 pub mod import_apt_artifacts_request {
     #[allow(unused_imports)]
     use super::*;
@@ -400,7 +400,7 @@ impl wkt::message::Message for ImportAptArtifactsErrorInfo {
     }
 }
 
-/// Defines additional types related to ImportAptArtifactsErrorInfo
+/// Defines additional types related to [ImportAptArtifactsErrorInfo].
 pub mod import_apt_artifacts_error_info {
     #[allow(unused_imports)]
     use super::*;
@@ -1892,7 +1892,7 @@ impl wkt::message::Message for Hash {
     }
 }
 
-/// Defines additional types related to Hash
+/// Defines additional types related to [Hash].
 pub mod hash {
     #[allow(unused_imports)]
     use super::*;
@@ -2942,7 +2942,7 @@ impl wkt::message::Message for CleanupPolicyCondition {
     }
 }
 
-/// Defines additional types related to CleanupPolicyCondition
+/// Defines additional types related to [CleanupPolicyCondition].
 pub mod cleanup_policy_condition {
     #[allow(unused_imports)]
     use super::*;
@@ -3174,7 +3174,7 @@ impl wkt::message::Message for CleanupPolicy {
     }
 }
 
-/// Defines additional types related to CleanupPolicy
+/// Defines additional types related to [CleanupPolicy].
 pub mod cleanup_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -3600,7 +3600,7 @@ impl wkt::message::Message for RemoteRepositoryConfig {
     }
 }
 
-/// Defines additional types related to RemoteRepositoryConfig
+/// Defines additional types related to [RemoteRepositoryConfig].
 pub mod remote_repository_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3669,7 +3669,7 @@ pub mod remote_repository_config {
         }
     }
 
-    /// Defines additional types related to UpstreamCredentials
+    /// Defines additional types related to [UpstreamCredentials].
     pub mod upstream_credentials {
         #[allow(unused_imports)]
         use super::*;
@@ -3846,7 +3846,7 @@ pub mod remote_repository_config {
         }
     }
 
-    /// Defines additional types related to DockerRepository
+    /// Defines additional types related to [DockerRepository].
     pub mod docker_repository {
         #[allow(unused_imports)]
         use super::*;
@@ -4070,7 +4070,7 @@ pub mod remote_repository_config {
         }
     }
 
-    /// Defines additional types related to MavenRepository
+    /// Defines additional types related to [MavenRepository].
     pub mod maven_repository {
         #[allow(unused_imports)]
         use super::*;
@@ -4294,7 +4294,7 @@ pub mod remote_repository_config {
         }
     }
 
-    /// Defines additional types related to NpmRepository
+    /// Defines additional types related to [NpmRepository].
     pub mod npm_repository {
         #[allow(unused_imports)]
         use super::*;
@@ -4518,7 +4518,7 @@ pub mod remote_repository_config {
         }
     }
 
-    /// Defines additional types related to PythonRepository
+    /// Defines additional types related to [PythonRepository].
     pub mod python_repository {
         #[allow(unused_imports)]
         use super::*;
@@ -4745,7 +4745,7 @@ pub mod remote_repository_config {
         }
     }
 
-    /// Defines additional types related to AptRepository
+    /// Defines additional types related to [AptRepository].
     pub mod apt_repository {
         #[allow(unused_imports)]
         use super::*;
@@ -4793,7 +4793,7 @@ pub mod remote_repository_config {
             }
         }
 
-        /// Defines additional types related to PublicRepository
+        /// Defines additional types related to [PublicRepository].
         pub mod public_repository {
             #[allow(unused_imports)]
             use super::*;
@@ -5033,7 +5033,7 @@ pub mod remote_repository_config {
         }
     }
 
-    /// Defines additional types related to YumRepository
+    /// Defines additional types related to [YumRepository].
     pub mod yum_repository {
         #[allow(unused_imports)]
         use super::*;
@@ -5081,7 +5081,7 @@ pub mod remote_repository_config {
             }
         }
 
-        /// Defines additional types related to PublicRepository
+        /// Defines additional types related to [PublicRepository].
         pub mod public_repository {
             #[allow(unused_imports)]
             use super::*;
@@ -5638,7 +5638,7 @@ impl wkt::message::Message for Repository {
     }
 }
 
-/// Defines additional types related to Repository
+/// Defines additional types related to [Repository].
 pub mod repository {
     #[allow(unused_imports)]
     use super::*;
@@ -5688,7 +5688,7 @@ pub mod repository {
         }
     }
 
-    /// Defines additional types related to MavenRepositoryConfig
+    /// Defines additional types related to [MavenRepositoryConfig].
     pub mod maven_repository_config {
         #[allow(unused_imports)]
         use super::*;
@@ -5869,7 +5869,7 @@ pub mod repository {
         }
     }
 
-    /// Defines additional types related to VulnerabilityScanningConfig
+    /// Defines additional types related to [VulnerabilityScanningConfig].
     pub mod vulnerability_scanning_config {
         #[allow(unused_imports)]
         use super::*;
@@ -6561,7 +6561,7 @@ impl wkt::message::Message for Rule {
     }
 }
 
-/// Defines additional types related to Rule
+/// Defines additional types related to [Rule].
 pub mod rule {
     #[allow(unused_imports)]
     use super::*;
@@ -7019,7 +7019,7 @@ impl wkt::message::Message for ProjectSettings {
     }
 }
 
-/// Defines additional types related to ProjectSettings
+/// Defines additional types related to [ProjectSettings].
 pub mod project_settings {
     #[allow(unused_imports)]
     use super::*;
@@ -8096,7 +8096,7 @@ impl wkt::message::Message for VPCSCConfig {
     }
 }
 
-/// Defines additional types related to VPCSCConfig
+/// Defines additional types related to [VPCSCConfig].
 pub mod vpcsc_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8302,7 +8302,7 @@ impl wkt::message::Message for YumArtifact {
     }
 }
 
-/// Defines additional types related to YumArtifact
+/// Defines additional types related to [YumArtifact].
 pub mod yum_artifact {
     #[allow(unused_imports)]
     use super::*;
@@ -8486,7 +8486,7 @@ impl wkt::message::Message for ImportYumArtifactsRequest {
     }
 }
 
-/// Defines additional types related to ImportYumArtifactsRequest
+/// Defines additional types related to [ImportYumArtifactsRequest].
 pub mod import_yum_artifacts_request {
     #[allow(unused_imports)]
     use super::*;
@@ -8582,7 +8582,7 @@ impl wkt::message::Message for ImportYumArtifactsErrorInfo {
     }
 }
 
-/// Defines additional types related to ImportYumArtifactsErrorInfo
+/// Defines additional types related to [ImportYumArtifactsErrorInfo].
 pub mod import_yum_artifacts_error_info {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -216,7 +216,7 @@ impl wkt::message::Message for StorageSource {
     }
 }
 
-/// Defines additional types related to StorageSource
+/// Defines additional types related to [StorageSource].
 pub mod storage_source {
     #[allow(unused_imports)]
     use super::*;
@@ -506,7 +506,7 @@ impl wkt::message::Message for RepoSource {
     }
 }
 
-/// Defines additional types related to RepoSource
+/// Defines additional types related to [RepoSource].
 pub mod repo_source {
     #[allow(unused_imports)]
     use super::*;
@@ -729,7 +729,7 @@ impl wkt::message::Message for Source {
     }
 }
 
-/// Defines additional types related to Source
+/// Defines additional types related to [Source].
 pub mod source {
     #[allow(unused_imports)]
     use super::*;
@@ -2082,7 +2082,7 @@ impl wkt::message::Message for Build {
     }
 }
 
-/// Defines additional types related to Build
+/// Defines additional types related to [Build].
 pub mod build {
     #[allow(unused_imports)]
     use super::*;
@@ -2128,7 +2128,7 @@ pub mod build {
         }
     }
 
-    /// Defines additional types related to Warning
+    /// Defines additional types related to [Warning].
     pub mod warning {
         #[allow(unused_imports)]
         use super::*;
@@ -2238,7 +2238,7 @@ pub mod build {
         }
     }
 
-    /// Defines additional types related to FailureInfo
+    /// Defines additional types related to [FailureInfo].
     pub mod failure_info {
         #[allow(unused_imports)]
         use super::*;
@@ -2500,7 +2500,7 @@ impl wkt::message::Message for Dependency {
     }
 }
 
-/// Defines additional types related to Dependency
+/// Defines additional types related to [Dependency].
 pub mod dependency {
     #[allow(unused_imports)]
     use super::*;
@@ -2671,7 +2671,7 @@ pub mod dependency {
         }
     }
 
-    /// Defines additional types related to GitSourceRepository
+    /// Defines additional types related to [GitSourceRepository].
     pub mod git_source_repository {
         #[allow(unused_imports)]
         use super::*;
@@ -2737,7 +2737,7 @@ impl wkt::message::Message for GitConfig {
     }
 }
 
-/// Defines additional types related to GitConfig
+/// Defines additional types related to [GitConfig].
 pub mod git_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2929,7 +2929,7 @@ impl wkt::message::Message for Artifacts {
     }
 }
 
-/// Defines additional types related to Artifacts
+/// Defines additional types related to [Artifacts].
 pub mod artifacts {
     #[allow(unused_imports)]
     use super::*;
@@ -3530,7 +3530,7 @@ impl wkt::message::Message for Hash {
     }
 }
 
-/// Defines additional types related to Hash
+/// Defines additional types related to [Hash].
 pub mod hash {
     #[allow(unused_imports)]
     use super::*;
@@ -4194,7 +4194,7 @@ impl wkt::message::Message for BuildApproval {
     }
 }
 
-/// Defines additional types related to BuildApproval
+/// Defines additional types related to [BuildApproval].
 pub mod build_approval {
     #[allow(unused_imports)]
     use super::*;
@@ -4379,7 +4379,7 @@ impl wkt::message::Message for ApprovalResult {
     }
 }
 
-/// Defines additional types related to ApprovalResult
+/// Defines additional types related to [ApprovalResult].
 pub mod approval_result {
     #[allow(unused_imports)]
     use super::*;
@@ -4577,7 +4577,7 @@ impl wkt::message::Message for GitRepoSource {
     }
 }
 
-/// Defines additional types related to GitRepoSource
+/// Defines additional types related to [GitRepoSource].
 pub mod git_repo_source {
     #[allow(unused_imports)]
     use super::*;
@@ -4757,7 +4757,7 @@ impl wkt::message::Message for GitFileSource {
     }
 }
 
-/// Defines additional types related to GitFileSource
+/// Defines additional types related to [GitFileSource].
 pub mod git_file_source {
     #[allow(unused_imports)]
     use super::*;
@@ -5279,7 +5279,7 @@ impl wkt::message::Message for BuildTrigger {
     }
 }
 
-/// Defines additional types related to BuildTrigger
+/// Defines additional types related to [BuildTrigger].
 pub mod build_trigger {
     #[allow(unused_imports)]
     use super::*;
@@ -5427,7 +5427,7 @@ impl wkt::message::Message for RepositoryEventConfig {
     }
 }
 
-/// Defines additional types related to RepositoryEventConfig
+/// Defines additional types related to [RepositoryEventConfig].
 pub mod repository_event_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5634,7 +5634,7 @@ impl wkt::message::Message for GitHubEventsConfig {
     }
 }
 
-/// Defines additional types related to GitHubEventsConfig
+/// Defines additional types related to [GitHubEventsConfig].
 pub mod git_hub_events_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5720,7 +5720,7 @@ impl wkt::message::Message for PubsubConfig {
     }
 }
 
-/// Defines additional types related to PubsubConfig
+/// Defines additional types related to [PubsubConfig].
 pub mod pubsub_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5866,7 +5866,7 @@ impl wkt::message::Message for WebhookConfig {
     }
 }
 
-/// Defines additional types related to WebhookConfig
+/// Defines additional types related to [WebhookConfig].
 pub mod webhook_config {
     #[allow(unused_imports)]
     use super::*;
@@ -6027,7 +6027,7 @@ impl wkt::message::Message for PullRequestFilter {
     }
 }
 
-/// Defines additional types related to PullRequestFilter
+/// Defines additional types related to [PullRequestFilter].
 pub mod pull_request_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -6214,7 +6214,7 @@ impl wkt::message::Message for PushFilter {
     }
 }
 
-/// Defines additional types related to PushFilter
+/// Defines additional types related to [PushFilter].
 pub mod push_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -6833,7 +6833,7 @@ impl wkt::message::Message for BuildOptions {
     }
 }
 
-/// Defines additional types related to BuildOptions
+/// Defines additional types related to [BuildOptions].
 pub mod build_options {
     #[allow(unused_imports)]
     use super::*;
@@ -7756,7 +7756,7 @@ impl wkt::message::Message for WorkerPool {
     }
 }
 
-/// Defines additional types related to WorkerPool
+/// Defines additional types related to [WorkerPool].
 pub mod worker_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -7914,7 +7914,7 @@ impl wkt::message::Message for PrivatePoolV1Config {
     }
 }
 
-/// Defines additional types related to PrivatePoolV1Config
+/// Defines additional types related to [PrivatePoolV1Config].
 pub mod private_pool_v_1_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8042,7 +8042,7 @@ pub mod private_pool_v_1_config {
         }
     }
 
-    /// Defines additional types related to NetworkConfig
+    /// Defines additional types related to [NetworkConfig].
     pub mod network_config {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -526,7 +526,7 @@ impl wkt::message::Message for Connection {
     }
 }
 
-/// Defines additional types related to Connection
+/// Defines additional types related to [Connection].
 pub mod connection {
     #[allow(unused_imports)]
     use super::*;
@@ -605,7 +605,7 @@ impl wkt::message::Message for InstallationState {
     }
 }
 
-/// Defines additional types related to InstallationState
+/// Defines additional types related to [InstallationState].
 pub mod installation_state {
     #[allow(unused_imports)]
     use super::*;
@@ -2394,7 +2394,7 @@ impl wkt::message::Message for FetchGitRefsRequest {
     }
 }
 
-/// Defines additional types related to FetchGitRefsRequest
+/// Defines additional types related to [FetchGitRefsRequest].
 pub mod fetch_git_refs_request {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -267,7 +267,7 @@ impl wkt::message::Message for Span {
     }
 }
 
-/// Defines additional types related to Span
+/// Defines additional types related to [Span].
 pub mod span {
     #[allow(unused_imports)]
     use super::*;
@@ -441,7 +441,7 @@ pub mod span {
         }
     }
 
-    /// Defines additional types related to TimeEvent
+    /// Defines additional types related to [TimeEvent].
     pub mod time_event {
         #[allow(unused_imports)]
         use super::*;
@@ -565,7 +565,7 @@ pub mod span {
             }
         }
 
-        /// Defines additional types related to MessageEvent
+        /// Defines additional types related to [MessageEvent].
         pub mod message_event {
             #[allow(unused_imports)]
             use super::*;
@@ -771,7 +771,7 @@ pub mod span {
         }
     }
 
-    /// Defines additional types related to Link
+    /// Defines additional types related to [Link].
     pub mod link {
         #[allow(unused_imports)]
         use super::*;
@@ -1070,7 +1070,7 @@ impl wkt::message::Message for AttributeValue {
     }
 }
 
-/// Defines additional types related to AttributeValue
+/// Defines additional types related to [AttributeValue].
 pub mod attribute_value {
     #[allow(unused_imports)]
     use super::*;
@@ -1141,7 +1141,7 @@ impl wkt::message::Message for StackTrace {
     }
 }
 
-/// Defines additional types related to StackTrace
+/// Defines additional types related to [StackTrace].
 pub mod stack_trace {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/devtools/containeranalysis/v1/src/model.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/model.rs
@@ -110,7 +110,7 @@ impl wkt::message::Message for VulnerabilityOccurrencesSummary {
     }
 }
 
-/// Defines additional types related to VulnerabilityOccurrencesSummary
+/// Defines additional types related to [VulnerabilityOccurrencesSummary].
 pub mod vulnerability_occurrences_summary {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -142,7 +142,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -537,7 +537,7 @@ impl wkt::message::Message for Database {
     }
 }
 
-/// Defines additional types related to Database
+/// Defines additional types related to [Database].
 pub mod database {
     #[allow(unused_imports)]
     use super::*;
@@ -685,7 +685,7 @@ pub mod database {
         }
     }
 
-    /// Defines additional types related to SourceInfo
+    /// Defines additional types related to [SourceInfo].
     pub mod source_info {
         #[allow(unused_imports)]
         use super::*;
@@ -894,7 +894,7 @@ pub mod database {
         }
     }
 
-    /// Defines additional types related to EncryptionConfig
+    /// Defines additional types related to [EncryptionConfig].
     pub mod encryption_config {
         #[allow(unused_imports)]
         use super::*;
@@ -1437,7 +1437,7 @@ impl wkt::message::Message for Field {
     }
 }
 
-/// Defines additional types related to Field
+/// Defines additional types related to [Field].
 pub mod field {
     #[allow(unused_imports)]
     use super::*;
@@ -1554,7 +1554,7 @@ pub mod field {
         }
     }
 
-    /// Defines additional types related to TtlConfig
+    /// Defines additional types related to [TtlConfig].
     pub mod ttl_config {
         #[allow(unused_imports)]
         use super::*;
@@ -3339,7 +3339,7 @@ impl wkt::message::Message for Index {
     }
 }
 
-/// Defines additional types related to Index
+/// Defines additional types related to [Index].
 pub mod index {
     #[allow(unused_imports)]
     use super::*;
@@ -3485,7 +3485,7 @@ pub mod index {
         }
     }
 
-    /// Defines additional types related to IndexField
+    /// Defines additional types related to [IndexField].
     pub mod index_field {
         #[allow(unused_imports)]
         use super::*;
@@ -3574,7 +3574,7 @@ pub mod index {
             }
         }
 
-        /// Defines additional types related to VectorConfig
+        /// Defines additional types related to [VectorConfig].
         pub mod vector_config {
             #[allow(unused_imports)]
             use super::*;
@@ -4200,7 +4200,7 @@ impl wkt::message::Message for FieldOperationMetadata {
     }
 }
 
-/// Defines additional types related to FieldOperationMetadata
+/// Defines additional types related to [FieldOperationMetadata].
 pub mod field_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -4253,7 +4253,7 @@ pub mod field_operation_metadata {
         }
     }
 
-    /// Defines additional types related to IndexConfigDelta
+    /// Defines additional types related to [IndexConfigDelta].
     pub mod index_config_delta {
         #[allow(unused_imports)]
         use super::*;
@@ -4353,7 +4353,7 @@ pub mod field_operation_metadata {
         }
     }
 
-    /// Defines additional types related to TtlConfigDelta
+    /// Defines additional types related to [TtlConfigDelta].
     pub mod ttl_config_delta {
         #[allow(unused_imports)]
         use super::*;
@@ -5184,7 +5184,7 @@ impl wkt::message::Message for BackupSchedule {
     }
 }
 
-/// Defines additional types related to BackupSchedule
+/// Defines additional types related to [BackupSchedule].
 pub mod backup_schedule {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -72,7 +72,7 @@ impl wkt::message::Message for AttestationNote {
     }
 }
 
-/// Defines additional types related to AttestationNote
+/// Defines additional types related to [AttestationNote].
 pub mod attestation_note {
     #[allow(unused_imports)]
     use super::*;
@@ -864,7 +864,7 @@ impl wkt::message::Message for ComplianceNote {
     }
 }
 
-/// Defines additional types related to ComplianceNote
+/// Defines additional types related to [ComplianceNote].
 pub mod compliance_note {
     #[allow(unused_imports)]
     use super::*;
@@ -1223,7 +1223,7 @@ impl wkt::message::Message for CVSSv3 {
     }
 }
 
-/// Defines additional types related to CVSSv3
+/// Defines additional types related to [CVSSv3].
 pub mod cvs_sv_3 {
     #[allow(unused_imports)]
     use super::*;
@@ -1727,7 +1727,7 @@ impl wkt::message::Message for Cvss {
     }
 }
 
-/// Defines additional types related to CVSS
+/// Defines additional types related to [CVSS].
 pub mod cvss {
     #[allow(unused_imports)]
     use super::*;
@@ -2295,7 +2295,7 @@ impl wkt::message::Message for DeploymentOccurrence {
     }
 }
 
-/// Defines additional types related to DeploymentOccurrence
+/// Defines additional types related to [DeploymentOccurrence].
 pub mod deployment_occurrence {
     #[allow(unused_imports)]
     use super::*;
@@ -2563,7 +2563,7 @@ impl wkt::message::Message for DiscoveryOccurrence {
     }
 }
 
-/// Defines additional types related to DiscoveryOccurrence
+/// Defines additional types related to [DiscoveryOccurrence].
 pub mod discovery_occurrence {
     #[allow(unused_imports)]
     use super::*;
@@ -2646,7 +2646,7 @@ pub mod discovery_occurrence {
         }
     }
 
-    /// Defines additional types related to SBOMStatus
+    /// Defines additional types related to [SBOMStatus].
     pub mod sbom_status {
         #[allow(unused_imports)]
         use super::*;
@@ -2763,7 +2763,7 @@ pub mod discovery_occurrence {
         }
     }
 
-    /// Defines additional types related to VulnerabilityAttestation
+    /// Defines additional types related to [VulnerabilityAttestation].
     pub mod vulnerability_attestation {
         #[allow(unused_imports)]
         use super::*;
@@ -3004,7 +3004,7 @@ impl wkt::message::Message for DSSEAttestationNote {
     }
 }
 
-/// Defines additional types related to DSSEAttestationNote
+/// Defines additional types related to [DSSEAttestationNote].
 pub mod dsse_attestation_note {
     #[allow(unused_imports)]
     use super::*;
@@ -3130,7 +3130,7 @@ impl wkt::message::Message for DSSEAttestationOccurrence {
     }
 }
 
-/// Defines additional types related to DSSEAttestationOccurrence
+/// Defines additional types related to [DSSEAttestationOccurrence].
 pub mod dsse_attestation_occurrence {
     #[allow(unused_imports)]
     use super::*;
@@ -3583,7 +3583,7 @@ impl wkt::message::Message for Occurrence {
     }
 }
 
-/// Defines additional types related to Occurrence
+/// Defines additional types related to [Occurrence].
 pub mod occurrence {
     #[allow(unused_imports)]
     use super::*;
@@ -4086,7 +4086,7 @@ impl wkt::message::Message for Note {
     }
 }
 
-/// Defines additional types related to Note
+/// Defines additional types related to [Note].
 pub mod note {
     #[allow(unused_imports)]
     use super::*;
@@ -5725,7 +5725,7 @@ impl wkt::message::Message for InTotoStatement {
     }
 }
 
-/// Defines additional types related to InTotoStatement
+/// Defines additional types related to [InTotoStatement].
 pub mod in_toto_statement {
     #[allow(unused_imports)]
     use super::*;
@@ -5855,7 +5855,7 @@ impl wkt::message::Message for InTotoSlsaProvenanceV1 {
     }
 }
 
-/// Defines additional types related to InTotoSlsaProvenanceV1
+/// Defines additional types related to [InTotoSlsaProvenanceV1].
 pub mod in_toto_slsa_provenance_v_1 {
     #[allow(unused_imports)]
     use super::*;
@@ -6746,7 +6746,7 @@ impl wkt::message::Message for Version {
     }
 }
 
-/// Defines additional types related to Version
+/// Defines additional types related to [Version].
 pub mod version {
     #[allow(unused_imports)]
     use super::*;
@@ -7451,7 +7451,7 @@ impl wkt::message::Message for SourceContext {
     }
 }
 
-/// Defines additional types related to SourceContext
+/// Defines additional types related to [SourceContext].
 pub mod source_context {
     #[allow(unused_imports)]
     use super::*;
@@ -7511,7 +7511,7 @@ impl wkt::message::Message for AliasContext {
     }
 }
 
-/// Defines additional types related to AliasContext
+/// Defines additional types related to [AliasContext].
 pub mod alias_context {
     #[allow(unused_imports)]
     use super::*;
@@ -7684,7 +7684,7 @@ impl wkt::message::Message for CloudRepoSourceContext {
     }
 }
 
-/// Defines additional types related to CloudRepoSourceContext
+/// Defines additional types related to [CloudRepoSourceContext].
 pub mod cloud_repo_source_context {
     #[allow(unused_imports)]
     use super::*;
@@ -7814,7 +7814,7 @@ impl wkt::message::Message for GerritSourceContext {
     }
 }
 
-/// Defines additional types related to GerritSourceContext
+/// Defines additional types related to [GerritSourceContext].
 pub mod gerrit_source_context {
     #[allow(unused_imports)]
     use super::*;
@@ -7954,7 +7954,7 @@ impl wkt::message::Message for RepoId {
     }
 }
 
-/// Defines additional types related to RepoId
+/// Defines additional types related to [RepoId].
 pub mod repo_id {
     #[allow(unused_imports)]
     use super::*;
@@ -8338,7 +8338,7 @@ impl wkt::message::Message for SlsaProvenance {
     }
 }
 
-/// Defines additional types related to SlsaProvenance
+/// Defines additional types related to [SlsaProvenance].
 pub mod slsa_provenance {
     #[allow(unused_imports)]
     use super::*;
@@ -8747,7 +8747,7 @@ impl wkt::message::Message for SlsaProvenanceZeroTwo {
     }
 }
 
-/// Defines additional types related to SlsaProvenanceZeroTwo
+/// Defines additional types related to [SlsaProvenanceZeroTwo].
 pub mod slsa_provenance_zero_two {
     #[allow(unused_imports)]
     use super::*;
@@ -9322,7 +9322,7 @@ impl wkt::message::Message for WindowsUpdate {
     }
 }
 
-/// Defines additional types related to WindowsUpdate
+/// Defines additional types related to [WindowsUpdate].
 pub mod windows_update {
     #[allow(unused_imports)]
     use super::*;
@@ -9602,7 +9602,7 @@ impl wkt::message::Message for VulnerabilityAssessmentNote {
     }
 }
 
-/// Defines additional types related to VulnerabilityAssessmentNote
+/// Defines additional types related to [VulnerabilityAssessmentNote].
 pub mod vulnerability_assessment_note {
     #[allow(unused_imports)]
     use super::*;
@@ -9761,7 +9761,7 @@ pub mod vulnerability_assessment_note {
         }
     }
 
-    /// Defines additional types related to Product
+    /// Defines additional types related to [Product].
     pub mod product {
         #[allow(unused_imports)]
         use super::*;
@@ -9936,7 +9936,7 @@ pub mod vulnerability_assessment_note {
         }
     }
 
-    /// Defines additional types related to Assessment
+    /// Defines additional types related to [Assessment].
     pub mod assessment {
         #[allow(unused_imports)]
         use super::*;
@@ -9981,7 +9981,7 @@ pub mod vulnerability_assessment_note {
             }
         }
 
-        /// Defines additional types related to Justification
+        /// Defines additional types related to [Justification].
         pub mod justification {
             #[allow(unused_imports)]
             use super::*;
@@ -10143,7 +10143,7 @@ pub mod vulnerability_assessment_note {
             }
         }
 
-        /// Defines additional types related to Remediation
+        /// Defines additional types related to [Remediation].
         pub mod remediation {
             #[allow(unused_imports)]
             use super::*;
@@ -10417,7 +10417,7 @@ impl wkt::message::Message for VulnerabilityNote {
     }
 }
 
-/// Defines additional types related to VulnerabilityNote
+/// Defines additional types related to [VulnerabilityNote].
 pub mod vulnerability_note {
     #[allow(unused_imports)]
     use super::*;
@@ -10710,7 +10710,7 @@ pub mod vulnerability_note {
         }
     }
 
-    /// Defines additional types related to WindowsDetail
+    /// Defines additional types related to [WindowsDetail].
     pub mod windows_detail {
         #[allow(unused_imports)]
         use super::*;
@@ -10959,7 +10959,7 @@ impl wkt::message::Message for VulnerabilityOccurrence {
     }
 }
 
-/// Defines additional types related to VulnerabilityOccurrence
+/// Defines additional types related to [VulnerabilityOccurrence].
 pub mod vulnerability_occurrence {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -68,7 +68,7 @@ impl wkt::message::Message for AuditData {
     }
 }
 
-/// Defines additional types related to AuditData
+/// Defines additional types related to [AuditData].
 pub mod audit_data {
     #[allow(unused_imports)]
     use super::*;
@@ -752,7 +752,7 @@ impl wkt::message::Message for ListServiceAccountKeysRequest {
     }
 }
 
-/// Defines additional types related to ListServiceAccountKeysRequest
+/// Defines additional types related to [ListServiceAccountKeysRequest].
 pub mod list_service_account_keys_request {
     #[allow(unused_imports)]
     use super::*;
@@ -1602,7 +1602,7 @@ impl wkt::message::Message for Role {
     }
 }
 
-/// Defines additional types related to Role
+/// Defines additional types related to [Role].
 pub mod role {
     #[allow(unused_imports)]
     use super::*;
@@ -2416,7 +2416,7 @@ impl wkt::message::Message for Permission {
     }
 }
 
-/// Defines additional types related to Permission
+/// Defines additional types related to [Permission].
 pub mod permission {
     #[allow(unused_imports)]
     use super::*;
@@ -2729,7 +2729,7 @@ impl wkt::message::Message for QueryAuditableServicesResponse {
     }
 }
 
-/// Defines additional types related to QueryAuditableServicesResponse
+/// Defines additional types related to [QueryAuditableServicesResponse].
 pub mod query_auditable_services_response {
     #[allow(unused_imports)]
     use super::*;
@@ -2848,7 +2848,7 @@ impl wkt::message::Message for LintPolicyRequest {
     }
 }
 
-/// Defines additional types related to LintPolicyRequest
+/// Defines additional types related to [LintPolicyRequest].
 pub mod lint_policy_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2957,7 +2957,7 @@ impl wkt::message::Message for LintResult {
     }
 }
 
-/// Defines additional types related to LintResult
+/// Defines additional types related to [LintResult].
 pub mod lint_result {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/iam/v1/src/model.rs
+++ b/src/generated/iam/v1/src/model.rs
@@ -730,7 +730,7 @@ impl wkt::message::Message for AuditLogConfig {
     }
 }
 
-/// Defines additional types related to AuditLogConfig
+/// Defines additional types related to [AuditLogConfig].
 pub mod audit_log_config {
     #[allow(unused_imports)]
     use super::*;
@@ -918,7 +918,7 @@ impl wkt::message::Message for BindingDelta {
     }
 }
 
-/// Defines additional types related to BindingDelta
+/// Defines additional types related to [BindingDelta].
 pub mod binding_delta {
     #[allow(unused_imports)]
     use super::*;
@@ -1051,7 +1051,7 @@ impl wkt::message::Message for AuditConfigDelta {
     }
 }
 
-/// Defines additional types related to AuditConfigDelta
+/// Defines additional types related to [AuditConfigDelta].
 pub mod audit_config_delta {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/iam/v2/src/model.rs
+++ b/src/generated/iam/v2/src/model.rs
@@ -429,7 +429,7 @@ impl wkt::message::Message for PolicyRule {
     }
 }
 
-/// Defines additional types related to PolicyRule
+/// Defines additional types related to [PolicyRule].
 pub mod policy_rule {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/iam/v3/src/model.rs
+++ b/src/generated/iam/v3/src/model.rs
@@ -349,7 +349,7 @@ impl wkt::message::Message for PolicyBinding {
     }
 }
 
-/// Defines additional types related to PolicyBinding
+/// Defines additional types related to [PolicyBinding].
 pub mod policy_binding {
     #[allow(unused_imports)]
     use super::*;
@@ -416,7 +416,7 @@ pub mod policy_binding {
         }
     }
 
-    /// Defines additional types related to Target
+    /// Defines additional types related to [Target].
     pub mod target {
         #[allow(unused_imports)]
         use super::*;
@@ -1744,7 +1744,7 @@ impl wkt::message::Message for PrincipalAccessBoundaryPolicyRule {
     }
 }
 
-/// Defines additional types related to PrincipalAccessBoundaryPolicyRule
+/// Defines additional types related to [PrincipalAccessBoundaryPolicyRule].
 pub mod principal_access_boundary_policy_rule {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/identity/accesscontextmanager/v1/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/model.rs
@@ -1609,7 +1609,7 @@ impl wkt::message::Message for AccessLevel {
     }
 }
 
-/// Defines additional types related to AccessLevel
+/// Defines additional types related to [AccessLevel].
 pub mod access_level {
     #[allow(unused_imports)]
     use super::*;
@@ -1678,7 +1678,7 @@ impl wkt::message::Message for BasicLevel {
     }
 }
 
-/// Defines additional types related to BasicLevel
+/// Defines additional types related to [BasicLevel].
 pub mod basic_level {
     #[allow(unused_imports)]
     use super::*;
@@ -2408,7 +2408,7 @@ impl wkt::message::Message for ServicePerimeter {
     }
 }
 
-/// Defines additional types related to ServicePerimeter
+/// Defines additional types related to [ServicePerimeter].
 pub mod service_perimeter {
     #[allow(unused_imports)]
     use super::*;
@@ -2618,7 +2618,7 @@ impl wkt::message::Message for ServicePerimeterConfig {
     }
 }
 
-/// Defines additional types related to ServicePerimeterConfig
+/// Defines additional types related to [ServicePerimeterConfig].
 pub mod service_perimeter_config {
     #[allow(unused_imports)]
     use super::*;
@@ -2761,7 +2761,7 @@ pub mod service_perimeter_config {
         }
     }
 
-    /// Defines additional types related to MethodSelector
+    /// Defines additional types related to [MethodSelector].
     pub mod method_selector {
         #[allow(unused_imports)]
         use super::*;
@@ -2940,7 +2940,7 @@ pub mod service_perimeter_config {
         }
     }
 
-    /// Defines additional types related to IngressSource
+    /// Defines additional types related to [IngressSource].
     pub mod ingress_source {
         #[allow(unused_imports)]
         use super::*;

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -427,7 +427,7 @@ impl wkt::message::Message for LogEntry {
     }
 }
 
-/// Defines additional types related to LogEntry
+/// Defines additional types related to [LogEntry].
 pub mod log_entry {
     #[allow(unused_imports)]
     use super::*;
@@ -1427,7 +1427,7 @@ impl wkt::message::Message for TailLogEntriesResponse {
     }
 }
 
-/// Defines additional types related to TailLogEntriesResponse
+/// Defines additional types related to [TailLogEntriesResponse].
 pub mod tail_log_entries_response {
     #[allow(unused_imports)]
     use super::*;
@@ -1474,7 +1474,7 @@ pub mod tail_log_entries_response {
         }
     }
 
-    /// Defines additional types related to SuppressionInfo
+    /// Defines additional types related to [SuppressionInfo].
     pub mod suppression_info {
         #[allow(unused_imports)]
         use super::*;
@@ -2137,7 +2137,7 @@ impl wkt::message::Message for LogSink {
     }
 }
 
-/// Defines additional types related to LogSink
+/// Defines additional types related to [LogSink].
 pub mod log_sink {
     #[allow(unused_imports)]
     use super::*;
@@ -5012,7 +5012,7 @@ impl wkt::message::Message for BucketMetadata {
     }
 }
 
-/// Defines additional types related to BucketMetadata
+/// Defines additional types related to [BucketMetadata].
 pub mod bucket_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -5160,7 +5160,7 @@ impl wkt::message::Message for LinkMetadata {
     }
 }
 
-/// Defines additional types related to LinkMetadata
+/// Defines additional types related to [LinkMetadata].
 pub mod link_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -5462,7 +5462,7 @@ impl wkt::message::Message for LogMetric {
     }
 }
 
-/// Defines additional types related to LogMetric
+/// Defines additional types related to [LogMetric].
 pub mod log_metric {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -154,7 +154,7 @@ impl wkt::message::Message for Operation {
     }
 }
 
-/// Defines additional types related to Operation
+/// Defines additional types related to [Operation].
 pub mod operation {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -242,7 +242,7 @@ impl wkt::message::Message for Aggregation {
     }
 }
 
-/// Defines additional types related to Aggregation
+/// Defines additional types related to [Aggregation].
 pub mod aggregation {
     #[allow(unused_imports)]
     use super::*;
@@ -723,7 +723,7 @@ impl wkt::message::Message for PickTimeSeriesFilter {
     }
 }
 
-/// Defines additional types related to PickTimeSeriesFilter
+/// Defines additional types related to [PickTimeSeriesFilter].
 pub mod pick_time_series_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -908,7 +908,7 @@ impl wkt::message::Message for StatisticalTimeSeriesFilter {
     }
 }
 
-/// Defines additional types related to StatisticalTimeSeriesFilter
+/// Defines additional types related to [StatisticalTimeSeriesFilter].
 pub mod statistical_time_series_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -1174,7 +1174,7 @@ impl wkt::message::Message for Dashboard {
     }
 }
 
-/// Defines additional types related to Dashboard
+/// Defines additional types related to [Dashboard].
 pub mod dashboard {
     #[allow(unused_imports)]
     use super::*;
@@ -1295,7 +1295,7 @@ impl wkt::message::Message for DashboardFilter {
     }
 }
 
-/// Defines additional types related to DashboardFilter
+/// Defines additional types related to [DashboardFilter].
 pub mod dashboard_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -1889,7 +1889,7 @@ impl wkt::message::Message for MosaicLayout {
     }
 }
 
-/// Defines additional types related to MosaicLayout
+/// Defines additional types related to [MosaicLayout].
 pub mod mosaic_layout {
     #[allow(unused_imports)]
     use super::*;
@@ -2004,7 +2004,7 @@ impl wkt::message::Message for RowLayout {
     }
 }
 
-/// Defines additional types related to RowLayout
+/// Defines additional types related to [RowLayout].
 pub mod row_layout {
     #[allow(unused_imports)]
     use super::*;
@@ -2092,7 +2092,7 @@ impl wkt::message::Message for ColumnLayout {
     }
 }
 
-/// Defines additional types related to ColumnLayout
+/// Defines additional types related to [ColumnLayout].
 pub mod column_layout {
     #[allow(unused_imports)]
     use super::*;
@@ -2378,7 +2378,7 @@ impl wkt::message::Message for TimeSeriesQuery {
     }
 }
 
-/// Defines additional types related to TimeSeriesQuery
+/// Defines additional types related to [TimeSeriesQuery].
 pub mod time_series_query {
     #[allow(unused_imports)]
     use super::*;
@@ -2544,7 +2544,7 @@ impl wkt::message::Message for TimeSeriesFilter {
     }
 }
 
-/// Defines additional types related to TimeSeriesFilter
+/// Defines additional types related to [TimeSeriesFilter].
 pub mod time_series_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -2712,7 +2712,7 @@ impl wkt::message::Message for TimeSeriesFilterRatio {
     }
 }
 
-/// Defines additional types related to TimeSeriesFilterRatio
+/// Defines additional types related to [TimeSeriesFilterRatio].
 pub mod time_series_filter_ratio {
     #[allow(unused_imports)]
     use super::*;
@@ -2857,7 +2857,7 @@ impl wkt::message::Message for Threshold {
     }
 }
 
-/// Defines additional types related to Threshold
+/// Defines additional types related to [Threshold].
 pub mod threshold {
     #[allow(unused_imports)]
     use super::*;
@@ -3096,7 +3096,7 @@ impl wkt::message::Message for PieChart {
     }
 }
 
-/// Defines additional types related to PieChart
+/// Defines additional types related to [PieChart].
 pub mod pie_chart {
     #[allow(unused_imports)]
     use super::*;
@@ -3420,7 +3420,7 @@ impl wkt::message::Message for Scorecard {
     }
 }
 
-/// Defines additional types related to Scorecard
+/// Defines additional types related to [Scorecard].
 pub mod scorecard {
     #[allow(unused_imports)]
     use super::*;
@@ -3658,7 +3658,7 @@ impl wkt::message::Message for TimeSeriesTable {
     }
 }
 
-/// Defines additional types related to TimeSeriesTable
+/// Defines additional types related to [TimeSeriesTable].
 pub mod time_series_table {
     #[allow(unused_imports)]
     use super::*;
@@ -3934,7 +3934,7 @@ impl wkt::message::Message for Text {
     }
 }
 
-/// Defines additional types related to Text
+/// Defines additional types related to [Text].
 pub mod text {
     #[allow(unused_imports)]
     use super::*;
@@ -4048,7 +4048,7 @@ pub mod text {
         }
     }
 
-    /// Defines additional types related to TextStyle
+    /// Defines additional types related to [TextStyle].
     pub mod text_style {
         #[allow(unused_imports)]
         use super::*;
@@ -4897,7 +4897,7 @@ impl wkt::message::Message for Widget {
     }
 }
 
-/// Defines additional types related to Widget
+/// Defines additional types related to [Widget].
 pub mod widget {
     #[allow(unused_imports)]
     use super::*;
@@ -5058,7 +5058,7 @@ impl wkt::message::Message for XyChart {
     }
 }
 
-/// Defines additional types related to XyChart
+/// Defines additional types related to [XyChart].
 pub mod xy_chart {
     #[allow(unused_imports)]
     use super::*;
@@ -5158,7 +5158,7 @@ pub mod xy_chart {
         }
     }
 
-    /// Defines additional types related to DataSet
+    /// Defines additional types related to [DataSet].
     pub mod data_set {
         #[allow(unused_imports)]
         use super::*;
@@ -5342,7 +5342,7 @@ pub mod xy_chart {
         }
     }
 
-    /// Defines additional types related to Axis
+    /// Defines additional types related to [Axis].
     pub mod axis {
         #[allow(unused_imports)]
         use super::*;
@@ -5437,7 +5437,7 @@ impl wkt::message::Message for ChartOptions {
     }
 }
 
-/// Defines additional types related to ChartOptions
+/// Defines additional types related to [ChartOptions].
 pub mod chart_options {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/monitoring/metricsscope/v1/src/model.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/model.rs
@@ -401,7 +401,7 @@ impl wkt::message::Message for OperationMetadata {
     }
 }
 
-/// Defines additional types related to OperationMetadata
+/// Defines additional types related to [OperationMetadata].
 pub mod operation_metadata {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -305,7 +305,7 @@ impl wkt::message::Message for AlertPolicy {
     }
 }
 
-/// Defines additional types related to AlertPolicy
+/// Defines additional types related to [AlertPolicy].
 pub mod alert_policy {
     #[allow(unused_imports)]
     use super::*;
@@ -394,7 +394,7 @@ pub mod alert_policy {
         }
     }
 
-    /// Defines additional types related to Documentation
+    /// Defines additional types related to [Documentation].
     pub mod documentation {
         #[allow(unused_imports)]
         use super::*;
@@ -760,7 +760,7 @@ pub mod alert_policy {
         }
     }
 
-    /// Defines additional types related to Condition
+    /// Defines additional types related to [Condition].
     pub mod condition {
         #[allow(unused_imports)]
         use super::*;
@@ -852,7 +852,7 @@ pub mod alert_policy {
             }
         }
 
-        /// Defines additional types related to Trigger
+        /// Defines additional types related to [Trigger].
         pub mod trigger {
             #[allow(unused_imports)]
             use super::*;
@@ -1084,7 +1084,7 @@ pub mod alert_policy {
             }
         }
 
-        /// Defines additional types related to MetricThreshold
+        /// Defines additional types related to [MetricThreshold].
         pub mod metric_threshold {
             #[allow(unused_imports)]
             use super::*;
@@ -1864,7 +1864,7 @@ pub mod alert_policy {
             }
         }
 
-        /// Defines additional types related to SqlCondition
+        /// Defines additional types related to [SqlCondition].
         pub mod sql_condition {
             #[allow(unused_imports)]
             use super::*;
@@ -2310,7 +2310,7 @@ pub mod alert_policy {
         }
     }
 
-    /// Defines additional types related to AlertStrategy
+    /// Defines additional types related to [AlertStrategy].
     pub mod alert_strategy {
         #[allow(unused_imports)]
         use super::*;
@@ -3120,7 +3120,7 @@ impl wkt::message::Message for TypedValue {
     }
 }
 
-/// Defines additional types related to TypedValue
+/// Defines additional types related to [TypedValue].
 pub mod typed_value {
     #[allow(unused_imports)]
     use super::*;
@@ -3380,7 +3380,7 @@ impl wkt::message::Message for Aggregation {
     }
 }
 
-/// Defines additional types related to Aggregation
+/// Defines additional types related to [Aggregation].
 pub mod aggregation {
     #[allow(unused_imports)]
     use super::*;
@@ -4107,7 +4107,7 @@ impl wkt::message::Message for ListGroupsRequest {
     }
 }
 
-/// Defines additional types related to ListGroupsRequest
+/// Defines additional types related to [ListGroupsRequest].
 pub mod list_groups_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4807,7 +4807,7 @@ impl wkt::message::Message for TimeSeriesDescriptor {
     }
 }
 
-/// Defines additional types related to TimeSeriesDescriptor
+/// Defines additional types related to [TimeSeriesDescriptor].
 pub mod time_series_descriptor {
     #[allow(unused_imports)]
     use super::*;
@@ -4932,7 +4932,7 @@ impl wkt::message::Message for TimeSeriesData {
     }
 }
 
-/// Defines additional types related to TimeSeriesData
+/// Defines additional types related to [TimeSeriesData].
 pub mod time_series_data {
     #[allow(unused_imports)]
     use super::*;
@@ -5089,7 +5089,7 @@ impl wkt::message::Message for LabelValue {
     }
 }
 
-/// Defines additional types related to LabelValue
+/// Defines additional types related to [LabelValue].
 pub mod label_value {
     #[allow(unused_imports)]
     use super::*;
@@ -5268,7 +5268,7 @@ impl wkt::message::Message for TextLocator {
     }
 }
 
-/// Defines additional types related to TextLocator
+/// Defines additional types related to [TextLocator].
 pub mod text_locator {
     #[allow(unused_imports)]
     use super::*;
@@ -5917,7 +5917,7 @@ impl wkt::message::Message for ListTimeSeriesRequest {
     }
 }
 
-/// Defines additional types related to ListTimeSeriesRequest
+/// Defines additional types related to [ListTimeSeriesRequest].
 pub mod list_time_series_request {
     #[allow(unused_imports)]
     use super::*;
@@ -6220,7 +6220,7 @@ impl wkt::message::Message for CreateTimeSeriesSummary {
     }
 }
 
-/// Defines additional types related to CreateTimeSeriesSummary
+/// Defines additional types related to [CreateTimeSeriesSummary].
 pub mod create_time_series_summary {
     #[allow(unused_imports)]
     use super::*;
@@ -6847,7 +6847,7 @@ impl wkt::message::Message for NotificationChannel {
     }
 }
 
-/// Defines additional types related to NotificationChannel
+/// Defines additional types related to [NotificationChannel].
 pub mod notification_channel {
     #[allow(unused_imports)]
     use super::*;
@@ -8016,7 +8016,7 @@ impl wkt::message::Message for Service {
     }
 }
 
-/// Defines additional types related to Service
+/// Defines additional types related to [Service].
 pub mod service {
     #[allow(unused_imports)]
     use super::*;
@@ -8884,7 +8884,7 @@ impl wkt::message::Message for ServiceLevelObjective {
     }
 }
 
-/// Defines additional types related to ServiceLevelObjective
+/// Defines additional types related to [ServiceLevelObjective].
 pub mod service_level_objective {
     #[allow(unused_imports)]
     use super::*;
@@ -9108,7 +9108,7 @@ impl wkt::message::Message for ServiceLevelIndicator {
     }
 }
 
-/// Defines additional types related to ServiceLevelIndicator
+/// Defines additional types related to [ServiceLevelIndicator].
 pub mod service_level_indicator {
     #[allow(unused_imports)]
     use super::*;
@@ -9283,7 +9283,7 @@ impl wkt::message::Message for BasicSli {
     }
 }
 
-/// Defines additional types related to BasicSli
+/// Defines additional types related to [BasicSli].
 pub mod basic_sli {
     #[allow(unused_imports)]
     use super::*;
@@ -9490,7 +9490,7 @@ impl wkt::message::Message for RequestBasedSli {
     }
 }
 
-/// Defines additional types related to RequestBasedSli
+/// Defines additional types related to [RequestBasedSli].
 pub mod request_based_sli {
     #[allow(unused_imports)]
     use super::*;
@@ -9811,7 +9811,7 @@ impl wkt::message::Message for WindowsBasedSli {
     }
 }
 
-/// Defines additional types related to WindowsBasedSli
+/// Defines additional types related to [WindowsBasedSli].
 pub mod windows_based_sli {
     #[allow(unused_imports)]
     use super::*;
@@ -9930,7 +9930,7 @@ pub mod windows_based_sli {
         }
     }
 
-    /// Defines additional types related to PerformanceThreshold
+    /// Defines additional types related to [PerformanceThreshold].
     pub mod performance_threshold {
         #[allow(unused_imports)]
         use super::*;
@@ -10751,7 +10751,7 @@ impl wkt::message::Message for Snooze {
     }
 }
 
-/// Defines additional types related to Snooze
+/// Defines additional types related to [Snooze].
 pub mod snooze {
     #[allow(unused_imports)]
     use super::*;
@@ -11274,7 +11274,7 @@ impl wkt::message::Message for InternalChecker {
     }
 }
 
-/// Defines additional types related to InternalChecker
+/// Defines additional types related to [InternalChecker].
 pub mod internal_checker {
     #[allow(unused_imports)]
     use super::*;
@@ -11417,7 +11417,7 @@ impl wkt::message::Message for SyntheticMonitorTarget {
     }
 }
 
-/// Defines additional types related to SyntheticMonitorTarget
+/// Defines additional types related to [SyntheticMonitorTarget].
 pub mod synthetic_monitor_target {
     #[allow(unused_imports)]
     use super::*;
@@ -11865,7 +11865,7 @@ impl wkt::message::Message for UptimeCheckConfig {
     }
 }
 
-/// Defines additional types related to UptimeCheckConfig
+/// Defines additional types related to [UptimeCheckConfig].
 pub mod uptime_check_config {
     #[allow(unused_imports)]
     use super::*;
@@ -12239,7 +12239,7 @@ pub mod uptime_check_config {
         }
     }
 
-    /// Defines additional types related to HttpCheck
+    /// Defines additional types related to [HttpCheck].
     pub mod http_check {
         #[allow(unused_imports)]
         use super::*;
@@ -12379,7 +12379,7 @@ pub mod uptime_check_config {
             }
         }
 
-        /// Defines additional types related to ResponseStatusCode
+        /// Defines additional types related to [ResponseStatusCode].
         pub mod response_status_code {
             #[allow(unused_imports)]
             use super::*;
@@ -12510,7 +12510,7 @@ pub mod uptime_check_config {
             }
         }
 
-        /// Defines additional types related to ServiceAgentAuthentication
+        /// Defines additional types related to [ServiceAgentAuthentication].
         pub mod service_agent_authentication {
             #[allow(unused_imports)]
             use super::*;
@@ -12868,7 +12868,7 @@ pub mod uptime_check_config {
         }
     }
 
-    /// Defines additional types related to ContentMatcher
+    /// Defines additional types related to [ContentMatcher].
     pub mod content_matcher {
         #[allow(unused_imports)]
         use super::*;
@@ -12919,7 +12919,7 @@ pub mod uptime_check_config {
             }
         }
 
-        /// Defines additional types related to JsonPathMatcher
+        /// Defines additional types related to [JsonPathMatcher].
         pub mod json_path_matcher {
             #[allow(unused_imports)]
             use super::*;

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -295,7 +295,7 @@ impl wkt::message::Message for ExclusionRule {
     }
 }
 
-/// Defines additional types related to ExclusionRule
+/// Defines additional types related to [ExclusionRule].
 pub mod exclusion_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -414,7 +414,7 @@ impl wkt::message::Message for InspectionRule {
     }
 }
 
-/// Defines additional types related to InspectionRule
+/// Defines additional types related to [InspectionRule].
 pub mod inspection_rule {
     #[allow(unused_imports)]
     use super::*;
@@ -669,7 +669,7 @@ impl wkt::message::Message for InspectConfig {
     }
 }
 
-/// Defines additional types related to InspectConfig
+/// Defines additional types related to [InspectConfig].
 pub mod inspect_config {
     #[allow(unused_imports)]
     use super::*;
@@ -810,7 +810,7 @@ pub mod inspect_config {
         }
     }
 
-    /// Defines additional types related to FindingLimits
+    /// Defines additional types related to [FindingLimits].
     pub mod finding_limits {
         #[allow(unused_imports)]
         use super::*;
@@ -907,7 +907,7 @@ impl wkt::message::Message for ByteContentItem {
     }
 }
 
-/// Defines additional types related to ByteContentItem
+/// Defines additional types related to [ByteContentItem].
 pub mod byte_content_item {
     #[allow(unused_imports)]
     use super::*;
@@ -1155,7 +1155,7 @@ impl wkt::message::Message for ContentItem {
     }
 }
 
-/// Defines additional types related to ContentItem
+/// Defines additional types related to [ContentItem].
 pub mod content_item {
     #[allow(unused_imports)]
     use super::*;
@@ -1227,7 +1227,7 @@ impl wkt::message::Message for Table {
     }
 }
 
-/// Defines additional types related to Table
+/// Defines additional types related to [Table].
 pub mod table {
     #[allow(unused_imports)]
     use super::*;
@@ -1798,7 +1798,7 @@ impl wkt::message::Message for ContentLocation {
     }
 }
 
-/// Defines additional types related to ContentLocation
+/// Defines additional types related to [ContentLocation].
 pub mod content_location {
     #[allow(unused_imports)]
     use super::*;
@@ -1894,7 +1894,7 @@ impl wkt::message::Message for MetadataLocation {
     }
 }
 
-/// Defines additional types related to MetadataLocation
+/// Defines additional types related to [MetadataLocation].
 pub mod metadata_location {
     #[allow(unused_imports)]
     use super::*;
@@ -2419,7 +2419,7 @@ impl wkt::message::Message for RedactImageRequest {
     }
 }
 
-/// Defines additional types related to RedactImageRequest
+/// Defines additional types related to [RedactImageRequest].
 pub mod redact_image_request {
     #[allow(unused_imports)]
     use super::*;
@@ -2536,7 +2536,7 @@ pub mod redact_image_request {
         }
     }
 
-    /// Defines additional types related to ImageRedactionConfig
+    /// Defines additional types related to [ImageRedactionConfig].
     pub mod image_redaction_config {
         #[allow(unused_imports)]
         use super::*;
@@ -3263,7 +3263,7 @@ impl wkt::message::Message for OutputStorageConfig {
     }
 }
 
-/// Defines additional types related to OutputStorageConfig
+/// Defines additional types related to [OutputStorageConfig].
 pub mod output_storage_config {
     #[allow(unused_imports)]
     use super::*;
@@ -3461,7 +3461,7 @@ impl wkt::message::Message for InspectDataSourceDetails {
     }
 }
 
-/// Defines additional types related to InspectDataSourceDetails
+/// Defines additional types related to [InspectDataSourceDetails].
 pub mod inspect_data_source_details {
     #[allow(unused_imports)]
     use super::*;
@@ -3734,7 +3734,7 @@ impl wkt::message::Message for DataProfileBigQueryRowSchema {
     }
 }
 
-/// Defines additional types related to DataProfileBigQueryRowSchema
+/// Defines additional types related to [DataProfileBigQueryRowSchema].
 pub mod data_profile_big_query_row_schema {
     #[allow(unused_imports)]
     use super::*;
@@ -3875,7 +3875,7 @@ impl wkt::message::Message for ActionDetails {
     }
 }
 
-/// Defines additional types related to ActionDetails
+/// Defines additional types related to [ActionDetails].
 pub mod action_details {
     #[allow(unused_imports)]
     use super::*;
@@ -3997,7 +3997,7 @@ impl wkt::message::Message for DeidentifyDataSourceDetails {
     }
 }
 
-/// Defines additional types related to DeidentifyDataSourceDetails
+/// Defines additional types related to [DeidentifyDataSourceDetails].
 pub mod deidentify_data_source_details {
     #[allow(unused_imports)]
     use super::*;
@@ -4325,7 +4325,7 @@ impl wkt::message::Message for InfoTypeCategory {
     }
 }
 
-/// Defines additional types related to InfoTypeCategory
+/// Defines additional types related to [InfoTypeCategory].
 pub mod info_type_category {
     #[allow(unused_imports)]
     use super::*;
@@ -5123,7 +5123,7 @@ impl wkt::message::Message for QuasiId {
     }
 }
 
-/// Defines additional types related to QuasiId
+/// Defines additional types related to [QuasiId].
 pub mod quasi_id {
     #[allow(unused_imports)]
     use super::*;
@@ -5220,7 +5220,7 @@ impl wkt::message::Message for StatisticalTable {
     }
 }
 
-/// Defines additional types related to StatisticalTable
+/// Defines additional types related to [StatisticalTable].
 pub mod statistical_table {
     #[allow(unused_imports)]
     use super::*;
@@ -5500,7 +5500,7 @@ impl wkt::message::Message for PrivacyMetric {
     }
 }
 
-/// Defines additional types related to PrivacyMetric
+/// Defines additional types related to [PrivacyMetric].
 pub mod privacy_metric {
     #[allow(unused_imports)]
     use super::*;
@@ -5761,7 +5761,7 @@ pub mod privacy_metric {
         }
     }
 
-    /// Defines additional types related to KMapEstimationConfig
+    /// Defines additional types related to [KMapEstimationConfig].
     pub mod k_map_estimation_config {
         #[allow(unused_imports)]
         use super::*;
@@ -5899,7 +5899,7 @@ pub mod privacy_metric {
             }
         }
 
-        /// Defines additional types related to TaggedField
+        /// Defines additional types related to [TaggedField].
         pub mod tagged_field {
             #[allow(unused_imports)]
             use super::*;
@@ -5999,7 +5999,7 @@ pub mod privacy_metric {
             }
         }
 
-        /// Defines additional types related to AuxiliaryTable
+        /// Defines additional types related to [AuxiliaryTable].
         pub mod auxiliary_table {
             #[allow(unused_imports)]
             use super::*;
@@ -6460,7 +6460,7 @@ impl wkt::message::Message for AnalyzeDataSourceRiskDetails {
     }
 }
 
-/// Defines additional types related to AnalyzeDataSourceRiskDetails
+/// Defines additional types related to [AnalyzeDataSourceRiskDetails].
 pub mod analyze_data_source_risk_details {
     #[allow(unused_imports)]
     use super::*;
@@ -6561,7 +6561,7 @@ pub mod analyze_data_source_risk_details {
         }
     }
 
-    /// Defines additional types related to CategoricalStatsResult
+    /// Defines additional types related to [CategoricalStatsResult].
     pub mod categorical_stats_result {
         #[allow(unused_imports)]
         use super::*;
@@ -6683,7 +6683,7 @@ pub mod analyze_data_source_risk_details {
         }
     }
 
-    /// Defines additional types related to KAnonymityResult
+    /// Defines additional types related to [KAnonymityResult].
     pub mod k_anonymity_result {
         #[allow(unused_imports)]
         use super::*;
@@ -6854,7 +6854,7 @@ pub mod analyze_data_source_risk_details {
         }
     }
 
-    /// Defines additional types related to LDiversityResult
+    /// Defines additional types related to [LDiversityResult].
     pub mod l_diversity_result {
         #[allow(unused_imports)]
         use super::*;
@@ -7060,7 +7060,7 @@ pub mod analyze_data_source_risk_details {
         }
     }
 
-    /// Defines additional types related to KMapEstimationResult
+    /// Defines additional types related to [KMapEstimationResult].
     pub mod k_map_estimation_result {
         #[allow(unused_imports)]
         use super::*;
@@ -7236,7 +7236,7 @@ pub mod analyze_data_source_risk_details {
         }
     }
 
-    /// Defines additional types related to DeltaPresenceEstimationResult
+    /// Defines additional types related to [DeltaPresenceEstimationResult].
     pub mod delta_presence_estimation_result {
         #[allow(unused_imports)]
         use super::*;
@@ -7703,7 +7703,7 @@ impl wkt::message::Message for Value {
     }
 }
 
-/// Defines additional types related to Value
+/// Defines additional types related to [Value].
 pub mod value {
     #[allow(unused_imports)]
     use super::*;
@@ -7791,7 +7791,7 @@ impl wkt::message::Message for QuoteInfo {
     }
 }
 
-/// Defines additional types related to QuoteInfo
+/// Defines additional types related to [QuoteInfo].
 pub mod quote_info {
     #[allow(unused_imports)]
     use super::*;
@@ -7877,7 +7877,7 @@ impl wkt::message::Message for DateTime {
     }
 }
 
-/// Defines additional types related to DateTime
+/// Defines additional types related to [DateTime].
 pub mod date_time {
     #[allow(unused_imports)]
     use super::*;
@@ -8059,7 +8059,7 @@ impl wkt::message::Message for DeidentifyConfig {
     }
 }
 
-/// Defines additional types related to DeidentifyConfig
+/// Defines additional types related to [DeidentifyConfig].
 pub mod deidentify_config {
     #[allow(unused_imports)]
     use super::*;
@@ -8115,7 +8115,7 @@ impl wkt::message::Message for ImageTransformations {
     }
 }
 
-/// Defines additional types related to ImageTransformations
+/// Defines additional types related to [ImageTransformations].
 pub mod image_transformations {
     #[allow(unused_imports)]
     use super::*;
@@ -8288,7 +8288,7 @@ pub mod image_transformations {
         }
     }
 
-    /// Defines additional types related to ImageTransformation
+    /// Defines additional types related to [ImageTransformation].
     pub mod image_transformation {
         #[allow(unused_imports)]
         use super::*;
@@ -8507,7 +8507,7 @@ impl wkt::message::Message for TransformationErrorHandling {
     }
 }
 
-/// Defines additional types related to TransformationErrorHandling
+/// Defines additional types related to [TransformationErrorHandling].
 pub mod transformation_error_handling {
     #[allow(unused_imports)]
     use super::*;
@@ -8995,7 +8995,7 @@ impl wkt::message::Message for PrimitiveTransformation {
     }
 }
 
-/// Defines additional types related to PrimitiveTransformation
+/// Defines additional types related to [PrimitiveTransformation].
 pub mod primitive_transformation {
     #[allow(unused_imports)]
     use super::*;
@@ -9065,7 +9065,7 @@ impl wkt::message::Message for TimePartConfig {
     }
 }
 
-/// Defines additional types related to TimePartConfig
+/// Defines additional types related to [TimePartConfig].
 pub mod time_part_config {
     #[allow(unused_imports)]
     use super::*;
@@ -9398,7 +9398,7 @@ impl wkt::message::Message for ReplaceDictionaryConfig {
     }
 }
 
-/// Defines additional types related to ReplaceDictionaryConfig
+/// Defines additional types related to [ReplaceDictionaryConfig].
 pub mod replace_dictionary_config {
     #[allow(unused_imports)]
     use super::*;
@@ -9550,7 +9550,7 @@ impl wkt::message::Message for CharsToIgnore {
     }
 }
 
-/// Defines additional types related to CharsToIgnore
+/// Defines additional types related to [CharsToIgnore].
 pub mod chars_to_ignore {
     #[allow(unused_imports)]
     use super::*;
@@ -9862,7 +9862,7 @@ impl wkt::message::Message for BucketingConfig {
     }
 }
 
-/// Defines additional types related to BucketingConfig
+/// Defines additional types related to [BucketingConfig].
 pub mod bucketing_config {
     #[allow(unused_imports)]
     use super::*;
@@ -10145,7 +10145,7 @@ impl wkt::message::Message for CryptoReplaceFfxFpeConfig {
     }
 }
 
-/// Defines additional types related to CryptoReplaceFfxFpeConfig
+/// Defines additional types related to [CryptoReplaceFfxFpeConfig].
 pub mod crypto_replace_ffx_fpe_config {
     #[allow(unused_imports)]
     use super::*;
@@ -10373,7 +10373,7 @@ impl wkt::message::Message for CryptoKey {
     }
 }
 
-/// Defines additional types related to CryptoKey
+/// Defines additional types related to [CryptoKey].
 pub mod crypto_key {
     #[allow(unused_imports)]
     use super::*;
@@ -10609,7 +10609,7 @@ impl wkt::message::Message for DateShiftConfig {
     }
 }
 
-/// Defines additional types related to DateShiftConfig
+/// Defines additional types related to [DateShiftConfig].
 pub mod date_shift_config {
     #[allow(unused_imports)]
     use super::*;
@@ -10666,7 +10666,7 @@ impl wkt::message::Message for InfoTypeTransformations {
     }
 }
 
-/// Defines additional types related to InfoTypeTransformations
+/// Defines additional types related to [InfoTypeTransformations].
 pub mod info_type_transformations {
     #[allow(unused_imports)]
     use super::*;
@@ -10863,7 +10863,7 @@ impl wkt::message::Message for FieldTransformation {
     }
 }
 
-/// Defines additional types related to FieldTransformation
+/// Defines additional types related to [FieldTransformation].
 pub mod field_transformation {
     #[allow(unused_imports)]
     use super::*;
@@ -11003,7 +11003,7 @@ impl wkt::message::Message for RecordCondition {
     }
 }
 
-/// Defines additional types related to RecordCondition
+/// Defines additional types related to [RecordCondition].
 pub mod record_condition {
     #[allow(unused_imports)]
     use super::*;
@@ -11201,7 +11201,7 @@ pub mod record_condition {
         }
     }
 
-    /// Defines additional types related to Expressions
+    /// Defines additional types related to [Expressions].
     pub mod expressions {
         #[allow(unused_imports)]
         use super::*;
@@ -11434,7 +11434,7 @@ impl wkt::message::Message for TransformationSummary {
     }
 }
 
-/// Defines additional types related to TransformationSummary
+/// Defines additional types related to [TransformationSummary].
 pub mod transformation_summary {
     #[allow(unused_imports)]
     use super::*;
@@ -11845,7 +11845,7 @@ impl wkt::message::Message for TransformationLocation {
     }
 }
 
-/// Defines additional types related to TransformationLocation
+/// Defines additional types related to [TransformationLocation].
 pub mod transformation_location {
     #[allow(unused_imports)]
     use super::*;
@@ -12035,7 +12035,7 @@ impl wkt::message::Message for TransformationDetailsStorageConfig {
     }
 }
 
-/// Defines additional types related to TransformationDetailsStorageConfig
+/// Defines additional types related to [TransformationDetailsStorageConfig].
 pub mod transformation_details_storage_config {
     #[allow(unused_imports)]
     use super::*;
@@ -12119,7 +12119,7 @@ impl wkt::message::Message for Schedule {
     }
 }
 
-/// Defines additional types related to Schedule
+/// Defines additional types related to [Schedule].
 pub mod schedule {
     #[allow(unused_imports)]
     use super::*;
@@ -12417,7 +12417,7 @@ impl wkt::message::Message for Error {
     }
 }
 
-/// Defines additional types related to Error
+/// Defines additional types related to [Error].
 pub mod error {
     #[allow(unused_imports)]
     use super::*;
@@ -12665,7 +12665,7 @@ impl wkt::message::Message for JobTrigger {
     }
 }
 
-/// Defines additional types related to JobTrigger
+/// Defines additional types related to [JobTrigger].
 pub mod job_trigger {
     #[allow(unused_imports)]
     use super::*;
@@ -12762,7 +12762,7 @@ pub mod job_trigger {
         }
     }
 
-    /// Defines additional types related to Trigger
+    /// Defines additional types related to [Trigger].
     pub mod trigger {
         #[allow(unused_imports)]
         use super::*;
@@ -13097,7 +13097,7 @@ impl wkt::message::Message for Action {
     }
 }
 
-/// Defines additional types related to Action
+/// Defines additional types related to [Action].
 pub mod action {
     #[allow(unused_imports)]
     use super::*;
@@ -13377,7 +13377,7 @@ pub mod action {
         }
     }
 
-    /// Defines additional types related to Deidentify
+    /// Defines additional types related to [Deidentify].
     pub mod deidentify {
         #[allow(unused_imports)]
         use super::*;
@@ -14587,7 +14587,7 @@ impl wkt::message::Message for CreateDlpJobRequest {
     }
 }
 
-/// Defines additional types related to CreateDlpJobRequest
+/// Defines additional types related to [CreateDlpJobRequest].
 pub mod create_dlp_job_request {
     #[allow(unused_imports)]
     use super::*;
@@ -15117,7 +15117,7 @@ impl wkt::message::Message for DataProfileAction {
     }
 }
 
-/// Defines additional types related to DataProfileAction
+/// Defines additional types related to [DataProfileAction].
 pub mod data_profile_action {
     #[allow(unused_imports)]
     use super::*;
@@ -15261,7 +15261,7 @@ pub mod data_profile_action {
         }
     }
 
-    /// Defines additional types related to PubSubNotification
+    /// Defines additional types related to [PubSubNotification].
     pub mod pub_sub_notification {
         #[allow(unused_imports)]
         use super::*;
@@ -15446,7 +15446,7 @@ pub mod data_profile_action {
         }
     }
 
-    /// Defines additional types related to TagResources
+    /// Defines additional types related to [TagResources].
     pub mod tag_resources {
         #[allow(unused_imports)]
         use super::*;
@@ -15544,7 +15544,7 @@ pub mod data_profile_action {
             }
         }
 
-        /// Defines additional types related to TagCondition
+        /// Defines additional types related to [TagCondition].
         pub mod tag_condition {
             #[allow(unused_imports)]
             use super::*;
@@ -15628,7 +15628,7 @@ pub mod data_profile_action {
             }
         }
 
-        /// Defines additional types related to TagValue
+        /// Defines additional types related to [TagValue].
         pub mod tag_value {
             #[allow(unused_imports)]
             use super::*;
@@ -16084,7 +16084,7 @@ impl wkt::message::Message for DataProfileLocation {
     }
 }
 
-/// Defines additional types related to DataProfileLocation
+/// Defines additional types related to [DataProfileLocation].
 pub mod data_profile_location {
     #[allow(unused_imports)]
     use super::*;
@@ -16325,7 +16325,7 @@ impl wkt::message::Message for DiscoveryConfig {
     }
 }
 
-/// Defines additional types related to DiscoveryConfig
+/// Defines additional types related to [DiscoveryConfig].
 pub mod discovery_config {
     #[allow(unused_imports)]
     use super::*;
@@ -16661,7 +16661,7 @@ impl wkt::message::Message for DiscoveryTarget {
     }
 }
 
-/// Defines additional types related to DiscoveryTarget
+/// Defines additional types related to [DiscoveryTarget].
 pub mod discovery_target {
     #[allow(unused_imports)]
     use super::*;
@@ -16829,7 +16829,7 @@ impl wkt::message::Message for BigQueryDiscoveryTarget {
     }
 }
 
-/// Defines additional types related to BigQueryDiscoveryTarget
+/// Defines additional types related to [BigQueryDiscoveryTarget].
 pub mod big_query_discovery_target {
     #[allow(unused_imports)]
     use super::*;
@@ -16989,7 +16989,7 @@ impl wkt::message::Message for DiscoveryBigQueryFilter {
     }
 }
 
-/// Defines additional types related to DiscoveryBigQueryFilter
+/// Defines additional types related to [DiscoveryBigQueryFilter].
 pub mod discovery_big_query_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -17109,7 +17109,7 @@ impl wkt::message::Message for BigQueryTableCollection {
     }
 }
 
-/// Defines additional types related to BigQueryTableCollection
+/// Defines additional types related to [BigQueryTableCollection].
 pub mod big_query_table_collection {
     #[allow(unused_imports)]
     use super::*;
@@ -17260,7 +17260,7 @@ impl wkt::message::Message for DiscoveryBigQueryConditions {
     }
 }
 
-/// Defines additional types related to DiscoveryBigQueryConditions
+/// Defines additional types related to [DiscoveryBigQueryConditions].
 pub mod discovery_big_query_conditions {
     #[allow(unused_imports)]
     use super::*;
@@ -17668,7 +17668,7 @@ impl wkt::message::Message for CloudSqlDiscoveryTarget {
     }
 }
 
-/// Defines additional types related to CloudSqlDiscoveryTarget
+/// Defines additional types related to [CloudSqlDiscoveryTarget].
 pub mod cloud_sql_discovery_target {
     #[allow(unused_imports)]
     use super::*;
@@ -17822,7 +17822,7 @@ impl wkt::message::Message for DiscoveryCloudSqlFilter {
     }
 }
 
-/// Defines additional types related to DiscoveryCloudSqlFilter
+/// Defines additional types related to [DiscoveryCloudSqlFilter].
 pub mod discovery_cloud_sql_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -17918,7 +17918,7 @@ impl wkt::message::Message for DatabaseResourceCollection {
     }
 }
 
-/// Defines additional types related to DatabaseResourceCollection
+/// Defines additional types related to [DatabaseResourceCollection].
 pub mod database_resource_collection {
     #[allow(unused_imports)]
     use super::*;
@@ -18182,7 +18182,7 @@ impl wkt::message::Message for DiscoveryCloudSqlConditions {
     }
 }
 
-/// Defines additional types related to DiscoveryCloudSqlConditions
+/// Defines additional types related to [DiscoveryCloudSqlConditions].
 pub mod discovery_cloud_sql_conditions {
     #[allow(unused_imports)]
     use super::*;
@@ -18398,7 +18398,7 @@ impl wkt::message::Message for DiscoveryCloudSqlGenerationCadence {
     }
 }
 
-/// Defines additional types related to DiscoveryCloudSqlGenerationCadence
+/// Defines additional types related to [DiscoveryCloudSqlGenerationCadence].
 pub mod discovery_cloud_sql_generation_cadence {
     #[allow(unused_imports)]
     use super::*;
@@ -18452,7 +18452,7 @@ pub mod discovery_cloud_sql_generation_cadence {
         }
     }
 
-    /// Defines additional types related to SchemaModifiedCadence
+    /// Defines additional types related to [SchemaModifiedCadence].
     pub mod schema_modified_cadence {
         #[allow(unused_imports)]
         use super::*;
@@ -18679,7 +18679,7 @@ impl wkt::message::Message for CloudStorageDiscoveryTarget {
     }
 }
 
-/// Defines additional types related to CloudStorageDiscoveryTarget
+/// Defines additional types related to [CloudStorageDiscoveryTarget].
 pub mod cloud_storage_discovery_target {
     #[allow(unused_imports)]
     use super::*;
@@ -18835,7 +18835,7 @@ impl wkt::message::Message for DiscoveryCloudStorageFilter {
     }
 }
 
-/// Defines additional types related to DiscoveryCloudStorageFilter
+/// Defines additional types related to [DiscoveryCloudStorageFilter].
 pub mod discovery_cloud_storage_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -18930,7 +18930,7 @@ impl wkt::message::Message for FileStoreCollection {
     }
 }
 
-/// Defines additional types related to FileStoreCollection
+/// Defines additional types related to [FileStoreCollection].
 pub mod file_store_collection {
     #[allow(unused_imports)]
     use super::*;
@@ -19050,7 +19050,7 @@ impl wkt::message::Message for FileStoreRegex {
     }
 }
 
-/// Defines additional types related to FileStoreRegex
+/// Defines additional types related to [FileStoreRegex].
 pub mod file_store_regex {
     #[allow(unused_imports)]
     use super::*;
@@ -19276,7 +19276,7 @@ impl wkt::message::Message for DiscoveryCloudStorageConditions {
     }
 }
 
-/// Defines additional types related to DiscoveryCloudStorageConditions
+/// Defines additional types related to [DiscoveryCloudStorageConditions].
 pub mod discovery_cloud_storage_conditions {
     #[allow(unused_imports)]
     use super::*;
@@ -19555,7 +19555,7 @@ impl wkt::message::Message for DiscoveryFileStoreConditions {
     }
 }
 
-/// Defines additional types related to DiscoveryFileStoreConditions
+/// Defines additional types related to [DiscoveryFileStoreConditions].
 pub mod discovery_file_store_conditions {
     #[allow(unused_imports)]
     use super::*;
@@ -19720,7 +19720,7 @@ impl wkt::message::Message for OtherCloudDiscoveryTarget {
     }
 }
 
-/// Defines additional types related to OtherCloudDiscoveryTarget
+/// Defines additional types related to [OtherCloudDiscoveryTarget].
 pub mod other_cloud_discovery_target {
     #[allow(unused_imports)]
     use super::*;
@@ -19871,7 +19871,7 @@ impl wkt::message::Message for DiscoveryOtherCloudFilter {
     }
 }
 
-/// Defines additional types related to DiscoveryOtherCloudFilter
+/// Defines additional types related to [DiscoveryOtherCloudFilter].
 pub mod discovery_other_cloud_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -19964,7 +19964,7 @@ impl wkt::message::Message for OtherCloudResourceCollection {
     }
 }
 
-/// Defines additional types related to OtherCloudResourceCollection
+/// Defines additional types related to [OtherCloudResourceCollection].
 pub mod other_cloud_resource_collection {
     #[allow(unused_imports)]
     use super::*;
@@ -20089,7 +20089,7 @@ impl wkt::message::Message for OtherCloudResourceRegex {
     }
 }
 
-/// Defines additional types related to OtherCloudResourceRegex
+/// Defines additional types related to [OtherCloudResourceRegex].
 pub mod other_cloud_resource_regex {
     #[allow(unused_imports)]
     use super::*;
@@ -20254,7 +20254,7 @@ impl wkt::message::Message for OtherCloudSingleResourceReference {
     }
 }
 
-/// Defines additional types related to OtherCloudSingleResourceReference
+/// Defines additional types related to [OtherCloudSingleResourceReference].
 pub mod other_cloud_single_resource_reference {
     #[allow(unused_imports)]
     use super::*;
@@ -20423,7 +20423,7 @@ impl wkt::message::Message for DiscoveryOtherCloudConditions {
     }
 }
 
-/// Defines additional types related to DiscoveryOtherCloudConditions
+/// Defines additional types related to [DiscoveryOtherCloudConditions].
 pub mod discovery_other_cloud_conditions {
     #[allow(unused_imports)]
     use super::*;
@@ -20490,7 +20490,7 @@ impl wkt::message::Message for AmazonS3BucketConditions {
     }
 }
 
-/// Defines additional types related to AmazonS3BucketConditions
+/// Defines additional types related to [AmazonS3BucketConditions].
 pub mod amazon_s_3_bucket_conditions {
     #[allow(unused_imports)]
     use super::*;
@@ -20774,7 +20774,7 @@ impl wkt::message::Message for DiscoveryStartingLocation {
     }
 }
 
-/// Defines additional types related to DiscoveryStartingLocation
+/// Defines additional types related to [DiscoveryStartingLocation].
 pub mod discovery_starting_location {
     #[allow(unused_imports)]
     use super::*;
@@ -20861,7 +20861,7 @@ impl wkt::message::Message for OtherCloudDiscoveryStartingLocation {
     }
 }
 
-/// Defines additional types related to OtherCloudDiscoveryStartingLocation
+/// Defines additional types related to [OtherCloudDiscoveryStartingLocation].
 pub mod other_cloud_discovery_starting_location {
     #[allow(unused_imports)]
     use super::*;
@@ -20947,7 +20947,7 @@ pub mod other_cloud_discovery_starting_location {
         }
     }
 
-    /// Defines additional types related to AwsDiscoveryStartingLocation
+    /// Defines additional types related to [AwsDiscoveryStartingLocation].
     pub mod aws_discovery_starting_location {
         #[allow(unused_imports)]
         use super::*;
@@ -21130,7 +21130,7 @@ impl wkt::message::Message for VertexDatasetDiscoveryTarget {
     }
 }
 
-/// Defines additional types related to VertexDatasetDiscoveryTarget
+/// Defines additional types related to [VertexDatasetDiscoveryTarget].
 pub mod vertex_dataset_discovery_target {
     #[allow(unused_imports)]
     use super::*;
@@ -21284,7 +21284,7 @@ impl wkt::message::Message for DiscoveryVertexDatasetFilter {
     }
 }
 
-/// Defines additional types related to DiscoveryVertexDatasetFilter
+/// Defines additional types related to [DiscoveryVertexDatasetFilter].
 pub mod discovery_vertex_dataset_filter {
     #[allow(unused_imports)]
     use super::*;
@@ -21378,7 +21378,7 @@ impl wkt::message::Message for VertexDatasetCollection {
     }
 }
 
-/// Defines additional types related to VertexDatasetCollection
+/// Defines additional types related to [VertexDatasetCollection].
 pub mod vertex_dataset_collection {
     #[allow(unused_imports)]
     use super::*;
@@ -21822,7 +21822,7 @@ impl wkt::message::Message for DlpJob {
     }
 }
 
-/// Defines additional types related to DlpJob
+/// Defines additional types related to [DlpJob].
 pub mod dlp_job {
     #[allow(unused_imports)]
     use super::*;
@@ -22736,7 +22736,7 @@ impl wkt::message::Message for LargeCustomDictionaryConfig {
     }
 }
 
-/// Defines additional types related to LargeCustomDictionaryConfig
+/// Defines additional types related to [LargeCustomDictionaryConfig].
 pub mod large_custom_dictionary_config {
     #[allow(unused_imports)]
     use super::*;
@@ -22931,7 +22931,7 @@ impl wkt::message::Message for StoredInfoTypeConfig {
     }
 }
 
-/// Defines additional types related to StoredInfoTypeConfig
+/// Defines additional types related to [StoredInfoTypeConfig].
 pub mod stored_info_type_config {
     #[allow(unused_imports)]
     use super::*;
@@ -23016,7 +23016,7 @@ impl wkt::message::Message for StoredInfoTypeStats {
     }
 }
 
-/// Defines additional types related to StoredInfoTypeStats
+/// Defines additional types related to [StoredInfoTypeStats].
 pub mod stored_info_type_stats {
     #[allow(unused_imports)]
     use super::*;
@@ -24380,7 +24380,7 @@ impl wkt::message::Message for DataRiskLevel {
     }
 }
 
-/// Defines additional types related to DataRiskLevel
+/// Defines additional types related to [DataRiskLevel].
 pub mod data_risk_level {
     #[allow(unused_imports)]
     use super::*;
@@ -25046,7 +25046,7 @@ impl wkt::message::Message for TableDataProfile {
     }
 }
 
-/// Defines additional types related to TableDataProfile
+/// Defines additional types related to [TableDataProfile].
 pub mod table_data_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -25537,7 +25537,7 @@ impl wkt::message::Message for ColumnDataProfile {
     }
 }
 
-/// Defines additional types related to ColumnDataProfile
+/// Defines additional types related to [ColumnDataProfile].
 pub mod column_data_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -26163,7 +26163,7 @@ impl wkt::message::Message for FileStoreDataProfile {
     }
 }
 
-/// Defines additional types related to FileStoreDataProfile
+/// Defines additional types related to [FileStoreDataProfile].
 pub mod file_store_data_profile {
     #[allow(unused_imports)]
     use super::*;
@@ -26833,7 +26833,7 @@ impl wkt::message::Message for DataProfilePubSubCondition {
     }
 }
 
-/// Defines additional types related to DataProfilePubSubCondition
+/// Defines additional types related to [DataProfilePubSubCondition].
 pub mod data_profile_pub_sub_condition {
     #[allow(unused_imports)]
     use super::*;
@@ -26944,7 +26944,7 @@ pub mod data_profile_pub_sub_condition {
         }
     }
 
-    /// Defines additional types related to PubSubCondition
+    /// Defines additional types related to [PubSubCondition].
     pub mod pub_sub_condition {
         #[allow(unused_imports)]
         use super::*;
@@ -27007,7 +27007,7 @@ pub mod data_profile_pub_sub_condition {
         }
     }
 
-    /// Defines additional types related to PubSubExpressions
+    /// Defines additional types related to [PubSubExpressions].
     pub mod pub_sub_expressions {
         #[allow(unused_imports)]
         use super::*;
@@ -27706,7 +27706,7 @@ impl wkt::message::Message for Connection {
     }
 }
 
-/// Defines additional types related to Connection
+/// Defines additional types related to [Connection].
 pub mod connection {
     #[allow(unused_imports)]
     use super::*;
@@ -27931,7 +27931,7 @@ impl wkt::message::Message for CloudSqlProperties {
     }
 }
 
-/// Defines additional types related to CloudSqlProperties
+/// Defines additional types related to [CloudSqlProperties].
 pub mod cloud_sql_properties {
     #[allow(unused_imports)]
     use super::*;
@@ -28136,7 +28136,7 @@ impl wkt::message::Message for FileClusterType {
     }
 }
 
-/// Defines additional types related to FileClusterType
+/// Defines additional types related to [FileClusterType].
 pub mod file_cluster_type {
     #[allow(unused_imports)]
     use super::*;
@@ -28290,7 +28290,7 @@ impl wkt::message::Message for ProcessingLocation {
     }
 }
 
-/// Defines additional types related to ProcessingLocation
+/// Defines additional types related to [ProcessingLocation].
 pub mod processing_location {
     #[allow(unused_imports)]
     use super::*;
@@ -28487,7 +28487,7 @@ impl wkt::message::Message for SensitivityScore {
     }
 }
 
-/// Defines additional types related to SensitivityScore
+/// Defines additional types related to [SensitivityScore].
 pub mod sensitivity_score {
     #[allow(unused_imports)]
     use super::*;
@@ -28845,7 +28845,7 @@ impl wkt::message::Message for CustomInfoType {
     }
 }
 
-/// Defines additional types related to CustomInfoType
+/// Defines additional types related to [CustomInfoType].
 pub mod custom_info_type {
     #[allow(unused_imports)]
     use super::*;
@@ -28976,7 +28976,7 @@ pub mod custom_info_type {
         }
     }
 
-    /// Defines additional types related to Dictionary
+    /// Defines additional types related to [Dictionary].
     pub mod dictionary {
         #[allow(unused_imports)]
         use super::*;
@@ -29178,7 +29178,7 @@ pub mod custom_info_type {
         }
     }
 
-    /// Defines additional types related to DetectionRule
+    /// Defines additional types related to [DetectionRule].
     pub mod detection_rule {
         #[allow(unused_imports)]
         use super::*;
@@ -29311,7 +29311,7 @@ pub mod custom_info_type {
             }
         }
 
-        /// Defines additional types related to LikelihoodAdjustment
+        /// Defines additional types related to [LikelihoodAdjustment].
         pub mod likelihood_adjustment {
             #[allow(unused_imports)]
             use super::*;
@@ -29875,7 +29875,7 @@ impl wkt::message::Message for CloudStorageOptions {
     }
 }
 
-/// Defines additional types related to CloudStorageOptions
+/// Defines additional types related to [CloudStorageOptions].
 pub mod cloud_storage_options {
     #[allow(unused_imports)]
     use super::*;
@@ -30192,7 +30192,7 @@ impl wkt::message::Message for BigQueryOptions {
     }
 }
 
-/// Defines additional types related to BigQueryOptions
+/// Defines additional types related to [BigQueryOptions].
 pub mod big_query_options {
     #[allow(unused_imports)]
     use super::*;
@@ -30431,7 +30431,7 @@ impl wkt::message::Message for StorageConfig {
     }
 }
 
-/// Defines additional types related to StorageConfig
+/// Defines additional types related to [StorageConfig].
 pub mod storage_config {
     #[allow(unused_imports)]
     use super::*;
@@ -30814,7 +30814,7 @@ impl wkt::message::Message for Key {
     }
 }
 
-/// Defines additional types related to Key
+/// Defines additional types related to [Key].
 pub mod key {
     #[allow(unused_imports)]
     use super::*;
@@ -30913,7 +30913,7 @@ pub mod key {
         }
     }
 
-    /// Defines additional types related to PathElement
+    /// Defines additional types related to [PathElement].
     pub mod path_element {
         #[allow(unused_imports)]
         use super::*;
@@ -31038,7 +31038,7 @@ impl wkt::message::Message for RecordKey {
     }
 }
 
-/// Defines additional types related to RecordKey
+/// Defines additional types related to [RecordKey].
 pub mod record_key {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/rpc/context/src/model.rs
+++ b/src/generated/rpc/context/src/model.rs
@@ -186,7 +186,7 @@ impl wkt::message::Message for AttributeContext {
     }
 }
 
-/// Defines additional types related to AttributeContext
+/// Defines additional types related to [AttributeContext].
 pub mod attribute_context {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/rpc/types/src/model.rs
+++ b/src/generated/rpc/types/src/model.rs
@@ -254,7 +254,7 @@ impl wkt::message::Message for QuotaFailure {
     }
 }
 
-/// Defines additional types related to QuotaFailure
+/// Defines additional types related to [QuotaFailure].
 pub mod quota_failure {
     #[allow(unused_imports)]
     use super::*;
@@ -346,7 +346,7 @@ impl wkt::message::Message for PreconditionFailure {
     }
 }
 
-/// Defines additional types related to PreconditionFailure
+/// Defines additional types related to [PreconditionFailure].
 pub mod precondition_failure {
     #[allow(unused_imports)]
     use super::*;
@@ -444,7 +444,7 @@ impl wkt::message::Message for BadRequest {
     }
 }
 
-/// Defines additional types related to BadRequest
+/// Defines additional types related to [BadRequest].
 pub mod bad_request {
     #[allow(unused_imports)]
     use super::*;
@@ -708,7 +708,7 @@ impl wkt::message::Message for Help {
     }
 }
 
-/// Defines additional types related to Help
+/// Defines additional types related to [Help].
 pub mod help {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -385,7 +385,7 @@ impl wkt::message::Message for Backup {
     }
 }
 
-/// Defines additional types related to Backup
+/// Defines additional types related to [Backup].
 pub mod backup {
     #[allow(unused_imports)]
     use super::*;
@@ -1482,7 +1482,7 @@ impl wkt::message::Message for CreateBackupEncryptionConfig {
     }
 }
 
-/// Defines additional types related to CreateBackupEncryptionConfig
+/// Defines additional types related to [CreateBackupEncryptionConfig].
 pub mod create_backup_encryption_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1646,7 +1646,7 @@ impl wkt::message::Message for CopyBackupEncryptionConfig {
     }
 }
 
-/// Defines additional types related to CopyBackupEncryptionConfig
+/// Defines additional types related to [CopyBackupEncryptionConfig].
 pub mod copy_backup_encryption_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1874,7 +1874,7 @@ impl wkt::message::Message for BackupScheduleSpec {
     }
 }
 
-/// Defines additional types related to BackupScheduleSpec
+/// Defines additional types related to [BackupScheduleSpec].
 pub mod backup_schedule_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -2073,7 +2073,7 @@ impl wkt::message::Message for BackupSchedule {
     }
 }
 
-/// Defines additional types related to BackupSchedule
+/// Defines additional types related to [BackupSchedule].
 pub mod backup_schedule {
     #[allow(unused_imports)]
     use super::*;
@@ -2649,7 +2649,7 @@ impl wkt::message::Message for EncryptionInfo {
     }
 }
 
-/// Defines additional types related to EncryptionInfo
+/// Defines additional types related to [EncryptionInfo].
 pub mod encryption_info {
     #[allow(unused_imports)]
     use super::*;
@@ -2793,7 +2793,7 @@ impl wkt::message::Message for RestoreInfo {
     }
 }
 
-/// Defines additional types related to RestoreInfo
+/// Defines additional types related to [RestoreInfo].
 pub mod restore_info {
     #[allow(unused_imports)]
     use super::*;
@@ -3007,7 +3007,7 @@ impl wkt::message::Message for Database {
     }
 }
 
-/// Defines additional types related to Database
+/// Defines additional types related to [Database].
 pub mod database {
     #[allow(unused_imports)]
     use super::*;
@@ -4241,7 +4241,7 @@ impl wkt::message::Message for RestoreDatabaseRequest {
     }
 }
 
-/// Defines additional types related to RestoreDatabaseRequest
+/// Defines additional types related to [RestoreDatabaseRequest].
 pub mod restore_database_request {
     #[allow(unused_imports)]
     use super::*;
@@ -4336,7 +4336,7 @@ impl wkt::message::Message for RestoreDatabaseEncryptionConfig {
     }
 }
 
-/// Defines additional types related to RestoreDatabaseEncryptionConfig
+/// Defines additional types related to [RestoreDatabaseEncryptionConfig].
 pub mod restore_database_encryption_config {
     #[allow(unused_imports)]
     use super::*;
@@ -4583,7 +4583,7 @@ impl wkt::message::Message for RestoreDatabaseMetadata {
     }
 }
 
-/// Defines additional types related to RestoreDatabaseMetadata
+/// Defines additional types related to [RestoreDatabaseMetadata].
 pub mod restore_database_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -4960,7 +4960,7 @@ impl wkt::message::Message for SplitPoints {
     }
 }
 
-/// Defines additional types related to SplitPoints
+/// Defines additional types related to [SplitPoints].
 pub mod split_points {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -172,7 +172,7 @@ impl wkt::message::Message for ReplicaInfo {
     }
 }
 
-/// Defines additional types related to ReplicaInfo
+/// Defines additional types related to [ReplicaInfo].
 pub mod replica_info {
     #[allow(unused_imports)]
     use super::*;
@@ -502,7 +502,7 @@ impl wkt::message::Message for InstanceConfig {
     }
 }
 
-/// Defines additional types related to InstanceConfig
+/// Defines additional types related to [InstanceConfig].
 pub mod instance_config {
     #[allow(unused_imports)]
     use super::*;
@@ -879,7 +879,7 @@ impl wkt::message::Message for ReplicaComputeCapacity {
     }
 }
 
-/// Defines additional types related to ReplicaComputeCapacity
+/// Defines additional types related to [ReplicaComputeCapacity].
 pub mod replica_compute_capacity {
     #[allow(unused_imports)]
     use super::*;
@@ -985,7 +985,7 @@ impl wkt::message::Message for AutoscalingConfig {
     }
 }
 
-/// Defines additional types related to AutoscalingConfig
+/// Defines additional types related to [AutoscalingConfig].
 pub mod autoscaling_config {
     #[allow(unused_imports)]
     use super::*;
@@ -1155,7 +1155,7 @@ pub mod autoscaling_config {
         }
     }
 
-    /// Defines additional types related to AutoscalingLimits
+    /// Defines additional types related to [AutoscalingLimits].
     pub mod autoscaling_limits {
         #[allow(unused_imports)]
         use super::*;
@@ -1284,7 +1284,7 @@ pub mod autoscaling_config {
         }
     }
 
-    /// Defines additional types related to AsymmetricAutoscalingOption
+    /// Defines additional types related to [AsymmetricAutoscalingOption].
     pub mod asymmetric_autoscaling_option {
         #[allow(unused_imports)]
         use super::*;
@@ -1644,7 +1644,7 @@ impl wkt::message::Message for Instance {
     }
 }
 
-/// Defines additional types related to Instance
+/// Defines additional types related to [Instance].
 pub mod instance {
     #[allow(unused_imports)]
     use super::*;
@@ -3105,7 +3105,7 @@ impl wkt::message::Message for FreeInstanceMetadata {
     }
 }
 
-/// Defines additional types related to FreeInstanceMetadata
+/// Defines additional types related to [FreeInstanceMetadata].
 pub mod free_instance_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -3539,7 +3539,7 @@ impl wkt::message::Message for InstancePartition {
     }
 }
 
-/// Defines additional types related to InstancePartition
+/// Defines additional types related to [InstancePartition].
 pub mod instance_partition {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -1433,7 +1433,7 @@ impl wkt::message::Message for AwsS3Data {
     }
 }
 
-/// Defines additional types related to AwsS3Data
+/// Defines additional types related to [AwsS3Data].
 pub mod aws_s_3_data {
     #[allow(unused_imports)]
     use super::*;
@@ -1810,7 +1810,7 @@ impl wkt::message::Message for AwsS3CompatibleData {
     }
 }
 
-/// Defines additional types related to AwsS3CompatibleData
+/// Defines additional types related to [AwsS3CompatibleData].
 pub mod aws_s_3_compatible_data {
     #[allow(unused_imports)]
     use super::*;
@@ -1907,7 +1907,7 @@ impl wkt::message::Message for S3CompatibleMetadata {
     }
 }
 
-/// Defines additional types related to S3CompatibleMetadata
+/// Defines additional types related to [S3CompatibleMetadata].
 pub mod s_3_compatible_metadata {
     #[allow(unused_imports)]
     use super::*;
@@ -2228,7 +2228,7 @@ impl wkt::message::Message for AgentPool {
     }
 }
 
-/// Defines additional types related to AgentPool
+/// Defines additional types related to [AgentPool].
 pub mod agent_pool {
     #[allow(unused_imports)]
     use super::*;
@@ -2430,7 +2430,7 @@ impl wkt::message::Message for TransferOptions {
     }
 }
 
-/// Defines additional types related to TransferOptions
+/// Defines additional types related to [TransferOptions].
 pub mod transfer_options {
     #[allow(unused_imports)]
     use super::*;
@@ -2961,7 +2961,7 @@ impl wkt::message::Message for TransferSpec {
     }
 }
 
-/// Defines additional types related to TransferSpec
+/// Defines additional types related to [TransferSpec].
 pub mod transfer_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -3161,7 +3161,7 @@ impl wkt::message::Message for ReplicationSpec {
     }
 }
 
-/// Defines additional types related to ReplicationSpec
+/// Defines additional types related to [ReplicationSpec].
 pub mod replication_spec {
     #[allow(unused_imports)]
     use super::*;
@@ -3346,7 +3346,7 @@ impl wkt::message::Message for MetadataOptions {
     }
 }
 
-/// Defines additional types related to MetadataOptions
+/// Defines additional types related to [MetadataOptions].
 pub mod metadata_options {
     #[allow(unused_imports)]
     use super::*;
@@ -4421,7 +4421,7 @@ impl wkt::message::Message for TransferJob {
     }
 }
 
-/// Defines additional types related to TransferJob
+/// Defines additional types related to [TransferJob].
 pub mod transfer_job {
     #[allow(unused_imports)]
     use super::*;
@@ -4956,7 +4956,7 @@ impl wkt::message::Message for NotificationConfig {
     }
 }
 
-/// Defines additional types related to NotificationConfig
+/// Defines additional types related to [NotificationConfig].
 pub mod notification_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5177,7 +5177,7 @@ impl wkt::message::Message for LoggingConfig {
     }
 }
 
-/// Defines additional types related to LoggingConfig
+/// Defines additional types related to [LoggingConfig].
 pub mod logging_config {
     #[allow(unused_imports)]
     use super::*;
@@ -5474,7 +5474,7 @@ impl wkt::message::Message for TransferOperation {
     }
 }
 
-/// Defines additional types related to TransferOperation
+/// Defines additional types related to [TransferOperation].
 pub mod transfer_operation {
     #[allow(unused_imports)]
     use super::*;

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -465,7 +465,7 @@ impl wkt::message::Message for DateTime {
     }
 }
 
-/// Defines additional types related to DateTime
+/// Defines additional types related to [DateTime].
 pub mod date_time {
     #[allow(unused_imports)]
     use super::*;
@@ -1093,7 +1093,7 @@ impl wkt::message::Message for PhoneNumber {
     }
 }
 
-/// Defines additional types related to PhoneNumber
+/// Defines additional types related to [PhoneNumber].
 pub mod phone_number {
     #[allow(unused_imports)]
     use super::*;

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -761,7 +761,7 @@ impl wkt::message::Message for DescriptorProto {
     }
 }
 
-/// Defines additional types related to DescriptorProto
+/// Defines additional types related to [DescriptorProto].
 pub mod descriptor_proto {
     #[allow(unused_imports)]
     use super::*;
@@ -931,7 +931,7 @@ impl wkt::message::Message for ExtensionRangeOptions {
     }
 }
 
-/// Defines additional types related to ExtensionRangeOptions
+/// Defines additional types related to [ExtensionRangeOptions].
 pub mod extension_range_options {
     #[allow(unused_imports)]
     use super::*;
@@ -1223,7 +1223,7 @@ impl wkt::message::Message for FieldDescriptorProto {
     }
 }
 
-/// Defines additional types related to FieldDescriptorProto
+/// Defines additional types related to [FieldDescriptorProto].
 pub mod field_descriptor_proto {
     #[allow(unused_imports)]
     use super::*;
@@ -1538,7 +1538,7 @@ impl wkt::message::Message for EnumDescriptorProto {
     }
 }
 
-/// Defines additional types related to EnumDescriptorProto
+/// Defines additional types related to [EnumDescriptorProto].
 pub mod enum_descriptor_proto {
     #[allow(unused_imports)]
     use super::*;
@@ -2057,7 +2057,7 @@ impl wkt::message::Message for FileOptions {
     }
 }
 
-/// Defines additional types related to FileOptions
+/// Defines additional types related to [FileOptions].
 pub mod file_options {
     #[allow(unused_imports)]
     use super::*;
@@ -2486,7 +2486,7 @@ impl wkt::message::Message for FieldOptions {
     }
 }
 
-/// Defines additional types related to FieldOptions
+/// Defines additional types related to [FieldOptions].
 pub mod field_options {
     #[allow(unused_imports)]
     use super::*;
@@ -3196,7 +3196,7 @@ impl wkt::message::Message for MethodOptions {
     }
 }
 
-/// Defines additional types related to MethodOptions
+/// Defines additional types related to [MethodOptions].
 pub mod method_options {
     #[allow(unused_imports)]
     use super::*;
@@ -3355,7 +3355,7 @@ impl wkt::message::Message for UninterpretedOption {
     }
 }
 
-/// Defines additional types related to UninterpretedOption
+/// Defines additional types related to [UninterpretedOption].
 pub mod uninterpreted_option {
     #[allow(unused_imports)]
     use super::*;
@@ -3493,7 +3493,7 @@ impl wkt::message::Message for FeatureSet {
     }
 }
 
-/// Defines additional types related to FeatureSet
+/// Defines additional types related to [FeatureSet].
 pub mod feature_set {
     #[allow(unused_imports)]
     use super::*;
@@ -3884,7 +3884,7 @@ impl wkt::message::Message for FeatureSetDefaults {
     }
 }
 
-/// Defines additional types related to FeatureSetDefaults
+/// Defines additional types related to [FeatureSetDefaults].
 pub mod feature_set_defaults {
     #[allow(unused_imports)]
     use super::*;
@@ -4026,7 +4026,7 @@ impl wkt::message::Message for SourceCodeInfo {
     }
 }
 
-/// Defines additional types related to SourceCodeInfo
+/// Defines additional types related to [SourceCodeInfo].
 pub mod source_code_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4229,7 +4229,7 @@ impl wkt::message::Message for GeneratedCodeInfo {
     }
 }
 
-/// Defines additional types related to GeneratedCodeInfo
+/// Defines additional types related to [GeneratedCodeInfo].
 pub mod generated_code_info {
     #[allow(unused_imports)]
     use super::*;
@@ -4312,7 +4312,7 @@ pub mod generated_code_info {
         }
     }
 
-    /// Defines additional types related to Annotation
+    /// Defines additional types related to [Annotation].
     pub mod annotation {
         #[allow(unused_imports)]
         use super::*;
@@ -4638,7 +4638,7 @@ impl wkt::message::Message for Field {
     }
 }
 
-/// Defines additional types related to Field
+/// Defines additional types related to [Field].
 pub mod field {
     #[allow(unused_imports)]
     use super::*;


### PR DESCRIPTION
We use Rust modules to generate nested messages and enums. The rustdoc
comments for these modules needed to link the corresponding message.
