### PR TITLE
cleanup!: remove `PollingPolicy` vestiges

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -253,14 +253,6 @@ impl ReqwestClient {
             .unwrap_or_else(|| self.retry_throttler.clone())
     }
 
-    // TODO(#1135) - remove backwards compat function
-    pub fn get_polling_policy(
-        &self,
-        options: &gax::options::RequestOptions,
-    ) -> Arc<dyn gax::polling_error_policy::PollingErrorPolicy> {
-        self.get_polling_error_policy(options)
-    }
-
     pub fn get_polling_error_policy(
         &self,
         options: &gax::options::RequestOptions,

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -52,7 +52,5 @@ pub mod loop_state;
 pub mod options;
 pub mod polling_backoff_policy;
 pub mod polling_error_policy;
-// TODO(#1135) - remove backwards compat
-pub use polling_error_policy as polling_policy;
 pub mod retry_policy;
 pub mod retry_throttler;

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -136,16 +136,6 @@ impl RequestOptions {
         self.retry_throttler = Some(v.into().0);
     }
 
-    // TODO(#1135) - remove backwards compat.
-    pub fn polling_policy(&self) -> &Option<Arc<dyn PollingErrorPolicy>> {
-        self.polling_error_policy()
-    }
-
-    // TODO(#1135) - remove backwards compat.
-    pub fn set_polling_policy<V: Into<PollingErrorPolicyArg>>(&mut self, v: V) {
-        self.set_polling_error_policy(v);
-    }
-
     /// Get the current polling policy override, if any.
     pub fn polling_error_policy(&self) -> &Option<Arc<dyn PollingErrorPolicy>> {
         &self.polling_error_policy

--- a/src/gax/src/polling_error_policy.rs
+++ b/src/gax/src/polling_error_policy.rs
@@ -43,9 +43,6 @@ use crate::error::Error;
 use crate::loop_state::LoopState;
 use std::sync::Arc;
 
-// TODO(#1135) - remove backwards compat
-pub use PollingErrorPolicy as PollingPolicy;
-
 /// Determines how errors are handled in the polling loop.
 ///
 /// Implementations of this trait determine if polling errors may resolve in


### PR DESCRIPTION
I temporarily left some backwards compatibility names to keep the PRs
small enough. This finally cleans all of them up.

Fixes #1135
