### PR TITLE
feat(generator/dart): handle encoding and decoding the 'bytes' data type

### DIFF
--- a/generator/dart/generated/google_cloud_protobuf/.sidekick.toml
+++ b/generator/dart/generated/google_cloud_protobuf/.sidekick.toml
@@ -26,3 +26,4 @@ include-list = "duration.proto,field_mask.proto"
 copyright-year = '2025'
 part-file = "src/protobuf.p.dart"
 dev-dependencies = "test"
+extra-imports = "dart:convert,dart:typed_data"

--- a/generator/dart/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -21,6 +21,9 @@
 /// Core Protobuf types used by most services.
 library;
 
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:google_cloud_gax/common.dart';
 import 'package:google_cloud_gax/src/json_helpers.dart';
 

--- a/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -117,6 +117,20 @@ class Any extends Message {
   String toString() => 'Any($typeName)';
 }
 
+/// A representation of the `bytes` (`api.BYTES_TYPE`) data type.
+class Bytes extends JsonEncodable {
+  final Uint8List data;
+
+  Bytes({required this.data});
+
+  factory Bytes.fromJson(String value) {
+    return Bytes(data: base64Decode(value));
+  }
+
+  @override
+  String toJson() => base64Encode(data);
+}
+
 /// Called from the Duration constructor to validate the construction
 /// parameters.
 extension DurationExtension on Duration {

--- a/generator/dart/generated/google_cloud_protobuf/test/bytes_test.dart
+++ b/generator/dart/generated/google_cloud_protobuf/test/bytes_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:typed_data';
+
+import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('encode empty', () {
+    final bytes = Bytes(data: Uint8List.fromList([]));
+    expect(bytes.toJson(), '');
+  });
+
+  test('encode simple', () {
+    final bytes = Bytes(data: Uint8List.fromList([1, 2, 3]));
+    expect(bytes.toJson(), 'AQID');
+  });
+
+  test('decode empty', () {
+    final bytes = Bytes.fromJson('AQID');
+    final actual = bytes.data.map((item) => '$item').join(',');
+    expect(actual, '1,2,3');
+  });
+
+  test('decode simple', () {
+    final bytes = Bytes.fromJson('bG9yZW0gaXBzdW0=');
+    final actual = bytes.data.map((item) => '$item').join(',');
+    // "lorem ipsum"
+    expect(actual, '108,111,114,101,109,32,105,112,115,117,109');
+  });
+
+  test('decode simple', () {
+    final bytes = Bytes.fromJson('YWJjMTIzIT8kKiYoKSctPUB+');
+    final actual = bytes.data.map((item) => '$item').join(',');
+    expect(actual, '97,98,99,49,50,51,33,63,36,42,38,40,41,39,45,61,64,126');
+  });
+}

--- a/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
@@ -21,8 +21,6 @@
 /// Defines RPC types.
 library;
 
-import 'dart:typed_data';
-
 import 'package:google_cloud_gax/common.dart';
 import 'package:google_cloud_gax/src/json_helpers.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
