### PR TITLE
doc(gax-internal): missing README file

### DIFF
--- a/src/gax-internal/README.md
+++ b/src/gax-internal/README.md
@@ -1,0 +1,15 @@
+# Google Cloud Client Libraries for Rust - Implementation Details
+
+This crate contains implementation details shared by many client libraries.
+The types, traits, and functions defined in this crate are undocumented.
+This is intentional, as they are not intended for general use and will be
+changed without notice.
+
+Maybe you were looking for [google-cloud-gax]? That crate contains public APIs
+intended for general use.
+
+This crate will remain unstable for the foreseeable future, even if used in the
+implementation for stable client libraries. We (the Google Cloud Client
+Libraries for Rust team) control both and will change both if needed.
+
+[google-cloud-gax]: https://crates.io/crates/google-cloud-gax

--- a/src/gax/README.md
+++ b/src/gax/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Client Libraries for Rust - Common Components
+# Google Cloud Client Libraries for Rust - Google API eXtensions
 
 This crate contains common components used by the Google Cloud Client Libraries
 for Rust. Please consult the crate documentation for details.


### PR DESCRIPTION
This is needed if we publish the crate.
