### PR TITLE
chore(deps): `tracing-subscriber` is optional

### DIFF
--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -20,7 +20,7 @@ publish           = false
 version           = "0.0.0"
 
 [features]
-log-integration-tests = []
+log-integration-tests = ["dep:tracing-subscriber"]
 run-integration-tests = []
 
 [dependencies]
@@ -35,7 +35,7 @@ rand               = "0.9"
 serde_json         = "1"
 tokio              = { version = "1", features = ["full", "macros"] }
 tracing            = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", optional = true }
 wkt                = { path = "../../src/wkt", package = "google-cloud-wkt" }
 
 [dependencies.firestore]


### PR DESCRIPTION
This is only used when the `log-integration-tests` feature is enabled
set.