### PR TITLE
refactor!: rename polling policy

### DIFF
--- a/guide/samples/src/polling_policies.rs
+++ b/guide/samples/src/polling_policies.rs
@@ -136,15 +136,15 @@ pub async fn rpc_backoff(project_id: &str) -> crate::Result<()> {
 pub async fn client_errors(project_id: &str) -> crate::Result<()> {
     // ANCHOR: client-errors-use
     use google_cloud_gax::options::ClientConfig;
-    use google_cloud_gax::polling_policy::Aip194Strict;
-    use google_cloud_gax::polling_policy::PollingPolicyExt;
+    use google_cloud_gax::polling_error_policy::Aip194Strict;
+    use google_cloud_gax::polling_error_policy::PollingErrorPolicyExt;
     use std::time::Duration;
     // ANCHOR_END: client-errors-use
     use speech::Poller;
 
     // ANCHOR: client-errors-client
     let client = speech::client::Speech::new_with_config(
-        ClientConfig::default().set_polling_policy(
+        ClientConfig::default().set_polling_error_policy(
             Aip194Strict
                 .with_attempt_limit(100)
                 .with_time_limit(Duration::from_secs(300)),
@@ -191,8 +191,8 @@ pub async fn client_errors(project_id: &str) -> crate::Result<()> {
 // ANCHOR: rpc-errors
 pub async fn rpc_errors(project_id: &str) -> crate::Result<()> {
     // ANCHOR: rpc-errors-use
-    use google_cloud_gax::polling_policy::Aip194Strict;
-    use google_cloud_gax::polling_policy::PollingPolicyExt;
+    use google_cloud_gax::polling_error_policy::Aip194Strict;
+    use google_cloud_gax::polling_error_policy::PollingErrorPolicyExt;
     use std::time::Duration;
     // ANCHOR_END: rpc-errors-use
     // ANCHOR: rpc-errors-builder-trait
@@ -211,7 +211,7 @@ pub async fn rpc_errors(project_id: &str) -> crate::Result<()> {
         ))
         // ANCHOR_END: rpc-errors-builder
         // ANCHOR: rpc-errors-rpc-polling-errors
-        .with_polling_policy(
+        .with_polling_error_policy(
             Aip194Strict
                 .with_attempt_limit(100)
                 .with_time_limit(Duration::from_secs(300)),

--- a/guide/src/configuring_polling_policies.md
+++ b/guide/src/configuring_polling_policies.md
@@ -30,7 +30,7 @@ There are two different policies controlling the behavior of the LRO loops:
 
 - The polling backoff policy controls how long the loop waits before polling
   the status of a LRO that is still in progress.
-- The polling policy controls what to do on an polling error. Some polling
+- The polling error policy controls what to do on an polling error. Some polling
   errors are unrecoverable, and indicate that the operation was aborted or the
   caller has no permissions to check the status of the LRO. Other polling errors
   are transient, and indicate a temporary problem in the client network or the
@@ -136,7 +136,7 @@ See [below](#configuring-the-polling-frequency-for-a-specific-request-complete-c
 ## Configuring the retryable polling errors for all requests in a client
 
 To configure the retryable errors we need to use a type implementing the
-[PollingPolicy] trait. The client libraries provide a number of them, a
+[PollingErrorPolicy] trait. The client libraries provide a number of them, a
 conservative choice is [Aip194Strict]:
 
 ```rust,ignore
@@ -173,7 +173,7 @@ See [below](#configuring-the-retryable-polling-errors-for-all-requests-in-a-clie
 ## Configuring the retryable polling errors for a specific request
 
 To configure the retryable errors we need to use a type implementing the
-[PollingPolicy] trait. The client libraries provide a number of them, a
+[PollingErrorPolicy] trait. The client libraries provide a number of them, a
 conservative choice is [Aip194Strict]:
 
 ```rust,ignore
@@ -231,10 +231,10 @@ See [below](#configuring-the-retryable-polling-errors-for-a-specific-request-com
 ```
 
 [aip-194]: https://google.aip.dev/194
-[aip194strict]: https://docs.rs/google-cloud-gax/latest/google_cloud_gax/polling_policy/struct.Aip194Strict.html
+[aip194strict]: https://docs.rs/google-cloud-gax/latest/google_cloud_gax/polling_error_policy/struct.Aip194Strict.html
 [exponentialbackoff]: https://docs.rs/google-cloud-gax/latest/google_cloud_gax/exponential_backoff/struct.ExponentialBackoff.html
 [per-request setting]: #configuring-the-polling-frequency-for-a-specific-request
 [pollingbackoffpolicy]: https://docs.rs/google-cloud-gax/latest/google_cloud_gax/polling_backoff_policy/trait.PollingBackoffPolicy.html
-[pollingpolicy]: https://docs.rs/google-cloud-gax/latest/google_cloud_gax/polling_policy/trait.PollingPolicy.html
+[pollingerrorpolicy]: https://docs.rs/google-cloud-gax/latest/google_cloud_gax/polling_error_policy/trait.PollingErrorPolicy.html
 [speech-to-text v2]: https://cloud.google.com/speech-to-text/v2
 [transcribe speech to text by using the command line]: https://cloud.google.com/speech-to-text/v2/docs/transcribe-api

--- a/guide/src/working_with_long_running_operations.md
+++ b/guide/src/working_with_long_running_operations.md
@@ -302,7 +302,7 @@ You can find the [full function](#manually-polling-a-long-running-operation-comp
 
 ## What's Next
 
-* [Configuring polling policies](/configuring_polling_policies.md) describes how
+- [Configuring polling policies](/configuring_polling_policies.md) describes how
   to customize error handling and backoff periods for LROs.
 
 [batch recognize]: https://cloud.google.com/speech-to-text/v2/docs/batch-recognize

--- a/guide/src/working_with_long_running_operations.md
+++ b/guide/src/working_with_long_running_operations.md
@@ -300,13 +300,10 @@ You can find the [full function](#manually-polling-a-long-running-operation-comp
 {{#rustdoc_include ../samples/src/lro.rs:manual}}
 ```
 
-<!--
-
 ## What's Next
 
-TODO(#574) - add links to polling policies
-
--->
+* [Configuring polling policies](/configuring_polling_policies.md) describes how
+  to customize error handling and backoff periods for LROs.
 
 [batch recognize]: https://cloud.google.com/speech-to-text/v2/docs/batch-recognize
 [configuring polling policies]: ./configuring_polling_policies.md

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -266,7 +266,7 @@ impl ReqwestClient {
         options: &gax::options::RequestOptions,
     ) -> Arc<dyn gax::polling_error_policy::PollingErrorPolicy> {
         options
-            .polling_policy()
+            .polling_error_policy()
             .clone()
             .or_else(|| self.polling_error_policy.clone())
             .unwrap_or_else(|| Arc::new(Aip194Strict))

--- a/src/gax-internal/tests/http_client_polling.rs
+++ b/src/gax-internal/tests/http_client_polling.rs
@@ -22,10 +22,10 @@ mod test {
     /// A test policy, the only interesting bit is the name, which is included
     /// in debug messages and used in the tests.
     #[derive(Debug)]
-    struct TestPollingPolicy {
+    struct TestErrorPolicy {
         pub _name: String,
     }
-    impl gax::polling_policy::PollingPolicy for TestPollingPolicy {
+    impl gax::polling_error_policy::PollingErrorPolicy for TestErrorPolicy {
         fn on_error(
             &self,
             _loop_start: std::time::Instant,
@@ -59,7 +59,7 @@ mod test {
 
         let options = gax::options::RequestOptions::default();
         // Verify the functions are callable from outside the crate.
-        let _ = client.get_polling_policy(&options);
+        let _ = client.get_polling_error_policy(&options);
         let _ = client.get_polling_backoff_policy(&options);
 
         Ok(())
@@ -70,21 +70,21 @@ mod test {
         let (endpoint, _server) = echo_server::start().await?;
         let config = ClientConfig::default()
             .set_credential(auth::credentials::testing::test_credentials())
-            .set_polling_policy(TestPollingPolicy {
-                _name: "client-polling".to_string(),
+            .set_polling_error_policy(TestErrorPolicy {
+                _name: "client-polling-error".to_string(),
             })
             .set_polling_backoff_policy(TestBackoffPolicy {
-                _name: "client-backoff".to_string(),
+                _name: "client-polling-backoff".to_string(),
             });
         let client = ReqwestClient::new(config, &endpoint).await?;
 
         let options = gax::options::RequestOptions::default();
-        let polling = client.get_polling_policy(&options);
+        let polling = client.get_polling_error_policy(&options);
         let fmt = format!("{polling:?}");
-        assert!(fmt.contains("client-polling"), "{polling:?}");
+        assert!(fmt.contains("client-polling-error"), "{polling:?}");
         let backoff = client.get_polling_backoff_policy(&options);
         let fmt = format!("{backoff:?}");
-        assert!(fmt.contains("client-backoff"), "{backoff:?}");
+        assert!(fmt.contains("client-polling-backoff"), "{backoff:?}");
 
         Ok(())
     }
@@ -94,27 +94,30 @@ mod test {
         let (endpoint, _server) = echo_server::start().await?;
         let config = ClientConfig::default()
             .set_credential(auth::credentials::testing::test_credentials())
-            .set_polling_policy(TestPollingPolicy {
-                _name: "client-polling".to_string(),
+            .set_polling_error_policy(TestErrorPolicy {
+                _name: "client-polling-error".to_string(),
             })
             .set_polling_backoff_policy(TestBackoffPolicy {
-                _name: "client-backoff".to_string(),
+                _name: "client-polling-backoff".to_string(),
             });
         let client = ReqwestClient::new(config, &endpoint).await?;
 
         let mut options = gax::options::RequestOptions::default();
-        options.set_polling_policy(TestPollingPolicy {
-            _name: "request-options-polling".to_string(),
+        options.set_polling_error_policy(TestErrorPolicy {
+            _name: "request-options-polling-error".to_string(),
         });
         options.set_polling_backoff_policy(TestBackoffPolicy {
-            _name: "request-options-backoff".to_string(),
+            _name: "request-options-polling-backoff".to_string(),
         });
-        let polling = client.get_polling_policy(&options);
+        let polling = client.get_polling_error_policy(&options);
         let fmt = format!("{polling:?}");
-        assert!(fmt.contains("request-options-polling"), "{polling:?}");
+        assert!(fmt.contains("request-options-polling-error"), "{polling:?}");
         let backoff = client.get_polling_backoff_policy(&options);
         let fmt = format!("{backoff:?}");
-        assert!(fmt.contains("request-options-backoff"), "{backoff:?}");
+        assert!(
+            fmt.contains("request-options-polling-backoff"),
+            "{backoff:?}"
+        );
 
         Ok(())
     }

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -51,6 +51,8 @@ pub mod exponential_backoff;
 pub mod loop_state;
 pub mod options;
 pub mod polling_backoff_policy;
-pub mod polling_policy;
+pub mod polling_error_policy;
+// TODO(#1135) - remove backwards compat
+pub use polling_error_policy as polling_policy;
 pub mod retry_policy;
 pub mod retry_throttler;

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -27,7 +27,7 @@
 
 use crate::backoff_policy::{BackoffPolicy, BackoffPolicyArg};
 use crate::polling_backoff_policy::{PollingBackoffPolicy, PollingBackoffPolicyArg};
-use crate::polling_policy::{PollingPolicy, PollingPolicyArg};
+use crate::polling_error_policy::{PollingErrorPolicy, PollingErrorPolicyArg};
 use crate::retry_policy::{RetryPolicy, RetryPolicyArg};
 use crate::retry_throttler::{RetryThrottlerArg, SharedRetryThrottler};
 use auth::credentials::Credential;
@@ -48,7 +48,7 @@ pub struct RequestOptions {
     retry_policy: Option<Arc<dyn RetryPolicy>>,
     backoff_policy: Option<Arc<dyn BackoffPolicy>>,
     retry_throttler: Option<SharedRetryThrottler>,
-    polling_policy: Option<Arc<dyn PollingPolicy>>,
+    polling_error_policy: Option<Arc<dyn PollingErrorPolicy>>,
     polling_backoff_policy: Option<Arc<dyn PollingBackoffPolicy>>,
 }
 
@@ -136,14 +136,24 @@ impl RequestOptions {
         self.retry_throttler = Some(v.into().0);
     }
 
+    // TODO(#1135) - remove backwards compat.
+    pub fn polling_policy(&self) -> &Option<Arc<dyn PollingErrorPolicy>> {
+        &self.polling_error_policy
+    }
+
+    // TODO(#1135) - remove backwards compat.
+    pub fn set_polling_policy<V: Into<PollingErrorPolicyArg>>(&mut self, v: V) {
+        self.polling_error_policy = Some(v.into().0);
+    }
+
     /// Get the current polling policy override, if any.
-    pub fn polling_policy(&self) -> &Option<Arc<dyn PollingPolicy>> {
-        &self.polling_policy
+    pub fn polling_error_policy(&self) -> &Option<Arc<dyn PollingErrorPolicy>> {
+        &self.polling_error_policy
     }
 
     /// Sets the polling policy configuration.
-    pub fn set_polling_policy<V: Into<PollingPolicyArg>>(&mut self, v: V) {
-        self.polling_policy = Some(v.into().0);
+    pub fn set_polling_error_policy<V: Into<PollingErrorPolicyArg>>(&mut self, v: V) {
+        self.polling_error_policy = Some(v.into().0);
     }
 
     /// Get the current polling backoff policy override, if any.
@@ -185,8 +195,8 @@ pub trait RequestOptionsBuilder {
     /// Sets the retry throttler configuration.
     fn with_retry_throttler<V: Into<RetryThrottlerArg>>(self, v: V) -> Self;
 
-    /// Sets the polling policy configuration.
-    fn with_polling_policy<V: Into<PollingPolicyArg>>(self, v: V) -> Self;
+    /// Sets the polling error policy configuration.
+    fn with_polling_error_policy<V: Into<PollingErrorPolicyArg>>(self, v: V) -> Self;
 
     /// Sets the polling backoff policy configuration.
     fn with_polling_backoff_policy<V: Into<PollingBackoffPolicyArg>>(self, v: V) -> Self;
@@ -237,8 +247,8 @@ where
         self
     }
 
-    fn with_polling_policy<V: Into<PollingPolicyArg>>(mut self, v: V) -> Self {
-        self.request_options().set_polling_policy(v);
+    fn with_polling_error_policy<V: Into<PollingErrorPolicyArg>>(mut self, v: V) -> Self {
+        self.request_options().set_polling_error_policy(v);
         self
     }
 
@@ -262,7 +272,7 @@ pub struct ClientConfig {
     retry_policy: Option<Arc<dyn RetryPolicy>>,
     backoff_policy: Option<Arc<dyn BackoffPolicy>>,
     retry_throttler: SharedRetryThrottler,
-    polling_policy: Option<Arc<dyn PollingPolicy>>,
+    polling_error_policy: Option<Arc<dyn PollingErrorPolicy>>,
     polling_backoff_policy: Option<Arc<dyn PollingBackoffPolicy>>,
 }
 
@@ -351,13 +361,13 @@ impl ClientConfig {
     }
 
     /// Get the current polling policy override, if any.
-    pub fn polling_policy(&self) -> &Option<Arc<dyn PollingPolicy>> {
-        &self.polling_policy
+    pub fn polling_error_policy(&self) -> &Option<Arc<dyn PollingErrorPolicy>> {
+        &self.polling_error_policy
     }
 
     /// Configure the polling backoff policy.
-    pub fn set_polling_policy<V: Into<PollingPolicyArg>>(mut self, v: V) -> Self {
-        self.polling_policy = Some(v.into().0);
+    pub fn set_polling_error_policy<V: Into<PollingErrorPolicyArg>>(mut self, v: V) -> Self {
+        self.polling_error_policy = Some(v.into().0);
         self
     }
 
@@ -384,7 +394,7 @@ impl std::default::Default for ClientConfig {
             retry_policy: None,
             backoff_policy: None,
             retry_throttler: Arc::new(Mutex::new(AdaptiveThrottler::default())),
-            polling_policy: None,
+            polling_error_policy: None,
             polling_backoff_policy: None,
         }
     }
@@ -394,7 +404,7 @@ impl std::default::Default for ClientConfig {
 mod test {
     use super::*;
     use crate::exponential_backoff::ExponentialBackoffBuilder;
-    use crate::polling_policy;
+    use crate::polling_error_policy;
     use crate::retry_policy::LimitedAttemptCount;
     use crate::retry_throttler::AdaptiveThrottler;
     use std::time::Duration;
@@ -438,7 +448,7 @@ mod test {
         opts.set_retry_throttler(AdaptiveThrottler::default());
         assert!(opts.retry_throttler().is_some(), "{opts:?}");
 
-        opts.set_polling_policy(polling_policy::Aip194Strict);
+        opts.set_polling_error_policy(polling_error_policy::Aip194Strict);
         assert!(opts.polling_policy().is_some(), "{opts:?}");
 
         opts.set_polling_backoff_policy(ExponentialBackoffBuilder::new().clamp());
@@ -500,7 +510,8 @@ mod test {
             "{builder:?}"
         );
 
-        let mut builder = TestBuilder::default().with_polling_policy(polling_policy::Aip194Strict);
+        let mut builder =
+            TestBuilder::default().with_polling_error_policy(polling_error_policy::Aip194Strict);
         assert!(
             builder.request_options().polling_policy().is_some(),
             "{builder:?}"
@@ -599,8 +610,9 @@ mod test {
 
     #[test]
     fn config_polling() {
-        let config = ClientConfig::new().set_polling_policy(polling_policy::AlwaysContinue);
-        assert!(config.polling_policy.is_some());
+        let config =
+            ClientConfig::new().set_polling_error_policy(polling_error_policy::AlwaysContinue);
+        assert!(config.polling_error_policy.is_some());
     }
 
     #[test]

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -138,12 +138,12 @@ impl RequestOptions {
 
     // TODO(#1135) - remove backwards compat.
     pub fn polling_policy(&self) -> &Option<Arc<dyn PollingErrorPolicy>> {
-        &self.polling_error_policy
+        self.polling_error_policy()
     }
 
     // TODO(#1135) - remove backwards compat.
     pub fn set_polling_policy<V: Into<PollingErrorPolicyArg>>(&mut self, v: V) {
-        self.polling_error_policy = Some(v.into().0);
+        self.set_polling_error_policy(v);
     }
 
     /// Get the current polling policy override, if any.
@@ -449,7 +449,7 @@ mod test {
         assert!(opts.retry_throttler().is_some(), "{opts:?}");
 
         opts.set_polling_error_policy(polling_error_policy::Aip194Strict);
-        assert!(opts.polling_policy().is_some(), "{opts:?}");
+        assert!(opts.polling_error_policy().is_some(), "{opts:?}");
 
         opts.set_polling_backoff_policy(ExponentialBackoffBuilder::new().clamp());
         assert!(opts.polling_backoff_policy().is_some(), "{opts:?}");
@@ -513,7 +513,7 @@ mod test {
         let mut builder =
             TestBuilder::default().with_polling_error_policy(polling_error_policy::Aip194Strict);
         assert!(
-            builder.request_options().polling_policy().is_some(),
+            builder.request_options().polling_error_policy().is_some(),
             "{builder:?}"
         );
 

--- a/src/gax/src/polling_error_policy.rs
+++ b/src/gax/src/polling_error_policy.rs
@@ -27,7 +27,9 @@
 //! # use google_cloud_gax::polling_error_policy::*;
 //! # use google_cloud_gax::options;
 //! use std::time::Duration;
-//! fn customize_polling_policy(config: options::ClientConfig) -> options::ClientConfig {
+//! fn customize_polling_error_policy(config: options::ClientConfig)
+//!     -> options::ClientConfig
+//! {
 //!     // Poll for at most 15 minutes or at most 50 attempts: whichever limit
 //!     // is reached first stops the polling loop.
 //!     config.set_polling_error_policy(

--- a/src/gax/src/polling_error_policy.rs
+++ b/src/gax/src/polling_error_policy.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Defines the trait for polling policies and some common implementations.
+//! Defines the types for polling error policies.
 //!
 //! The client libraries automatically poll long-running operations (LROs) and
 //! need to (1) distinguish between transient and permanent errors, and (2)
@@ -24,13 +24,13 @@
 //!
 //! # Example:
 //! ```
-//! # use google_cloud_gax::polling_policy::*;
+//! # use google_cloud_gax::polling_error_policy::*;
 //! # use google_cloud_gax::options;
 //! use std::time::Duration;
 //! fn customize_polling_policy(config: options::ClientConfig) -> options::ClientConfig {
 //!     // Poll for at most 15 minutes or at most 50 attempts: whichever limit
 //!     // is reached first stops the polling loop.
-//!     config.set_polling_policy(
+//!     config.set_polling_error_policy(
 //!         Aip194Strict
 //!             .with_time_limit(Duration::from_secs(15 * 60))
 //!             .with_attempt_limit(50))
@@ -41,11 +41,14 @@ use crate::error::Error;
 use crate::loop_state::LoopState;
 use std::sync::Arc;
 
+// TODO(#1135) - remove backwards compat
+pub use PollingErrorPolicy as PollingPolicy;
+
 /// Determines how errors are handled in the polling loop.
 ///
 /// Implementations of this trait determine if polling errors may resolve in
 /// future attempts, and for how long the polling loop may continue.
-pub trait PollingPolicy: Send + Sync + std::fmt::Debug {
+pub trait PollingErrorPolicy: Send + Sync + std::fmt::Debug {
     /// Query the polling policy after an error.
     ///
     /// # Parameters
@@ -73,28 +76,28 @@ pub trait PollingPolicy: Send + Sync + std::fmt::Debug {
     }
 }
 
-/// A helper type to use [PollingPolicy] in client and request options.
+/// A helper type to use [PollingErrorPolicy] in client and request options.
 #[derive(Clone)]
-pub struct PollingPolicyArg(pub(crate) Arc<dyn PollingPolicy>);
+pub struct PollingErrorPolicyArg(pub(crate) Arc<dyn PollingErrorPolicy>);
 
-impl<T> std::convert::From<T> for PollingPolicyArg
+impl<T> std::convert::From<T> for PollingErrorPolicyArg
 where
-    T: PollingPolicy + 'static,
+    T: PollingErrorPolicy + 'static,
 {
     fn from(value: T) -> Self {
         Self(Arc::new(value))
     }
 }
 
-impl std::convert::From<Arc<dyn PollingPolicy>> for PollingPolicyArg {
-    fn from(value: Arc<dyn PollingPolicy>) -> Self {
+impl std::convert::From<Arc<dyn PollingErrorPolicy>> for PollingErrorPolicyArg {
+    fn from(value: Arc<dyn PollingErrorPolicy>) -> Self {
         Self(value)
     }
 }
 
-/// Extension trait for [PollingPolicy]
-pub trait PollingPolicyExt: PollingPolicy + Sized {
-    /// Decorate a [PollingPolicy] to limit the total elapsed time in the
+/// Extension trait for [PollingErrorPolicy]
+pub trait PollingErrorPolicyExt: PollingErrorPolicy + Sized {
+    /// Decorate a [PollingErrorPolicy] to limit the total elapsed time in the
     /// polling loop.
     ///
     /// While the time spent in the polling loop (including time in backoff) is
@@ -106,7 +109,7 @@ pub trait PollingPolicyExt: PollingPolicy + Sized {
     /// # Example
     /// ```
     /// # use google_cloud_gax::*;
-    /// use polling_policy::*;
+    /// use polling_error_policy::*;
     /// use std::time::{Duration, Instant};
     /// let policy = Aip194Strict.with_time_limit(Duration::from_secs(10)).with_attempt_limit(3);
     /// let attempt_count = 4;
@@ -116,7 +119,7 @@ pub trait PollingPolicyExt: PollingPolicy + Sized {
         LimitedElapsedTime::custom(self, maximum_duration)
     }
 
-    /// Decorate a [PollingPolicy] to limit the number of poll attempts.
+    /// Decorate a [PollingErrorPolicy] to limit the number of poll attempts.
     ///
     /// This policy decorates an inner policy and limits the total number of
     /// attempts. Note that `on_error()` is called only after a polling attempt.
@@ -132,7 +135,7 @@ pub trait PollingPolicyExt: PollingPolicy + Sized {
     /// # Example
     /// ```
     /// # use google_cloud_gax::*;
-    /// use polling_policy::*;
+    /// use polling_error_policy::*;
     /// use std::time::Instant;
     /// let policy = Aip194Strict.with_attempt_limit(3);
     /// assert!(policy.on_error(Instant::now(), 0, error::Error::authentication(format!("transient"))).is_continue());
@@ -145,7 +148,7 @@ pub trait PollingPolicyExt: PollingPolicy + Sized {
     }
 }
 
-impl<T: PollingPolicy> PollingPolicyExt for T {}
+impl<T: PollingErrorPolicy> PollingErrorPolicyExt for T {}
 
 /// A polling policy that strictly follows [AIP-194].
 ///
@@ -158,7 +161,7 @@ impl<T: PollingPolicy> PollingPolicyExt for T {}
 /// # Example
 /// ```
 /// # use google_cloud_gax::*;
-/// # use google_cloud_gax::polling_policy::*;
+/// # use google_cloud_gax::polling_error_policy::*;
 /// use std::time::Instant;
 /// let policy = Aip194Strict.with_attempt_limit(3);
 /// let attempt_count = 4;
@@ -169,7 +172,7 @@ impl<T: PollingPolicy> PollingPolicyExt for T {}
 #[derive(Clone, Debug)]
 pub struct Aip194Strict;
 
-impl PollingPolicy for Aip194Strict {
+impl PollingErrorPolicy for Aip194Strict {
     fn on_error(
         &self,
         _loop_start: std::time::Instant,
@@ -216,7 +219,7 @@ impl PollingPolicy for Aip194Strict {
 /// # Example
 /// ```
 /// # use google_cloud_gax::*;
-/// # use google_cloud_gax::polling_policy::*;
+/// # use google_cloud_gax::polling_error_policy::*;
 /// use std::time::Instant;
 /// let policy = AlwaysContinue;
 /// assert!(policy.on_error(Instant::now(), 1, error::Error::other("err")).is_continue());
@@ -226,7 +229,7 @@ impl PollingPolicy for Aip194Strict {
 #[derive(Clone, Debug)]
 pub struct AlwaysContinue;
 
-impl PollingPolicy for AlwaysContinue {
+impl PollingErrorPolicy for AlwaysContinue {
     fn on_error(
         &self,
         _loop_start: std::time::Instant,
@@ -255,7 +258,7 @@ impl PollingPolicy for AlwaysContinue {
 #[derive(Debug)]
 pub struct LimitedElapsedTime<P = Aip194Strict>
 where
-    P: PollingPolicy,
+    P: PollingErrorPolicy,
 {
     inner: P,
     maximum_duration: std::time::Duration,
@@ -267,7 +270,7 @@ impl LimitedElapsedTime {
     /// # Example
     /// ```
     /// # use google_cloud_gax::*;
-    /// # use google_cloud_gax::polling_policy::*;
+    /// # use google_cloud_gax::polling_error_policy::*;
     /// use std::time::{Duration, Instant};
     /// let policy = LimitedElapsedTime::new(Duration::from_secs(10));
     /// let start = Instant::now() - Duration::from_secs(20);
@@ -283,14 +286,14 @@ impl LimitedElapsedTime {
 
 impl<P> LimitedElapsedTime<P>
 where
-    P: PollingPolicy,
+    P: PollingErrorPolicy,
 {
     /// Creates a new instance with a custom inner policy.
     ///
     /// # Example
     /// ```
     /// # use google_cloud_gax::*;
-    /// # use google_cloud_gax::polling_policy::*;
+    /// # use google_cloud_gax::polling_error_policy::*;
     /// use std::time::{Duration, Instant};
     /// let policy = LimitedElapsedTime::custom(AlwaysContinue, Duration::from_secs(10));
     /// let start = Instant::now() - Duration::from_secs(20);
@@ -317,9 +320,9 @@ where
     }
 }
 
-impl<P> PollingPolicy for LimitedElapsedTime<P>
+impl<P> PollingErrorPolicy for LimitedElapsedTime<P>
 where
-    P: PollingPolicy + 'static,
+    P: PollingErrorPolicy + 'static,
 {
     fn on_error(&self, start: std::time::Instant, count: u32, error: Error) -> LoopState {
         match self.inner.on_error(start, count, error) {
@@ -363,7 +366,7 @@ where
 #[derive(Debug)]
 pub struct LimitedAttemptCount<P = Aip194Strict>
 where
-    P: PollingPolicy,
+    P: PollingErrorPolicy,
 {
     inner: P,
     maximum_attempts: u32,
@@ -375,7 +378,7 @@ impl LimitedAttemptCount {
     /// # Example
     /// ```
     /// # use google_cloud_gax::*;
-    /// # use google_cloud_gax::polling_policy::*;
+    /// # use google_cloud_gax::polling_error_policy::*;
     /// use std::time::Instant;
     /// let policy = LimitedAttemptCount::new(5);
     /// let attempt_count = 10;
@@ -391,13 +394,13 @@ impl LimitedAttemptCount {
 
 impl<P> LimitedAttemptCount<P>
 where
-    P: PollingPolicy,
+    P: PollingErrorPolicy,
 {
     /// Creates a new instance with a custom inner policy.
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_gax::polling_policy::*;
+    /// # use google_cloud_gax::polling_error_policy::*;
     /// # use google_cloud_gax::*;
     /// use std::time::Instant;
     /// let policy = LimitedAttemptCount::custom(AlwaysContinue, 2);
@@ -424,9 +427,9 @@ where
     }
 }
 
-impl<P> PollingPolicy for LimitedAttemptCount<P>
+impl<P> PollingErrorPolicy for LimitedAttemptCount<P>
 where
-    P: PollingPolicy,
+    P: PollingErrorPolicy,
 {
     fn on_error(&self, start: std::time::Instant, count: u32, error: Error) -> LoopState {
         match self.inner.on_error(start, count, error) {
@@ -500,7 +503,7 @@ mod tests {
     mockall::mock! {
         #[derive(Debug)]
         Policy {}
-        impl PollingPolicy for Policy {
+        impl PollingErrorPolicy for Policy {
             fn on_error(&self, loop_start: std::time::Instant, attempt_count: u32, error: Error) -> LoopState;
             fn on_in_progress(&self, loop_start: std::time::Instant, attempt_count: u32, operation_name: &str) -> Option<Error>;
         }
@@ -510,10 +513,10 @@ mod tests {
     #[test]
     fn polling_policy_arg() {
         let policy = LimitedAttemptCount::new(3);
-        let _ = PollingPolicyArg::from(policy);
+        let _ = PollingErrorPolicyArg::from(policy);
 
-        let policy: Arc<dyn PollingPolicy> = Arc::new(LimitedAttemptCount::new(3));
-        let _ = PollingPolicyArg::from(policy);
+        let policy: Arc<dyn PollingErrorPolicy> = Arc::new(LimitedAttemptCount::new(3));
+        let _ = PollingErrorPolicyArg::from(policy);
     }
 
     #[test]

--- a/src/lro/tests/fake_library/builders.rs
+++ b/src/lro/tests/fake_library/builders.rs
@@ -68,7 +68,7 @@ impl CreateResource {
             super::model::CreateResourceMetadata,
         >;
 
-        let polling_policy = self.stub.get_polling_policy(&self.options);
+        let polling_error_policy = self.stub.get_polling_error_policy(&self.options);
         let polling_backoff_policy = self.stub.get_polling_backoff_policy(&self.options);
         let stub = self.stub.clone();
         let mut options = self.options.clone();
@@ -90,7 +90,7 @@ impl CreateResource {
             let op = self.send().await?;
             Ok(Operation::new(op))
         };
-        google_cloud_lro::new_poller(polling_policy, polling_backoff_policy, start, query)
+        google_cloud_lro::new_poller(polling_error_policy, polling_backoff_policy, start, query)
     }
 }
 


### PR DESCRIPTION
The policy is all about handling polling errors, renaming to
`PollingErrorPolicy` makes the intent clearer, and more consistent with
the names of other policies.

Part of the work for #1135