@@ -733,7 +731,7 @@ class HttpRequest extends Message {
   final List<HttpHeader>? headers;
 
   /// The HTTP request body. If the body is not expected, it should be empty.
-  final Uint8List? body;
+  final Bytes? body;
 
   HttpRequest({
     this.method,
@@ -747,7 +745,7 @@ class HttpRequest extends Message {
       method: json['method'],
       uri: json['uri'],
       headers: decodeList(json['headers'], HttpHeader.fromJson),
-      body: json['body'],
+      body: decode(json['body'], Bytes.fromJson),
     );
   }
 
@@ -757,7 +755,7 @@ class HttpRequest extends Message {
       if (method != null) 'method': method,
       if (uri != null) 'uri': uri,
       if (headers != null) 'headers': encodeList(headers),
-      if (body != null) 'body': body,
+      if (body != null) 'body': body!.toJson(),
     };
   }
 
@@ -787,7 +785,7 @@ class HttpResponse extends Message {
   final List<HttpHeader>? headers;
 
   /// The HTTP response body. If the body is not expected, it should be empty.
-  final Uint8List? body;
+  final Bytes? body;
 
   HttpResponse({
     this.status,
@@ -801,7 +799,7 @@ class HttpResponse extends Message {
       status: json['status'],
       reason: json['reason'],
       headers: decodeList(json['headers'], HttpHeader.fromJson),
-      body: json['body'],
+      body: decode(json['body'], Bytes.fromJson),
     );
   }
 
@@ -811,7 +809,7 @@ class HttpResponse extends Message {
       if (status != null) 'status': status,
       if (reason != null) 'reason': reason,
       if (headers != null) 'headers': encodeList(headers),
-      if (body != null) 'body': body,
+      if (body != null) 'body': body!.toJson(),
     };
   }
 

--- a/generator/dart/tests/test/bytes_test.dart
+++ b/generator/dart/tests/test/bytes_test.dart
@@ -1,0 +1,61 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:google_cloud_rpc/rpc.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group("test 'bytes' encoding", () {
+    test('rpc.HttpResponse.body', () {
+      final data = '''{
+  "status": 200,
+  "reason": "OK",
+  "headers": [],
+  "body": "$base64EncodedText"
+}''';
+      final json = jsonDecode(data);
+      final response = HttpResponse.fromJson(json);
+
+      expect(response.status, 200);
+      expect(response.reason, 'OK');
+      expect(response.headers, isEmpty);
+      expect(response.body!.data, isNotEmpty);
+
+      final body = response.body!;
+      final bodyText = utf8.decode(body.data);
+      expect(bodyText, expectedText);
+
+      // Re-encode HttpResponse and validate.
+      final jsonEncoder = JsonEncoder.withIndent('  ');
+
+      final encodedActual = jsonEncoder.convert(response.toJson());
+      final encodedExpected = jsonEncoder.convert(json);
+      expect(encodedActual, encodedExpected);
+    });
+  });
+}
+
+const String expectedText = '''
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.''';
+
+const String base64EncodedText =
+    'TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC'
+    'wgc2VkIGRvIGVpdXNtb2QgdGVtcG9yCmluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBt'
+    'YWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzCm5vc3RydWQgZXhlcm'
+    'NpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBj'
+    'b25zZXF1YXQu';

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -228,7 +228,7 @@ func TestFieldType(t *testing.T) {
 		{api.FLOAT_TYPE, "double"},
 		{api.DOUBLE_TYPE, "double"},
 		{api.STRING_TYPE, "String"},
-		{api.BYTES_TYPE, "Uint8List"},
+		{api.BYTES_TYPE, "Bytes"},
 	} {
 		field := &api.Field{
 			Name:     "parent",
@@ -330,6 +330,8 @@ func TestFieldType_Maps(t *testing.T) {
 }
 
 func TestFieldType_Bytes(t *testing.T) {
+	sampleDartImpot := "package:sample/sample.dart"
+
 	field := &api.Field{
 		Name:     "test",
 		JSONName: "test",
@@ -345,20 +347,23 @@ func TestFieldType_Bytes(t *testing.T) {
 	annotate := newAnnotateModel(model)
 	annotate.annotateModel(map[string]string{})
 	annotate.imports = map[string]string{}
+	annotate.packageMapping["google.protobuf"] = sampleDartImpot
 
-	got := annotate.fieldType(field)
-	want := "Uint8List"
-	if got != want {
-		t.Errorf("unexpected type name, got: %s want: %s", got, want)
+	{
+		got := annotate.fieldType(field)
+		want := "Bytes"
+		if got != want {
+			t.Errorf("unexpected type name, got: %s want: %s", got, want)
+		}
 	}
 
-	// verify the typed_data import
+	// verify the google.protobuf import
 	if !(len(annotate.imports) > 0) {
-		t.Errorf("unexpected: no typed_data import added")
+		t.Errorf("unexpected: no google.protobuf import added")
 	}
 
 	for _, got := range annotate.imports {
-		want := "dart:typed_data"
+		want := sampleDartImpot
 		if got != want {
 			t.Errorf("unexpected import, got: %s want: %s", got, want)
 		}

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -22,8 +22,6 @@
 /// Provides convenience while improving security.
 library;
 
-import 'dart:typed_data';
-
 import 'package:google_cloud_gax/common.dart';
 import 'package:google_cloud_gax/src/json_helpers.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
@@ -1018,7 +1016,7 @@ class SecretPayload extends Message {
   static const String fullyQualifiedName = 'google.cloud.secretmanager.v1.SecretPayload';
 
   /// The secret data. Must be no larger than 64KiB.
-  final Uint8List? data;
+  final Bytes? data;
 
   /// Optional. If specified,
   /// `SecretManagerService`
@@ -1045,7 +1043,7 @@ class SecretPayload extends Message {
 
   factory SecretPayload.fromJson(Map<String, dynamic> json) {
     return SecretPayload(
-      data: json['data'],
+      data: decode(json['data'], Bytes.fromJson),
       dataCrc32C: json['dataCrc32C'],
     );
   }
@@ -1053,7 +1051,7 @@ class SecretPayload extends Message {
   @override
   Object toJson() {
     return {
-      if (data != null) 'data': data,
+      if (data != null) 'data': data!.toJson(),
       if (dataCrc32C != null) 'dataCrc32C': dataCrc32C,
     };
   }


### PR DESCRIPTION
- handle encoding and decoding the 'bytes' data type
- fix https://github.com/googleapis/google-cloud-rust/issues/1563

Opening this as a draft PR aince after implementing this I'm second guessing introducing a new `Bytes` class. We could just as easily always JSON encode / decode to the existing Dart `Uint8List` type.
