### PR TITLE
feat(generator/dart): handle OneOfs in generated code

### DIFF
--- a/generator/dart/generated/google_cloud_language/lib/language.dart
+++ b/generator/dart/generated/google_cloud_language/lib/language.dart
@@ -83,6 +83,8 @@ class LanguageService {
 }
 
 /// Represents the input to API methods.
+///
+/// Only one of [content] or [gcsContentUri] can be specified.
 class Document extends Message {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Document';
 

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -64,6 +64,10 @@ func qualifiedName(m *api.Message) string {
 	return strings.TrimPrefix(m.ID, ".")
 }
 
+func fieldName(field *api.Field) string {
+	return strcase.ToLowerCamel(field.Name)
+}
+
 func enumName(e *api.Enum) string {
 	if e.Parent != nil {
 		return messageName(e.Parent) + "$" + strcase.ToCamel(e.Name)
@@ -177,4 +181,26 @@ func runExternalCommand(c string, arg ...string) error {
 		return fmt.Errorf("%v: %v\n%s", cmd, err, output)
 	}
 	return nil
+}
+
+func describeOneOf(oneof *api.OneOf) string {
+	fields := oneof.Fields
+
+	names := make([]string, len(fields))
+	for i, field := range fields {
+		names[i] = "[" + fieldName(field) + "]"
+	}
+
+	description := ""
+
+	if len(fields) == 1 {
+		description = names[0]
+	} else if len(fields) > 0 {
+		list := strings.Join(names[:len(names)-1], ", ")
+		last := names[len(names)-1]
+
+		description = list + " or " + last
+	}
+
+	return "Only one of " + description + " can be specified."
 }

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -591,3 +591,62 @@ func TestHttpPathFmt(t *testing.T) {
 		})
 	}
 }
+
+func TestDescribeOneOf(t *testing.T) {
+	field1 := &api.Field{
+		Name:     "oneof_field",
+		JSONName: "oneofField",
+		ID:       ".test.Message.oneof_field",
+		Typez:    api.STRING_TYPE,
+		IsOneOf:  true,
+	}
+	field2 := &api.Field{
+		Name:     "oneof_field_repeated",
+		JSONName: "oneofFieldRepeated",
+		ID:       ".test.Message.oneof_field_repeated",
+		Typez:    api.STRING_TYPE,
+		Repeated: true,
+		IsOneOf:  true,
+	}
+	field3 := &api.Field{
+		Name:     "oneof_field_map",
+		JSONName: "oneofFieldMap",
+		ID:       ".test.Message.oneof_field_map",
+		Typez:    api.MESSAGE_TYPE,
+		TypezID:  ".test.$Map",
+		Repeated: false,
+		IsOneOf:  true,
+	}
+
+	for _, test := range []struct {
+		name   string
+		fields []*api.Field
+		want   string
+	}{
+		{
+			name: "one", fields: []*api.Field{field1},
+			want: "Only one of [oneofField] can be specified.",
+		},
+		{
+			name: "two", fields: []*api.Field{field1, field2},
+			want: "Only one of [oneofField] or [oneofFieldRepeated] can be specified.",
+		},
+		{
+			name: "several", fields: []*api.Field{field1, field2, field3},
+			want: "Only one of [oneofField], [oneofFieldRepeated] or [oneofFieldMap] can be specified.",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			oneof := &api.OneOf{
+				Name:          "type",
+				ID:            ".test.Message.type",
+				Documentation: "Say something clever about this oneof.",
+				Fields:        test.fields,
+			}
+
+			if got := describeOneOf(oneof); got != test.want {
+				t.Errorf("unexpected describeOneOf, got=%q, want=%q", got, test.want)
+			}
+		})
+	}
+}

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -213,6 +213,8 @@ class SecretManagerService {
 /// A `Secret` is made up of zero or more
 /// `SecretVersions` that represent
 /// the secret data.
+///
+/// Only one of [expireTime] or [ttl] can be specified.
 class Secret extends Message {
   static const String fullyQualifiedName = 'google.cloud.secretmanager.v1.Secret';
 
@@ -522,6 +524,8 @@ class SecretVersion$State extends Enum {
 }
 
 /// A policy that defines the replication and encryption configuration of data.
+///
+/// Only one of [automatic] or [userManaged] can be specified.
 class Replication extends Message {
   static const String fullyQualifiedName = 'google.cloud.secretmanager.v1.Replication';
 
@@ -725,6 +729,8 @@ class CustomerManagedEncryption extends Message {
 
 /// The replication status of a
 /// `SecretVersion`.
+///
+/// Only one of [automatic] or [userManaged] can be specified.
 class ReplicationStatus extends Message {
   static const String fullyQualifiedName = 'google.cloud.secretmanager.v1.ReplicationStatus';
 


### PR DESCRIPTION
- handle `OneOf`s in generated code
- fix https://github.com/googleapis/google-cloud-rust/issues/1576

This PR handles `OneOf`s by generating documentation related to the mutually exclusive fields (`'Only one of [foo], [bar] or [baz] can be specified.'`). This seems reasonable in terms of decoding objects from the server - assuming that we're getting  correctly formatted messages from the server.

We could add validation in the message constructors for objects that the user creates - throw errors if more than one OneOf field is set. I don't know if that's expected or not - how much validation we're expected to do here.
