### PR TITLE
cleanup(gax)!: seal `RequestOptionsBuilder`; hide `RequestBuilder`

### DIFF
--- a/generator/internal/rust/templates/crate/src/builders.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builders.rs.mustache
@@ -181,7 +181,8 @@ pub mod {{Codec.ModuleName}} {
         {{/InputType.OneOfs}}
     }
 
-    impl gax::options::RequestBuilder for {{Codec.BuilderName}} {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for {{Codec.BuilderName}} {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/generator/testdata/rust/openapi/golden/src/builders.rs
+++ b/generator/testdata/rust/openapi/golden/src/builders.rs
@@ -102,7 +102,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -149,7 +150,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -220,7 +222,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecrets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecrets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -273,7 +276,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -350,7 +354,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecretsByProjectAndLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecretsByProjectAndLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -409,7 +414,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecretByProjectAndLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecretByProjectAndLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -468,7 +474,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -527,7 +534,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddSecretVersionByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddSecretVersionByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -574,7 +582,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -627,7 +636,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -686,7 +696,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -739,7 +750,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecretByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecretByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -798,7 +810,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSecretByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSecretByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -863,7 +876,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSecretByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSecretByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -940,7 +954,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecretVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecretVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1023,7 +1038,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecretVersionsByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecretVersionsByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1076,7 +1092,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1135,7 +1152,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecretVersionByProjectAndLocationAndSecretAndVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1188,7 +1206,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AccessSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AccessSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1247,7 +1266,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1312,7 +1332,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1377,7 +1398,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1442,7 +1464,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1507,7 +1530,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1572,7 +1596,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DestroySecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DestroySecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1637,7 +1662,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1702,7 +1728,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1767,7 +1794,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicyByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicyByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1820,7 +1848,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1879,7 +1908,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicyByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicyByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1943,7 +1973,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2007,7 +2038,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissionsByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissionsByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/builders.rs
@@ -84,7 +84,8 @@ pub mod iam_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -131,7 +132,8 @@ pub mod iam_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -183,7 +185,8 @@ pub mod iam_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/generator/testdata/rust/protobuf/golden/location/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builders.rs
@@ -102,7 +102,8 @@ pub mod locations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -143,7 +144,8 @@ pub mod locations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
@@ -102,7 +102,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecrets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecrets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -155,7 +156,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -202,7 +204,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -243,7 +246,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -290,7 +294,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -337,7 +342,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -408,7 +414,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecretVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecretVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -449,7 +456,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -490,7 +498,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AccessSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AccessSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -537,7 +546,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -584,7 +594,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -631,7 +642,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DestroySecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DestroySecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -684,7 +696,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -731,7 +744,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -783,7 +797,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -854,7 +869,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -895,7 +911,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/firestore/src/generated/gapic/builders.rs
+++ b/src/firestore/src/generated/gapic/builders.rs
@@ -94,7 +94,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -200,7 +201,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -271,7 +273,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -321,7 +324,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -374,7 +378,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for BeginTransaction {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BeginTransaction {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -430,7 +435,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for Commit {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Commit {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -477,7 +483,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for Rollback {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Rollback {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -571,7 +578,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for PartitionQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PartitionQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -638,7 +646,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCollectionIds {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCollectionIds {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -701,7 +710,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchWrite {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchWrite {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -772,7 +782,8 @@ pub mod firestore {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -163,7 +163,7 @@ impl RequestOptions {
 /// These builders can be used to set the request parameters, e.g., the name of
 /// the resource targeted by the RPC, as well as any options affecting the
 /// request, such as additional headers or timeouts.
-pub trait RequestOptionsBuilder {
+pub trait RequestOptionsBuilder : internal::RequestBuilder {
     /// If `v` is `true`, treat the RPC underlying this method as idempotent.
     fn with_idempotency(self, v: bool) -> Self;
 
@@ -192,20 +192,25 @@ pub trait RequestOptionsBuilder {
     fn with_polling_backoff_policy<V: Into<PollingBackoffPolicyArg>>(self, v: V) -> Self;
 }
 
-/// Simplify implementation of the [RequestOptionsBuilder] trait in generated
-/// code.
-///
-/// This is an implementation detail, most applications have little need to
-/// worry about or use this trait.
-pub trait RequestBuilder {
-    fn request_options(&mut self) -> &mut RequestOptions;
+/// This module contains implementation details. It is not part of the public
+/// API. Types inside may be changed or removed without warnings. Applications
+///  should not use any types contained within.
+#[doc(hidden)]
+pub mod internal {
+    /// Simplify implementation of the [super::RequestOptionsBuilder] trait in
+    /// generated code.
+    ///
+    /// This is an implementation detail, most applications have little need to
+    /// worry about or use this trait.
+    pub trait RequestBuilder {
+        fn request_options(&mut self) -> &mut super::RequestOptions;
+    }
 }
 
-/// Implements the [RequestOptionsBuilder] trait for any [RequestBuilder]
-/// implementation.
+/// Implements the sealed [RequestOptionsBuilder] trait.
 impl<T> RequestOptionsBuilder for T
 where
-    T: RequestBuilder,
+    T: internal::RequestBuilder,
 {
     fn with_idempotency(mut self, v: bool) -> Self {
         self.request_options().set_idempotency(v);
@@ -386,6 +391,7 @@ impl std::default::Default for ClientConfig {
 
 #[cfg(test)]
 mod test {
+    use super::internal::*;
     use super::*;
     use crate::exponential_backoff::ExponentialBackoffBuilder;
     use crate::polling_error_policy;

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -163,7 +163,7 @@ impl RequestOptions {
 /// These builders can be used to set the request parameters, e.g., the name of
 /// the resource targeted by the RPC, as well as any options affecting the
 /// request, such as additional headers or timeouts.
-pub trait RequestOptionsBuilder : internal::RequestBuilder {
+pub trait RequestOptionsBuilder: internal::RequestBuilder {
     /// If `v` is `true`, treat the RPC underlying this method as idempotent.
     fn with_idempotency(self, v: bool) -> Self;
 

--- a/src/generated/api/apikeys/v2/src/builders.rs
+++ b/src/generated/api/apikeys/v2/src/builders.rs
@@ -121,7 +121,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -194,7 +195,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for ListKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -233,7 +235,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for GetKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -274,7 +277,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for GetKeyString {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetKeyString {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -359,7 +363,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -441,7 +446,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -517,7 +523,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -558,7 +565,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -602,7 +610,8 @@ pub mod api_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/api/servicecontrol/v1/src/builders.rs
+++ b/src/generated/api/servicecontrol/v1/src/builders.rs
@@ -91,7 +91,8 @@ pub mod quota_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for AllocateQuota {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AllocateQuota {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -171,7 +172,8 @@ pub mod service_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for Check {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Check {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -227,7 +229,8 @@ pub mod service_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for Report {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Report {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/api/servicecontrol/v2/src/builders.rs
+++ b/src/generated/api/servicecontrol/v2/src/builders.rs
@@ -106,7 +106,8 @@ pub mod service_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for Check {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Check {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -162,7 +163,8 @@ pub mod service_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for Report {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Report {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/api/servicemanagement/v1/src/builders.rs
+++ b/src/generated/api/servicemanagement/v1/src/builders.rs
@@ -107,7 +107,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -231,7 +233,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -307,7 +310,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -389,7 +393,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -460,7 +465,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServiceConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServiceConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -519,7 +525,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServiceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServiceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -572,7 +579,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServiceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServiceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -672,7 +680,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SubmitConfigSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubmitConfigSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -749,7 +758,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServiceRollouts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServiceRollouts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -799,7 +809,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServiceRollout {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServiceRollout {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -889,7 +900,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServiceRollout {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServiceRollout {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -939,7 +951,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateConfigReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateConfigReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -998,7 +1011,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1048,7 +1062,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1103,7 +1118,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1180,7 +1196,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1224,7 +1241,8 @@ pub mod service_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/api/serviceusage/v1/src/builders.rs
+++ b/src/generated/api/serviceusage/v1/src/builders.rs
@@ -115,7 +115,8 @@ pub mod service_usage {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -214,7 +215,8 @@ pub mod service_usage {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -255,7 +257,8 @@ pub mod service_usage {
         }
     }
 
-    impl gax::options::RequestBuilder for GetService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -329,7 +332,8 @@ pub mod service_usage {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -425,7 +429,8 @@ pub mod service_usage {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchEnableServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchEnableServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -480,7 +485,8 @@ pub mod service_usage {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchGetServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchGetServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -557,7 +563,8 @@ pub mod service_usage {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -601,7 +608,8 @@ pub mod service_usage {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/appengine/v1/src/builders.rs
+++ b/src/generated/appengine/v1/src/builders.rs
@@ -74,7 +74,8 @@ pub mod applications {
         }
     }
 
-    impl gax::options::RequestBuilder for GetApplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetApplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod applications {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateApplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateApplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -261,7 +263,8 @@ pub mod applications {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateApplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateApplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -344,7 +347,8 @@ pub mod applications {
         }
     }
 
-    impl gax::options::RequestBuilder for RepairApplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RepairApplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -421,7 +425,8 @@ pub mod applications {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -465,7 +470,8 @@ pub mod applications {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -559,7 +565,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -600,7 +607,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -703,7 +711,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -779,7 +788,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -856,7 +866,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -900,7 +911,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1000,7 +1012,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1047,7 +1060,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1136,7 +1150,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1233,7 +1248,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1309,7 +1325,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1386,7 +1403,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1430,7 +1448,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1524,7 +1543,8 @@ pub mod instances {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1565,7 +1585,8 @@ pub mod instances {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1641,7 +1662,8 @@ pub mod instances {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1726,7 +1748,8 @@ pub mod instances {
         }
     }
 
-    impl gax::options::RequestBuilder for DebugInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DebugInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1803,7 +1826,8 @@ pub mod instances {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1847,7 +1871,8 @@ pub mod instances {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1950,7 +1975,8 @@ pub mod firewall {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIngressRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIngressRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2007,7 +2033,8 @@ pub mod firewall {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchUpdateIngressRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchUpdateIngressRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2060,7 +2087,8 @@ pub mod firewall {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIngressRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIngressRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2101,7 +2129,8 @@ pub mod firewall {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIngressRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIngressRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2163,7 +2192,8 @@ pub mod firewall {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateIngressRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateIngressRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2207,7 +2237,8 @@ pub mod firewall {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIngressRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIngressRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2284,7 +2315,8 @@ pub mod firewall {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2328,7 +2360,8 @@ pub mod firewall {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2425,7 +2458,8 @@ pub mod authorized_domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAuthorizedDomains {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAuthorizedDomains {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2502,7 +2536,8 @@ pub mod authorized_domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2546,7 +2581,8 @@ pub mod authorized_domains {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2657,7 +2693,8 @@ pub mod authorized_certificates {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAuthorizedCertificates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAuthorizedCertificates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2711,7 +2748,8 @@ pub mod authorized_certificates {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAuthorizedCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAuthorizedCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2770,7 +2808,8 @@ pub mod authorized_certificates {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAuthorizedCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAuthorizedCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2838,7 +2877,8 @@ pub mod authorized_certificates {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAuthorizedCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAuthorizedCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2886,7 +2926,8 @@ pub mod authorized_certificates {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAuthorizedCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAuthorizedCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2965,7 +3006,8 @@ pub mod authorized_certificates {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3011,7 +3053,8 @@ pub mod authorized_certificates {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3108,7 +3151,8 @@ pub mod domain_mappings {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDomainMappings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDomainMappings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3152,7 +3196,8 @@ pub mod domain_mappings {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDomainMapping {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDomainMapping {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3253,7 +3298,8 @@ pub mod domain_mappings {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDomainMapping {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDomainMapping {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3354,7 +3400,8 @@ pub mod domain_mappings {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDomainMapping {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDomainMapping {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3433,7 +3480,8 @@ pub mod domain_mappings {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDomainMapping {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDomainMapping {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3510,7 +3558,8 @@ pub mod domain_mappings {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3554,7 +3603,8 @@ pub mod domain_mappings {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/bigtable/admin/v2/src/builders.rs
+++ b/src/generated/bigtable/admin/v2/src/builders.rs
@@ -143,7 +143,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -186,7 +187,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -235,7 +237,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -328,7 +331,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -425,7 +429,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for PartialUpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PartialUpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -468,7 +473,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -564,7 +570,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -607,7 +614,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -656,7 +664,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -790,7 +799,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -887,7 +897,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for PartialUpdateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PartialUpdateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -930,7 +941,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -997,7 +1009,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAppProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAppProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1040,7 +1053,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAppProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAppProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1110,7 +1124,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAppProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAppProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1213,7 +1228,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAppProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAppProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1265,7 +1281,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAppProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAppProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1317,7 +1334,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1378,7 +1396,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1435,7 +1454,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1520,7 +1540,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListHotTablets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListHotTablets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1620,7 +1641,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLogicalView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLogicalView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1663,7 +1685,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLogicalView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLogicalView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1736,7 +1759,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLogicalViews {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLogicalViews {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1833,7 +1857,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateLogicalView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateLogicalView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1885,7 +1910,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLogicalView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLogicalView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1989,7 +2015,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMaterializedView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMaterializedView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2035,7 +2062,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMaterializedView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMaterializedView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2108,7 +2136,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMaterializedViews {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMaterializedViews {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2209,7 +2238,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMaterializedView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMaterializedView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2261,7 +2291,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMaterializedView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMaterializedView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2340,7 +2371,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2386,7 +2418,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2432,7 +2465,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2478,7 +2512,8 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2571,7 +2606,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2668,7 +2704,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTableFromSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTableFromSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2742,7 +2779,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTables {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTables {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2789,7 +2827,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2885,7 +2924,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2926,7 +2966,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3005,7 +3046,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3105,7 +3147,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAuthorizedView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAuthorizedView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3185,7 +3228,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAuthorizedViews {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAuthorizedViews {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3238,7 +3282,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAuthorizedView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAuthorizedView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3341,7 +3386,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAuthorizedView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAuthorizedView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3391,7 +3437,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAuthorizedView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAuthorizedView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3452,7 +3499,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ModifyColumnFamilies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ModifyColumnFamilies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3502,7 +3550,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DropRowRange {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DropRowRange {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3548,7 +3597,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateConsistencyToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateConsistencyToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3607,7 +3657,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CheckConsistency {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CheckConsistency {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3710,7 +3761,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for SnapshotTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SnapshotTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3751,7 +3803,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3819,7 +3872,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSnapshots {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSnapshots {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3860,7 +3914,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3954,7 +4009,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3995,7 +4051,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4048,7 +4105,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4089,7 +4147,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4169,7 +4228,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4263,7 +4323,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4362,7 +4423,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CopyBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CopyBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4412,7 +4474,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4471,7 +4534,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4526,7 +4590,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4603,7 +4668,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4647,7 +4713,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4691,7 +4758,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4735,7 +4803,8 @@ pub mod bigtable_table_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/accessapproval/v1/src/builders.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builders.rs
@@ -110,7 +110,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for ListApprovalRequests {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListApprovalRequests {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for GetApprovalRequest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetApprovalRequest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -207,7 +209,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for ApproveApprovalRequest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApproveApprovalRequest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -251,7 +254,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for DismissApprovalRequest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DismissApprovalRequest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -297,7 +301,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for InvalidateApprovalRequest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InvalidateApprovalRequest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -343,7 +348,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAccessApprovalSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAccessApprovalSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -401,7 +407,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAccessApprovalSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAccessApprovalSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -447,7 +454,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAccessApprovalSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAccessApprovalSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -493,7 +501,8 @@ pub mod access_approval {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAccessApprovalServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAccessApprovalServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/advisorynotifications/v1/src/builders.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/builders.rs
@@ -120,7 +120,8 @@ pub mod advisory_notifications_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNotifications {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNotifications {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -169,7 +170,8 @@ pub mod advisory_notifications_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNotification {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNotification {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -212,7 +214,8 @@ pub mod advisory_notifications_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -258,7 +261,8 @@ pub mod advisory_notifications_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/aiplatform/v1/src/builders.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builders.rs
@@ -122,7 +122,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -169,7 +170,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -222,7 +224,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -308,7 +311,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatasets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatasets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -384,7 +388,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -477,7 +482,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -568,7 +574,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -664,7 +671,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDatasetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDatasetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -720,7 +728,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDatasetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDatasetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -799,7 +808,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDatasetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDatasetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -849,7 +859,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDatasetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDatasetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -938,7 +949,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatasetVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatasetVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1025,7 +1037,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreDatasetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreDatasetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1111,7 +1124,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDataItems {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDataItems {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1244,7 +1258,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchDataItems {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchDataItems {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1333,7 +1348,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSavedQueries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSavedQueries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1412,7 +1428,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSavedQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSavedQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1462,7 +1479,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAnnotationSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAnnotationSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1548,7 +1566,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAnnotations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAnnotations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1625,7 +1644,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1666,7 +1686,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1725,7 +1746,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1775,7 +1797,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1830,7 +1853,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1907,7 +1931,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1951,7 +1976,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1995,7 +2021,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2039,7 +2066,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2089,7 +2117,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2228,7 +2257,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDeploymentResourcePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDeploymentResourcePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2276,7 +2306,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeploymentResourcePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeploymentResourcePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2353,7 +2384,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeploymentResourcePools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeploymentResourcePools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2458,7 +2490,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDeploymentResourcePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDeploymentResourcePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2541,7 +2574,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDeploymentResourcePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDeploymentResourcePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2614,7 +2648,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryDeployedModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryDeployedModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2693,7 +2728,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2736,7 +2772,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2797,7 +2834,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2849,7 +2887,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2906,7 +2945,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2985,7 +3025,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3031,7 +3072,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3077,7 +3119,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3123,7 +3166,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3175,7 +3219,8 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3298,7 +3343,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3339,7 +3385,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3425,7 +3472,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEndpoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEndpoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3478,7 +3526,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3568,7 +3617,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEndpointLongRunning {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEndpointLongRunning {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3644,7 +3694,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3749,7 +3800,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeployModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeployModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3851,7 +3903,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeployModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeployModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3956,7 +4009,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for MutateDeployedModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MutateDeployedModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4033,7 +4087,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4074,7 +4129,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4133,7 +4189,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4183,7 +4240,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4238,7 +4296,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4315,7 +4374,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4359,7 +4419,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4403,7 +4464,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4447,7 +4509,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4497,7 +4560,8 @@ pub mod endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4578,7 +4642,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EvaluateInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EvaluateInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4655,7 +4720,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4696,7 +4762,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4755,7 +4822,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4805,7 +4873,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4860,7 +4929,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4937,7 +5007,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4981,7 +5052,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5025,7 +5097,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5069,7 +5142,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5119,7 +5193,8 @@ pub mod evaluation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5255,7 +5330,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeatureOnlineStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeatureOnlineStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5301,7 +5377,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeatureOnlineStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeatureOnlineStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5390,7 +5467,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeatureOnlineStores {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeatureOnlineStores {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5495,7 +5573,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeatureOnlineStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeatureOnlineStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5584,7 +5663,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeatureOnlineStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeatureOnlineStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5692,7 +5772,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeatureView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeatureView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5735,7 +5816,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeatureView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeatureView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5820,7 +5902,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeatureViews {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeatureViews {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5919,7 +6002,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeatureView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeatureView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6000,7 +6084,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeatureView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeatureView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6043,7 +6128,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SyncFeatureView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SyncFeatureView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6089,7 +6175,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeatureViewSync {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeatureViewSync {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6174,7 +6261,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeatureViewSyncs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeatureViewSyncs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6253,7 +6341,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6296,7 +6385,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6357,7 +6447,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6409,7 +6500,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6466,7 +6558,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6545,7 +6638,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6591,7 +6685,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6637,7 +6732,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6683,7 +6779,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6735,7 +6832,8 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6827,7 +6925,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchFeatureValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchFeatureValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6888,7 +6987,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchNearestEntities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchNearestEntities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6967,7 +7067,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7010,7 +7111,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7071,7 +7173,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7123,7 +7226,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7180,7 +7284,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7259,7 +7364,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7305,7 +7411,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7351,7 +7458,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7397,7 +7505,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7449,7 +7558,8 @@ pub mod feature_online_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7581,7 +7691,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeatureGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeatureGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7624,7 +7735,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeatureGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeatureGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7709,7 +7821,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeatureGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeatureGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7810,7 +7923,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeatureGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeatureGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7897,7 +8011,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeatureGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeatureGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7994,7 +8109,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8094,7 +8210,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateFeatures {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateFeatures {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8137,7 +8254,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8231,7 +8349,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeatures {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeatures {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8325,7 +8444,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8403,7 +8523,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8482,7 +8603,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8525,7 +8647,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8586,7 +8709,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8638,7 +8762,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8695,7 +8820,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8774,7 +8900,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8820,7 +8947,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8866,7 +8994,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8912,7 +9041,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8964,7 +9094,8 @@ pub mod feature_registry_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9053,7 +9184,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReadFeatureValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReadFeatureValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9110,7 +9242,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WriteFeatureValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WriteFeatureValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9189,7 +9322,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9232,7 +9366,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9293,7 +9428,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9345,7 +9481,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9402,7 +9539,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9481,7 +9619,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9527,7 +9666,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9573,7 +9713,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9619,7 +9760,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9671,7 +9813,8 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9803,7 +9946,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeaturestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeaturestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9846,7 +9990,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeaturestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeaturestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9937,7 +10082,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeaturestores {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeaturestores {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10038,7 +10184,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeaturestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeaturestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10125,7 +10272,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeaturestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeaturestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10227,7 +10375,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10270,7 +10419,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10358,7 +10508,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10416,7 +10567,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10503,7 +10655,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10600,7 +10753,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10700,7 +10854,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateFeatures {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateFeatures {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10743,7 +10898,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10837,7 +10993,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeatures {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeatures {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10892,7 +11049,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10970,7 +11128,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11114,7 +11273,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportFeatureValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportFeatureValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11258,7 +11418,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchReadFeatureValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchReadFeatureValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11387,7 +11548,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportFeatureValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportFeatureValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11487,7 +11649,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeatureValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeatureValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11563,7 +11726,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchFeatures {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchFeatures {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11642,7 +11806,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11685,7 +11850,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11746,7 +11912,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11798,7 +11965,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11855,7 +12023,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11934,7 +12103,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11980,7 +12150,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12026,7 +12197,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12072,7 +12244,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12124,7 +12297,8 @@ pub mod featurestore_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12203,7 +12377,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCachedContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCachedContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12247,7 +12422,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCachedContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCachedContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12303,7 +12479,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCachedContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCachedContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12347,7 +12524,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCachedContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCachedContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12418,7 +12596,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCachedContents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCachedContents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12495,7 +12674,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12536,7 +12716,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12595,7 +12776,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12645,7 +12827,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12700,7 +12883,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12777,7 +12961,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12821,7 +13006,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12865,7 +13051,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12909,7 +13096,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12959,7 +13147,8 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13035,7 +13224,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTuningJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTuningJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13076,7 +13266,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTuningJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTuningJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13150,7 +13341,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTuningJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTuningJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13191,7 +13383,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelTuningJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelTuningJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13311,7 +13504,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RebaseTunedModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RebaseTunedModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13388,7 +13582,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13429,7 +13624,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13488,7 +13684,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13538,7 +13735,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13593,7 +13791,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13670,7 +13869,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13714,7 +13914,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13758,7 +13959,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13802,7 +14004,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13852,7 +14055,8 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13978,7 +14182,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIndexEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIndexEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14024,7 +14229,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIndexEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIndexEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14109,7 +14315,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIndexEndpoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIndexEndpoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14167,7 +14374,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateIndexEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateIndexEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14248,7 +14456,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIndexEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIndexEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14343,7 +14552,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeployIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeployIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14435,7 +14645,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeployIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeployIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14533,7 +14744,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for MutateDeployedIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MutateDeployedIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14612,7 +14824,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14655,7 +14868,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14716,7 +14930,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14768,7 +14983,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14825,7 +15041,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14904,7 +15121,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14950,7 +15168,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -14996,7 +15215,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15042,7 +15262,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15094,7 +15315,8 @@ pub mod index_endpoint_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15209,7 +15431,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15250,7 +15473,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15330,7 +15554,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIndexes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIndexes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15422,7 +15647,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15498,7 +15724,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15562,7 +15789,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpsertDatapoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpsertDatapoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15617,7 +15845,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveDatapoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveDatapoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15694,7 +15923,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15735,7 +15965,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15794,7 +16025,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15844,7 +16076,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15899,7 +16132,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -15976,7 +16210,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16020,7 +16255,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16064,7 +16300,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16108,7 +16345,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16158,7 +16396,8 @@ pub mod index_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16234,7 +16473,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCustomJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCustomJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16275,7 +16515,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCustomJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCustomJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16355,7 +16596,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCustomJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCustomJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16431,7 +16673,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCustomJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCustomJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16472,7 +16715,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelCustomJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelCustomJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16527,7 +16771,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDataLabelingJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDataLabelingJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16571,7 +16816,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataLabelingJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataLabelingJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16660,7 +16906,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDataLabelingJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDataLabelingJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16739,7 +16986,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataLabelingJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataLabelingJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16783,7 +17031,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelDataLabelingJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelDataLabelingJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16840,7 +17089,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateHyperparameterTuningJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateHyperparameterTuningJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16886,7 +17136,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetHyperparameterTuningJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetHyperparameterTuningJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -16973,7 +17224,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListHyperparameterTuningJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListHyperparameterTuningJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17054,7 +17306,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteHyperparameterTuningJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteHyperparameterTuningJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17100,7 +17353,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelHyperparameterTuningJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelHyperparameterTuningJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17150,7 +17404,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNasJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNasJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17191,7 +17446,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNasJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNasJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17271,7 +17527,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNasJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNasJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17347,7 +17604,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNasJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNasJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17388,7 +17646,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelNasJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelNasJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17432,7 +17691,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNasTrialDetail {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNasTrialDetail {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17503,7 +17763,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNasTrialDetails {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNasTrialDetails {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17560,7 +17821,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBatchPredictionJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBatchPredictionJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17604,7 +17866,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBatchPredictionJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBatchPredictionJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17691,7 +17954,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBatchPredictionJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBatchPredictionJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17772,7 +18036,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBatchPredictionJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBatchPredictionJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17818,7 +18083,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelBatchPredictionJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelBatchPredictionJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17875,7 +18141,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateModelDeploymentMonitoringJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateModelDeploymentMonitoringJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -17995,7 +18262,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchModelDeploymentMonitoringStatsAnomalies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchModelDeploymentMonitoringStatsAnomalies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18041,7 +18309,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetModelDeploymentMonitoringJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetModelDeploymentMonitoringJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18128,7 +18397,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModelDeploymentMonitoringJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModelDeploymentMonitoringJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18231,7 +18501,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateModelDeploymentMonitoringJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateModelDeploymentMonitoringJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18312,7 +18583,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteModelDeploymentMonitoringJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteModelDeploymentMonitoringJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18358,7 +18630,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PauseModelDeploymentMonitoringJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PauseModelDeploymentMonitoringJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18404,7 +18677,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeModelDeploymentMonitoringJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeModelDeploymentMonitoringJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18481,7 +18755,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18522,7 +18797,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18581,7 +18857,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18631,7 +18908,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18686,7 +18964,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18763,7 +19042,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18807,7 +19087,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18851,7 +19132,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18895,7 +19177,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -18945,7 +19228,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19071,7 +19355,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CountTokens {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CountTokens {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19140,7 +19425,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ComputeTokens {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ComputeTokens {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19217,7 +19503,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19258,7 +19545,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19317,7 +19605,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19367,7 +19656,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19422,7 +19712,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19499,7 +19790,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19543,7 +19835,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19587,7 +19880,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19631,7 +19925,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19681,7 +19976,8 @@ pub mod llm_utility_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19771,7 +20067,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FindNeighbors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FindNeighbors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19832,7 +20129,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReadIndexDatapoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReadIndexDatapoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19909,7 +20207,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -19950,7 +20249,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20009,7 +20309,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20059,7 +20360,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20114,7 +20416,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20191,7 +20494,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20235,7 +20539,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20279,7 +20584,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20323,7 +20629,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20373,7 +20680,8 @@ pub mod match_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20501,7 +20809,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMetadataStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMetadataStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20545,7 +20854,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMetadataStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMetadataStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20616,7 +20926,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMetadataStores {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMetadataStores {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20705,7 +21016,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMetadataStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMetadataStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20761,7 +21073,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateArtifact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateArtifact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20802,7 +21115,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetArtifact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetArtifact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20882,7 +21196,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListArtifacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListArtifacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -20941,7 +21256,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateArtifact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateArtifact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21023,7 +21339,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteArtifact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteArtifact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21117,7 +21434,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeArtifacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeArtifacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21173,7 +21491,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateContext {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateContext {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21214,7 +21533,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetContext {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetContext {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21294,7 +21614,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListContexts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListContexts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21353,7 +21674,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateContext {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateContext {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21441,7 +21763,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteContext {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteContext {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21535,7 +21858,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeContexts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeContexts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21603,7 +21927,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddContextArtifactsAndExecutions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddContextArtifactsAndExecutions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21658,7 +21983,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddContextChildren {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddContextChildren {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21713,7 +22039,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveContextChildren {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveContextChildren {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21759,7 +22086,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryContextLineageSubgraph {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryContextLineageSubgraph {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21815,7 +22143,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21856,7 +22185,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21936,7 +22266,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExecutions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExecutions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -21995,7 +22326,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22077,7 +22409,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22171,7 +22504,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeExecutions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeExecutions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22226,7 +22560,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddExecutionEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddExecutionEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22272,7 +22607,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryExecutionInputsAndOutputs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryExecutionInputsAndOutputs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22331,7 +22667,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMetadataSchema {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMetadataSchema {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22375,7 +22712,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMetadataSchema {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMetadataSchema {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22452,7 +22790,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMetadataSchemas {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMetadataSchemas {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22510,7 +22849,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryArtifactLineageSubgraph {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryArtifactLineageSubgraph {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22587,7 +22927,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22628,7 +22969,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22687,7 +23029,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22737,7 +23080,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22792,7 +23136,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22869,7 +23214,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22913,7 +23259,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -22957,7 +23304,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23001,7 +23349,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23051,7 +23400,8 @@ pub mod metadata_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23158,7 +23508,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchMigratableResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchMigratableResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23256,7 +23607,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchMigrateResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchMigrateResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23333,7 +23685,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23374,7 +23727,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23433,7 +23787,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23483,7 +23838,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23538,7 +23894,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23615,7 +23972,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23659,7 +24017,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23703,7 +24062,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23747,7 +24107,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23797,7 +24158,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23891,7 +24253,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPublisherModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPublisherModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -23968,7 +24331,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24009,7 +24373,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24068,7 +24433,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24118,7 +24484,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24173,7 +24540,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24250,7 +24618,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24294,7 +24663,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24338,7 +24708,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24382,7 +24753,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24432,7 +24804,8 @@ pub mod model_garden_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24569,7 +24942,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UploadModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UploadModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24610,7 +24984,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24696,7 +25071,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24785,7 +25161,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModelVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModelVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24860,7 +25237,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModelVersionCheckpoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModelVersionCheckpoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -24913,7 +25291,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25011,7 +25390,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateExplanationDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateExplanationDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25087,7 +25467,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25166,7 +25547,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteModelVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteModelVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25221,7 +25603,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for MergeVersionAliases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MergeVersionAliases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25316,7 +25699,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25424,7 +25808,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CopyModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CopyModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25477,7 +25862,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportModelEvaluation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportModelEvaluation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25534,7 +25920,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchImportModelEvaluationSlices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchImportModelEvaluationSlices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25591,7 +25978,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchImportEvaluatedAnnotations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchImportEvaluatedAnnotations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25635,7 +26023,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetModelEvaluation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetModelEvaluation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25718,7 +26107,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModelEvaluations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModelEvaluations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25764,7 +26154,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetModelEvaluationSlice {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetModelEvaluationSlice {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25851,7 +26242,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModelEvaluationSlices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModelEvaluationSlices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25928,7 +26320,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -25969,7 +26362,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26028,7 +26422,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26078,7 +26473,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26133,7 +26529,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26210,7 +26607,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26254,7 +26652,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26298,7 +26697,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26342,7 +26742,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26392,7 +26793,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26527,7 +26929,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNotebookRuntimeTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNotebookRuntimeTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26573,7 +26976,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNotebookRuntimeTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNotebookRuntimeTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26666,7 +27070,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNotebookRuntimeTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNotebookRuntimeTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26747,7 +27152,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNotebookRuntimeTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNotebookRuntimeTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26807,7 +27213,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNotebookRuntimeTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNotebookRuntimeTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26915,7 +27322,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AssignNotebookRuntime {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AssignNotebookRuntime {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -26959,7 +27367,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNotebookRuntime {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNotebookRuntime {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27048,7 +27457,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNotebookRuntimes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNotebookRuntimes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27127,7 +27537,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNotebookRuntime {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNotebookRuntime {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27214,7 +27625,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpgradeNotebookRuntime {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpgradeNotebookRuntime {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27301,7 +27713,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartNotebookRuntime {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartNotebookRuntime {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27388,7 +27801,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StopNotebookRuntime {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopNotebookRuntime {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27494,7 +27908,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNotebookExecutionJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNotebookExecutionJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27546,7 +27961,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNotebookExecutionJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNotebookExecutionJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27639,7 +28055,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNotebookExecutionJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNotebookExecutionJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27720,7 +28137,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNotebookExecutionJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNotebookExecutionJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27797,7 +28215,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27838,7 +28257,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27897,7 +28317,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -27947,7 +28368,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28002,7 +28424,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28079,7 +28502,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28123,7 +28547,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28167,7 +28592,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28211,7 +28637,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28261,7 +28688,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28397,7 +28825,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePersistentResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePersistentResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28443,7 +28872,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPersistentResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPersistentResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28520,7 +28950,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPersistentResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPersistentResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28603,7 +29034,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePersistentResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePersistentResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28708,7 +29140,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePersistentResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePersistentResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28799,7 +29232,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RebootPersistentResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RebootPersistentResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28878,7 +29312,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28921,7 +29356,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -28982,7 +29418,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29034,7 +29471,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29091,7 +29529,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29170,7 +29609,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29216,7 +29656,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29262,7 +29703,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29308,7 +29750,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29360,7 +29803,8 @@ pub mod persistent_resource_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29441,7 +29885,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTrainingPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTrainingPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29485,7 +29930,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTrainingPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTrainingPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29568,7 +30014,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTrainingPipelines {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTrainingPipelines {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29647,7 +30094,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTrainingPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTrainingPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29691,7 +30139,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelTrainingPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelTrainingPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29750,7 +30199,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePipelineJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePipelineJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29791,7 +30241,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPipelineJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPipelineJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29880,7 +30331,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPipelineJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPipelineJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -29959,7 +30411,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePipelineJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePipelineJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30059,7 +30512,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeletePipelineJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeletePipelineJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30103,7 +30557,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelPipelineJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelPipelineJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30203,7 +30658,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCancelPipelineJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCancelPipelineJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30280,7 +30736,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30321,7 +30778,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30380,7 +30838,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30430,7 +30889,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30485,7 +30945,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30562,7 +31023,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30606,7 +31068,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30650,7 +31113,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30694,7 +31158,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30744,7 +31209,8 @@ pub mod pipeline_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30826,7 +31292,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Predict {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Predict {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30876,7 +31343,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RawPredict {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RawPredict {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30937,7 +31405,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DirectPredict {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DirectPredict {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -30993,7 +31462,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DirectRawPredict {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DirectRawPredict {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31066,7 +31536,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Explain {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Explain {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31186,7 +31657,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31263,7 +31735,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31304,7 +31777,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31363,7 +31837,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31413,7 +31888,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31468,7 +31944,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31545,7 +32022,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31589,7 +32067,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31633,7 +32112,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31677,7 +32157,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31727,7 +32208,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31813,7 +32295,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryReasoningEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryReasoningEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31892,7 +32375,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31935,7 +32419,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -31996,7 +32481,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32048,7 +32534,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32105,7 +32592,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32184,7 +32672,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32230,7 +32719,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32276,7 +32766,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32322,7 +32813,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32374,7 +32866,8 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32500,7 +32993,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateReasoningEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateReasoningEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32546,7 +33040,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReasoningEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReasoningEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32625,7 +33120,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReasoningEngines {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReasoningEngines {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32726,7 +33222,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateReasoningEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateReasoningEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32807,7 +33304,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteReasoningEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteReasoningEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32886,7 +33384,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32929,7 +33428,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -32990,7 +33490,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33042,7 +33543,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33099,7 +33601,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33178,7 +33681,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33224,7 +33728,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33270,7 +33775,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33316,7 +33822,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33368,7 +33875,8 @@ pub mod reasoning_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33444,7 +33952,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33520,7 +34029,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33561,7 +34071,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33641,7 +34152,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSchedules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSchedules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33682,7 +34194,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PauseSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PauseSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33729,7 +34242,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33782,7 +34296,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33859,7 +34374,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33900,7 +34416,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -33959,7 +34476,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34009,7 +34527,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34064,7 +34583,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34141,7 +34661,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34185,7 +34706,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34229,7 +34751,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34273,7 +34796,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34323,7 +34847,8 @@ pub mod schedule_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34449,7 +34974,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSpecialistPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSpecialistPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34495,7 +35021,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSpecialistPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSpecialistPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34574,7 +35101,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSpecialistPools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSpecialistPools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34661,7 +35189,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSpecialistPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSpecialistPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34762,7 +35291,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSpecialistPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSpecialistPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34841,7 +35371,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34884,7 +35415,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34945,7 +35477,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -34997,7 +35530,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35054,7 +35588,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35133,7 +35668,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35179,7 +35715,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35225,7 +35762,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35271,7 +35809,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35323,7 +35862,8 @@ pub mod specialist_pool_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35443,7 +35983,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTensorboard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTensorboard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35484,7 +36025,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTensorboard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTensorboard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35581,7 +36123,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTensorboard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTensorboard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35670,7 +36213,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTensorboards {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTensorboards {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35749,7 +36293,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTensorboard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTensorboard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35793,7 +36338,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReadTensorboardUsage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReadTensorboardUsage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35837,7 +36383,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReadTensorboardSize {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReadTensorboardSize {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35900,7 +36447,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTensorboardExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTensorboardExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -35946,7 +36494,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTensorboardExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTensorboardExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36006,7 +36555,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTensorboardExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTensorboardExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36099,7 +36649,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTensorboardExperiments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTensorboardExperiments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36180,7 +36731,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTensorboardExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTensorboardExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36239,7 +36791,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTensorboardRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTensorboardRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36296,7 +36849,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateTensorboardRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateTensorboardRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36340,7 +36894,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTensorboardRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTensorboardRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36396,7 +36951,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTensorboardRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTensorboardRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36485,7 +37041,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTensorboardRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTensorboardRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36564,7 +37121,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTensorboardRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTensorboardRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36621,7 +37179,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateTensorboardTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateTensorboardTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36687,7 +37246,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTensorboardTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTensorboardTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36733,7 +37293,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTensorboardTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTensorboardTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36793,7 +37354,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTensorboardTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTensorboardTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36886,7 +37448,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTensorboardTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTensorboardTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -36967,7 +37530,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTensorboardTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTensorboardTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37026,7 +37590,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchReadTensorboardTimeSeriesData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchReadTensorboardTimeSeriesData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37084,7 +37649,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReadTensorboardTimeSeriesData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReadTensorboardTimeSeriesData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37141,7 +37707,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WriteTensorboardExperimentData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WriteTensorboardExperimentData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37198,7 +37765,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WriteTensorboardRunData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WriteTensorboardRunData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37285,7 +37853,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportTensorboardTimeSeriesData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportTensorboardTimeSeriesData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37362,7 +37931,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37403,7 +37973,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37462,7 +38033,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37512,7 +38084,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37567,7 +38140,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37644,7 +38218,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37688,7 +38263,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37732,7 +38308,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37776,7 +38353,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37826,7 +38404,8 @@ pub mod tensorboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -37947,7 +38526,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRagCorpus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRagCorpus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38034,7 +38614,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRagCorpus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRagCorpus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38077,7 +38658,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRagCorpus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRagCorpus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38147,7 +38729,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRagCorpora {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRagCorpora {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38231,7 +38814,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRagCorpus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRagCorpus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38294,7 +38878,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UploadRagFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UploadRagFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38391,7 +38976,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportRagFiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportRagFiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38434,7 +39020,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRagFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRagFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38504,7 +39091,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRagFiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRagFiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38582,7 +39170,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRagFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRagFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38661,7 +39250,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38704,7 +39294,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38765,7 +39356,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38817,7 +39409,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38874,7 +39467,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38953,7 +39547,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -38999,7 +39594,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39045,7 +39641,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39091,7 +39688,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39143,7 +39741,8 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39233,7 +39832,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RetrieveContexts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetrieveContexts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39307,7 +39907,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AugmentPrompt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AugmentPrompt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39382,7 +39983,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CorroborateContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CorroborateContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39459,7 +40061,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39500,7 +40103,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39559,7 +40163,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39609,7 +40214,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39664,7 +40270,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39741,7 +40348,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39785,7 +40393,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39829,7 +40438,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39873,7 +40483,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39923,7 +40534,8 @@ pub mod vertex_rag_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -39999,7 +40611,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateStudy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateStudy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40040,7 +40653,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetStudy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetStudy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40108,7 +40722,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListStudies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListStudies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40149,7 +40764,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteStudy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteStudy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40196,7 +40812,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupStudy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupStudy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40301,7 +40918,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SuggestTrials {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SuggestTrials {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40351,7 +40969,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTrial {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTrial {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40392,7 +41011,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTrial {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTrial {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40460,7 +41080,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTrials {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTrials {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40513,7 +41134,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddTrialMeasurement {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddTrialMeasurement {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40575,7 +41197,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CompleteTrial {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CompleteTrial {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40616,7 +41239,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTrial {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTrial {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40705,7 +41329,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CheckTrialEarlyStoppingState {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CheckTrialEarlyStoppingState {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40746,7 +41371,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StopTrial {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopTrial {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40790,7 +41416,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOptimalTrials {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOptimalTrials {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40867,7 +41494,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40908,7 +41536,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -40967,7 +41596,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -41017,7 +41647,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -41072,7 +41703,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -41149,7 +41781,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -41193,7 +41826,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -41237,7 +41871,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -41281,7 +41916,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -41331,7 +41967,8 @@ pub mod vizier_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/alloydb/v1/src/builders.rs
+++ b/src/generated/cloud/alloydb/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -265,7 +267,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -373,7 +376,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -473,7 +477,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -569,7 +574,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for PromoteCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PromoteCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -662,7 +668,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for SwitchoverCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SwitchoverCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -776,7 +783,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -884,7 +892,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecondaryCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecondaryCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -964,7 +973,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1011,7 +1021,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1117,7 +1128,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1228,7 +1240,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecondaryInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecondaryInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1328,7 +1341,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1437,7 +1451,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1531,7 +1546,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1625,7 +1641,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for FailoverInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FailoverInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1725,7 +1742,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for InjectFault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InjectFault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1827,7 +1845,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for RestartInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestartInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1897,7 +1916,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ExecuteSql {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExecuteSql {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1977,7 +1997,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2018,7 +2039,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2123,7 +2145,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2231,7 +2254,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2325,7 +2349,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2400,7 +2425,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSupportedDatabaseFlags {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSupportedDatabaseFlags {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2473,7 +2499,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateClientCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateClientCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2523,7 +2550,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnectionInfo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnectionInfo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2602,7 +2630,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUsers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUsers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2643,7 +2672,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetUser {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetUser {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2708,7 +2738,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateUser {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateUser {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2776,7 +2807,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateUser {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateUser {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2829,7 +2861,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteUser {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteUser {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2903,7 +2936,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatabases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatabases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2980,7 +3014,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3021,7 +3056,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3098,7 +3134,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3142,7 +3179,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3186,7 +3224,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3230,7 +3269,8 @@ pub mod alloy_db_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/apigateway/v1/src/builders.rs
+++ b/src/generated/cloud/apigateway/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGateways {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGateways {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -247,7 +249,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -337,7 +340,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -413,7 +417,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -492,7 +497,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListApis {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListApis {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -531,7 +537,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -621,7 +628,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -708,7 +716,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -784,7 +793,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -864,7 +874,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListApiConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListApiConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -914,7 +925,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetApiConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetApiConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1008,7 +1020,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateApiConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateApiConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1099,7 +1112,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateApiConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateApiConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1175,7 +1189,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteApiConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteApiConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1252,7 +1267,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1296,7 +1312,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1340,7 +1357,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1384,7 +1402,8 @@ pub mod api_gateway_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/apigeeconnect/v1/src/builders.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builders.rs
@@ -101,7 +101,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/apihub/v1/src/builders.rs
+++ b/src/generated/cloud/apihub/v1/src/builders.rs
@@ -86,7 +86,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -125,7 +126,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -198,7 +200,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListApis {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListApis {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -248,7 +251,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -295,7 +299,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -351,7 +356,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -392,7 +398,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -466,7 +473,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -519,7 +527,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -566,7 +575,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -619,7 +629,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -660,7 +671,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -701,7 +713,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSpecContents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSpecContents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -774,7 +787,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSpecs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSpecs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -824,7 +838,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -865,7 +880,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -906,7 +922,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetApiOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetApiOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -983,7 +1000,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListApiOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListApiOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1024,7 +1042,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDefinition {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDefinition {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1083,7 +1102,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1124,7 +1144,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1198,7 +1219,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeployments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeployments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1254,7 +1276,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1298,7 +1321,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1354,7 +1378,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAttribute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAttribute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1395,7 +1420,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAttribute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAttribute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1448,7 +1474,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAttribute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAttribute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1489,7 +1516,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAttribute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAttribute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1563,7 +1591,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAttributes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAttributes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1643,7 +1672,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1702,7 +1732,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateExternalApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateExternalApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1743,7 +1774,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetExternalApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetExternalApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1799,7 +1831,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateExternalApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateExternalApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1843,7 +1876,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteExternalApi {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteExternalApi {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1914,7 +1948,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExternalApis {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExternalApis {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1991,7 +2026,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2032,7 +2068,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2109,7 +2146,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2153,7 +2191,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2197,7 +2236,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2241,7 +2281,8 @@ pub mod api_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2326,7 +2367,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDependency {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDependency {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2367,7 +2409,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDependency {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDependency {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2423,7 +2466,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDependency {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDependency {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2467,7 +2511,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDependency {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDependency {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2544,7 +2589,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDependencies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDependencies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2621,7 +2667,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2662,7 +2709,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2739,7 +2787,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2783,7 +2832,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2827,7 +2877,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2871,7 +2922,8 @@ pub mod api_hub_dependencies {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2967,7 +3019,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateHostProjectRegistration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateHostProjectRegistration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3015,7 +3068,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetHostProjectRegistration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetHostProjectRegistration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3104,7 +3158,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListHostProjectRegistrations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListHostProjectRegistrations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3183,7 +3238,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3226,7 +3282,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3305,7 +3362,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3351,7 +3409,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3397,7 +3456,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3443,7 +3503,8 @@ pub mod host_project_registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3510,7 +3571,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetStyleGuide {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetStyleGuide {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3566,7 +3628,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateStyleGuide {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateStyleGuide {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3610,7 +3673,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetStyleGuideContents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetStyleGuideContents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3651,7 +3715,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for LintSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LintSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3728,7 +3793,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3769,7 +3835,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3846,7 +3913,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3890,7 +3958,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3934,7 +4003,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3978,7 +4048,8 @@ pub mod linting_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4045,7 +4116,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPlugin {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPlugin {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4086,7 +4158,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for EnablePlugin {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnablePlugin {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4127,7 +4200,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for DisablePlugin {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisablePlugin {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4204,7 +4278,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4245,7 +4320,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4322,7 +4398,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4366,7 +4443,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4410,7 +4488,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4454,7 +4533,8 @@ pub mod api_hub_plugin {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4578,7 +4658,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateApiHubInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateApiHubInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4622,7 +4703,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for GetApiHubInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetApiHubInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4666,7 +4748,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupApiHubInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupApiHubInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4743,7 +4826,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4784,7 +4868,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4861,7 +4946,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4905,7 +4991,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4949,7 +5036,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4993,7 +5081,8 @@ pub mod provisioning {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5089,7 +5178,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRuntimeProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRuntimeProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5137,7 +5227,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRuntimeProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRuntimeProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5226,7 +5317,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRuntimeProjectAttachments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRuntimeProjectAttachments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5274,7 +5366,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRuntimeProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRuntimeProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5322,7 +5415,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupRuntimeProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupRuntimeProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5401,7 +5495,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5444,7 +5539,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5523,7 +5619,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5569,7 +5666,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5615,7 +5713,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5661,7 +5760,8 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/apphub/v1/src/builders.rs
+++ b/src/generated/cloud/apphub/v1/src/builders.rs
@@ -79,7 +79,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupServiceProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupServiceProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServiceProjectAttachments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServiceProjectAttachments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -279,7 +281,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServiceProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServiceProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -325,7 +328,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServiceProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServiceProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -412,7 +416,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteServiceProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteServiceProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -458,7 +463,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DetachServiceProjectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DetachServiceProjectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -543,7 +549,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDiscoveredServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDiscoveredServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -587,7 +594,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDiscoveredService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDiscoveredService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -639,7 +647,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupDiscoveredService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupDiscoveredService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -719,7 +728,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -818,7 +828,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -859,7 +870,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -955,7 +967,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1037,7 +1050,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1124,7 +1138,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDiscoveredWorkloads {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDiscoveredWorkloads {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1168,7 +1183,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDiscoveredWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDiscoveredWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1220,7 +1236,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupDiscoveredWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupDiscoveredWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1300,7 +1317,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkloads {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkloads {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1400,7 +1418,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1441,7 +1460,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1538,7 +1558,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1620,7 +1641,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1703,7 +1725,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListApplications {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListApplications {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1806,7 +1829,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateApplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateApplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1847,7 +1871,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetApplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetApplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1947,7 +1972,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateApplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateApplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2032,7 +2058,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteApplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteApplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2109,7 +2136,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2150,7 +2178,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2209,7 +2238,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2259,7 +2289,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2314,7 +2345,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2391,7 +2423,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2435,7 +2468,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2479,7 +2513,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2523,7 +2558,8 @@ pub mod app_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/asset/v1/src/builders.rs
+++ b/src/generated/cloud/asset/v1/src/builders.rs
@@ -158,7 +158,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportAssets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportAssets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -260,7 +261,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAssets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAssets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -341,7 +343,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchGetAssetsHistory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchGetAssetsHistory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -394,7 +397,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeed {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeed {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -435,7 +439,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeed {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeed {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -476,7 +481,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeeds {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeeds {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -526,7 +532,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeed {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeed {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -567,7 +574,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeed {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeed {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -667,7 +675,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchAllResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchAllResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -761,7 +770,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchAllIamPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchAllIamPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -825,7 +835,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -936,7 +947,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeIamPolicyLongrunning {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeIamPolicyLongrunning {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -992,7 +1004,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeMove {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeMove {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1080,7 +1093,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryAssets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryAssets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1139,7 +1153,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSavedQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSavedQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1180,7 +1195,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSavedQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSavedQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1257,7 +1273,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSavedQueries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSavedQueries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1313,7 +1330,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSavedQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSavedQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1357,7 +1375,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSavedQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSavedQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1414,7 +1433,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchGetEffectiveIamPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchGetEffectiveIamPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1497,7 +1517,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeOrgPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeOrgPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1586,7 +1607,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeOrgPolicyGovernedContainers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeOrgPolicyGovernedContainers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1673,7 +1695,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeOrgPolicyGovernedAssets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeOrgPolicyGovernedAssets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1717,7 +1740,8 @@ pub mod asset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/assuredworkloads/v1/src/builders.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builders.rs
@@ -134,7 +134,8 @@ pub mod assured_workloads_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -189,7 +190,8 @@ pub mod assured_workloads_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -248,7 +250,8 @@ pub mod assured_workloads_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RestrictAllowedResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestrictAllowedResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -297,7 +300,8 @@ pub mod assured_workloads_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -340,7 +344,8 @@ pub mod assured_workloads_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -416,7 +421,8 @@ pub mod assured_workloads_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkloads {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkloads {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -495,7 +501,8 @@ pub mod assured_workloads_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -541,7 +548,8 @@ pub mod assured_workloads_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/backupdr/v1/src/builders.rs
+++ b/src/generated/cloud/backupdr/v1/src/builders.rs
@@ -122,7 +122,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for ListManagementServers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListManagementServers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetManagementServer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetManagementServer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -272,7 +274,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateManagementServer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateManagementServer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +360,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteManagementServer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteManagementServer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -466,7 +470,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackupVault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackupVault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -555,7 +560,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupVaults {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupVaults {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -642,7 +648,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchUsableBackupVaults {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchUsableBackupVaults {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -689,7 +696,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupVault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupVault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -801,7 +809,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackupVault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackupVault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -916,7 +925,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackupVault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackupVault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -996,7 +1006,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDataSources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDataSources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1037,7 +1048,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1143,7 +1155,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDataSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDataSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1229,7 +1242,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1276,7 +1290,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1372,7 +1387,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1456,7 +1472,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1566,7 +1583,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1669,7 +1687,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackupPlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackupPlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1710,7 +1729,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupPlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupPlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1790,7 +1810,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupPlans {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupPlans {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1875,7 +1896,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackupPlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackupPlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1988,7 +2010,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackupPlanAssociation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackupPlanAssociation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2034,7 +2057,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupPlanAssociation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupPlanAssociation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2115,7 +2139,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupPlanAssociations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupPlanAssociations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2202,7 +2227,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackupPlanAssociation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackupPlanAssociation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2296,7 +2322,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for TriggerBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TriggerBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2393,7 +2420,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for InitializeService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InitializeService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2470,7 +2498,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2511,7 +2540,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2570,7 +2600,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2620,7 +2651,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2675,7 +2707,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2752,7 +2785,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2796,7 +2830,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2840,7 +2875,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2884,7 +2920,8 @@ pub mod backup_dr {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/baremetalsolution/v2/src/builders.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builders.rs
@@ -107,7 +107,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -239,7 +241,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -286,7 +289,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for RenameInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RenameInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -368,7 +372,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -450,7 +455,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for StartInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -530,7 +536,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for StopInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -619,7 +626,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableInteractiveSerialConsole {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableInteractiveSerialConsole {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -708,7 +716,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableInteractiveSerialConsole {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableInteractiveSerialConsole {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -799,7 +808,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for DetachLun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DetachLun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -867,7 +877,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSSHKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSSHKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -923,7 +934,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSSHKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSSHKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -964,7 +976,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSSHKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSSHKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1038,7 +1051,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVolumes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVolumes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1079,7 +1093,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1169,7 +1184,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1216,7 +1232,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for RenameVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RenameVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1292,7 +1309,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for EvictVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EvictVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1376,7 +1394,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ResizeVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResizeVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1450,7 +1469,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNetworks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNetworks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1494,7 +1514,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNetworkUsage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNetworkUsage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1535,7 +1556,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1625,7 +1647,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1678,7 +1701,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVolumeSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVolumeSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1761,7 +1785,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreVolumeSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreVolumeSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1805,7 +1830,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVolumeSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVolumeSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1849,7 +1875,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVolumeSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVolumeSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1920,7 +1947,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVolumeSnapshots {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVolumeSnapshots {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1959,7 +1987,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2026,7 +2055,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2102,7 +2132,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for EvictLun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EvictLun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2143,7 +2174,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNfsShare {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNfsShare {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2217,7 +2249,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNfsShares {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNfsShares {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2308,7 +2341,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNfsShare {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNfsShare {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2396,7 +2430,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNfsShare {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNfsShare {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2443,7 +2478,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for RenameNfsShare {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RenameNfsShare {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2519,7 +2555,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNfsShare {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNfsShare {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2592,7 +2629,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProvisioningQuotas {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProvisioningQuotas {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2655,7 +2693,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for SubmitProvisioningConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubmitProvisioningConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2699,7 +2738,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProvisioningConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProvisioningConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2762,7 +2802,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateProvisioningConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateProvisioningConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2828,7 +2869,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProvisioningConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProvisioningConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2875,7 +2917,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for RenameNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RenameNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2943,7 +2986,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOSImages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOSImages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3020,7 +3064,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3061,7 +3106,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3105,7 +3151,8 @@ pub mod bare_metal_solution {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builders.rs
@@ -120,7 +120,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAppConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAppConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAppConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAppConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -280,7 +282,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAppConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAppConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -397,7 +400,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAppConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAppConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -493,7 +497,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAppConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAppConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -572,7 +577,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResolveAppConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResolveAppConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -651,7 +657,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -694,7 +701,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -755,7 +763,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -807,7 +816,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -864,7 +874,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -943,7 +954,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -989,7 +1001,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1035,7 +1048,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1081,7 +1095,8 @@ pub mod app_connections_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builders.rs
@@ -120,7 +120,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAppConnectors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAppConnectors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -163,7 +164,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAppConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAppConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -277,7 +279,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAppConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAppConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -388,7 +391,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAppConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAppConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -484,7 +488,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAppConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAppConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -589,7 +594,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReportStatus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReportStatus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -668,7 +674,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -711,7 +718,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -772,7 +780,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -824,7 +833,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -881,7 +891,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -960,7 +971,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1006,7 +1018,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1052,7 +1065,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1098,7 +1112,8 @@ pub mod app_connectors_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAppGateways {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAppGateways {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAppGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAppGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -264,7 +266,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAppGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAppGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +360,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAppGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAppGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -434,7 +438,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -475,7 +480,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -534,7 +540,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -584,7 +591,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -639,7 +647,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -716,7 +725,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -760,7 +770,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -804,7 +815,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -848,7 +860,8 @@ pub mod app_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builders.rs
@@ -124,7 +124,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClientConnectorServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClientConnectorServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -172,7 +173,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetClientConnectorService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetClientConnectorService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -295,7 +297,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateClientConnectorService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateClientConnectorService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -418,7 +421,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateClientConnectorService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateClientConnectorService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -517,7 +521,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteClientConnectorService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteClientConnectorService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -596,7 +601,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -639,7 +645,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -700,7 +707,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -752,7 +760,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -809,7 +818,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -888,7 +898,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -934,7 +945,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -980,7 +992,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1026,7 +1039,8 @@ pub mod client_connector_services_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builders.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builders.rs
@@ -120,7 +120,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClientGateways {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClientGateways {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetClientGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetClientGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -280,7 +282,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateClientGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateClientGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -376,7 +379,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteClientGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteClientGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -455,7 +459,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -498,7 +503,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -559,7 +565,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -611,7 +618,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -668,7 +676,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -747,7 +756,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -793,7 +803,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -839,7 +850,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -885,7 +897,8 @@ pub mod client_gateways_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builders.rs
@@ -108,7 +108,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDataExchanges {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDataExchanges {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -181,7 +182,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOrgDataExchanges {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOrgDataExchanges {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -224,7 +226,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataExchange {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataExchange {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -285,7 +288,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDataExchange {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDataExchange {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -343,7 +347,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDataExchange {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDataExchange {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -389,7 +394,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataExchange {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataExchange {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -459,7 +465,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListListings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListListings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -502,7 +509,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetListing {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetListing {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -560,7 +568,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateListing {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateListing {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -615,7 +624,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateListing {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateListing {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -658,7 +668,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteListing {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteListing {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -715,7 +726,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SubscribeListing {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubscribeListing {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -820,7 +832,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SubscribeDataExchange {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubscribeDataExchange {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -907,7 +920,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RefreshSubscription {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RefreshSubscription {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -950,7 +964,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSubscription {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSubscription {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1029,7 +1044,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSubscriptions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSubscriptions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1112,7 +1128,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSharedResourceSubscriptions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSharedResourceSubscriptions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1158,7 +1175,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RevokeSubscription {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RevokeSubscription {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1239,7 +1257,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSubscription {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSubscription {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1291,7 +1310,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1352,7 +1372,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1409,7 +1430,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1455,7 +1477,8 @@ pub mod analytics_hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/bigquery/connection/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/builders.rs
@@ -92,7 +92,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -133,7 +134,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -201,7 +203,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -263,7 +266,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -307,7 +311,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +362,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -416,7 +422,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -471,7 +478,8 @@ pub mod connection_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/builders.rs
@@ -86,7 +86,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDataPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDataPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -142,7 +143,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDataPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDataPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -192,7 +194,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RenameDataPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RenameDataPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +239,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -277,7 +281,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -354,7 +359,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDataPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDataPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -404,7 +410,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -463,7 +470,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -518,7 +526,8 @@ pub mod data_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builders.rs
@@ -78,7 +78,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDataSources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDataSources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -221,7 +223,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTransferConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTransferConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -297,7 +300,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTransferConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTransferConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -343,7 +347,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTransferConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTransferConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -389,7 +394,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTransferConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTransferConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -473,7 +479,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTransferConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTransferConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -534,7 +541,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ScheduleTransferRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ScheduleTransferRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -591,7 +599,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartManualTransferRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartManualTransferRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -634,7 +643,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTransferRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTransferRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -680,7 +690,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTransferRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTransferRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -773,7 +784,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTransferRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTransferRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -857,7 +869,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTransferLogs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTransferLogs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -900,7 +913,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CheckValidCreds {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CheckValidCreds {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -957,7 +971,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnrollDataSources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnrollDataSources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1014,7 +1029,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UnenrollDataSources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UnenrollDataSources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1093,7 +1109,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1136,7 +1153,8 @@ pub mod data_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/bigquery/migration/v2/src/builders.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/builders.rs
@@ -90,7 +90,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMigrationWorkflow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMigrationWorkflow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -140,7 +141,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMigrationWorkflow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMigrationWorkflow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -219,7 +221,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMigrationWorkflows {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMigrationWorkflows {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -265,7 +268,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMigrationWorkflow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMigrationWorkflow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -309,7 +313,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartMigrationWorkflow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartMigrationWorkflow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -359,7 +364,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMigrationSubtask {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMigrationSubtask {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -442,7 +448,8 @@ pub mod migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMigrationSubtasks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMigrationSubtasks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/bigquery/reservation/v1/src/builders.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/builders.rs
@@ -92,7 +92,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateReservation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateReservation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -163,7 +164,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReservations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReservations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -204,7 +206,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReservation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReservation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -248,7 +251,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteReservation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteReservation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -304,7 +308,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateReservation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateReservation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -348,7 +353,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FailoverReservation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FailoverReservation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -417,7 +423,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCapacityCommitment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCapacityCommitment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -492,7 +499,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCapacityCommitments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCapacityCommitments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -536,7 +544,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCapacityCommitment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCapacityCommitment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -588,7 +597,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCapacityCommitment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCapacityCommitment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -648,7 +658,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCapacityCommitment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCapacityCommitment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -700,7 +711,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SplitCapacityCommitment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SplitCapacityCommitment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -757,7 +769,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for MergeCapacityCommitments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MergeCapacityCommitments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -816,7 +829,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAssignment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAssignment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -884,7 +898,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAssignments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAssignments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -928,7 +943,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAssignment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAssignment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1005,7 +1021,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchAssignments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchAssignments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1082,7 +1099,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchAllAssignments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchAllAssignments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1135,7 +1153,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for MoveAssignment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MoveAssignment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1191,7 +1210,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAssignment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAssignment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1235,7 +1255,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBiReservation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBiReservation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1291,7 +1312,8 @@ pub mod reservation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBiReservation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBiReservation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/bigquery/v2/src/builders.rs
+++ b/src/generated/cloud/bigquery/v2/src/builders.rs
@@ -95,7 +95,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -151,7 +152,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for InsertDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InsertDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -216,7 +218,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PatchDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PatchDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -281,7 +284,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -334,7 +338,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -402,7 +407,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatasets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatasets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -458,7 +464,8 @@ pub mod dataset_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -537,7 +544,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -599,7 +607,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -661,7 +670,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PatchModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PatchModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -714,7 +724,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -784,7 +795,8 @@ pub mod project_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -863,7 +875,8 @@ pub mod routine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRoutine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRoutine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -919,7 +932,8 @@ pub mod routine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for InsertRoutine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InsertRoutine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -981,7 +995,8 @@ pub mod routine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRoutine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRoutine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1034,7 +1049,8 @@ pub mod routine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRoutine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRoutine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1102,7 +1118,8 @@ pub mod routine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRoutines {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRoutines {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1215,7 +1232,8 @@ pub mod row_access_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRowAccessPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRowAccessPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1279,7 +1297,8 @@ pub mod row_access_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRowAccessPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRowAccessPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1348,7 +1367,8 @@ pub mod row_access_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRowAccessPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRowAccessPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1423,7 +1443,8 @@ pub mod row_access_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRowAccessPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRowAccessPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1493,7 +1514,8 @@ pub mod row_access_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRowAccessPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRowAccessPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1570,7 +1592,8 @@ pub mod row_access_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeleteRowAccessPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeleteRowAccessPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1664,7 +1687,8 @@ pub mod table_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1720,7 +1744,8 @@ pub mod table_service {
         }
     }
 
-    impl gax::options::RequestBuilder for InsertTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InsertTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1791,7 +1816,8 @@ pub mod table_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PatchTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PatchTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1862,7 +1888,8 @@ pub mod table_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1915,7 +1942,8 @@ pub mod table_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1977,7 +2005,8 @@ pub mod table_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTables {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTables {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/billing/v1/src/builders.rs
+++ b/src/generated/cloud/billing/v1/src/builders.rs
@@ -77,7 +77,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBillingAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBillingAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBillingAccounts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBillingAccounts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -216,7 +218,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBillingAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBillingAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -269,7 +272,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBillingAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBillingAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -342,7 +346,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProjectBillingInfo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProjectBillingInfo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -386,7 +391,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProjectBillingInfo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProjectBillingInfo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -443,7 +449,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProjectBillingInfo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProjectBillingInfo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -493,7 +500,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -552,7 +560,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -607,7 +616,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -657,7 +667,8 @@ pub mod cloud_billing {
         }
     }
 
-    impl gax::options::RequestBuilder for MoveBillingAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MoveBillingAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -745,7 +756,8 @@ pub mod cloud_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -833,7 +845,8 @@ pub mod cloud_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSkus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSkus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/binaryauthorization/v1/src/builders.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/builders.rs
@@ -78,7 +78,8 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -124,7 +125,8 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -182,7 +184,8 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAttestor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAttestor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -225,7 +228,8 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAttestor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAttestor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -271,7 +275,8 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAttestor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAttestor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -341,7 +346,8 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAttestors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAttestors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -384,7 +390,8 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAttestor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAttestor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -451,7 +458,8 @@ pub mod system_policy_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSystemPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSystemPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -546,7 +554,8 @@ pub mod validation_helper_v_1 {
         }
     }
 
-    impl gax::options::RequestBuilder for ValidateAttestationOccurrence {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ValidateAttestationOccurrence {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/certificatemanager/v1/src/builders.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builders.rs
@@ -116,7 +116,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCertificates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCertificates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -157,7 +158,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -348,7 +351,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -427,7 +431,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -510,7 +515,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCertificateMaps {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCertificateMaps {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -554,7 +560,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificateMap {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificateMap {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -652,7 +659,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCertificateMap {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCertificateMap {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -747,7 +755,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCertificateMap {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCertificateMap {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -826,7 +835,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCertificateMap {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCertificateMap {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -913,7 +923,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCertificateMapEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCertificateMapEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -957,7 +968,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificateMapEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificateMapEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1059,7 +1071,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCertificateMapEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCertificateMapEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1158,7 +1171,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCertificateMapEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCertificateMapEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1239,7 +1253,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCertificateMapEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCertificateMapEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1322,7 +1337,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDnsAuthorizations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDnsAuthorizations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1366,7 +1382,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDnsAuthorization {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDnsAuthorization {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1466,7 +1483,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDnsAuthorization {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDnsAuthorization {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1563,7 +1581,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDnsAuthorization {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDnsAuthorization {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1642,7 +1661,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDnsAuthorization {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDnsAuthorization {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1729,7 +1749,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCertificateIssuanceConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCertificateIssuanceConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1775,7 +1796,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificateIssuanceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificateIssuanceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1882,7 +1904,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCertificateIssuanceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCertificateIssuanceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1963,7 +1986,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCertificateIssuanceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCertificateIssuanceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2046,7 +2070,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTrustConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTrustConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2087,7 +2112,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTrustConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTrustConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2184,7 +2210,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTrustConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTrustConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2278,7 +2305,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTrustConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTrustConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2363,7 +2391,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTrustConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTrustConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2440,7 +2469,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2481,7 +2511,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2558,7 +2589,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2602,7 +2634,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2646,7 +2679,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2690,7 +2724,8 @@ pub mod certificate_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/builders.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/builders.rs
@@ -78,7 +78,8 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkload {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkload {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkloads {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkloads {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -203,7 +205,8 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCustomer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCustomer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -285,7 +288,8 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCustomers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCustomers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -331,7 +335,8 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEkmConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEkmConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -377,7 +382,8 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPartnerPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPartnerPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -466,7 +472,8 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAccessApprovalRequests {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAccessApprovalRequests {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -509,7 +516,8 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPartner {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPartner {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -628,7 +636,8 @@ pub mod cloud_controls_partner_monitoring {
         }
     }
 
-    impl gax::options::RequestBuilder for ListViolations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListViolations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -671,7 +680,8 @@ pub mod cloud_controls_partner_monitoring {
         }
     }
 
-    impl gax::options::RequestBuilder for GetViolation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetViolation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/clouddms/v1/src/builders.rs
+++ b/src/generated/cloud/clouddms/v1/src/builders.rs
@@ -120,7 +120,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMigrationJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMigrationJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -163,7 +164,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -268,7 +270,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -370,7 +373,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -463,7 +467,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -553,7 +558,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -637,7 +643,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StopMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -721,7 +728,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -805,7 +813,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PromoteMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PromoteMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -907,7 +916,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for VerifyMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for VerifyMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -997,7 +1007,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RestartMigrationJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestartMigrationJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1066,7 +1077,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateSshScript {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateSshScript {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1136,7 +1148,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateTcpProxyScript {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateTcpProxyScript {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1223,7 +1236,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnectionProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnectionProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1269,7 +1283,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1391,7 +1406,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1510,7 +1526,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1605,7 +1622,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1721,7 +1739,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1767,7 +1786,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1854,7 +1874,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPrivateConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPrivateConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1943,7 +1964,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1989,7 +2011,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2072,7 +2095,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConversionWorkspaces {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConversionWorkspaces {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2182,7 +2206,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2289,7 +2314,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2384,7 +2410,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2451,7 +2478,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMappingRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMappingRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2503,7 +2531,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMappingRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMappingRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2576,7 +2605,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMappingRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMappingRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2619,7 +2649,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMappingRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMappingRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2723,7 +2754,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SeedConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SeedConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2834,7 +2866,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportMappingRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportMappingRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2939,7 +2972,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ConvertConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ConvertConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3032,7 +3066,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CommitConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CommitConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3119,7 +3154,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RollbackConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RollbackConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3235,7 +3271,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ApplyConversionWorkspace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApplyConversionWorkspace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3345,7 +3382,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DescribeDatabaseEntities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DescribeDatabaseEntities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3412,7 +3450,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchBackgroundJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchBackgroundJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3468,7 +3507,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DescribeConversionWorkspaceRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DescribeConversionWorkspaceRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3523,7 +3563,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchStaticIps {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchStaticIps {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3602,7 +3643,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3645,7 +3687,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3706,7 +3749,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3758,7 +3802,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3815,7 +3860,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3894,7 +3940,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3940,7 +3987,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3986,7 +4034,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4032,7 +4081,8 @@ pub mod data_migration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builders.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builders.rs
@@ -78,7 +78,8 @@ pub mod license_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLicensePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLicensePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -136,7 +137,8 @@ pub mod license_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateLicensePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateLicensePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -188,7 +190,8 @@ pub mod license_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Assign {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Assign {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -242,7 +245,8 @@ pub mod license_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Unassign {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Unassign {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -317,7 +321,8 @@ pub mod license_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnumerateLicensedUsers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnumerateLicensedUsers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -363,7 +368,8 @@ pub mod license_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -494,7 +500,8 @@ pub mod consumer_procurement_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PlaceOrder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PlaceOrder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -537,7 +544,8 @@ pub mod consumer_procurement_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOrder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOrder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -613,7 +621,8 @@ pub mod consumer_procurement_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOrders {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOrders {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -716,7 +725,8 @@ pub mod consumer_procurement_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ModifyOrder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ModifyOrder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -813,7 +823,8 @@ pub mod consumer_procurement_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOrder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOrder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -859,7 +870,8 @@ pub mod consumer_procurement_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/confidentialcomputing/v1/src/builders.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builders.rs
@@ -87,7 +87,8 @@ pub mod confidential_computing {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateChallenge {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateChallenge {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -188,7 +189,8 @@ pub mod confidential_computing {
         }
     }
 
-    impl gax::options::RequestBuilder for VerifyAttestation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for VerifyAttestation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -267,7 +269,8 @@ pub mod confidential_computing {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -310,7 +313,8 @@ pub mod confidential_computing {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/config/v1/src/builders.rs
+++ b/src/generated/cloud/config/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeployments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeployments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -257,7 +259,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +360,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -460,7 +464,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -540,7 +545,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -581,7 +587,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -622,7 +629,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for GetResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -702,7 +710,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ListResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -754,7 +763,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportDeploymentStatefile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportDeploymentStatefile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -800,7 +810,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportRevisionStatefile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportRevisionStatefile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -853,7 +864,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportStatefile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportStatefile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -900,7 +912,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteStatefile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteStatefile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -979,7 +992,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for LockDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LockDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1067,7 +1081,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for UnlockDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UnlockDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1108,7 +1123,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportLockInfo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportLockInfo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1207,7 +1223,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePreview {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePreview {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1248,7 +1265,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPreview {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPreview {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1328,7 +1346,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPreviews {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPreviews {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1412,7 +1431,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePreview {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePreview {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1456,7 +1476,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportPreviewResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportPreviewResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1539,7 +1560,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTerraformVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTerraformVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1583,7 +1605,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTerraformVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTerraformVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1660,7 +1683,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1701,7 +1725,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1760,7 +1785,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1810,7 +1836,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1865,7 +1892,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1942,7 +1970,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1986,7 +2015,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2030,7 +2060,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2074,7 +2105,8 @@ pub mod config {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/connectors/v1/src/builders.rs
+++ b/src/generated/cloud/connectors/v1/src/builders.rs
@@ -119,7 +119,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -263,7 +265,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +360,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -436,7 +440,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -504,7 +509,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProviders {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProviders {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -545,7 +551,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProvider {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProvider {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -613,7 +620,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnectors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnectors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -654,7 +662,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -731,7 +740,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnectorVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnectorVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -781,7 +791,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnectorVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnectorVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -827,7 +838,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnectionSchemaMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnectionSchemaMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -914,7 +926,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for RefreshConnectionSchemaMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RefreshConnectionSchemaMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -995,7 +1008,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRuntimeEntitySchemas {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRuntimeEntitySchemas {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1076,7 +1090,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRuntimeActionSchemas {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRuntimeActionSchemas {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1120,7 +1135,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRuntimeConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRuntimeConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1164,7 +1180,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGlobalSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGlobalSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1241,7 +1258,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1282,7 +1300,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1341,7 +1360,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1391,7 +1411,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1446,7 +1467,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1523,7 +1545,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1567,7 +1590,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1611,7 +1635,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1655,7 +1680,8 @@ pub mod connectors {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/contactcenterinsights/v1/src/builders.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builders.rs
@@ -96,7 +96,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -216,7 +217,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UploadConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UploadConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -274,7 +276,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -323,7 +326,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -414,7 +418,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConversations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConversations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -466,7 +471,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -559,7 +565,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAnalysis {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAnalysis {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -602,7 +609,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAnalysis {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAnalysis {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -678,7 +686,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAnalyses {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAnalyses {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -721,7 +730,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAnalysis {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAnalysis {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -835,7 +845,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for BulkAnalyzeConversations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BulkAnalyzeConversations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -944,7 +955,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for BulkDeleteConversations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BulkDeleteConversations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1090,7 +1102,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for IngestConversations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for IngestConversations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1213,7 +1226,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportInsightsData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportInsightsData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1307,7 +1321,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIssueModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIssueModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1365,7 +1380,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateIssueModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateIssueModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1408,7 +1424,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIssueModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIssueModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1451,7 +1468,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIssueModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIssueModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1534,7 +1552,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIssueModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIssueModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1623,7 +1642,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeployIssueModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeployIssueModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1712,7 +1732,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeployIssueModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeployIssueModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1812,7 +1833,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportIssueModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportIssueModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1916,7 +1938,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportIssueModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportIssueModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1959,7 +1982,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIssue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIssue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2002,7 +2026,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIssues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIssues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2057,7 +2082,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateIssue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateIssue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2100,7 +2126,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIssue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIssue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2148,7 +2175,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CalculateIssueModelStats {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CalculateIssueModelStats {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2203,7 +2231,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePhraseMatcher {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePhraseMatcher {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2249,7 +2278,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPhraseMatcher {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPhraseMatcher {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2328,7 +2358,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPhraseMatchers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPhraseMatchers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2374,7 +2405,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePhraseMatcher {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePhraseMatcher {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2432,7 +2464,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePhraseMatcher {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePhraseMatcher {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2481,7 +2514,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CalculateStats {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CalculateStats {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2524,7 +2558,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2579,7 +2614,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2634,7 +2670,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAnalysisRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAnalysisRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2677,7 +2714,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAnalysisRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAnalysisRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2750,7 +2788,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAnalysisRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAnalysisRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2808,7 +2847,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAnalysisRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAnalysisRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2854,7 +2894,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAnalysisRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAnalysisRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2900,7 +2941,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEncryptionSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEncryptionSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2994,7 +3036,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for InitializeEncryptionSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InitializeEncryptionSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3043,7 +3086,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3086,7 +3130,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3155,7 +3200,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListViews {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListViews {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3207,7 +3253,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3250,7 +3297,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3371,7 +3419,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryMetrics {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryMetrics {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3432,7 +3481,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateQaQuestion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateQaQuestion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3475,7 +3525,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetQaQuestion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetQaQuestion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3533,7 +3584,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateQaQuestion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateQaQuestion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3579,7 +3631,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteQaQuestion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteQaQuestion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3649,7 +3702,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListQaQuestions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListQaQuestions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3710,7 +3764,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateQaScorecard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateQaScorecard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3753,7 +3808,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetQaScorecard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetQaScorecard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3811,7 +3867,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateQaScorecard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateQaScorecard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3863,7 +3920,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteQaScorecard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteQaScorecard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3936,7 +3994,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListQaScorecards {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListQaScorecards {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4001,7 +4060,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateQaScorecardRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateQaScorecardRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4047,7 +4107,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetQaScorecardRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetQaScorecardRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4150,7 +4211,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for TuneQaScorecardRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TuneQaScorecardRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4198,7 +4260,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeployQaScorecardRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeployQaScorecardRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4246,7 +4309,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeployQaScorecardRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeployQaScorecardRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4300,7 +4364,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteQaScorecardRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteQaScorecardRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4383,7 +4448,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListQaScorecardRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListQaScorecardRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4444,7 +4510,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeedbackLabel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeedbackLabel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4523,7 +4590,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeedbackLabels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeedbackLabels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4569,7 +4637,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeedbackLabel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeedbackLabel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4627,7 +4696,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeedbackLabel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeedbackLabel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4673,7 +4743,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeedbackLabel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeedbackLabel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4752,7 +4823,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAllFeedbackLabels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAllFeedbackLabels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4860,7 +4932,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for BulkUploadFeedbackLabels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BulkUploadFeedbackLabels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5002,7 +5075,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for BulkDownloadFeedbackLabels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BulkDownloadFeedbackLabels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5081,7 +5155,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5127,7 +5202,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5173,7 +5249,8 @@ pub mod contact_center_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builders.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builders.rs
@@ -91,7 +91,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for ProcessOpenLineageRunEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ProcessOpenLineageRunEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -147,7 +148,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateProcess {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateProcess {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -206,7 +208,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProcess {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProcess {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -247,7 +250,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProcess {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProcess {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -315,7 +319,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProcesses {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProcesses {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -397,7 +402,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteProcess {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteProcess {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -450,7 +456,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -506,7 +513,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -545,7 +553,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -612,7 +621,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -694,7 +704,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -753,7 +764,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLineageEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLineageEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -794,7 +806,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLineageEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLineageEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -865,7 +878,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLineageEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLineageEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -915,7 +929,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLineageEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLineageEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -992,7 +1007,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchLinks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchLinks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1078,7 +1094,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchSearchLinkProcesses {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchSearchLinkProcesses {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1155,7 +1172,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1199,7 +1217,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1243,7 +1262,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1287,7 +1307,8 @@ pub mod lineage {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/datacatalog/v1/src/builders.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builders.rs
@@ -124,7 +124,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchCatalog {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchCatalog {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -183,7 +184,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEntryGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEntryGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -230,7 +232,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEntryGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEntryGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -286,7 +289,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEntryGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEntryGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -336,7 +340,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEntryGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEntryGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -404,7 +409,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEntryGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEntryGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -460,7 +466,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -513,7 +520,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -554,7 +562,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -595,7 +604,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -651,7 +661,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -725,7 +736,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -778,7 +790,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ModifyEntryOverview {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ModifyEntryOverview {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -831,7 +844,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ModifyEntryContacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ModifyEntryContacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -890,7 +904,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTagTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTagTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -931,7 +946,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTagTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTagTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -987,7 +1003,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTagTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTagTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1037,7 +1054,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTagTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTagTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1098,7 +1116,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTagTemplateField {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTagTemplateField {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1162,7 +1181,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTagTemplateField {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTagTemplateField {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1212,7 +1232,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for RenameTagTemplateField {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RenameTagTemplateField {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1267,7 +1288,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for RenameTagTemplateFieldEnumValue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RenameTagTemplateFieldEnumValue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1317,7 +1339,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTagTemplateField {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTagTemplateField {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1364,7 +1387,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1414,7 +1438,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1455,7 +1480,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1522,7 +1548,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTags {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTags {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1627,7 +1654,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ReconcileTags {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReconcileTags {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1668,7 +1696,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for StarEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StarEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1709,7 +1738,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for UnstarEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UnstarEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1768,7 +1798,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1818,7 +1849,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1873,7 +1905,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1970,7 +2003,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2022,7 +2056,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for SetConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2063,7 +2098,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for RetrieveConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetrieveConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2109,7 +2145,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for RetrieveEffectiveConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetrieveEffectiveConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2186,7 +2223,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2230,7 +2268,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2274,7 +2313,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2318,7 +2358,8 @@ pub mod data_catalog {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2394,7 +2435,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTaxonomy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTaxonomy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2435,7 +2477,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTaxonomy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTaxonomy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2488,7 +2531,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTaxonomy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTaxonomy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2562,7 +2606,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTaxonomies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTaxonomies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2603,7 +2648,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTaxonomy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTaxonomy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2653,7 +2699,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePolicyTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePolicyTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2694,7 +2741,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePolicyTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePolicyTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2747,7 +2795,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePolicyTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePolicyTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2815,7 +2864,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPolicyTags {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPolicyTags {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2856,7 +2906,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPolicyTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPolicyTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2906,7 +2957,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2965,7 +3017,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3020,7 +3073,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3097,7 +3151,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3141,7 +3196,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3185,7 +3241,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3229,7 +3286,8 @@ pub mod policy_tag_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3311,7 +3369,8 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    impl gax::options::RequestBuilder for ReplaceTaxonomy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReplaceTaxonomy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3366,7 +3425,8 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportTaxonomies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportTaxonomies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3434,7 +3494,8 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportTaxonomies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportTaxonomies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3513,7 +3574,8 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3559,7 +3621,8 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3605,7 +3668,8 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3651,7 +3715,8 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/datafusion/v1/src/builders.rs
+++ b/src/generated/cloud/datafusion/v1/src/builders.rs
@@ -110,7 +110,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAvailableVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAvailableVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -190,7 +191,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -231,7 +233,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -325,7 +328,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -401,7 +405,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -492,7 +497,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -571,7 +577,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for RestartInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestartInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -648,7 +655,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -692,7 +700,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -736,7 +745,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -780,7 +790,8 @@ pub mod data_fusion {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/dataproc/v1/src/builders.rs
+++ b/src/generated/cloud/dataproc/v1/src/builders.rs
@@ -92,7 +92,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAutoscalingPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAutoscalingPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -143,7 +144,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAutoscalingPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAutoscalingPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -189,7 +191,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAutoscalingPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAutoscalingPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -266,7 +269,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAutoscalingPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAutoscalingPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -314,7 +318,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAutoscalingPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAutoscalingPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -375,7 +380,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -427,7 +433,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -484,7 +491,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -563,7 +571,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -609,7 +618,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -655,7 +665,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -701,7 +712,8 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -827,7 +839,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBatch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBatch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -868,7 +881,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBatch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBatch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -948,7 +962,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBatches {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBatches {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -989,7 +1004,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBatch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBatch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1048,7 +1064,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1098,7 +1115,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1153,7 +1171,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1230,7 +1249,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1274,7 +1294,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1318,7 +1339,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1362,7 +1384,8 @@ pub mod batch_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1498,7 +1521,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1623,7 +1647,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1727,7 +1752,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for StopCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1831,7 +1857,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for StartCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1933,7 +1960,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1986,7 +2014,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2066,7 +2095,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2208,7 +2238,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DiagnoseCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DiagnoseCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2267,7 +2298,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2317,7 +2349,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2372,7 +2405,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2449,7 +2483,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2493,7 +2528,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2537,7 +2573,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2581,7 +2618,8 @@ pub mod cluster_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2666,7 +2704,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for SubmitJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubmitJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2760,7 +2799,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for SubmitJobAsOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubmitJobAsOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2811,7 +2851,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2905,7 +2946,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2973,7 +3015,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3026,7 +3069,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3079,7 +3123,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3138,7 +3183,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3188,7 +3234,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3243,7 +3290,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3320,7 +3368,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3364,7 +3413,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3408,7 +3458,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3452,7 +3503,8 @@ pub mod job_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3583,7 +3635,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNodeGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNodeGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3686,7 +3739,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ResizeNodeGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResizeNodeGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3729,7 +3783,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNodeGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNodeGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3790,7 +3845,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3842,7 +3898,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3899,7 +3956,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3978,7 +4036,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4024,7 +4083,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4070,7 +4130,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4116,7 +4177,8 @@ pub mod node_group_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4199,7 +4261,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSessionTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSessionTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4248,7 +4311,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSessionTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSessionTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4294,7 +4358,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSessionTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSessionTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4373,7 +4438,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSessionTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSessionTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4419,7 +4485,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSessionTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSessionTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4480,7 +4547,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4532,7 +4600,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4589,7 +4658,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4668,7 +4738,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4714,7 +4785,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4760,7 +4832,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4806,7 +4879,8 @@ pub mod session_template_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4933,7 +5007,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4974,7 +5049,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5048,7 +5124,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSessions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSessions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5137,7 +5214,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for TerminateSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TerminateSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5223,7 +5301,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5282,7 +5361,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5332,7 +5412,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5387,7 +5468,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5464,7 +5546,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5508,7 +5591,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5552,7 +5636,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5596,7 +5681,8 @@ pub mod session_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5679,7 +5765,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWorkflowTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWorkflowTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5731,7 +5818,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkflowTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkflowTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5837,7 +5925,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for InstantiateWorkflowTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InstantiateWorkflowTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5935,7 +6024,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for InstantiateInlineWorkflowTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InstantiateInlineWorkflowTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5984,7 +6074,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWorkflowTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWorkflowTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6057,7 +6148,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkflowTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkflowTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6109,7 +6201,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWorkflowTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWorkflowTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6170,7 +6263,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6222,7 +6316,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6279,7 +6374,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6358,7 +6454,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6404,7 +6501,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6450,7 +6548,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6496,7 +6595,8 @@ pub mod workflow_template_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/datastream/v1/src/builders.rs
+++ b/src/generated/cloud/datastream/v1/src/builders.rs
@@ -118,7 +118,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnectionProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnectionProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -162,7 +163,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -282,7 +284,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -399,7 +402,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -486,7 +490,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -565,7 +570,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for DiscoverConnectionProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DiscoverConnectionProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -645,7 +651,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for ListStreams {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListStreams {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -686,7 +693,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for GetStream {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetStream {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -797,7 +805,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateStream {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateStream {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -905,7 +914,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateStream {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateStream {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -987,7 +997,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteStream {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteStream {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1080,7 +1091,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for RunStream {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunStream {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1121,7 +1133,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for GetStreamObject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetStreamObject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1176,7 +1189,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupStreamObject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupStreamObject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1247,7 +1261,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for ListStreamObjects {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListStreamObjects {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1291,7 +1306,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for StartBackfillJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartBackfillJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1332,7 +1348,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for StopBackfillJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopBackfillJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1385,7 +1402,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchStaticIps {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchStaticIps {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1499,7 +1517,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1543,7 +1562,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1628,7 +1648,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPrivateConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPrivateConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1721,7 +1742,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1820,7 +1842,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1861,7 +1884,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1941,7 +1965,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2023,7 +2048,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2100,7 +2126,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2141,7 +2168,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2218,7 +2246,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2262,7 +2291,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2306,7 +2336,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2350,7 +2381,8 @@ pub mod datastream {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/deploy/v1/src/builders.rs
+++ b/src/generated/cloud/deploy/v1/src/builders.rs
@@ -116,7 +116,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeliveryPipelines {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeliveryPipelines {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeliveryPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeliveryPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -272,7 +274,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDeliveryPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDeliveryPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -387,7 +390,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDeliveryPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDeliveryPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -496,7 +500,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDeliveryPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDeliveryPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -576,7 +581,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTargets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTargets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -669,7 +675,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for RollbackTarget {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RollbackTarget {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -710,7 +717,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTarget {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTarget {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -815,7 +823,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTarget {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTarget {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -923,7 +932,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTarget {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTarget {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1023,7 +1033,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTarget {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTarget {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1106,7 +1117,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCustomTargetTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCustomTargetTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1150,7 +1162,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCustomTargetType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCustomTargetType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1262,7 +1275,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCustomTargetType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCustomTargetType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1377,7 +1391,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCustomTargetType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCustomTargetType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1480,7 +1495,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCustomTargetType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCustomTargetType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1560,7 +1576,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReleases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReleases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1601,7 +1618,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRelease {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRelease {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1717,7 +1735,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRelease {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRelease {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1758,7 +1777,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for AbandonRelease {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AbandonRelease {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1867,7 +1887,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDeployPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDeployPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1979,7 +2000,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDeployPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDeployPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2082,7 +2104,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDeployPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDeployPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2165,7 +2188,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeployPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeployPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2206,7 +2230,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeployPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeployPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2264,7 +2289,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ApproveRollout {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApproveRollout {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2322,7 +2348,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for AdvanceRollout {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AdvanceRollout {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2374,7 +2401,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelRollout {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelRollout {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2454,7 +2482,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRollouts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRollouts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2495,7 +2524,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRollout {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRollout {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2617,7 +2647,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRollout {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRollout {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2681,7 +2712,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for IgnoreJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for IgnoreJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2745,7 +2777,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for RetryJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetryJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2825,7 +2858,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListJobRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListJobRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2866,7 +2900,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJobRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJobRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2918,7 +2953,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for TerminateJobRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TerminateJobRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2959,7 +2995,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3068,7 +3105,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAutomation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAutomation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3180,7 +3218,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAutomation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAutomation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3283,7 +3322,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAutomation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAutomation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3324,7 +3364,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAutomation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAutomation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3404,7 +3445,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAutomations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAutomations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3448,7 +3490,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAutomationRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAutomationRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3531,7 +3574,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAutomationRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAutomationRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3575,7 +3619,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelAutomationRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelAutomationRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3652,7 +3697,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3693,7 +3739,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3752,7 +3799,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3802,7 +3850,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3857,7 +3906,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3934,7 +3984,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3978,7 +4029,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4022,7 +4074,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4066,7 +4119,8 @@ pub mod cloud_deploy {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/developerconnect/v1/src/builders.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -263,7 +265,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -375,7 +378,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -472,7 +476,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -586,7 +591,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGitRepositoryLink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGitRepositoryLink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -685,7 +691,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGitRepositoryLink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGitRepositoryLink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -770,7 +777,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGitRepositoryLinks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGitRepositoryLinks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -814,7 +822,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGitRepositoryLink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGitRepositoryLink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -858,7 +867,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchReadWriteToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchReadWriteToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -899,7 +909,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchReadToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchReadToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -974,7 +985,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchLinkableGitRepositories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchLinkableGitRepositories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1020,7 +1032,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchGitHubInstallations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchGitHubInstallations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1082,7 +1095,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchGitRefs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchGitRefs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1159,7 +1173,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1200,7 +1215,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1277,7 +1293,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1321,7 +1338,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1365,7 +1383,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1409,7 +1428,8 @@ pub mod developer_connect {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/dialogflow/cx/v3/src/builders.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builders.rs
@@ -101,7 +101,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAgents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAgents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -142,7 +143,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -192,7 +194,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -245,7 +248,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -286,7 +290,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -400,7 +405,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -494,7 +500,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -541,7 +548,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ValidateAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ValidateAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -593,7 +601,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAgentValidationResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAgentValidationResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -643,7 +652,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGenerativeSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGenerativeSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -703,7 +713,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGenerativeSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGenerativeSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -780,7 +791,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -821,7 +833,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -898,7 +911,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -942,7 +956,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -986,7 +1001,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1086,7 +1102,8 @@ pub mod changelogs {
         }
     }
 
-    impl gax::options::RequestBuilder for ListChangelogs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListChangelogs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1127,7 +1144,8 @@ pub mod changelogs {
         }
     }
 
-    impl gax::options::RequestBuilder for GetChangelog {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetChangelog {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1204,7 +1222,8 @@ pub mod changelogs {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1245,7 +1264,8 @@ pub mod changelogs {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1322,7 +1342,8 @@ pub mod changelogs {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1366,7 +1387,8 @@ pub mod changelogs {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1410,7 +1432,8 @@ pub mod changelogs {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1504,7 +1527,8 @@ pub mod deployments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeployments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeployments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1545,7 +1569,8 @@ pub mod deployments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1622,7 +1647,8 @@ pub mod deployments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1663,7 +1689,8 @@ pub mod deployments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1740,7 +1767,8 @@ pub mod deployments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1784,7 +1812,8 @@ pub mod deployments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1828,7 +1857,8 @@ pub mod deployments {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1901,7 +1931,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1960,7 +1991,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2022,7 +2054,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2072,7 +2105,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2146,7 +2180,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2270,7 +2305,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2383,7 +2419,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2460,7 +2497,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2501,7 +2539,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2578,7 +2617,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2622,7 +2662,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2666,7 +2707,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2763,7 +2805,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEnvironments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEnvironments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2804,7 +2847,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2892,7 +2936,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2983,7 +3028,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3027,7 +3073,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3102,7 +3149,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for LookupEnvironmentHistory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LookupEnvironmentHistory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3189,7 +3237,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for RunContinuousTest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunContinuousTest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3264,7 +3313,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListContinuousTestResults {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListContinuousTestResults {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3350,7 +3400,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for DeployFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeployFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3427,7 +3478,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3468,7 +3520,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3545,7 +3598,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3589,7 +3643,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3633,7 +3688,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3727,7 +3783,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExperiments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExperiments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3768,7 +3825,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3821,7 +3879,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3877,7 +3936,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3921,7 +3981,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3962,7 +4023,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for StartExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4003,7 +4065,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for StopExperiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopExperiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4080,7 +4143,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4121,7 +4185,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4198,7 +4263,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4242,7 +4308,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4286,7 +4353,8 @@ pub mod experiments {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4365,7 +4433,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4412,7 +4481,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4485,7 +4555,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFlows {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFlows {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4532,7 +4603,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4588,7 +4660,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4664,7 +4737,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for TrainFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TrainFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4711,7 +4785,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for ValidateFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ValidateFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4763,7 +4838,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFlowValidationResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFlowValidationResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4868,7 +4944,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4956,7 +5033,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportFlow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportFlow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5033,7 +5111,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5074,7 +5153,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5151,7 +5231,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5195,7 +5276,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5239,7 +5321,8 @@ pub mod flows {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5339,7 +5422,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGenerators {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGenerators {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5386,7 +5470,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGenerator {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGenerator {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5442,7 +5527,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGenerator {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGenerator {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5501,7 +5587,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGenerator {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGenerator {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5548,7 +5635,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGenerator {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGenerator {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5625,7 +5713,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5666,7 +5755,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5743,7 +5833,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5787,7 +5878,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5831,7 +5923,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5937,7 +6030,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIntents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIntents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5984,7 +6078,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6040,7 +6135,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6099,7 +6195,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6140,7 +6237,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6240,7 +6338,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportIntents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportIntents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6353,7 +6452,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportIntents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportIntents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6430,7 +6530,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6471,7 +6572,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6548,7 +6650,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6592,7 +6695,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6636,7 +6740,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6735,7 +6840,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6782,7 +6888,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6835,7 +6942,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6891,7 +6999,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6938,7 +7047,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7015,7 +7125,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7056,7 +7167,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7133,7 +7245,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7177,7 +7290,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7221,7 +7335,8 @@ pub mod pages {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7306,7 +7421,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecuritySettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecuritySettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7352,7 +7468,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecuritySettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecuritySettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7412,7 +7529,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSecuritySettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSecuritySettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7485,7 +7603,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecuritySettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecuritySettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7531,7 +7650,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSecuritySettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSecuritySettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7610,7 +7730,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7653,7 +7774,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7732,7 +7854,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7778,7 +7901,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7824,7 +7948,8 @@ pub mod security_settings_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7920,7 +8045,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for DetectIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DetectIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7985,7 +8111,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for MatchIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MatchIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8051,7 +8178,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for FulfillIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FulfillIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8119,7 +8247,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for SubmitAnswerFeedback {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubmitAnswerFeedback {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8196,7 +8325,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8237,7 +8367,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8314,7 +8445,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8358,7 +8490,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8402,7 +8535,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8501,7 +8635,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSessionEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSessionEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8545,7 +8680,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSessionEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSessionEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8602,7 +8738,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSessionEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSessionEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8662,7 +8799,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSessionEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSessionEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8708,7 +8846,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSessionEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSessionEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8785,7 +8924,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8826,7 +8966,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8903,7 +9044,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8947,7 +9089,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8991,7 +9134,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9094,7 +9238,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTestCases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTestCases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9149,7 +9294,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeleteTestCases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeleteTestCases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9190,7 +9336,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTestCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTestCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9240,7 +9387,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTestCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTestCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9293,7 +9441,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTestCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTestCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9381,7 +9530,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for RunTestCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunTestCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9485,7 +9635,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchRunTestCases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchRunTestCases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9538,7 +9689,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for CalculateCoverage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CalculateCoverage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9629,7 +9781,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportTestCases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportTestCases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9737,7 +9890,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportTestCases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportTestCases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9814,7 +9968,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTestCaseResults {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTestCaseResults {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9858,7 +10013,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTestCaseResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTestCaseResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9935,7 +10091,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9976,7 +10133,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10053,7 +10211,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10097,7 +10256,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10141,7 +10301,8 @@ pub mod test_cases {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10252,7 +10413,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTransitionRouteGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTransitionRouteGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10306,7 +10468,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTransitionRouteGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTransitionRouteGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10371,7 +10534,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTransitionRouteGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTransitionRouteGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10439,7 +10603,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTransitionRouteGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTransitionRouteGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10493,7 +10658,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTransitionRouteGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTransitionRouteGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10572,7 +10738,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10615,7 +10782,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10694,7 +10862,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10740,7 +10909,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10786,7 +10956,8 @@ pub mod transition_route_groups {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10880,7 +11051,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10921,7 +11093,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11010,7 +11183,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11063,7 +11237,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11104,7 +11279,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11186,7 +11362,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for LoadVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LoadVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11239,7 +11416,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for CompareVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CompareVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11316,7 +11494,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11357,7 +11536,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11434,7 +11614,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11478,7 +11659,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11522,7 +11704,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11616,7 +11799,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWebhooks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWebhooks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11657,7 +11841,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWebhook {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWebhook {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11707,7 +11892,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWebhook {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWebhook {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11760,7 +11946,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWebhook {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWebhook {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11807,7 +11994,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWebhook {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWebhook {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11884,7 +12072,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11925,7 +12114,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12002,7 +12192,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12046,7 +12237,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12090,7 +12282,8 @@ pub mod webhooks {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/dialogflow/v2/src/builders.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builders.rs
@@ -74,7 +74,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -127,7 +128,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for SetAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -168,7 +170,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +239,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchAgents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchAgents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -312,7 +316,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for TrainAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TrainAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -394,7 +399,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -479,7 +485,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -564,7 +571,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreAgent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreAgent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -614,7 +622,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetValidationResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetValidationResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -691,7 +700,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -732,7 +742,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -809,7 +820,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -853,7 +865,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -897,7 +910,8 @@ pub mod agents {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1000,7 +1014,8 @@ pub mod answer_records {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAnswerRecords {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAnswerRecords {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1056,7 +1071,8 @@ pub mod answer_records {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAnswerRecord {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAnswerRecord {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1133,7 +1149,8 @@ pub mod answer_records {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1174,7 +1191,8 @@ pub mod answer_records {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1251,7 +1269,8 @@ pub mod answer_records {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1295,7 +1314,8 @@ pub mod answer_records {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1339,7 +1359,8 @@ pub mod answer_records {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1433,7 +1454,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for ListContexts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListContexts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1474,7 +1496,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for GetContext {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetContext {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1524,7 +1547,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateContext {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateContext {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1577,7 +1601,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateContext {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateContext {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1618,7 +1643,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteContext {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteContext {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1662,7 +1688,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAllContexts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAllContexts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1739,7 +1766,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1780,7 +1808,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1857,7 +1886,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1901,7 +1931,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1945,7 +1976,8 @@ pub mod contexts {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2030,7 +2062,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2107,7 +2140,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConversations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConversations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2148,7 +2182,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2192,7 +2227,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for CompleteConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CompleteConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2250,7 +2286,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for IngestContextReferences {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for IngestContextReferences {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2324,7 +2361,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMessages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMessages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2393,7 +2431,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for SuggestConversationSummary {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SuggestConversationSummary {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2471,7 +2510,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateStatelessSummary {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateStatelessSummary {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2562,7 +2602,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateStatelessSuggestion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateStatelessSuggestion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2671,7 +2712,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchKnowledge {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchKnowledge {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2732,7 +2774,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateSuggestions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateSuggestions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2809,7 +2852,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2850,7 +2894,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2927,7 +2972,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2971,7 +3017,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3015,7 +3062,8 @@ pub mod conversations {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3145,7 +3193,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConversationDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConversationDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3191,7 +3240,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConversationDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConversationDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3268,7 +3318,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConversationDatasets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConversationDatasets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3357,7 +3408,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConversationDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConversationDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3455,7 +3507,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportConversationData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportConversationData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3534,7 +3587,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3577,7 +3631,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3656,7 +3711,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3702,7 +3758,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3748,7 +3805,8 @@ pub mod conversation_datasets {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3874,7 +3932,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConversationModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConversationModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3918,7 +3977,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConversationModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConversationModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3991,7 +4051,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConversationModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConversationModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4076,7 +4137,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConversationModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConversationModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4161,7 +4223,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for DeployConversationModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeployConversationModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4248,7 +4311,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeployConversationModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeployConversationModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4294,7 +4358,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConversationModelEvaluation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConversationModelEvaluation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4369,7 +4434,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConversationModelEvaluations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConversationModelEvaluations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4469,7 +4535,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConversationModelEvaluation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConversationModelEvaluation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4546,7 +4613,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4587,7 +4655,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4664,7 +4733,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4708,7 +4778,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4752,7 +4823,8 @@ pub mod conversation_models {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4857,7 +4929,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConversationProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConversationProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4903,7 +4976,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConversationProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConversationProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4962,7 +5036,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConversationProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConversationProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5024,7 +5099,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConversationProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConversationProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5072,7 +5148,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConversationProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConversationProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5187,7 +5264,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for SetSuggestionFeatureConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetSuggestionFeatureConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5296,7 +5374,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for ClearSuggestionFeatureConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ClearSuggestionFeatureConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5375,7 +5454,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5418,7 +5498,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5497,7 +5578,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5543,7 +5625,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5589,7 +5672,8 @@ pub mod conversation_profiles {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5689,7 +5773,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5730,7 +5815,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5819,7 +5905,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5929,7 +6016,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6007,7 +6095,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6099,7 +6188,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6200,7 +6290,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for ReloadDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReloadDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6303,7 +6394,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6380,7 +6472,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6421,7 +6514,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6498,7 +6592,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6542,7 +6637,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6586,7 +6682,8 @@ pub mod documents {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6660,7 +6757,8 @@ pub mod encryption_spec_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEncryptionSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEncryptionSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6754,7 +6852,8 @@ pub mod encryption_spec_service {
         }
     }
 
-    impl gax::options::RequestBuilder for InitializeEncryptionSpec {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InitializeEncryptionSpec {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6833,7 +6932,8 @@ pub mod encryption_spec_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6876,7 +6976,8 @@ pub mod encryption_spec_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6955,7 +7056,8 @@ pub mod encryption_spec_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7001,7 +7103,8 @@ pub mod encryption_spec_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7047,7 +7150,8 @@ pub mod encryption_spec_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7147,7 +7251,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7194,7 +7299,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7253,7 +7359,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7315,7 +7422,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7359,7 +7467,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7467,7 +7576,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchUpdateEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchUpdateEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7557,7 +7667,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeleteEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeleteEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7653,7 +7764,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateEntities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateEntities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7758,7 +7870,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchUpdateEntities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchUpdateEntities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7854,7 +7967,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeleteEntities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeleteEntities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7931,7 +8045,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7972,7 +8087,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8049,7 +8165,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8093,7 +8210,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8137,7 +8255,8 @@ pub mod entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8234,7 +8353,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEnvironments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEnvironments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8275,7 +8395,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8334,7 +8455,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8396,7 +8518,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8440,7 +8563,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8511,7 +8635,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEnvironmentHistory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEnvironmentHistory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8588,7 +8713,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8629,7 +8755,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8706,7 +8833,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8750,7 +8878,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8794,7 +8923,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8861,7 +8991,8 @@ pub mod fulfillments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFulfillment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFulfillment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8917,7 +9048,8 @@ pub mod fulfillments {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFulfillment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFulfillment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8994,7 +9126,8 @@ pub mod fulfillments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9035,7 +9168,8 @@ pub mod fulfillments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9112,7 +9246,8 @@ pub mod fulfillments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9156,7 +9291,8 @@ pub mod fulfillments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9200,7 +9336,8 @@ pub mod fulfillments {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9282,7 +9419,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGenerator {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGenerator {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9323,7 +9461,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGenerator {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGenerator {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9391,7 +9530,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGenerators {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGenerators {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9432,7 +9572,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGenerator {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGenerator {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9485,7 +9626,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGenerator {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGenerator {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9562,7 +9704,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9603,7 +9746,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9680,7 +9824,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9724,7 +9869,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9768,7 +9914,8 @@ pub mod generators {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9874,7 +10021,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIntents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIntents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9927,7 +10075,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -9989,7 +10138,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10054,7 +10204,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10095,7 +10246,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10208,7 +10360,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchUpdateIntents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchUpdateIntents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10298,7 +10451,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeleteIntents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeleteIntents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10375,7 +10529,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10416,7 +10571,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10493,7 +10649,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10537,7 +10694,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10581,7 +10739,8 @@ pub mod intents {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10684,7 +10843,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for ListKnowledgeBases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListKnowledgeBases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10728,7 +10888,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for GetKnowledgeBase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetKnowledgeBase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10781,7 +10942,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateKnowledgeBase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateKnowledgeBase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10831,7 +10993,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteKnowledgeBase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteKnowledgeBase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10887,7 +11050,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateKnowledgeBase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateKnowledgeBase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -10964,7 +11128,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11005,7 +11170,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11082,7 +11248,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11126,7 +11293,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11170,7 +11338,8 @@ pub mod knowledge_bases {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11249,7 +11418,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateParticipant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateParticipant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11290,7 +11460,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for GetParticipant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetParticipant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11361,7 +11532,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for ListParticipants {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListParticipants {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11417,7 +11589,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateParticipant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateParticipant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11513,7 +11686,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11577,7 +11751,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for SuggestArticles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SuggestArticles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11644,7 +11819,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for SuggestFaqAnswers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SuggestFaqAnswers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11709,7 +11885,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for SuggestSmartReplies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SuggestSmartReplies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11771,7 +11948,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for SuggestKnowledgeAssist {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SuggestKnowledgeAssist {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11848,7 +12026,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11889,7 +12068,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -11966,7 +12146,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12010,7 +12191,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12054,7 +12236,8 @@ pub mod participants {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12165,7 +12348,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for DetectIntent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DetectIntent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12242,7 +12426,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12283,7 +12468,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12360,7 +12546,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12404,7 +12591,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12448,7 +12636,8 @@ pub mod sessions {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12547,7 +12736,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSessionEntityTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSessionEntityTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12591,7 +12781,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSessionEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSessionEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12648,7 +12839,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSessionEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSessionEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12708,7 +12900,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSessionEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSessionEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12754,7 +12947,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSessionEntityType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSessionEntityType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12831,7 +13025,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12872,7 +13067,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12949,7 +13145,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -12993,7 +13190,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13037,7 +13235,8 @@ pub mod session_entity_types {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13131,7 +13330,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13172,7 +13372,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13222,7 +13423,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13275,7 +13477,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13316,7 +13519,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13393,7 +13597,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13434,7 +13639,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13511,7 +13717,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13555,7 +13762,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -13599,7 +13807,8 @@ pub mod versions {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/discoveryengine/v1/src/builders.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builders.rs
@@ -98,7 +98,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CompleteQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CompleteQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -198,7 +199,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportSuggestionDenyListEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportSuggestionDenyListEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -287,7 +289,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeSuggestionDenyListEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeSuggestionDenyListEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -396,7 +399,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportCompletionSuggestions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportCompletionSuggestions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -485,7 +489,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeCompletionSuggestions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeCompletionSuggestions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -562,7 +567,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -606,7 +612,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -650,7 +657,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -732,7 +740,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -773,7 +782,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -826,7 +836,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -867,7 +878,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -941,7 +953,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListControls {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListControls {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1018,7 +1031,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1062,7 +1076,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1106,7 +1121,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1251,7 +1267,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ConverseConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ConverseConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1306,7 +1323,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1352,7 +1370,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1410,7 +1429,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1453,7 +1473,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConversation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConversation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1538,7 +1559,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConversations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConversations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1674,7 +1696,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnswerQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnswerQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1717,7 +1740,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAnswer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAnswer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1769,7 +1793,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1812,7 +1837,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1867,7 +1893,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1910,7 +1937,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1992,7 +2020,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSessions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSessions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2071,7 +2100,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2117,7 +2147,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2163,7 +2194,8 @@ pub mod conversational_search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2296,7 +2328,8 @@ pub mod data_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDataStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDataStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2337,7 +2370,8 @@ pub mod data_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2411,7 +2445,8 @@ pub mod data_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDataStores {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDataStores {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2487,7 +2522,8 @@ pub mod data_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2540,7 +2576,8 @@ pub mod data_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDataStore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDataStore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2617,7 +2654,8 @@ pub mod data_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2661,7 +2699,8 @@ pub mod data_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2705,7 +2744,8 @@ pub mod data_store_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2772,7 +2812,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2840,7 +2881,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2896,7 +2938,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2955,7 +2998,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2996,7 +3040,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3128,7 +3173,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3240,7 +3286,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3297,7 +3344,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchGetDocumentsMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchGetDocumentsMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3374,7 +3422,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3418,7 +3467,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3462,7 +3512,8 @@ pub mod document_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3582,7 +3633,8 @@ pub mod engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3658,7 +3710,8 @@ pub mod engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3711,7 +3764,8 @@ pub mod engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3752,7 +3806,8 @@ pub mod engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3826,7 +3881,8 @@ pub mod engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEngines {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEngines {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3903,7 +3959,8 @@ pub mod engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3947,7 +4004,8 @@ pub mod engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3991,7 +4049,8 @@ pub mod engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4128,7 +4187,8 @@ pub mod grounded_generation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateGroundedContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateGroundedContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4210,7 +4270,8 @@ pub mod grounded_generation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CheckGrounding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CheckGrounding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4289,7 +4350,8 @@ pub mod grounded_generation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4335,7 +4397,8 @@ pub mod grounded_generation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4381,7 +4444,8 @@ pub mod grounded_generation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4502,7 +4566,8 @@ pub mod project_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ProvisionProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ProvisionProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4579,7 +4644,8 @@ pub mod project_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4623,7 +4689,8 @@ pub mod project_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4667,7 +4734,8 @@ pub mod project_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4778,7 +4846,8 @@ pub mod rank_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Rank {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Rank {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4855,7 +4924,8 @@ pub mod rank_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4899,7 +4969,8 @@ pub mod rank_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4943,7 +5014,8 @@ pub mod rank_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5063,7 +5135,8 @@ pub mod recommendation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Recommend {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Recommend {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5142,7 +5215,8 @@ pub mod recommendation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5188,7 +5262,8 @@ pub mod recommendation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5234,7 +5309,8 @@ pub mod recommendation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5301,7 +5377,8 @@ pub mod schema_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSchema {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSchema {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5369,7 +5446,8 @@ pub mod schema_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSchemas {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSchemas {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5463,7 +5541,8 @@ pub mod schema_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSchema {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSchema {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5551,7 +5630,8 @@ pub mod schema_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSchema {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSchema {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5627,7 +5707,8 @@ pub mod schema_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSchema {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSchema {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5704,7 +5785,8 @@ pub mod schema_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5748,7 +5830,8 @@ pub mod schema_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5792,7 +5875,8 @@ pub mod schema_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6079,7 +6163,8 @@ pub mod search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Search {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Search {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6342,7 +6427,8 @@ pub mod search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchLite {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchLite {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6419,7 +6505,8 @@ pub mod search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6463,7 +6550,8 @@ pub mod search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6507,7 +6595,8 @@ pub mod search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6656,7 +6745,8 @@ pub mod search_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TrainCustomModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TrainCustomModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6702,7 +6792,8 @@ pub mod search_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCustomModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCustomModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6781,7 +6872,8 @@ pub mod search_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6827,7 +6919,8 @@ pub mod search_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6873,7 +6966,8 @@ pub mod search_tuning_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6947,7 +7041,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSiteSearchEngine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSiteSearchEngine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7041,7 +7136,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTargetSite {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTargetSite {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7141,7 +7237,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateTargetSites {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateTargetSites {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7184,7 +7281,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTargetSite {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTargetSite {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7272,7 +7370,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTargetSite {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTargetSite {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7355,7 +7454,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTargetSite {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTargetSite {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7425,7 +7525,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTargetSites {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTargetSites {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7516,7 +7617,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableAdvancedSiteSearch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableAdvancedSiteSearch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7607,7 +7709,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableAdvancedSiteSearch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableAdvancedSiteSearch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7708,7 +7811,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RecrawlUris {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RecrawlUris {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7797,7 +7901,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchVerifyTargetSites {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchVerifyTargetSites {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7874,7 +7979,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchDomainVerificationStatus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchDomainVerificationStatus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7953,7 +8059,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -7999,7 +8106,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8045,7 +8153,8 @@ pub mod site_search_engine_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8127,7 +8236,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WriteUserEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WriteUserEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8189,7 +8299,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CollectUserEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CollectUserEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8283,7 +8394,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeUserEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeUserEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8388,7 +8500,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportUserEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportUserEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8465,7 +8578,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8509,7 +8623,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -8553,7 +8668,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/documentai/v1/src/builders.rs
+++ b/src/generated/cloud/documentai/v1/src/builders.rs
@@ -128,7 +128,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ProcessDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ProcessDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -260,7 +261,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchProcessDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchProcessDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -306,7 +308,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchProcessorTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchProcessorTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -379,7 +382,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProcessorTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProcessorTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -425,7 +429,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProcessorType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProcessorType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -495,7 +500,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProcessors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProcessors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -538,7 +544,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProcessor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProcessor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -675,7 +682,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TrainProcessorVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TrainProcessorVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -721,7 +729,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProcessorVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProcessorVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -794,7 +803,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProcessorVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProcessorVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -878,7 +888,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteProcessorVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteProcessorVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -967,7 +978,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeployProcessorVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeployProcessorVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1058,7 +1070,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeployProcessorVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeployProcessorVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1110,7 +1123,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateProcessor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateProcessor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1188,7 +1202,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteProcessor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteProcessor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1272,7 +1287,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableProcessor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableProcessor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1361,7 +1377,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableProcessor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableProcessor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1458,7 +1475,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetDefaultProcessorVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetDefaultProcessorVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1577,7 +1595,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReviewDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReviewDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1679,7 +1698,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EvaluateProcessorVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EvaluateProcessorVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1722,7 +1742,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEvaluation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEvaluation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1792,7 +1813,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEvaluations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEvaluations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1871,7 +1893,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1914,7 +1937,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1993,7 +2017,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2039,7 +2064,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2085,7 +2111,8 @@ pub mod document_processor_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/domains/v1/src/builders.rs
+++ b/src/generated/cloud/domains/v1/src/builders.rs
@@ -80,7 +80,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchDomains {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchDomains {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -132,7 +133,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for RetrieveRegisterParameters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetrieveRegisterParameters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -257,7 +259,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for RegisterDomain {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RegisterDomain {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -309,7 +312,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for RetrieveTransferParameters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetrieveTransferParameters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -434,7 +438,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for TransferDomain {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TransferDomain {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -511,7 +516,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRegistrations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRegistrations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -552,7 +558,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRegistration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRegistration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -646,7 +653,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRegistration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRegistration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -750,7 +758,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ConfigureManagementSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ConfigureManagementSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -856,7 +865,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ConfigureDnsSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ConfigureDnsSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -975,7 +985,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ConfigureContactSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ConfigureContactSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1057,7 +1068,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportRegistration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportRegistration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1136,7 +1148,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRegistration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRegistration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1182,7 +1195,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for RetrieveAuthorizationCode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetrieveAuthorizationCode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1226,7 +1240,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetAuthorizationCode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetAuthorizationCode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1303,7 +1318,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1347,7 +1363,8 @@ pub mod domains {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/edgecontainer/v1/src/builders.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -253,7 +255,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -349,7 +352,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -448,7 +452,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for UpgradeCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpgradeCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -530,7 +535,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -574,7 +580,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAccessToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAccessToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -620,7 +627,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateOfflineCredential {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateOfflineCredential {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -700,7 +708,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNodePools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNodePools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -741,7 +750,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -841,7 +851,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -938,7 +949,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1020,7 +1032,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1100,7 +1113,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMachines {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMachines {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1141,7 +1155,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMachine {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMachine {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1224,7 +1239,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVpnConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVpnConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1268,7 +1284,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVpnConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVpnConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1372,7 +1389,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVpnConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVpnConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1457,7 +1475,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVpnConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVpnConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1498,7 +1517,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServerConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServerConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1575,7 +1595,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1616,7 +1637,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1693,7 +1715,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1737,7 +1760,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1781,7 +1805,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1825,7 +1850,8 @@ pub mod edge_container {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/edgenetwork/v1/src/builders.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builders.rs
@@ -74,7 +74,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for InitializeZone {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InitializeZone {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -153,7 +154,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for ListZones {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListZones {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -194,7 +196,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for GetZone {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetZone {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -274,7 +277,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNetworks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNetworks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -315,7 +319,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -356,7 +361,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for DiagnoseNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DiagnoseNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -455,7 +461,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -537,7 +544,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -617,7 +625,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSubnets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSubnets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -658,7 +667,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSubnet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSubnet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -757,7 +767,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSubnet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSubnet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -853,7 +864,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSubnet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSubnet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -935,7 +947,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSubnet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSubnet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1018,7 +1031,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInterconnects {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInterconnects {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1059,7 +1073,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInterconnect {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInterconnect {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1103,7 +1118,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for DiagnoseInterconnect {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DiagnoseInterconnect {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1190,7 +1206,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInterconnectAttachments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInterconnectAttachments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1236,7 +1253,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInterconnectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInterconnectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1349,7 +1367,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInterconnectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInterconnectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1436,7 +1455,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInterconnectAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInterconnectAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1516,7 +1536,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRouters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRouters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1557,7 +1578,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRouter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRouter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1598,7 +1620,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for DiagnoseRouter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DiagnoseRouter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1697,7 +1720,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRouter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRouter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1793,7 +1817,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRouter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRouter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1875,7 +1900,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRouter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRouter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1952,7 +1978,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1993,7 +2020,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2070,7 +2098,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2114,7 +2143,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2158,7 +2188,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2202,7 +2233,8 @@ pub mod edge_network {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/essentialcontacts/v1/src/builders.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builders.rs
@@ -87,7 +87,8 @@ pub mod essential_contacts_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateContact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateContact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -142,7 +143,8 @@ pub mod essential_contacts_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateContact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateContact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -212,7 +214,8 @@ pub mod essential_contacts_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListContacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListContacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -255,7 +258,8 @@ pub mod essential_contacts_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetContact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetContact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -298,7 +302,8 @@ pub mod essential_contacts_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteContact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteContact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -379,7 +384,8 @@ pub mod essential_contacts_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ComputeContacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ComputeContacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -442,7 +448,8 @@ pub mod essential_contacts_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SendTestMessage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SendTestMessage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/eventarc/v1/src/builders.rs
+++ b/src/generated/cloud/eventarc/v1/src/builders.rs
@@ -74,7 +74,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTriggers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTriggers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -253,7 +255,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -355,7 +358,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -451,7 +455,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -492,7 +497,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -566,7 +572,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListChannels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListChannels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -665,7 +672,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -761,7 +769,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -845,7 +854,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -886,7 +896,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProvider {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProvider {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -966,7 +977,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProviders {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProviders {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1010,7 +1022,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetChannelConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetChannelConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1083,7 +1096,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListChannelConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListChannelConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1185,7 +1199,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateChannelConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateChannelConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1270,7 +1285,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteChannelConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteChannelConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1314,7 +1330,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGoogleChannelConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGoogleChannelConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1374,7 +1391,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGoogleChannelConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGoogleChannelConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1415,7 +1433,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMessageBus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMessageBus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1498,7 +1517,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMessageBuses {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMessageBuses {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1556,7 +1576,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMessageBusEnrollments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMessageBusEnrollments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1659,7 +1680,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMessageBus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMessageBus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1765,7 +1787,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMessageBus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMessageBus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1865,7 +1888,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMessageBus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMessageBus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1906,7 +1930,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEnrollment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEnrollment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1986,7 +2011,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEnrollments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEnrollments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2089,7 +2115,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEnrollment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEnrollment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2195,7 +2222,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEnrollment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEnrollment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2295,7 +2323,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEnrollment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEnrollment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2336,7 +2365,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2416,7 +2446,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPipelines {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPipelines {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2516,7 +2547,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2619,7 +2651,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2716,7 +2749,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePipeline {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePipeline {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2760,7 +2794,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGoogleApiSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGoogleApiSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2843,7 +2878,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGoogleApiSources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGoogleApiSources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2949,7 +2985,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGoogleApiSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGoogleApiSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3058,7 +3095,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGoogleApiSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGoogleApiSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3159,7 +3197,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGoogleApiSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGoogleApiSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3236,7 +3275,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3277,7 +3317,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3336,7 +3377,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3386,7 +3428,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3441,7 +3484,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3518,7 +3562,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3562,7 +3607,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3606,7 +3652,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3650,7 +3697,8 @@ pub mod eventarc {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/filestore/v1/src/builders.rs
+++ b/src/generated/cloud/filestore/v1/src/builders.rs
@@ -117,7 +117,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -257,7 +259,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -351,7 +354,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -448,7 +452,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -536,7 +541,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for RevertInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RevertInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -622,7 +628,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -710,7 +717,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSnapshots {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSnapshots {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -753,7 +761,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -850,7 +859,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -930,7 +940,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1024,7 +1035,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1106,7 +1118,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1149,7 +1162,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1246,7 +1260,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1326,7 +1341,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1420,7 +1436,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1508,7 +1525,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for PromoteReplica {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PromoteReplica {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1587,7 +1605,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1630,7 +1649,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1709,7 +1729,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1755,7 +1776,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1801,7 +1823,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1847,7 +1870,8 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/financialservices/v1/src/builders.rs
+++ b/src/generated/cloud/financialservices/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -351,7 +354,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -433,7 +437,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -554,7 +559,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportRegisteredParties {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportRegisteredParties {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -658,7 +664,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportRegisteredParties {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportRegisteredParties {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -738,7 +745,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatasets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatasets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -779,7 +787,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -878,7 +887,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -974,7 +984,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1056,7 +1067,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1136,7 +1148,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1177,7 +1190,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1276,7 +1290,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1372,7 +1387,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1468,7 +1484,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportModelMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportModelMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1550,7 +1567,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1633,7 +1651,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEngineConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEngineConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1674,7 +1693,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEngineConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEngineConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1777,7 +1797,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEngineConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEngineConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1877,7 +1898,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEngineConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEngineConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1977,7 +1999,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportEngineConfigMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportEngineConfigMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2062,7 +2085,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEngineConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEngineConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2106,7 +2130,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEngineVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEngineVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2189,7 +2214,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEngineVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEngineVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2272,7 +2298,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPredictionResults {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPredictionResults {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2316,7 +2343,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPredictionResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPredictionResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2422,7 +2450,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePredictionResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePredictionResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2525,7 +2554,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePredictionResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePredictionResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2625,7 +2655,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportPredictionResultMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportPredictionResultMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2710,7 +2741,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePredictionResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePredictionResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2793,7 +2825,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBacktestResults {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBacktestResults {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2837,7 +2870,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBacktestResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBacktestResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2941,7 +2975,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBacktestResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBacktestResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3042,7 +3077,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBacktestResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBacktestResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3142,7 +3178,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportBacktestResultMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportBacktestResultMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3227,7 +3264,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBacktestResult {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBacktestResult {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3304,7 +3342,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3345,7 +3384,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3422,7 +3462,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3466,7 +3507,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3510,7 +3552,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3554,7 +3597,8 @@ pub mod aml {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/functions/v2/src/builders.rs
+++ b/src/generated/cloud/functions/v2/src/builders.rs
@@ -80,7 +80,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFunction {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFunction {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFunctions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFunctions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFunction {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFunction {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -345,7 +348,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFunction {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFunction {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -421,7 +425,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFunction {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFunction {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -477,7 +482,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateUploadUrl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateUploadUrl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -521,7 +527,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateDownloadUrl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateDownloadUrl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -568,7 +575,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRuntimes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRuntimes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -645,7 +653,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -704,7 +713,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -754,7 +764,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -809,7 +820,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -886,7 +898,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -930,7 +943,8 @@ pub mod function_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/gkebackup/v1/src/builders.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builders.rs
@@ -130,7 +130,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackupPlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackupPlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -210,7 +211,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupPlans {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupPlans {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -251,7 +253,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupPlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupPlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -345,7 +348,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackupPlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackupPlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -430,7 +434,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackupPlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackupPlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -523,7 +528,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -603,7 +609,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -644,7 +651,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -734,7 +742,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -822,7 +831,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -905,7 +915,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVolumeBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVolumeBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -946,7 +957,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVolumeBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVolumeBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1043,7 +1055,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRestorePlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRestorePlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1126,7 +1139,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRestorePlans {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRestorePlans {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1167,7 +1181,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRestorePlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRestorePlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1261,7 +1276,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRestorePlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRestorePlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1352,7 +1368,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRestorePlan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRestorePlan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1445,7 +1462,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1525,7 +1543,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRestores {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRestores {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1566,7 +1585,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1656,7 +1676,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1744,7 +1765,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1827,7 +1849,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVolumeRestores {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVolumeRestores {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1871,7 +1894,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVolumeRestore {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVolumeRestore {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1917,7 +1941,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupIndexDownloadUrl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupIndexDownloadUrl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1994,7 +2019,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2035,7 +2061,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2094,7 +2121,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2144,7 +2172,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2199,7 +2228,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2276,7 +2306,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2320,7 +2351,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2364,7 +2396,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2408,7 +2441,8 @@ pub mod backup_for_gke {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/builders.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/builders.rs
@@ -106,7 +106,8 @@ pub mod gateway_control {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateCredentials {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateCredentials {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/gkehub/v1/src/builders.rs
+++ b/src/generated/cloud/gkehub/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMemberships {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMemberships {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -193,7 +194,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFeatures {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFeatures {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -234,7 +236,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMembership {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMembership {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -275,7 +278,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -378,7 +382,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMembership {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMembership {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -477,7 +482,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -568,7 +574,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMembership {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMembership {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -656,7 +663,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -762,7 +770,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMembership {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMembership {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -864,7 +873,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFeature {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFeature {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -946,7 +956,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateConnectManifest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateConnectManifest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1023,7 +1034,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1067,7 +1079,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1111,7 +1124,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1155,7 +1169,8 @@ pub mod gke_hub {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/gkemulticloud/v1/src/builders.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builders.rs
@@ -137,7 +137,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAttachedCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAttachedCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -238,7 +239,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAttachedCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAttachedCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -354,7 +356,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportAttachedCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportAttachedCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -398,7 +401,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAttachedCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAttachedCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -469,7 +473,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAttachedClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAttachedClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -572,7 +577,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAttachedCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAttachedCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -618,7 +624,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAttachedServerConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAttachedServerConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -689,7 +696,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAttachedClusterInstallManifest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAttachedClusterInstallManifest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -783,7 +791,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAttachedClusterAgentToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAttachedClusterAgentToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -860,7 +869,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -904,7 +914,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -948,7 +959,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -992,7 +1004,8 @@ pub mod attached_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1121,7 +1134,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAwsCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAwsCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1221,7 +1235,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAwsCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAwsCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1262,7 +1277,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAwsCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAwsCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1330,7 +1346,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAwsClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAwsClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1433,7 +1450,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAwsCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAwsCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1533,7 +1551,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAwsClusterAgentToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAwsClusterAgentToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1577,7 +1596,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAwsAccessToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAwsAccessToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1680,7 +1700,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAwsNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAwsNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1780,7 +1801,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAwsNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAwsNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1870,7 +1892,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for RollbackAwsNodePoolUpdate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RollbackAwsNodePoolUpdate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1911,7 +1934,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAwsNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAwsNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1982,7 +2006,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAwsNodePools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAwsNodePools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2085,7 +2110,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAwsNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAwsNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2129,7 +2155,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAwsOpenIdConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAwsOpenIdConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2173,7 +2200,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAwsJsonWebKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAwsJsonWebKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2217,7 +2245,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAwsServerConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAwsServerConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2294,7 +2323,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2338,7 +2368,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2382,7 +2413,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2426,7 +2458,8 @@ pub mod aws_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2555,7 +2588,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAzureClient {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAzureClient {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2596,7 +2630,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAzureClient {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAzureClient {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2667,7 +2702,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAzureClients {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAzureClients {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2758,7 +2794,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAzureClient {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAzureClient {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2861,7 +2898,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAzureCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAzureCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2961,7 +2999,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAzureCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAzureCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3002,7 +3041,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAzureCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAzureCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3073,7 +3113,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAzureClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAzureClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3176,7 +3217,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAzureCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAzureCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3276,7 +3318,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAzureClusterAgentToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAzureClusterAgentToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3322,7 +3365,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAzureAccessToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAzureAccessToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3426,7 +3470,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAzureNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAzureNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3527,7 +3572,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAzureNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAzureNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3571,7 +3617,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAzureNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAzureNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3642,7 +3689,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAzureNodePools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAzureNodePools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3745,7 +3793,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAzureNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAzureNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3789,7 +3838,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAzureOpenIdConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAzureOpenIdConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3833,7 +3883,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAzureJsonWebKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAzureJsonWebKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3877,7 +3928,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAzureServerConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAzureServerConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3954,7 +4006,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3998,7 +4051,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4042,7 +4096,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4086,7 +4141,8 @@ pub mod azure_clusters {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/gsuiteaddons/v1/src/builders.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/builders.rs
@@ -77,7 +77,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAuthorization {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAuthorization {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -136,7 +137,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -183,7 +185,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for ReplaceDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReplaceDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -224,7 +227,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -292,7 +296,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeployments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeployments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -342,7 +347,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -386,7 +392,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for InstallDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InstallDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -430,7 +437,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for UninstallDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UninstallDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -474,7 +482,8 @@ pub mod g_suite_add_ons {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstallStatus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstallStatus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/iap/v1/src/builders.rs
+++ b/src/generated/cloud/iap/v1/src/builders.rs
@@ -96,7 +96,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -205,7 +207,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -248,7 +251,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIapSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIapSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -306,7 +310,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateIapSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateIapSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -379,7 +384,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTunnelDestGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTunnelDestGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -442,7 +448,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTunnelDestGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTunnelDestGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -488,7 +495,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTunnelDestGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTunnelDestGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -534,7 +542,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTunnelDestGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTunnelDestGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -594,7 +603,8 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTunnelDestGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTunnelDestGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -665,7 +675,8 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBrands {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBrands {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -717,7 +728,8 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBrand {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBrand {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -760,7 +772,8 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBrand {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBrand {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -819,7 +832,8 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIdentityAwareProxyClient {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIdentityAwareProxyClient {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -896,7 +910,8 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIdentityAwareProxyClients {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIdentityAwareProxyClients {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -944,7 +959,8 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIdentityAwareProxyClient {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIdentityAwareProxyClient {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -992,7 +1008,8 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetIdentityAwareProxyClientSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetIdentityAwareProxyClientSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1040,7 +1057,8 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIdentityAwareProxyClient {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIdentityAwareProxyClient {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/ids/v1/src/builders.rs
+++ b/src/generated/cloud/ids/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod ids {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEndpoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEndpoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod ids {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod ids {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -336,7 +339,8 @@ pub mod ids {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -413,7 +417,8 @@ pub mod ids {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -457,7 +462,8 @@ pub mod ids {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -501,7 +507,8 @@ pub mod ids {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -545,7 +552,8 @@ pub mod ids {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/kms/inventory/v1/src/builders.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builders.rs
@@ -105,7 +105,8 @@ pub mod key_dashboard_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCryptoKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCryptoKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -177,7 +178,8 @@ pub mod key_tracking_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProtectedResourcesSummary {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProtectedResourcesSummary {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -269,7 +271,8 @@ pub mod key_tracking_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchProtectedResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchProtectedResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/kms/v1/src/builders.rs
+++ b/src/generated/cloud/kms/v1/src/builders.rs
@@ -128,7 +128,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateKeyHandle {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateKeyHandle {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -169,7 +170,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for GetKeyHandle {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetKeyHandle {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -243,7 +245,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for ListKeyHandles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListKeyHandles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -320,7 +323,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -361,7 +365,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -420,7 +425,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -470,7 +476,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -525,7 +532,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -569,7 +577,8 @@ pub mod autokey {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -651,7 +660,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAutokeyConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAutokeyConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -695,7 +705,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAutokeyConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAutokeyConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -741,7 +752,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ShowEffectiveAutokeyConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ShowEffectiveAutokeyConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -818,7 +830,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -859,7 +872,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -918,7 +932,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -968,7 +983,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1023,7 +1039,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1067,7 +1084,8 @@ pub mod autokey_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1176,7 +1194,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEkmConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEkmConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1220,7 +1239,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEkmConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEkmConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1279,7 +1299,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEkmConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEkmConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1335,7 +1356,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEkmConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEkmConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1376,7 +1398,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEkmConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEkmConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1429,7 +1452,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEkmConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEkmConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1473,7 +1497,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for VerifyConnectivity {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for VerifyConnectivity {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1550,7 +1575,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1591,7 +1617,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1650,7 +1677,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1700,7 +1728,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1755,7 +1784,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1799,7 +1829,8 @@ pub mod ekm_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1909,7 +1940,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListKeyRings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListKeyRings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2000,7 +2032,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCryptoKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCryptoKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2094,7 +2127,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCryptoKeyVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCryptoKeyVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2176,7 +2210,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListImportJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListImportJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2219,7 +2254,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetKeyRing {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetKeyRing {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2262,7 +2298,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCryptoKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCryptoKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2308,7 +2345,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCryptoKeyVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCryptoKeyVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2360,7 +2398,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPublicKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPublicKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2403,7 +2442,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetImportJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetImportJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2461,7 +2501,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateKeyRing {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateKeyRing {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2525,7 +2566,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCryptoKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCryptoKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2582,7 +2624,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCryptoKeyVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCryptoKeyVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2668,7 +2711,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportCryptoKeyVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportCryptoKeyVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2726,7 +2770,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateImportJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateImportJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2781,7 +2826,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCryptoKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCryptoKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2841,7 +2887,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCryptoKeyVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCryptoKeyVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2895,7 +2942,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCryptoKeyPrimaryVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCryptoKeyPrimaryVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2943,7 +2991,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DestroyCryptoKeyVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DestroyCryptoKeyVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2991,7 +3040,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreCryptoKeyVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreCryptoKeyVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3064,7 +3114,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Encrypt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Encrypt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3137,7 +3188,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Decrypt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Decrypt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3227,7 +3279,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RawEncrypt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RawEncrypt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3323,7 +3376,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RawDecrypt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RawDecrypt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3399,7 +3453,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AsymmetricSign {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AsymmetricSign {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3460,7 +3515,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AsymmetricDecrypt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AsymmetricDecrypt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3518,7 +3574,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for MacSign {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MacSign {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3591,7 +3648,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for MacVerify {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MacVerify {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3652,7 +3710,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateRandomBytes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateRandomBytes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3731,7 +3790,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3774,7 +3834,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3835,7 +3896,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3887,7 +3949,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3944,7 +4007,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3990,7 +4054,8 @@ pub mod key_management_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/language/v2/src/builders.rs
+++ b/src/generated/cloud/language/v2/src/builders.rs
@@ -86,7 +86,8 @@ pub mod language_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeSentiment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeSentiment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -136,7 +137,8 @@ pub mod language_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnalyzeEntities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnalyzeEntities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -180,7 +182,8 @@ pub mod language_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ClassifyText {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ClassifyText {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -233,7 +236,8 @@ pub mod language_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ModerateText {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ModerateText {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -294,7 +298,8 @@ pub mod language_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnnotateText {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnnotateText {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/location/src/builders.rs
+++ b/src/generated/cloud/location/src/builders.rs
@@ -107,7 +107,8 @@ pub mod locations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod locations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/managedidentities/v1/src/builders.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builders.rs
@@ -133,7 +133,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMicrosoftAdDomain {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMicrosoftAdDomain {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -179,7 +180,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetAdminPassword {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetAdminPassword {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -261,7 +263,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDomains {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDomains {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -304,7 +307,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDomain {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDomain {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -394,7 +398,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDomain {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDomain {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -472,7 +477,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDomain {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDomain {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -559,7 +565,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AttachTrust {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AttachTrust {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -657,7 +664,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReconfigureTrust {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReconfigureTrust {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -744,7 +752,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DetachTrust {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DetachTrust {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -831,7 +840,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ValidateTrust {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ValidateTrust {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -910,7 +920,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -956,7 +967,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1002,7 +1014,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1048,7 +1061,8 @@ pub mod managed_identities_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/memcache/v1/src/builders.rs
+++ b/src/generated/cloud/memcache/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -248,7 +250,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -339,7 +342,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -439,7 +443,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateParameters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateParameters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -515,7 +520,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -611,7 +617,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for ApplyParameters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApplyParameters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -713,7 +720,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for RescheduleMaintenance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RescheduleMaintenance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -790,7 +798,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -831,7 +840,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -908,7 +918,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -952,7 +963,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -996,7 +1008,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1040,7 +1053,8 @@ pub mod cloud_memcache {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/memorystore/v1/src/builders.rs
+++ b/src/generated/cloud/memorystore/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -351,7 +354,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -433,7 +437,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -479,7 +484,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -556,7 +562,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -597,7 +604,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -674,7 +682,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -718,7 +727,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -762,7 +772,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -806,7 +817,8 @@ pub mod memorystore {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/metastore/v1/src/builders.rs
+++ b/src/generated/cloud/metastore/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -253,7 +255,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -349,7 +352,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -431,7 +435,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -514,7 +519,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMetadataImports {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMetadataImports {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -558,7 +564,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMetadataImport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMetadataImport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -662,7 +669,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMetadataImport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMetadataImport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -763,7 +771,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMetadataImport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMetadataImport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -869,7 +878,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -968,7 +978,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1048,7 +1059,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1089,7 +1101,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1188,7 +1201,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1270,7 +1284,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1358,7 +1373,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryMetadata {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryMetadata {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1461,7 +1477,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for MoveTableToDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MoveTableToDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1562,7 +1579,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for AlterMetadataResourceLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AlterMetadataResourceLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1639,7 +1657,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1680,7 +1699,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1739,7 +1759,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1789,7 +1810,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1844,7 +1866,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1921,7 +1944,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1965,7 +1989,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2009,7 +2034,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2053,7 +2079,8 @@ pub mod dataproc_metastore {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2163,7 +2190,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFederations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFederations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2206,7 +2234,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFederation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFederation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2311,7 +2340,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFederation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFederation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2413,7 +2443,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFederation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFederation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2500,7 +2531,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFederation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFederation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2579,7 +2611,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2622,7 +2655,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2683,7 +2717,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2735,7 +2770,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2792,7 +2828,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2871,7 +2908,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2917,7 +2955,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2963,7 +3002,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3009,7 +3049,8 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/migrationcenter/v1/src/builders.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builders.rs
@@ -119,7 +119,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAssets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAssets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAsset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAsset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -225,7 +227,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAsset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAsset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -280,7 +283,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchUpdateAssets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchUpdateAssets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -327,7 +331,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAsset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAsset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -388,7 +393,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeleteAssets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeleteAssets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -447,7 +453,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ReportAssetFrames {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReportAssetFrames {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -508,7 +515,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for AggregateAssetsValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AggregateAssetsValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -608,7 +616,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateImportJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateImportJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -694,7 +703,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListImportJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListImportJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -741,7 +751,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetImportJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetImportJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -829,7 +840,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteImportJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteImportJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -926,7 +938,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateImportJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateImportJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1011,7 +1024,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ValidateImportJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ValidateImportJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1093,7 +1107,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for RunImportJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunImportJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1137,7 +1152,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetImportDataFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetImportDataFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1220,7 +1236,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListImportDataFiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListImportDataFiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1324,7 +1341,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateImportDataFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateImportDataFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1409,7 +1427,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteImportDataFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteImportDataFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1489,7 +1508,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1530,7 +1550,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1629,7 +1650,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1725,7 +1747,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1807,7 +1830,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1909,7 +1933,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for AddAssetsToGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddAssetsToGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2011,7 +2036,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveAssetsFromGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveAssetsFromGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2085,7 +2111,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListErrorFrames {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListErrorFrames {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2132,7 +2159,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetErrorFrame {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetErrorFrame {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2212,7 +2240,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2253,7 +2282,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2352,7 +2382,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2448,7 +2479,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2530,7 +2562,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2607,7 +2640,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPreferenceSets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPreferenceSets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2651,7 +2685,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPreferenceSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPreferenceSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2755,7 +2790,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePreferenceSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePreferenceSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2856,7 +2892,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePreferenceSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePreferenceSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2941,7 +2978,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePreferenceSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePreferenceSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2982,7 +3020,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3079,7 +3118,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3182,7 +3222,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateReportConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateReportConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3223,7 +3264,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReportConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReportConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3306,7 +3348,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReportConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReportConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3397,7 +3440,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteReportConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteReportConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3496,7 +3540,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3543,7 +3588,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3629,7 +3675,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReports {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReports {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3711,7 +3758,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3788,7 +3836,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3829,7 +3878,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3906,7 +3956,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3950,7 +4001,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3994,7 +4046,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4038,7 +4091,8 @@ pub mod migration_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/modelarmor/v1/src/builders.rs
+++ b/src/generated/cloud/modelarmor/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -216,7 +218,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -275,7 +278,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -322,7 +326,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -363,7 +368,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFloorSetting {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFloorSetting {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -419,7 +425,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFloorSetting {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFloorSetting {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -472,7 +479,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for SanitizeUserPrompt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SanitizeUserPrompt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -531,7 +539,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for SanitizeModelResponse {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SanitizeModelResponse {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -608,7 +617,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -649,7 +659,8 @@ pub mod model_armor {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/netapp/v1/src/builders.rs
+++ b/src/generated/cloud/netapp/v1/src/builders.rs
@@ -116,7 +116,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListStoragePools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListStoragePools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -213,7 +214,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateStoragePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateStoragePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetStoragePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetStoragePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -348,7 +351,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateStoragePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateStoragePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -427,7 +431,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteStoragePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteStoragePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -517,7 +522,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ValidateDirectoryService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ValidateDirectoryService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -601,7 +607,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for SwitchActiveReplicaZone {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SwitchActiveReplicaZone {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -681,7 +688,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVolumes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVolumes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -722,7 +730,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -815,7 +824,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -905,7 +915,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -987,7 +998,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1071,7 +1083,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for RevertVolume {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RevertVolume {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1151,7 +1164,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSnapshots {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSnapshots {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1192,7 +1206,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1286,7 +1301,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1362,7 +1378,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1453,7 +1470,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1536,7 +1554,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListActiveDirectories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListActiveDirectories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1580,7 +1599,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetActiveDirectory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetActiveDirectory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1678,7 +1698,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateActiveDirectory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateActiveDirectory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1773,7 +1794,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateActiveDirectory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateActiveDirectory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1852,7 +1874,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteActiveDirectory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteActiveDirectory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1932,7 +1955,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListKmsConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListKmsConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2026,7 +2050,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateKmsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateKmsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2067,7 +2092,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetKmsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetKmsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2158,7 +2184,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateKmsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateKmsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2237,7 +2264,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for EncryptVolumes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EncryptVolumes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2278,7 +2306,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for VerifyKmsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for VerifyKmsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2354,7 +2383,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteKmsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteKmsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2437,7 +2467,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReplications {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReplications {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2478,7 +2509,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2575,7 +2607,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateReplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateReplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2654,7 +2687,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteReplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteReplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2748,7 +2782,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateReplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateReplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2833,7 +2868,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for StopReplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopReplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2915,7 +2951,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeReplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeReplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2999,7 +3036,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ReverseReplicationDirection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReverseReplicationDirection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3110,7 +3148,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for EstablishPeering {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EstablishPeering {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3189,7 +3228,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for SyncReplication {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SyncReplication {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3286,7 +3326,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackupVault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackupVault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3327,7 +3368,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupVault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupVault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3410,7 +3452,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupVaults {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupVaults {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3504,7 +3547,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackupVault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackupVault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3583,7 +3627,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackupVault {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackupVault {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3676,7 +3721,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3717,7 +3763,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3797,7 +3844,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3873,7 +3921,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3963,7 +4012,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4060,7 +4110,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackupPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackupPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4101,7 +4152,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4184,7 +4236,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4278,7 +4331,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackupPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackupPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4357,7 +4411,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackupPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackupPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4437,7 +4492,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListQuotaRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListQuotaRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4478,7 +4534,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetQuotaRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetQuotaRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4572,7 +4629,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateQuotaRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateQuotaRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4663,7 +4721,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateQuotaRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateQuotaRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4739,7 +4798,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteQuotaRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteQuotaRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4816,7 +4876,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4857,7 +4918,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4934,7 +4996,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4978,7 +5041,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5022,7 +5086,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5066,7 +5131,8 @@ pub mod net_app {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/networkconnectivity/v1/src/builders.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builders.rs
@@ -112,7 +112,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListHubs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListHubs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -151,7 +152,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetHub {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetHub {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -247,7 +249,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateHub {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateHub {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -340,7 +343,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateHub {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateHub {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -422,7 +426,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteHub {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteHub {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -522,7 +527,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListHubSpokes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListHubSpokes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -608,7 +614,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryHubStatus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryHubStatus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -688,7 +695,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSpokes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSpokes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -729,7 +737,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSpoke {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSpoke {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -828,7 +837,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSpoke {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSpoke {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -924,7 +934,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSpoke {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSpoke {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1024,7 +1035,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RejectHubSpoke {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RejectHubSpoke {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1118,7 +1130,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AcceptHubSpoke {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AcceptHubSpoke {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1200,7 +1213,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSpoke {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSpoke {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1241,7 +1255,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRouteTable {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRouteTable {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1282,7 +1297,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1362,7 +1378,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1442,7 +1459,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRouteTables {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRouteTables {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1483,7 +1501,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1563,7 +1582,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1659,7 +1679,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1736,7 +1757,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1777,7 +1799,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1836,7 +1859,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1886,7 +1910,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1941,7 +1966,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2018,7 +2044,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2062,7 +2089,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2106,7 +2134,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2150,7 +2179,8 @@ pub mod hub_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2263,7 +2293,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPolicyBasedRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPolicyBasedRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2309,7 +2340,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPolicyBasedRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPolicyBasedRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2417,7 +2449,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePolicyBasedRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePolicyBasedRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2504,7 +2537,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePolicyBasedRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePolicyBasedRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2583,7 +2617,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2626,7 +2661,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2687,7 +2723,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2739,7 +2776,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2796,7 +2834,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2875,7 +2914,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2921,7 +2961,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2967,7 +3008,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3013,7 +3055,8 @@ pub mod policy_based_routing_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/networkmanagement/v1/src/builders.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builders.rs
@@ -120,7 +120,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnectivityTests {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnectivityTests {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnectivityTest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnectivityTest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -266,7 +268,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnectivityTest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnectivityTest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -363,7 +366,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConnectivityTest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConnectivityTest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -448,7 +452,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RerunConnectivityTest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RerunConnectivityTest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -529,7 +534,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnectivityTest {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnectivityTest {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -608,7 +614,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -651,7 +658,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -712,7 +720,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -764,7 +773,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -821,7 +831,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -900,7 +911,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -946,7 +958,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -992,7 +1005,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1038,7 +1052,8 @@ pub mod reachability_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1149,7 +1164,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVpcFlowLogsConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVpcFlowLogsConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1193,7 +1209,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVpcFlowLogsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVpcFlowLogsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1295,7 +1312,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVpcFlowLogsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVpcFlowLogsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1394,7 +1412,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVpcFlowLogsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVpcFlowLogsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1475,7 +1494,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVpcFlowLogsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVpcFlowLogsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1552,7 +1572,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1593,7 +1614,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1652,7 +1674,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1702,7 +1725,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1757,7 +1781,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1834,7 +1859,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1878,7 +1904,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1922,7 +1949,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1966,7 +1994,8 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/networksecurity/v1/src/builders.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builders.rs
@@ -108,7 +108,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAuthorizationPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAuthorizationPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -152,7 +153,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAuthorizationPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAuthorizationPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAuthorizationPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAuthorizationPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -353,7 +356,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAuthorizationPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAuthorizationPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -434,7 +438,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAuthorizationPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAuthorizationPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -505,7 +510,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServerTlsPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServerTlsPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -549,7 +555,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServerTlsPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServerTlsPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -649,7 +656,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServerTlsPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServerTlsPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -746,7 +754,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateServerTlsPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateServerTlsPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -825,7 +834,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteServerTlsPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteServerTlsPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -896,7 +906,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClientTlsPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClientTlsPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -940,7 +951,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for GetClientTlsPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetClientTlsPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1040,7 +1052,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateClientTlsPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateClientTlsPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1137,7 +1150,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateClientTlsPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateClientTlsPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1216,7 +1230,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteClientTlsPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteClientTlsPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1293,7 +1308,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1334,7 +1350,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1393,7 +1410,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1443,7 +1461,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1498,7 +1517,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1575,7 +1595,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1619,7 +1640,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1663,7 +1685,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1707,7 +1730,8 @@ pub mod network_security {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/networkservices/v1/src/builders.rs
+++ b/src/generated/cloud/networkservices/v1/src/builders.rs
@@ -120,7 +120,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLbTrafficExtensions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLbTrafficExtensions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -164,7 +165,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLbTrafficExtension {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLbTrafficExtension {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -272,7 +274,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLbTrafficExtension {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLbTrafficExtension {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -377,7 +380,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateLbTrafficExtension {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateLbTrafficExtension {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -464,7 +468,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLbTrafficExtension {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLbTrafficExtension {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -547,7 +552,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLbRouteExtensions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLbRouteExtensions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -591,7 +597,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLbRouteExtension {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLbRouteExtension {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -697,7 +704,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLbRouteExtension {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLbRouteExtension {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -800,7 +808,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateLbRouteExtension {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateLbRouteExtension {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -885,7 +894,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLbRouteExtension {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLbRouteExtension {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -962,7 +972,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1003,7 +1014,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1062,7 +1074,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1112,7 +1125,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1167,7 +1181,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1244,7 +1259,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1288,7 +1304,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1332,7 +1349,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1376,7 +1394,8 @@ pub mod dep_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1473,7 +1492,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEndpointPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEndpointPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1517,7 +1537,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEndpointPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEndpointPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1615,7 +1636,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEndpointPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEndpointPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1710,7 +1732,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEndpointPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEndpointPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1789,7 +1812,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEndpointPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEndpointPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1857,7 +1881,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGateways {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGateways {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1898,7 +1923,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1991,7 +2017,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2081,7 +2108,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2157,7 +2185,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGateway {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGateway {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2225,7 +2254,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGrpcRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGrpcRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2266,7 +2296,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGrpcRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGrpcRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2360,7 +2391,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGrpcRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGrpcRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2451,7 +2483,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGrpcRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGrpcRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2527,7 +2560,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGrpcRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGrpcRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2595,7 +2629,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListHttpRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListHttpRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2636,7 +2671,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetHttpRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetHttpRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2730,7 +2766,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateHttpRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateHttpRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2821,7 +2858,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateHttpRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateHttpRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2897,7 +2935,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteHttpRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteHttpRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2965,7 +3004,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTcpRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTcpRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3006,7 +3046,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTcpRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTcpRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3100,7 +3141,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTcpRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTcpRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3191,7 +3233,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTcpRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTcpRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3267,7 +3310,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTcpRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTcpRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3335,7 +3379,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTlsRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTlsRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3376,7 +3421,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTlsRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTlsRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3470,7 +3516,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTlsRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTlsRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3561,7 +3608,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTlsRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTlsRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3637,7 +3685,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTlsRoute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTlsRoute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3708,7 +3757,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServiceBindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServiceBindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3752,7 +3802,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServiceBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServiceBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3850,7 +3901,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServiceBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServiceBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3929,7 +3981,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteServiceBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteServiceBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3997,7 +4050,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMeshes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMeshes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4038,7 +4092,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMesh {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMesh {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4128,7 +4183,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMesh {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMesh {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4215,7 +4271,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMesh {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMesh {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4291,7 +4348,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMesh {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMesh {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4368,7 +4426,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4409,7 +4468,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4468,7 +4528,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4518,7 +4579,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4573,7 +4635,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4650,7 +4713,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4694,7 +4758,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4738,7 +4803,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4782,7 +4848,8 @@ pub mod network_services {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/notebooks/v2/src/builders.rs
+++ b/src/generated/cloud/notebooks/v2/src/builders.rs
@@ -113,7 +113,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -351,7 +354,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -433,7 +437,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -512,7 +517,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -591,7 +597,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StopInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -670,7 +677,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -716,7 +724,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CheckInstanceUpgradability {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CheckInstanceUpgradability {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -795,7 +804,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpgradeInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpgradeInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -889,7 +899,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RollbackInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RollbackInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -988,7 +999,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DiagnoseInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DiagnoseInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1065,7 +1077,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1106,7 +1119,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1165,7 +1179,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1215,7 +1230,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1270,7 +1286,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1347,7 +1364,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1391,7 +1409,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1435,7 +1454,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1479,7 +1499,8 @@ pub mod notebook_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/optimization/v1/src/builders.rs
+++ b/src/generated/cloud/optimization/v1/src/builders.rs
@@ -215,7 +215,8 @@ pub mod fleet_routing {
         }
     }
 
-    impl gax::options::RequestBuilder for OptimizeTours {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for OptimizeTours {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -311,7 +312,8 @@ pub mod fleet_routing {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchOptimizeTours {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchOptimizeTours {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -355,7 +357,8 @@ pub mod fleet_routing {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/oracledatabase/v1/src/builders.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builders.rs
@@ -108,7 +108,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCloudExadataInfrastructures {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCloudExadataInfrastructures {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCloudExadataInfrastructure {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCloudExadataInfrastructure {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -267,7 +269,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCloudExadataInfrastructure {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCloudExadataInfrastructure {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -360,7 +363,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCloudExadataInfrastructure {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCloudExadataInfrastructure {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -437,7 +441,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCloudVmClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCloudVmClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -481,7 +486,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCloudVmCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCloudVmCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -585,7 +591,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCloudVmCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCloudVmCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -676,7 +683,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCloudVmCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCloudVmCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -747,7 +755,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEntitlements {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEntitlements {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -815,7 +824,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDbServers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDbServers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -883,7 +893,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDbNodes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDbNodes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -951,7 +962,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGiVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGiVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1022,7 +1034,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDbSystemShapes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDbSystemShapes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1109,7 +1122,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAutonomousDatabases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAutonomousDatabases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1153,7 +1167,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAutonomousDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAutonomousDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1261,7 +1276,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAutonomousDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAutonomousDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1348,7 +1364,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAutonomousDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAutonomousDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1442,7 +1459,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreAutonomousDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreAutonomousDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1506,7 +1524,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAutonomousDatabaseWallet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAutonomousDatabaseWallet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1581,7 +1600,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAutonomousDbVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAutonomousDbVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1664,7 +1684,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAutonomousDatabaseCharacterSets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAutonomousDatabaseCharacterSets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1745,7 +1766,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAutonomousDatabaseBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAutonomousDatabaseBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1822,7 +1844,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1863,7 +1886,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1940,7 +1964,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1984,7 +2009,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2028,7 +2054,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2072,7 +2099,8 @@ pub mod oracle_database {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builders.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builders.rs
@@ -124,7 +124,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -165,7 +166,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +238,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEnvironments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEnvironments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -336,7 +339,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -415,7 +419,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -482,7 +487,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ExecuteAirflowCommand {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExecuteAirflowCommand {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -550,7 +556,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for StopAirflowCommand {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopAirflowCommand {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -618,7 +625,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for PollAirflowCommand {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PollAirflowCommand {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -692,7 +700,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkloads {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkloads {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -778,7 +787,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for CheckUpgrade {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CheckUpgrade {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -835,7 +845,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateUserWorkloadsSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateUserWorkloadsSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -879,7 +890,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetUserWorkloadsSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetUserWorkloadsSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -954,7 +966,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUserWorkloadsSecrets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUserWorkloadsSecrets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1005,7 +1018,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateUserWorkloadsSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateUserWorkloadsSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1051,7 +1065,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteUserWorkloadsSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteUserWorkloadsSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1108,7 +1123,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateUserWorkloadsConfigMap {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateUserWorkloadsConfigMap {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1154,7 +1170,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetUserWorkloadsConfigMap {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetUserWorkloadsConfigMap {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1229,7 +1246,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUserWorkloadsConfigMaps {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUserWorkloadsConfigMaps {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1280,7 +1298,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateUserWorkloadsConfigMap {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateUserWorkloadsConfigMap {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1326,7 +1345,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteUserWorkloadsConfigMap {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteUserWorkloadsConfigMap {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1412,7 +1432,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for SaveSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SaveSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1522,7 +1543,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for LoadSnapshot {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LoadSnapshot {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1607,7 +1629,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for DatabaseFailover {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DatabaseFailover {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1653,7 +1676,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchDatabaseProperties {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchDatabaseProperties {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1730,7 +1754,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1774,7 +1799,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1818,7 +1844,8 @@ pub mod environments {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1921,7 +1948,8 @@ pub mod image_versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListImageVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListImageVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1998,7 +2026,8 @@ pub mod image_versions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2042,7 +2071,8 @@ pub mod image_versions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2086,7 +2116,8 @@ pub mod image_versions {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/orgpolicy/v2/src/builders.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/builders.rs
@@ -101,7 +101,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConstraints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConstraints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -169,7 +170,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -210,7 +212,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +257,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEffectivePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEffectivePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -304,7 +308,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +362,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -404,7 +410,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -459,7 +466,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCustomConstraint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCustomConstraint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -508,7 +516,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCustomConstraint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCustomConstraint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -552,7 +561,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCustomConstraint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCustomConstraint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -623,7 +633,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCustomConstraints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCustomConstraints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -667,7 +678,8 @@ pub mod org_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCustomConstraint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCustomConstraint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/osconfig/v1/src/builders.rs
+++ b/src/generated/cloud/osconfig/v1/src/builders.rs
@@ -127,7 +127,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ExecutePatchJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExecutePatchJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -168,7 +169,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPatchJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPatchJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -209,7 +211,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelPatchJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelPatchJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -283,7 +286,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPatchJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPatchJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -364,7 +368,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPatchJobInstanceDetails {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPatchJobInstanceDetails {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -423,7 +428,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePatchDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePatchDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -467,7 +473,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPatchDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPatchDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -538,7 +545,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPatchDeployments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPatchDeployments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -582,7 +590,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePatchDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePatchDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -638,7 +647,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePatchDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePatchDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -682,7 +692,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PausePatchDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PausePatchDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -726,7 +737,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumePatchDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumePatchDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -770,7 +782,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -814,7 +827,8 @@ pub mod os_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -950,7 +964,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateOSPolicyAssignment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateOSPolicyAssignment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1055,7 +1070,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateOSPolicyAssignment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateOSPolicyAssignment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1101,7 +1117,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOSPolicyAssignment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOSPolicyAssignment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1178,7 +1195,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOSPolicyAssignments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOSPolicyAssignments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1255,7 +1273,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOSPolicyAssignmentRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOSPolicyAssignmentRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1342,7 +1361,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOSPolicyAssignment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOSPolicyAssignment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1390,7 +1410,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOSPolicyAssignmentReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOSPolicyAssignmentReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1473,7 +1494,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOSPolicyAssignmentReports {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOSPolicyAssignmentReports {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1522,7 +1544,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInventory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInventory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1604,7 +1627,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInventories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInventories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1650,7 +1674,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVulnerabilityReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVulnerabilityReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1733,7 +1758,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVulnerabilityReports {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVulnerabilityReports {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1779,7 +1805,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1825,7 +1852,8 @@ pub mod os_config_zonal_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/oslogin/v1/src/builders.rs
+++ b/src/generated/cloud/oslogin/v1/src/builders.rs
@@ -88,7 +88,8 @@ pub mod os_login_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSshPublicKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSshPublicKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -132,7 +133,8 @@ pub mod os_login_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePosixAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePosixAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -176,7 +178,8 @@ pub mod os_login_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSshPublicKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSshPublicKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -229,7 +232,8 @@ pub mod os_login_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLoginProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLoginProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -270,7 +274,8 @@ pub mod os_login_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSshPublicKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSshPublicKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -342,7 +347,8 @@ pub mod os_login_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportSshPublicKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportSshPublicKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -406,7 +412,8 @@ pub mod os_login_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSshPublicKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSshPublicKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/parallelstore/v1/src/builders.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -351,7 +354,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -433,7 +437,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -543,7 +548,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -653,7 +659,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -730,7 +737,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -771,7 +779,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -848,7 +857,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -892,7 +902,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -936,7 +947,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -980,7 +992,8 @@ pub mod parallelstore {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/parametermanager/v1/src/builders.rs
+++ b/src/generated/cloud/parametermanager/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListParameters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListParameters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetParameter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetParameter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -216,7 +218,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateParameter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateParameter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -275,7 +278,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateParameter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateParameter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -322,7 +326,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteParameter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteParameter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -405,7 +410,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListParameterVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListParameterVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -455,7 +461,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetParameterVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetParameterVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -499,7 +506,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for RenderParameterVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RenderParameterVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -566,7 +574,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateParameterVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateParameterVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -630,7 +639,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateParameterVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateParameterVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -680,7 +690,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteParameterVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteParameterVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -757,7 +768,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -798,7 +810,8 @@ pub mod parameter_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/policysimulator/v1/src/builders.rs
+++ b/src/generated/cloud/policysimulator/v1/src/builders.rs
@@ -74,7 +74,8 @@ pub mod simulator {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReplay {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReplay {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -162,7 +163,8 @@ pub mod simulator {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateReplay {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateReplay {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -233,7 +235,8 @@ pub mod simulator {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReplayResults {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReplayResults {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -310,7 +313,8 @@ pub mod simulator {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -354,7 +358,8 @@ pub mod simulator {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/builders.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/builders.rs
@@ -84,7 +84,8 @@ pub mod policy_troubleshooter {
         }
     }
 
-    impl gax::options::RequestBuilder for TroubleshootIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TroubleshootIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/policytroubleshooter/v1/src/builders.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/builders.rs
@@ -80,7 +80,8 @@ pub mod iam_checker {
         }
     }
 
-    impl gax::options::RequestBuilder for TroubleshootIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TroubleshootIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/builders.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/builders.rs
@@ -81,7 +81,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CheckOnboardingStatus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CheckOnboardingStatus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEntitlements {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEntitlements {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -256,7 +258,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchEntitlements {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchEntitlements {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -299,7 +302,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEntitlement {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEntitlement {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -404,7 +408,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEntitlement {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEntitlement {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -500,7 +505,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEntitlement {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEntitlement {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -596,7 +602,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEntitlement {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEntitlement {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -678,7 +685,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGrants {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGrants {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -765,7 +773,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchGrants {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchGrants {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -808,7 +817,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGrant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGrant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -866,7 +876,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGrant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGrant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -915,7 +926,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ApproveGrant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApproveGrant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -964,7 +976,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DenyGrant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DenyGrant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1050,7 +1063,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for RevokeGrant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RevokeGrant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1129,7 +1143,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1172,7 +1187,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1251,7 +1267,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1297,7 +1314,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1343,7 +1361,8 @@ pub mod privileged_access_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/builders.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/builders.rs
@@ -137,7 +137,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCollector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCollector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +237,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAnnotation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAnnotation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -279,7 +281,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAnnotation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAnnotation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -361,7 +364,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCollectors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCollectors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -404,7 +408,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCollector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCollector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -503,7 +508,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCollector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCollector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -590,7 +596,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCollector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCollector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -677,7 +684,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeCollector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeCollector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -767,7 +775,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for RegisterCollector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RegisterCollector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -854,7 +863,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for PauseCollector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PauseCollector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -933,7 +943,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -976,7 +987,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1055,7 +1067,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1101,7 +1114,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1147,7 +1161,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1193,7 +1208,8 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builders.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builders.rs
@@ -90,7 +90,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAssessment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAssessment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -179,7 +180,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnnotateAssessment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnnotateAssessment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -228,7 +230,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -297,7 +300,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -345,7 +349,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RetrieveLegacySecretKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetrieveLegacySecretKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -386,7 +391,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -438,7 +444,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -481,7 +488,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -530,7 +538,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for MigrateKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MigrateKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -582,7 +591,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddIpOverride {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddIpOverride {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -637,7 +647,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveIpOverride {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveIpOverride {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -707,7 +718,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIpOverrides {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIpOverrides {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -750,7 +762,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMetrics {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMetrics {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -805,7 +818,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFirewallPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFirewallPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -878,7 +892,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFirewallPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFirewallPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -924,7 +939,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFirewallPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFirewallPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -982,7 +998,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFirewallPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFirewallPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1028,7 +1045,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFirewallPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFirewallPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1087,7 +1105,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReorderFirewallPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReorderFirewallPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1164,7 +1183,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRelatedAccountGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRelatedAccountGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1243,7 +1263,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRelatedAccountGroupMemberships {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRelatedAccountGroupMemberships {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1334,7 +1355,8 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchRelatedAccountGroupMemberships {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchRelatedAccountGroupMemberships {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/recommender/v1/src/builders.rs
+++ b/src/generated/cloud/recommender/v1/src/builders.rs
@@ -107,7 +107,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInsights {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInsights {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInsight {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInsight {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -210,7 +212,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for MarkInsightAccepted {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MarkInsightAccepted {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -287,7 +290,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRecommendations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRecommendations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -331,7 +335,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRecommendation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRecommendation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -383,7 +388,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for MarkRecommendationDismissed {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MarkRecommendationDismissed {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -447,7 +453,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for MarkRecommendationClaimed {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MarkRecommendationClaimed {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -511,7 +518,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for MarkRecommendationSucceeded {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MarkRecommendationSucceeded {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -575,7 +583,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for MarkRecommendationFailed {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MarkRecommendationFailed {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -619,7 +628,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRecommenderConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRecommenderConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -685,7 +695,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRecommenderConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRecommenderConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -729,7 +740,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInsightTypeConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInsightTypeConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -795,7 +807,8 @@ pub mod recommender {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInsightTypeConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInsightTypeConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/redis/cluster/v1/src/builders.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builders.rs
@@ -101,7 +101,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -142,7 +143,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +238,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -318,7 +321,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -415,7 +419,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -461,7 +466,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for GetClusterCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetClusterCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -562,7 +568,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for RescheduleClusterMaintenance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RescheduleClusterMaintenance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -633,7 +640,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupCollections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupCollections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -677,7 +685,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupCollection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupCollection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -745,7 +754,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -786,7 +796,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -868,7 +879,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -955,7 +967,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1046,7 +1059,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for BackupCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BackupCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1123,7 +1137,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1164,7 +1179,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1241,7 +1257,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1285,7 +1302,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1329,7 +1347,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1373,7 +1392,8 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/redis/v1/src/builders.rs
+++ b/src/generated/cloud/redis/v1/src/builders.rs
@@ -101,7 +101,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -142,7 +143,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -186,7 +188,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstanceAuthString {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstanceAuthString {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -280,7 +283,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -371,7 +375,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -456,7 +461,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for UpgradeInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpgradeInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -544,7 +550,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -632,7 +639,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -725,7 +733,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for FailoverInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FailoverInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -801,7 +810,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -903,7 +913,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for RescheduleMaintenance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RescheduleMaintenance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -980,7 +991,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1021,7 +1033,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1098,7 +1111,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1142,7 +1156,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1186,7 +1201,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1230,7 +1246,8 @@ pub mod cloud_redis {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/resourcemanager/v3/src/builders.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builders.rs
@@ -74,7 +74,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFolder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFolder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFolders {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFolders {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -216,7 +218,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchFolders {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchFolders {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -298,7 +301,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFolder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFolder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -389,7 +393,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFolder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFolder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -473,7 +478,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for MoveFolder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MoveFolder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -552,7 +558,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFolder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFolder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -631,7 +638,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteFolder {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteFolder {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -681,7 +689,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -740,7 +749,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -795,7 +805,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -839,7 +850,8 @@ pub mod folders {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -906,7 +918,8 @@ pub mod organizations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOrganization {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOrganization {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -977,7 +990,8 @@ pub mod organizations {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchOrganizations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchOrganizations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1027,7 +1041,8 @@ pub mod organizations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1086,7 +1101,8 @@ pub mod organizations {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1141,7 +1157,8 @@ pub mod organizations {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1185,7 +1202,8 @@ pub mod organizations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1252,7 +1270,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1326,7 +1345,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProjects {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProjects {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1394,7 +1414,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchProjects {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchProjects {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1476,7 +1497,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1567,7 +1589,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1652,7 +1675,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for MoveProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MoveProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1731,7 +1755,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1811,7 +1836,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1861,7 +1887,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1920,7 +1947,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1975,7 +2003,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2019,7 +2048,8 @@ pub mod projects {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2113,7 +2143,8 @@ pub mod tag_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTagBindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTagBindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2205,7 +2236,8 @@ pub mod tag_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTagBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTagBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2286,7 +2318,8 @@ pub mod tag_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTagBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTagBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2357,7 +2390,8 @@ pub mod tag_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEffectiveTags {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEffectiveTags {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2401,7 +2435,8 @@ pub mod tag_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2521,7 +2556,8 @@ pub mod tag_holds {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTagHold {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTagHold {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2603,7 +2639,8 @@ pub mod tag_holds {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTagHold {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTagHold {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2677,7 +2714,8 @@ pub mod tag_holds {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTagHolds {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTagHolds {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2721,7 +2759,8 @@ pub mod tag_holds {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2815,7 +2854,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTagKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTagKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2856,7 +2896,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTagKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTagKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2900,7 +2941,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNamespacedTagKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNamespacedTagKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2988,7 +3030,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTagKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTagKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3085,7 +3128,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTagKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTagKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3176,7 +3220,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTagKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTagKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3226,7 +3271,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3285,7 +3331,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3340,7 +3387,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3384,7 +3432,8 @@ pub mod tag_keys {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3478,7 +3527,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTagValues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTagValues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3519,7 +3569,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTagValue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTagValue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3563,7 +3614,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNamespacedTagValue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNamespacedTagValue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3652,7 +3704,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTagValue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTagValue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3750,7 +3803,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTagValue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTagValue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3842,7 +3896,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTagValue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTagValue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3892,7 +3947,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3951,7 +4007,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4006,7 +4063,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4050,7 +4108,8 @@ pub mod tag_values {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/retail/v2/src/builders.rs
+++ b/src/generated/cloud/retail/v2/src/builders.rs
@@ -133,7 +133,8 @@ pub mod analytics_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportAnalyticsMetrics {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportAnalyticsMetrics {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -210,7 +211,8 @@ pub mod analytics_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod analytics_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -348,7 +351,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCatalogs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCatalogs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -401,7 +405,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCatalog {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCatalog {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -463,7 +468,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetDefaultBranch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetDefaultBranch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -507,7 +513,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDefaultBranch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDefaultBranch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -551,7 +558,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCompletionConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCompletionConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -609,7 +617,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCompletionConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCompletionConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -653,7 +662,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAttributesConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAttributesConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -711,7 +721,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAttributesConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAttributesConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -766,7 +777,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddCatalogAttribute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddCatalogAttribute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -816,7 +828,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveCatalogAttribute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveCatalogAttribute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -882,7 +895,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReplaceCatalogAttribute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReplaceCatalogAttribute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -959,7 +973,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1003,7 +1018,8 @@ pub mod catalog_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1123,7 +1139,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CompleteQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CompleteQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1225,7 +1242,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportCompletionData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportCompletionData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1302,7 +1320,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1346,7 +1365,8 @@ pub mod completion_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1428,7 +1448,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1469,7 +1490,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1522,7 +1544,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1563,7 +1586,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1637,7 +1661,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListControls {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListControls {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1714,7 +1739,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1758,7 +1784,8 @@ pub mod control_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1850,7 +1877,8 @@ pub mod generative_question_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGenerativeQuestionsFeatureConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGenerativeQuestionsFeatureConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1898,7 +1926,8 @@ pub mod generative_question_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGenerativeQuestionsFeatureConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGenerativeQuestionsFeatureConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1946,7 +1975,8 @@ pub mod generative_question_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGenerativeQuestionConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGenerativeQuestionConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2008,7 +2038,8 @@ pub mod generative_question_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGenerativeQuestionConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGenerativeQuestionConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2069,7 +2100,8 @@ pub mod generative_question_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchUpdateGenerativeQuestionConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchUpdateGenerativeQuestionConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2148,7 +2180,8 @@ pub mod generative_question_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2194,7 +2227,8 @@ pub mod generative_question_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2313,7 +2347,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2354,7 +2389,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2395,7 +2431,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PauseModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PauseModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2436,7 +2473,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2477,7 +2515,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2545,7 +2584,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2598,7 +2638,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2678,7 +2719,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TuneModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TuneModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2755,7 +2797,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2799,7 +2842,8 @@ pub mod model_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2919,7 +2963,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Predict {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Predict {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2996,7 +3041,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3040,7 +3086,8 @@ pub mod prediction_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3122,7 +3169,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateProduct {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateProduct {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3163,7 +3211,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProduct {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProduct {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3243,7 +3292,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProducts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProducts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3302,7 +3352,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProduct {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProduct {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3343,7 +3394,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteProduct {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteProduct {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3437,7 +3489,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeProducts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeProducts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3567,7 +3620,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportProducts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportProducts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3670,7 +3724,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetInventory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetInventory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3786,7 +3841,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddFulfillmentPlaces {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddFulfillmentPlaces {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3907,7 +3963,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveFulfillmentPlaces {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveFulfillmentPlaces {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4023,7 +4080,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddLocalInventories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddLocalInventories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4136,7 +4194,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveLocalInventories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveLocalInventories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4213,7 +4272,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4257,7 +4317,8 @@ pub mod product_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4535,7 +4596,8 @@ pub mod search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Search {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Search {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4612,7 +4674,8 @@ pub mod search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4656,7 +4719,8 @@ pub mod search_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4745,7 +4809,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServingConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServingConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4791,7 +4856,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteServingConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteServingConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4849,7 +4915,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateServingConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateServingConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4895,7 +4962,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServingConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServingConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4968,7 +5036,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServingConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServingConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5017,7 +5086,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5066,7 +5136,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveControl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveControl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5145,7 +5216,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5191,7 +5263,8 @@ pub mod serving_config_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5273,7 +5346,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WriteUserEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WriteUserEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5352,7 +5426,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CollectUserEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CollectUserEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5444,7 +5519,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeUserEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeUserEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5549,7 +5625,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportUserEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportUserEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5647,7 +5724,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RejoinUserEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RejoinUserEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5724,7 +5802,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5768,7 +5847,8 @@ pub mod user_event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/run/v2/src/builders.rs
+++ b/src/generated/cloud/run/v2/src/builders.rs
@@ -121,7 +121,8 @@ pub mod builds {
         }
     }
 
-    impl gax::options::RequestBuilder for SubmitBuild {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubmitBuild {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -198,7 +199,8 @@ pub mod builds {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -242,7 +244,8 @@ pub mod builds {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -286,7 +289,8 @@ pub mod builds {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -336,7 +340,8 @@ pub mod builds {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -403,7 +408,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -477,7 +483,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExecutions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExecutions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -565,7 +572,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -653,7 +661,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -730,7 +739,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -774,7 +784,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -818,7 +829,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -868,7 +880,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -988,7 +1001,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1027,7 +1041,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1100,7 +1115,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for ListJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1188,7 +1204,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1276,7 +1293,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1373,7 +1391,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for RunJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1423,7 +1442,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1482,7 +1502,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1537,7 +1558,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1614,7 +1636,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1658,7 +1681,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1702,7 +1726,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1752,7 +1777,8 @@ pub mod jobs {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1819,7 +1845,8 @@ pub mod revisions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1893,7 +1920,8 @@ pub mod revisions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1981,7 +2009,8 @@ pub mod revisions {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRevision {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRevision {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2058,7 +2087,8 @@ pub mod revisions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2102,7 +2132,8 @@ pub mod revisions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2146,7 +2177,8 @@ pub mod revisions {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2196,7 +2228,8 @@ pub mod revisions {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2319,7 +2352,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2360,7 +2394,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2434,7 +2469,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2534,7 +2570,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2622,7 +2659,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2672,7 +2710,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2731,7 +2770,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2786,7 +2826,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2863,7 +2904,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2907,7 +2949,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2951,7 +2994,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3001,7 +3045,8 @@ pub mod services {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3068,7 +3113,8 @@ pub mod tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTask {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTask {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3141,7 +3187,8 @@ pub mod tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTasks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTasks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3218,7 +3265,8 @@ pub mod tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3262,7 +3310,8 @@ pub mod tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3306,7 +3355,8 @@ pub mod tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3356,7 +3406,8 @@ pub mod tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/scheduler/v1/src/builders.rs
+++ b/src/generated/cloud/scheduler/v1/src/builders.rs
@@ -100,7 +100,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for ListJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -139,7 +140,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -186,7 +188,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +239,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -277,7 +281,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -318,7 +323,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for PauseJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PauseJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -359,7 +365,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -398,7 +405,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for RunJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -475,7 +483,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -516,7 +525,8 @@ pub mod cloud_scheduler {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/secretmanager/v1/src/builders.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builders.rs
@@ -111,7 +111,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecrets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecrets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -169,7 +170,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -224,7 +226,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -267,7 +270,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -322,7 +326,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -371,7 +376,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -450,7 +456,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecretVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecretVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -496,7 +503,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -542,7 +550,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AccessSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AccessSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -594,7 +603,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -646,7 +656,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -698,7 +709,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DestroySecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DestroySecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -759,7 +771,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -811,7 +824,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -868,7 +882,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -947,7 +962,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -990,7 +1006,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/securesourcemanager/v1/src/builders.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builders.rs
@@ -117,7 +117,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -262,7 +264,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -346,7 +349,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -431,7 +435,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRepositories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRepositories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -474,7 +479,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -573,7 +579,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -660,7 +667,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -712,7 +720,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicyRepo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicyRepo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -773,7 +782,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicyRepo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicyRepo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -830,7 +840,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissionsRepo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissionsRepo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -929,7 +940,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBranchRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBranchRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -999,7 +1011,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBranchRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBranchRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1042,7 +1055,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBranchRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBranchRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1144,7 +1158,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBranchRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBranchRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1231,7 +1246,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBranchRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBranchRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1310,7 +1326,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1353,7 +1370,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1414,7 +1432,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1466,7 +1485,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1523,7 +1543,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1602,7 +1623,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1648,7 +1670,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1694,7 +1717,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1740,7 +1764,8 @@ pub mod secure_source_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/security/privateca/v1/src/builders.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builders.rs
@@ -117,7 +117,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -245,7 +247,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCertificates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCertificates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -303,7 +306,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RevokeCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RevokeCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -367,7 +371,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCertificate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCertificate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -477,7 +482,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ActivateCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ActivateCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -587,7 +593,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -686,7 +693,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -779,7 +787,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -827,7 +836,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchCertificateAuthorityCsr {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchCertificateAuthorityCsr {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -875,7 +885,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -964,7 +975,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCertificateAuthorities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCertificateAuthorities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1057,7 +1069,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1168,7 +1181,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1275,7 +1289,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCertificateAuthority {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCertificateAuthority {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1376,7 +1391,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCaPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCaPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1474,7 +1490,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCaPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCaPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1517,7 +1534,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCaPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCaPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1599,7 +1617,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCaPools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCaPools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1689,7 +1708,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCaPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCaPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1738,7 +1758,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchCaCerts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchCaCerts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1786,7 +1807,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificateRevocationList {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificateRevocationList {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1875,7 +1897,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCertificateRevocationLists {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCertificateRevocationLists {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1984,7 +2007,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCertificateRevocationList {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCertificateRevocationList {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2094,7 +2118,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCertificateTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCertificateTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2183,7 +2208,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCertificateTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCertificateTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2229,7 +2255,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCertificateTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCertificateTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2318,7 +2345,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCertificateTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCertificateTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2425,7 +2453,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCertificateTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCertificateTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2504,7 +2533,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2547,7 +2577,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2608,7 +2639,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2660,7 +2692,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2717,7 +2750,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2796,7 +2830,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2842,7 +2877,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2888,7 +2924,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2934,7 +2971,8 @@ pub mod certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/security/publicca/v1/src/builders.rs
+++ b/src/generated/cloud/security/publicca/v1/src/builders.rs
@@ -94,7 +94,8 @@ pub mod public_certificate_authority_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateExternalAccountKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateExternalAccountKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/securitycenter/v2/src/builders.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builders.rs
@@ -90,7 +90,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateResourceValueConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateResourceValueConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -186,7 +187,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for BulkMuteFindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BulkMuteFindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -245,7 +247,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBigQueryExport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBigQueryExport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -301,7 +304,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateFinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateFinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -360,7 +364,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMuteConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMuteConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -423,7 +428,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNotificationConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNotificationConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -473,7 +479,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -517,7 +524,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBigQueryExport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBigQueryExport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -561,7 +569,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMuteConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMuteConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -607,7 +616,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNotificationConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNotificationConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -653,7 +663,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteResourceValueConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteResourceValueConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -697,7 +708,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBigQueryExport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBigQueryExport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -738,7 +750,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSimulation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSimulation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -782,7 +795,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetValuedResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetValuedResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -832,7 +846,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -873,7 +888,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMuteConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMuteConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -917,7 +933,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNotificationConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNotificationConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -961,7 +978,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetResourceValueConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetResourceValueConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1002,7 +1020,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1082,7 +1101,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GroupFindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GroupFindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1156,7 +1176,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAttackPaths {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAttackPaths {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1227,7 +1248,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBigQueryExports {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBigQueryExports {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1316,7 +1338,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1384,7 +1407,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMuteConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMuteConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1459,7 +1483,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNotificationConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNotificationConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1534,7 +1559,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListResourceValueConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListResourceValueConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1602,7 +1628,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1685,7 +1712,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListValuedResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListValuedResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1732,7 +1760,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for SetFindingState {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetFindingState {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1791,7 +1820,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1838,7 +1868,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for SetMute {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetMute {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1893,7 +1924,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1949,7 +1981,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBigQueryExport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBigQueryExport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2005,7 +2038,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateExternalSystem {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateExternalSystem {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2058,7 +2092,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2114,7 +2149,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMuteConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMuteConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2174,7 +2210,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNotificationConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNotificationConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2234,7 +2271,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateResourceValueConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateResourceValueConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2290,7 +2328,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSecurityMarks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSecurityMarks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2343,7 +2382,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2420,7 +2460,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2464,7 +2505,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2508,7 +2550,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2552,7 +2595,8 @@ pub mod security_center {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/securityposture/v1/src/builders.rs
+++ b/src/generated/cloud/securityposture/v1/src/builders.rs
@@ -101,7 +101,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPostures {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPostures {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -172,7 +173,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPostureRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPostureRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -219,7 +221,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPosture {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPosture {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -312,7 +315,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePosture {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePosture {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -408,7 +412,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePosture {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePosture {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -490,7 +495,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePosture {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePosture {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -580,7 +586,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for ExtractPosture {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExtractPosture {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -659,7 +666,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPostureDeployments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPostureDeployments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -703,7 +711,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPostureDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPostureDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -805,7 +814,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePostureDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePostureDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -904,7 +914,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePostureDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePostureDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -991,7 +1002,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePostureDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePostureDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1068,7 +1080,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPostureTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPostureTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1118,7 +1131,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPostureTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPostureTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1195,7 +1209,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1236,7 +1251,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1313,7 +1329,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1357,7 +1374,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1401,7 +1419,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1445,7 +1464,8 @@ pub mod security_posture {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/servicedirectory/v1/src/builders.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/builders.rs
@@ -86,7 +86,8 @@ pub mod lookup_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResolveService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResolveService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -163,7 +164,8 @@ pub mod lookup_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -204,7 +206,8 @@ pub mod lookup_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -290,7 +293,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNamespace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNamespace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -372,7 +376,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNamespaces {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNamespaces {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -415,7 +420,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNamespace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNamespace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -470,7 +476,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNamespace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNamespace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -513,7 +520,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNamespace {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNamespace {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -571,7 +579,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -653,7 +662,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -696,7 +706,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -751,7 +762,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -794,7 +806,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -852,7 +865,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -934,7 +948,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEndpoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEndpoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -977,7 +992,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1032,7 +1048,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1075,7 +1092,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEndpoint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEndpoint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1127,7 +1145,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1188,7 +1207,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1245,7 +1265,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1324,7 +1345,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1367,7 +1389,8 @@ pub mod registration_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/servicehealth/v1/src/builders.rs
+++ b/src/generated/cloud/servicehealth/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod service_health {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod service_health {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -239,7 +241,8 @@ pub mod service_health {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOrganizationEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOrganizationEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -283,7 +286,8 @@ pub mod service_health {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOrganizationEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOrganizationEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -364,7 +368,8 @@ pub mod service_health {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOrganizationImpacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOrganizationImpacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -408,7 +413,8 @@ pub mod service_health {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOrganizationImpact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOrganizationImpact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -485,7 +491,8 @@ pub mod service_health {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -526,7 +533,8 @@ pub mod service_health {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/shell/v1/src/builders.rs
+++ b/src/generated/cloud/shell/v1/src/builders.rs
@@ -74,7 +74,8 @@ pub mod cloud_shell_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -178,7 +179,8 @@ pub mod cloud_shell_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -286,7 +288,8 @@ pub mod cloud_shell_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AuthorizeEnvironment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AuthorizeEnvironment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -374,7 +377,8 @@ pub mod cloud_shell_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddPublicKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddPublicKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -462,7 +466,8 @@ pub mod cloud_shell_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RemovePublicKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemovePublicKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -506,7 +511,8 @@ pub mod cloud_shell_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/speech/v2/src/builders.rs
+++ b/src/generated/cloud/speech/v2/src/builders.rs
@@ -136,7 +136,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRecognizer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRecognizer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -210,7 +211,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRecognizers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRecognizers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -251,7 +253,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRecognizer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRecognizer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -351,7 +354,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRecognizer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRecognizer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -451,7 +455,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRecognizer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRecognizer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -545,7 +550,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteRecognizer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteRecognizer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -613,7 +619,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for Recognize {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Recognize {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -746,7 +753,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchRecognize {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchRecognize {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -787,7 +795,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -840,7 +849,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -943,7 +953,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCustomClass {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCustomClass {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1020,7 +1031,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCustomClasses {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCustomClasses {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1061,7 +1073,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCustomClass {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCustomClass {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1161,7 +1174,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCustomClass {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCustomClass {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1261,7 +1275,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCustomClass {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCustomClass {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1355,7 +1370,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteCustomClass {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteCustomClass {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1455,7 +1471,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePhraseSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePhraseSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1529,7 +1546,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPhraseSets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPhraseSets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1570,7 +1588,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPhraseSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPhraseSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1667,7 +1686,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePhraseSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePhraseSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1764,7 +1784,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePhraseSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePhraseSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1858,7 +1879,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeletePhraseSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeletePhraseSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1935,7 +1957,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1976,7 +1999,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2053,7 +2077,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2097,7 +2122,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2141,7 +2167,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2185,7 +2212,8 @@ pub mod speech {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/sql/v1/src/builders.rs
+++ b/src/generated/cloud/sql/v1/src/builders.rs
@@ -84,7 +84,8 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Delete {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Delete {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -137,7 +138,8 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Get {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Get {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -190,7 +192,8 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Insert {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Insert {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -249,7 +252,8 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for List {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for List {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -327,7 +331,8 @@ pub mod sql_connect_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnectSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnectSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -398,7 +403,8 @@ pub mod sql_connect_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateEphemeralCert {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateEphemeralCert {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -476,7 +482,8 @@ pub mod sql_databases_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Delete {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Delete {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -529,7 +536,8 @@ pub mod sql_databases_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Get {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Get {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -582,7 +590,8 @@ pub mod sql_databases_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Insert {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Insert {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -629,7 +638,8 @@ pub mod sql_databases_service {
         }
     }
 
-    impl gax::options::RequestBuilder for List {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for List {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -688,7 +698,8 @@ pub mod sql_databases_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Patch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Patch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -747,7 +758,8 @@ pub mod sql_databases_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Update {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Update {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -813,7 +825,8 @@ pub mod sql_flags_service {
         }
     }
 
-    impl gax::options::RequestBuilder for List {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for List {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -885,7 +898,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddServerCa {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddServerCa {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -938,7 +952,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Clone {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Clone {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -985,7 +1000,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Delete {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Delete {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1038,7 +1054,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DemoteMaster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DemoteMaster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1091,7 +1108,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Demote {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Demote {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1144,7 +1162,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Export {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Export {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1197,7 +1216,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Failover {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Failover {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1250,7 +1270,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Reencrypt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Reencrypt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1297,7 +1318,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Get {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Get {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1350,7 +1372,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Import {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Import {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1397,7 +1420,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Insert {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Insert {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1456,7 +1480,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for List {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for List {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1503,7 +1528,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServerCas {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServerCas {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1556,7 +1582,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Patch {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Patch {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1609,7 +1636,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PromoteReplica {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PromoteReplica {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1662,7 +1690,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Switchover {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Switchover {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1709,7 +1738,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetSslConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetSslConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1756,7 +1786,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Restart {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Restart {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1809,7 +1840,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1862,7 +1894,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RotateServerCa {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RotateServerCa {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1909,7 +1942,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartReplica {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartReplica {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1956,7 +1990,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StopReplica {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopReplica {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2009,7 +2044,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TruncateLog {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TruncateLog {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2062,7 +2098,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Update {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Update {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2115,7 +2152,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEphemeral {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEphemeral {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2168,7 +2206,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RescheduleMaintenance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RescheduleMaintenance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2251,7 +2290,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for VerifyExternalSyncSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for VerifyExternalSyncSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2328,7 +2368,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartExternalSync {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartExternalSync {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2381,7 +2422,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PerformDiskShrink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PerformDiskShrink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2428,7 +2470,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDiskShrinkConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDiskShrinkConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2475,7 +2518,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetReplicaSize {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetReplicaSize {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2522,7 +2566,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLatestRecoveryTime {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLatestRecoveryTime {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2575,7 +2620,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AcquireSsrsLease {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AcquireSsrsLease {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2622,7 +2668,8 @@ pub mod sql_instances_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReleaseSsrsLease {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReleaseSsrsLease {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2694,7 +2741,8 @@ pub mod sql_operations_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Get {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Get {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2753,7 +2801,8 @@ pub mod sql_operations_service {
         }
     }
 
-    impl gax::options::RequestBuilder for List {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for List {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2800,7 +2849,8 @@ pub mod sql_operations_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Cancel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Cancel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2878,7 +2928,8 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Delete {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Delete {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2931,7 +2982,8 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Get {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Get {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2984,7 +3036,8 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Insert {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Insert {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3031,7 +3084,8 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    impl gax::options::RequestBuilder for List {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for List {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3097,7 +3151,8 @@ pub mod sql_tiers_service {
         }
     }
 
-    impl gax::options::RequestBuilder for List {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for List {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3181,7 +3236,8 @@ pub mod sql_users_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Delete {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Delete {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3240,7 +3296,8 @@ pub mod sql_users_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Get {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Get {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3293,7 +3350,8 @@ pub mod sql_users_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Insert {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Insert {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3340,7 +3398,8 @@ pub mod sql_users_service {
         }
     }
 
-    impl gax::options::RequestBuilder for List {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for List {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3405,7 +3464,8 @@ pub mod sql_users_service {
         }
     }
 
-    impl gax::options::RequestBuilder for Update {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for Update {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/storageinsights/v1/src/builders.rs
+++ b/src/generated/cloud/storageinsights/v1/src/builders.rs
@@ -116,7 +116,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReportConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReportConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -157,7 +158,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReportConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReportConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -216,7 +218,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateReportConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateReportConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -278,7 +281,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateReportConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateReportConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -334,7 +338,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteReportConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteReportConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -417,7 +422,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReportDetails {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReportDetails {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -458,7 +464,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReportDetail {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReportDetail {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -535,7 +542,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -576,7 +584,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -653,7 +662,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -697,7 +707,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -741,7 +752,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -785,7 +797,8 @@ pub mod storage_insights {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/support/v2/src/builders.rs
+++ b/src/generated/cloud/support/v2/src/builders.rs
@@ -105,7 +105,8 @@ pub mod case_attachment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAttachments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAttachments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -172,7 +173,8 @@ pub mod case_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -245,7 +247,8 @@ pub mod case_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -319,7 +322,8 @@ pub mod case_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchCases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchCases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -366,7 +370,8 @@ pub mod case_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -416,7 +421,8 @@ pub mod case_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -466,7 +472,8 @@ pub mod case_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EscalateCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EscalateCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -507,7 +514,8 @@ pub mod case_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CloseCase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CloseCase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -582,7 +590,8 @@ pub mod case_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchCaseClassifications {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchCaseClassifications {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -676,7 +685,8 @@ pub mod comment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListComments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListComments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -726,7 +736,8 @@ pub mod comment_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateComment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateComment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/talent/v4/src/builders.rs
+++ b/src/generated/cloud/talent/v4/src/builders.rs
@@ -83,7 +83,8 @@ pub mod company_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCompany {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCompany {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -124,7 +125,8 @@ pub mod company_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCompany {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCompany {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -177,7 +179,8 @@ pub mod company_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCompany {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCompany {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -218,7 +221,8 @@ pub mod company_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCompany {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCompany {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -292,7 +296,8 @@ pub mod company_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCompanies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCompanies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -336,7 +341,8 @@ pub mod company_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -450,7 +456,8 @@ pub mod completion {
         }
     }
 
-    impl gax::options::RequestBuilder for CompleteQuery {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CompleteQuery {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -494,7 +501,8 @@ pub mod completion {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -573,7 +581,8 @@ pub mod event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateClientEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateClientEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -617,7 +626,8 @@ pub mod event_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -690,7 +700,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -783,7 +794,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -822,7 +834,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -872,7 +885,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -974,7 +988,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchUpdateJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchUpdateJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1015,7 +1030,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1108,7 +1124,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeleteJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeleteJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1187,7 +1204,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1352,7 +1370,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1517,7 +1536,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchJobsForAlert {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchJobsForAlert {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1561,7 +1581,8 @@ pub mod job_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1637,7 +1658,8 @@ pub mod tenant_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTenant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTenant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1678,7 +1700,8 @@ pub mod tenant_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTenant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTenant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1731,7 +1754,8 @@ pub mod tenant_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTenant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTenant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1772,7 +1796,8 @@ pub mod tenant_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTenant {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTenant {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1840,7 +1865,8 @@ pub mod tenant_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTenants {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTenants {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1884,7 +1910,8 @@ pub mod tenant_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/tasks/v2/src/builders.rs
+++ b/src/generated/cloud/tasks/v2/src/builders.rs
@@ -107,7 +107,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for ListQueues {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListQueues {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetQueue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetQueue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -198,7 +200,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateQueue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateQueue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -251,7 +254,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateQueue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateQueue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -292,7 +296,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteQueue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteQueue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -333,7 +338,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeQueue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeQueue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -374,7 +380,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for PauseQueue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PauseQueue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -415,7 +422,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeQueue {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeQueue {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -465,7 +473,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -524,7 +533,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -579,7 +589,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -652,7 +663,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTasks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTasks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -699,7 +711,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTask {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTask {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -752,7 +765,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTask {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTask {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -793,7 +807,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTask {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTask {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -840,7 +855,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for RunTask {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunTask {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -917,7 +933,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -958,7 +975,8 @@ pub mod cloud_tasks {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/telcoautomation/v1/src/builders.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builders.rs
@@ -120,7 +120,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOrchestrationClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOrchestrationClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOrchestrationCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOrchestrationCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -274,7 +276,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateOrchestrationCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateOrchestrationCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -361,7 +364,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOrchestrationCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOrchestrationCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -441,7 +445,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEdgeSlms {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEdgeSlms {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -482,7 +487,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEdgeSlm {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEdgeSlm {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -581,7 +587,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEdgeSlm {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEdgeSlm {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -663,7 +670,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEdgeSlm {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEdgeSlm {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -719,7 +727,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBlueprint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBlueprint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -772,7 +781,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBlueprint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBlueprint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -819,7 +829,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBlueprint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBlueprint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -860,7 +871,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBlueprint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBlueprint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -934,7 +946,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBlueprints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBlueprints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -978,7 +991,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ApproveBlueprint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApproveBlueprint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1022,7 +1036,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ProposeBlueprint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ProposeBlueprint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1063,7 +1078,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for RejectBlueprint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RejectBlueprint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1136,7 +1152,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBlueprintRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBlueprintRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1217,7 +1234,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchBlueprintRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchBlueprintRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1298,7 +1316,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchDeploymentRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchDeploymentRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1344,7 +1363,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for DiscardBlueprintChanges {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DiscardBlueprintChanges {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1415,7 +1435,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPublicBlueprints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPublicBlueprints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1459,7 +1480,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPublicBlueprint {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPublicBlueprint {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1518,7 +1540,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1574,7 +1597,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1621,7 +1645,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1665,7 +1690,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1739,7 +1765,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeployments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeployments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1814,7 +1841,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeploymentRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeploymentRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1860,7 +1888,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for DiscardDeploymentChanges {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DiscardDeploymentChanges {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1901,7 +1930,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ApplyDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApplyDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1947,7 +1977,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ComputeDeploymentStatus {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ComputeDeploymentStatus {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1997,7 +2028,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for RollbackDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RollbackDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2041,7 +2073,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetHydratedDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetHydratedDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2116,7 +2149,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListHydratedDeployments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListHydratedDeployments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2176,7 +2210,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateHydratedDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateHydratedDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2222,7 +2257,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ApplyHydratedDeployment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApplyHydratedDeployment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2299,7 +2335,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2340,7 +2377,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2417,7 +2455,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2461,7 +2500,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2505,7 +2545,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2549,7 +2590,8 @@ pub mod telco_automation {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/texttospeech/v1/src/builders.rs
+++ b/src/generated/cloud/texttospeech/v1/src/builders.rs
@@ -74,7 +74,8 @@ pub mod text_to_speech {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVoices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVoices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -150,7 +151,8 @@ pub mod text_to_speech {
         }
     }
 
-    impl gax::options::RequestBuilder for SynthesizeSpeech {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SynthesizeSpeech {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -227,7 +229,8 @@ pub mod text_to_speech {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -271,7 +274,8 @@ pub mod text_to_speech {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -421,7 +425,8 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    impl gax::options::RequestBuilder for SynthesizeLongAudio {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SynthesizeLongAudio {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -500,7 +505,8 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -546,7 +552,8 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/timeseriesinsights/v1/src/builders.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builders.rs
@@ -105,7 +105,8 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDataSets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDataSets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -157,7 +158,8 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDataSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDataSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -200,7 +202,8 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +257,8 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for AppendEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AppendEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -347,7 +351,8 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryDataSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryDataSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -430,7 +435,8 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for EvaluateSlice {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EvaluateSlice {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -503,7 +509,8 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    impl gax::options::RequestBuilder for EvaluateTimeseries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EvaluateTimeseries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/tpu/v2/src/builders.rs
+++ b/src/generated/cloud/tpu/v2/src/builders.rs
@@ -100,7 +100,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNodes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNodes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -141,7 +142,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -231,7 +233,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -307,7 +310,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -385,7 +389,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for StopNode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopNode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -463,7 +468,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for StartNode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartNode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -550,7 +556,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -621,7 +628,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for ListQueuedResources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListQueuedResources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -665,7 +673,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for GetQueuedResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetQueuedResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -769,7 +778,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateQueuedResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateQueuedResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -860,7 +870,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteQueuedResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteQueuedResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -943,7 +954,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetQueuedResource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetQueuedResource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -989,7 +1001,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateServiceIdentity {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateServiceIdentity {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1072,7 +1085,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAcceleratorTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAcceleratorTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1116,7 +1130,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAcceleratorType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAcceleratorType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1199,7 +1214,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRuntimeVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRuntimeVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1243,7 +1259,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRuntimeVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRuntimeVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1304,7 +1321,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGuestAttributes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGuestAttributes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1381,7 +1399,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1422,7 +1441,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1499,7 +1519,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1543,7 +1564,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1587,7 +1609,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1631,7 +1654,8 @@ pub mod tpu {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/translate/v3/src/builders.rs
+++ b/src/generated/cloud/translate/v3/src/builders.rs
@@ -142,7 +142,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TranslateText {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TranslateText {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -200,7 +201,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RomanizeText {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RomanizeText {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -273,7 +275,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DetectLanguage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DetectLanguage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -329,7 +332,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSupportedLanguages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSupportedLanguages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -459,7 +463,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TranslateDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TranslateDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -614,7 +619,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchTranslateText {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchTranslateText {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -792,7 +798,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchTranslateDocument {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchTranslateDocument {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -881,7 +888,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGlossary {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGlossary {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -973,7 +981,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGlossary {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGlossary {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1047,7 +1056,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGlossaries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGlossaries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1088,7 +1098,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGlossary {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGlossary {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1170,7 +1181,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGlossary {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGlossary {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1214,7 +1226,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGlossaryEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGlossaryEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1285,7 +1298,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGlossaryEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGlossaryEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1338,7 +1352,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGlossaryEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGlossaryEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1385,7 +1400,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGlossaryEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGlossaryEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1429,7 +1445,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGlossaryEntry {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGlossaryEntry {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1517,7 +1534,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1558,7 +1576,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1626,7 +1645,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatasets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatasets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1702,7 +1722,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1759,7 +1780,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAdaptiveMtDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAdaptiveMtDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1805,7 +1827,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAdaptiveMtDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAdaptiveMtDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1849,7 +1872,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAdaptiveMtDataset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAdaptiveMtDataset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1928,7 +1952,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAdaptiveMtDatasets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAdaptiveMtDatasets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2015,7 +2040,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AdaptiveMtTranslate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AdaptiveMtTranslate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2059,7 +2085,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAdaptiveMtFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAdaptiveMtFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2103,7 +2130,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAdaptiveMtFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAdaptiveMtFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2158,7 +2186,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportAdaptiveMtFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportAdaptiveMtFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2229,7 +2258,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAdaptiveMtFiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAdaptiveMtFiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2304,7 +2334,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAdaptiveMtSentences {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAdaptiveMtSentences {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2389,7 +2420,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2476,7 +2508,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportData {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportData {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2550,7 +2583,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExamples {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExamples {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2637,7 +2671,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2711,7 +2746,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListModels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListModels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2752,7 +2788,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2828,7 +2865,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteModel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteModel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2905,7 +2943,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2946,7 +2985,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3023,7 +3063,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3067,7 +3108,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3111,7 +3153,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3155,7 +3198,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3205,7 +3249,8 @@ pub mod translation_service {
         }
     }
 
-    impl gax::options::RequestBuilder for WaitOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WaitOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/video/livestream/v1/src/builders.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builders.rs
@@ -132,7 +132,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -212,7 +213,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListChannels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListChannels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -253,7 +255,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -341,7 +344,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -437,7 +441,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -525,7 +530,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StartChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -613,7 +619,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for StopChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -712,7 +719,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInput {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInput {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -792,7 +800,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInputs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInputs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -833,7 +842,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInput {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInput {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -915,7 +925,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInput {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInput {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1011,7 +1022,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInput {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInput {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1073,7 +1085,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1153,7 +1166,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListEvents {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListEvents {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1194,7 +1208,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1241,7 +1256,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteEvent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteEvent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1320,7 +1336,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClips {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClips {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1361,7 +1378,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetClip {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetClip {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1457,7 +1475,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateClip {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateClip {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1539,7 +1558,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteClip {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteClip {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1638,7 +1658,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAsset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAsset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1720,7 +1741,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAsset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAsset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1761,7 +1783,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAsset {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAsset {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1841,7 +1864,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAssets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAssets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1882,7 +1906,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1975,7 +2000,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2052,7 +2078,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2093,7 +2120,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2170,7 +2198,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2214,7 +2243,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2258,7 +2288,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2302,7 +2333,8 @@ pub mod livestream_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/video/stitcher/v1/src/builders.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builders.rs
@@ -130,7 +130,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCdnKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCdnKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -212,7 +213,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCdnKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCdnKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -255,7 +257,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCdnKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCdnKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -333,7 +336,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCdnKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCdnKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -425,7 +429,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCdnKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCdnKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -480,7 +485,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVodSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVodSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -523,7 +529,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVodSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVodSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -596,7 +603,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVodStitchDetails {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVodStitchDetails {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -642,7 +650,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVodStitchDetail {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVodStitchDetail {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -715,7 +724,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVodAdTagDetails {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVodAdTagDetails {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -761,7 +771,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVodAdTagDetail {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVodAdTagDetail {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -834,7 +845,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLiveAdTagDetails {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLiveAdTagDetails {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -880,7 +892,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLiveAdTagDetail {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLiveAdTagDetail {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -981,7 +994,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSlate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSlate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1063,7 +1077,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSlates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSlates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1106,7 +1121,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSlate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSlate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1198,7 +1214,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSlate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSlate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1276,7 +1293,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSlate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSlate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1331,7 +1349,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLiveSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLiveSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1374,7 +1393,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLiveSession {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLiveSession {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1479,7 +1499,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLiveConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLiveConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1561,7 +1582,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLiveConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLiveConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1604,7 +1626,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLiveConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLiveConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1685,7 +1708,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLiveConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLiveConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1781,7 +1805,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateLiveConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateLiveConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1883,7 +1908,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVodConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVodConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1965,7 +1991,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVodConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVodConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2008,7 +2035,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVodConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVodConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2086,7 +2114,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVodConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVodConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2179,7 +2208,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVodConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVodConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2258,7 +2288,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2304,7 +2335,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2350,7 +2382,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2396,7 +2429,8 @@ pub mod video_stitcher_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/video/transcoder/v1/src/builders.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/builders.rs
@@ -80,7 +80,8 @@ pub mod transcoder_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -159,7 +160,8 @@ pub mod transcoder_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -198,7 +200,8 @@ pub mod transcoder_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -245,7 +248,8 @@ pub mod transcoder_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -304,7 +308,8 @@ pub mod transcoder_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateJobTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateJobTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -387,7 +392,8 @@ pub mod transcoder_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListJobTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListJobTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -428,7 +434,8 @@ pub mod transcoder_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJobTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJobTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -478,7 +485,8 @@ pub mod transcoder_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteJobTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteJobTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/videointelligence/v1/src/builders.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builders.rs
@@ -157,7 +157,8 @@ pub mod video_intelligence_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AnnotateVideo {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AnnotateVideo {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +237,8 @@ pub mod video_intelligence_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -282,7 +284,8 @@ pub mod video_intelligence_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -328,7 +331,8 @@ pub mod video_intelligence_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -374,7 +378,8 @@ pub mod video_intelligence_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/vision/v1/src/builders.rs
+++ b/src/generated/cloud/vision/v1/src/builders.rs
@@ -99,7 +99,8 @@ pub mod image_annotator {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchAnnotateImages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchAnnotateImages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -165,7 +166,8 @@ pub mod image_annotator {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchAnnotateFiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchAnnotateFiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -285,7 +287,8 @@ pub mod image_annotator {
         }
     }
 
-    impl gax::options::RequestBuilder for AsyncBatchAnnotateImages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AsyncBatchAnnotateImages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -396,7 +399,8 @@ pub mod image_annotator {
         }
     }
 
-    impl gax::options::RequestBuilder for AsyncBatchAnnotateFiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AsyncBatchAnnotateFiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -440,7 +444,8 @@ pub mod image_annotator {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -525,7 +530,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateProductSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateProductSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -593,7 +599,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProductSets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProductSets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -634,7 +641,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProductSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProductSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -690,7 +698,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProductSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProductSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -734,7 +743,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteProductSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteProductSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -790,7 +800,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateProduct {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateProduct {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -858,7 +869,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProducts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProducts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -899,7 +911,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProduct {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProduct {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -952,7 +965,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProduct {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProduct {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -993,7 +1007,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteProduct {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteProduct {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1052,7 +1067,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateReferenceImage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateReferenceImage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1096,7 +1112,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteReferenceImage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteReferenceImage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1167,7 +1184,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReferenceImages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReferenceImages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1211,7 +1229,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReferenceImage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReferenceImage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1261,7 +1280,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for AddProductToProductSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddProductToProductSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1313,7 +1333,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveProductFromProductSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveProductFromProductSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1388,7 +1409,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProductsInProductSet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProductsInProductSet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1486,7 +1508,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportProductSets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportProductSets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1577,7 +1600,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for PurgeProducts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PurgeProducts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1621,7 +1645,8 @@ pub mod product_search {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/vmmigration/v1/src/builders.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSources {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSources {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -154,7 +155,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -253,7 +255,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -349,7 +352,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -431,7 +435,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSource {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSource {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -478,7 +483,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchInventory {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchInventory {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -569,7 +575,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUtilizationReports {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUtilizationReports {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -619,7 +626,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetUtilizationReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetUtilizationReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -727,7 +735,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateUtilizationReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateUtilizationReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -814,7 +823,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteUtilizationReport {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteUtilizationReport {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -901,7 +911,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatacenterConnectors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatacenterConnectors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -945,7 +956,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDatacenterConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDatacenterConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1053,7 +1065,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDatacenterConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDatacenterConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1140,7 +1153,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDatacenterConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDatacenterConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1231,7 +1245,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for UpgradeAppliance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpgradeAppliance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1334,7 +1349,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMigratingVm {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMigratingVm {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1423,7 +1439,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMigratingVms {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMigratingVms {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1470,7 +1487,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMigratingVm {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMigratingVm {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1570,7 +1588,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMigratingVm {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMigratingVm {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1649,7 +1668,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMigratingVm {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMigratingVm {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1731,7 +1751,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for StartMigration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartMigration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1813,7 +1834,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeMigration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeMigration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1895,7 +1917,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for PauseMigration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PauseMigration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1980,7 +2003,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for FinalizeMigration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FinalizeMigration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2080,7 +2104,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCloneJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCloneJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2162,7 +2187,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelCloneJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelCloneJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2242,7 +2268,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCloneJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCloneJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2283,7 +2310,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCloneJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCloneJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2386,7 +2414,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCutoverJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCutoverJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2471,7 +2500,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelCutoverJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelCutoverJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2551,7 +2581,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCutoverJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCutoverJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2592,7 +2623,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCutoverJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCutoverJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2672,7 +2704,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2713,7 +2746,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2812,7 +2846,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2908,7 +2943,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2990,7 +3026,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3081,7 +3118,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for AddGroupMigration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddGroupMigration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3172,7 +3210,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for RemoveGroupMigration {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RemoveGroupMigration {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3255,7 +3294,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTargetProjects {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTargetProjects {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3299,7 +3339,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTargetProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTargetProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3403,7 +3444,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTargetProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTargetProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3504,7 +3546,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTargetProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTargetProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3589,7 +3632,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTargetProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTargetProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3672,7 +3716,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListReplicationCycles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListReplicationCycles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3716,7 +3761,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetReplicationCycle {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetReplicationCycle {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3793,7 +3839,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3834,7 +3881,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3911,7 +3959,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3955,7 +4004,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3999,7 +4049,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4043,7 +4094,8 @@ pub mod vm_migration {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/vmwareengine/v1/src/builders.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builders.rs
@@ -116,7 +116,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPrivateClouds {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPrivateClouds {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -157,7 +158,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPrivateCloud {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPrivateCloud {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -266,7 +268,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePrivateCloud {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePrivateCloud {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -366,7 +369,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePrivateCloud {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePrivateCloud {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -466,7 +470,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePrivateCloud {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePrivateCloud {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -554,7 +559,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeletePrivateCloud {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeletePrivateCloud {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -634,7 +640,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -675,7 +682,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -780,7 +788,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -882,7 +891,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -964,7 +974,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1031,7 +1042,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNodes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNodes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1072,7 +1084,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1155,7 +1168,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExternalAddresses {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExternalAddresses {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1232,7 +1246,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchNetworkPolicyExternalAddresses {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchNetworkPolicyExternalAddresses {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1276,7 +1291,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetExternalAddress {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetExternalAddress {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1380,7 +1396,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateExternalAddress {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateExternalAddress {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1481,7 +1498,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateExternalAddress {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateExternalAddress {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1566,7 +1584,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteExternalAddress {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteExternalAddress {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1634,7 +1653,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSubnets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSubnets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1675,7 +1695,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSubnet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSubnet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1765,7 +1786,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSubnet {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSubnet {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1852,7 +1874,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExternalAccessRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExternalAccessRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1896,7 +1919,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetExternalAccessRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetExternalAccessRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2004,7 +2028,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateExternalAccessRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateExternalAccessRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2109,7 +2134,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateExternalAccessRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateExternalAccessRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2196,7 +2222,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteExternalAccessRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteExternalAccessRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2279,7 +2306,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLoggingServers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLoggingServers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2323,7 +2351,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLoggingServer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLoggingServer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2427,7 +2456,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLoggingServer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLoggingServer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2528,7 +2558,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateLoggingServer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateLoggingServer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2613,7 +2644,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLoggingServer {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLoggingServer {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2687,7 +2719,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNodeTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNodeTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2728,7 +2761,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNodeType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNodeType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2772,7 +2806,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ShowNsxCredentials {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ShowNsxCredentials {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2822,7 +2857,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ShowVcenterCredentials {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ShowVcenterCredentials {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2910,7 +2946,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetNsxCredentials {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetNsxCredentials {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3006,7 +3043,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ResetVcenterCredentials {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResetVcenterCredentials {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3050,7 +3088,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDnsForwarding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDnsForwarding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3151,7 +3190,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDnsForwarding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDnsForwarding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3195,7 +3235,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNetworkPeering {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNetworkPeering {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3278,7 +3319,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNetworkPeerings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNetworkPeerings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3382,7 +3424,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNetworkPeering {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNetworkPeering {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3467,7 +3510,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNetworkPeering {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNetworkPeering {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3568,7 +3612,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNetworkPeering {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNetworkPeering {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3645,7 +3690,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPeeringRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPeeringRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3751,7 +3797,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateHcxActivationKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateHcxActivationKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3822,7 +3869,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListHcxActivationKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListHcxActivationKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3866,7 +3914,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetHcxActivationKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetHcxActivationKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3910,7 +3959,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNetworkPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNetworkPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3993,7 +4043,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNetworkPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNetworkPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4097,7 +4148,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNetworkPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNetworkPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4198,7 +4250,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNetworkPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNetworkPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4283,7 +4336,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNetworkPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNetworkPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4370,7 +4424,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListManagementDnsZoneBindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListManagementDnsZoneBindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4416,7 +4471,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetManagementDnsZoneBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetManagementDnsZoneBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4529,7 +4585,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateManagementDnsZoneBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateManagementDnsZoneBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4636,7 +4693,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateManagementDnsZoneBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateManagementDnsZoneBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4723,7 +4781,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteManagementDnsZoneBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteManagementDnsZoneBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4816,7 +4875,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for RepairManagementDnsZoneBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RepairManagementDnsZoneBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -4924,7 +4984,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateVmwareEngineNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateVmwareEngineNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5029,7 +5090,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVmwareEngineNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVmwareEngineNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5122,7 +5184,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVmwareEngineNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVmwareEngineNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5166,7 +5229,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVmwareEngineNetwork {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVmwareEngineNetwork {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5253,7 +5317,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVmwareEngineNetworks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVmwareEngineNetworks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5361,7 +5426,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5405,7 +5471,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5490,7 +5557,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPrivateConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPrivateConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5595,7 +5663,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5682,7 +5751,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePrivateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePrivateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5759,7 +5829,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPrivateConnectionPeeringRoutes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPrivateConnectionPeeringRoutes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5857,7 +5928,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GrantDnsBindPermission {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GrantDnsBindPermission {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -5901,7 +5973,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDnsBindPermission {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDnsBindPermission {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6001,7 +6074,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for RevokeDnsBindPermission {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RevokeDnsBindPermission {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6078,7 +6152,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6119,7 +6194,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6178,7 +6254,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6228,7 +6305,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6283,7 +6361,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6360,7 +6439,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6404,7 +6484,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -6448,7 +6529,8 @@ pub mod vmware_engine {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/vpcaccess/v1/src/builders.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builders.rs
@@ -127,7 +127,8 @@ pub mod vpc_access_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -168,7 +169,8 @@ pub mod vpc_access_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +238,8 @@ pub mod vpc_access_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnectors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnectors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -312,7 +315,8 @@ pub mod vpc_access_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnector {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnector {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -389,7 +393,8 @@ pub mod vpc_access_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -466,7 +471,8 @@ pub mod vpc_access_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -510,7 +516,8 @@ pub mod vpc_access_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/webrisk/v1/src/builders.rs
+++ b/src/generated/cloud/webrisk/v1/src/builders.rs
@@ -94,7 +94,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ComputeThreatListDiff {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ComputeThreatListDiff {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -146,7 +147,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchUris {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchUris {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -198,7 +200,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchHashes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchHashes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -251,7 +254,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSubmission {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSubmission {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +361,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SubmitUri {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SubmitUri {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -434,7 +439,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -478,7 +484,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -522,7 +529,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -566,7 +574,8 @@ pub mod web_risk_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/websecurityscanner/v1/src/builders.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/builders.rs
@@ -86,7 +86,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateScanConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateScanConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -130,7 +131,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteScanConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteScanConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -171,7 +173,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for GetScanConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetScanConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -239,7 +242,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for ListScanConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListScanConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -295,7 +299,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateScanConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateScanConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -336,7 +341,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for StartScanRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartScanRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -377,7 +383,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for GetScanRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetScanRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -445,7 +452,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for ListScanRuns {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListScanRuns {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -486,7 +494,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for StopScanRun {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopScanRun {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -554,7 +563,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for ListCrawledUrls {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListCrawledUrls {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -595,7 +605,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -669,7 +680,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -713,7 +725,8 @@ pub mod web_security_scanner {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFindingTypeStats {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFindingTypeStats {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/workflows/executions/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/builders.rs
@@ -119,7 +119,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExecutions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExecutions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -169,7 +170,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -216,7 +218,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for GetExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -257,7 +260,8 @@ pub mod executions {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelExecution {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelExecution {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/workflows/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/v1/src/builders.rs
@@ -113,7 +113,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkflows {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkflows {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -160,7 +161,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkflow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkflow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWorkflow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWorkflow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -330,7 +333,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWorkflow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWorkflow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -421,7 +425,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWorkflow {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWorkflow {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -492,7 +497,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkflowRevisions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkflowRevisions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -569,7 +575,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -610,7 +617,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -687,7 +695,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -731,7 +740,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -775,7 +785,8 @@ pub mod workflows {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/cloud/workstations/v1/src/builders.rs
+++ b/src/generated/cloud/workstations/v1/src/builders.rs
@@ -77,7 +77,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkstationCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkstationCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -152,7 +153,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkstationClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkstationClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -260,7 +262,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWorkstationCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWorkstationCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -371,7 +374,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWorkstationCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWorkstationCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -474,7 +478,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWorkstationCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWorkstationCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -518,7 +523,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkstationConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkstationConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -591,7 +597,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkstationConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkstationConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -666,7 +673,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUsableWorkstationConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUsableWorkstationConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -774,7 +782,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWorkstationConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWorkstationConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -885,7 +894,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWorkstationConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWorkstationConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -988,7 +998,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWorkstationConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWorkstationConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1029,7 +1040,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkstation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkstation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1100,7 +1112,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkstations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkstations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1173,7 +1186,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUsableWorkstations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUsableWorkstations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1276,7 +1290,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWorkstation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWorkstation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1382,7 +1397,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWorkstation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWorkstation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1476,7 +1492,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWorkstation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWorkstation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1570,7 +1587,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for StartWorkstation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartWorkstation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1661,7 +1679,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for StopWorkstation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StopWorkstation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1716,7 +1735,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAccessToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAccessToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1775,7 +1795,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1825,7 +1846,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1880,7 +1902,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1957,7 +1980,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2001,7 +2025,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2045,7 +2070,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2089,7 +2115,8 @@ pub mod workstations {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/container/v1/src/builders.rs
+++ b/src/generated/container/v1/src/builders.rs
@@ -86,7 +86,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListClusters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListClusters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -145,7 +146,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -207,7 +209,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -275,7 +278,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -591,7 +595,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -668,7 +673,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetNodePoolAutoscaling {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetNodePoolAutoscaling {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -736,7 +742,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetLoggingService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetLoggingService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -804,7 +811,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetMonitoringService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetMonitoringService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -872,7 +880,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetAddonsConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetAddonsConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -942,7 +951,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1007,7 +1017,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateMaster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateMaster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1084,7 +1095,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetMasterAuth {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetMasterAuth {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1143,7 +1155,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteCluster {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteCluster {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1196,7 +1209,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1255,7 +1269,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1314,7 +1329,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1367,7 +1383,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServerConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServerConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1408,7 +1425,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJSONWebKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJSONWebKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1467,7 +1485,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNodePools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNodePools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1532,7 +1551,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1600,7 +1620,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1665,7 +1686,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNodePool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNodePool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1711,7 +1733,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CompleteNodePoolUpgrade {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CompleteNodePoolUpgrade {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1787,7 +1810,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for RollbackNodePoolUpgrade {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RollbackNodePoolUpgrade {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1864,7 +1888,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetNodePoolManagement {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetNodePoolManagement {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1941,7 +1966,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetLabels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetLabels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2006,7 +2032,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetLegacyAbac {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetLegacyAbac {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2071,7 +2098,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for StartIPRotation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for StartIPRotation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2133,7 +2161,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CompleteIPRotation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CompleteIPRotation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2204,7 +2233,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetNodePoolSize {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetNodePoolSize {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2275,7 +2305,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetNetworkPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetNetworkPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2348,7 +2379,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetMaintenancePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetMaintenancePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2425,7 +2457,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUsableSubnetworks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUsableSubnetworks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2471,7 +2504,8 @@ pub mod cluster_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CheckAutopilotCompatibility {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CheckAutopilotCompatibility {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/datastore/admin/v1/src/builders.rs
+++ b/src/generated/datastore/admin/v1/src/builders.rs
@@ -141,7 +141,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportEntities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportEntities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -243,7 +244,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportEntities {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportEntities {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -331,7 +333,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -416,7 +419,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -463,7 +467,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -537,7 +542,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIndexes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIndexes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -614,7 +620,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -658,7 +665,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -702,7 +710,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -746,7 +755,8 @@ pub mod datastore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/devtools/artifactregistry/v1/src/builders.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builders.rs
@@ -110,7 +110,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDockerImages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDockerImages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -151,7 +152,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDockerImage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDockerImage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -222,7 +224,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMavenArtifacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMavenArtifacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -266,7 +269,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMavenArtifact {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMavenArtifact {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -334,7 +338,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNpmPackages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNpmPackages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -375,7 +380,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNpmPackage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNpmPackage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -446,7 +452,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPythonPackages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPythonPackages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -490,7 +497,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPythonPackage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPythonPackage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -586,7 +594,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportAptArtifacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportAptArtifacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -682,7 +691,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportYumArtifacts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportYumArtifacts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -765,7 +775,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRepositories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRepositories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -806,7 +817,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -903,7 +915,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -959,7 +972,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1038,7 +1052,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1118,7 +1133,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPackages {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPackages {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1159,7 +1175,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPackage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPackage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1235,7 +1252,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePackage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePackage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1321,7 +1339,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1368,7 +1387,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1450,7 +1470,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1548,7 +1569,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchDeleteVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchDeleteVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1601,7 +1623,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1680,7 +1703,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1721,7 +1745,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1797,7 +1822,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1847,7 +1873,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateFile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateFile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1920,7 +1947,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTags {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTags {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1959,7 +1987,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2012,7 +2041,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2062,7 +2092,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2103,7 +2134,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTag {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTag {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2156,7 +2188,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2223,7 +2256,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2264,7 +2298,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2314,7 +2349,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2355,7 +2391,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2414,7 +2451,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2464,7 +2502,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2519,7 +2558,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2563,7 +2603,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProjectSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProjectSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2619,7 +2660,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProjectSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProjectSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2660,7 +2702,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVPCSCConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVPCSCConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2716,7 +2759,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateVPCSCConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateVPCSCConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2769,7 +2813,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePackage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePackage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2843,7 +2888,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAttachments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAttachments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2884,7 +2930,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2981,7 +3028,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3060,7 +3108,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAttachment {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAttachment {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3137,7 +3186,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3178,7 +3228,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3222,7 +3273,8 @@ pub mod artifact_registry {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/devtools/cloudbuild/v1/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builders.rs
@@ -127,7 +127,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBuild {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBuild {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -180,7 +181,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBuild {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBuild {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -260,7 +262,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBuilds {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBuilds {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -313,7 +316,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelBuild {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelBuild {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -404,7 +408,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for RetryBuild {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RetryBuild {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -492,7 +497,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for ApproveBuild {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ApproveBuild {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -551,7 +557,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBuildTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBuildTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -604,7 +611,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBuildTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBuildTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -681,7 +689,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBuildTriggers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBuildTriggers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -737,7 +746,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBuildTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBuildTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -805,7 +815,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBuildTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBuildTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -905,7 +916,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for RunBuildTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunBuildTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -976,7 +988,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for ReceiveTriggerWebhook {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReceiveTriggerWebhook {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1082,7 +1095,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateWorkerPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateWorkerPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1123,7 +1137,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for GetWorkerPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetWorkerPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1223,7 +1238,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteWorkerPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteWorkerPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1326,7 +1342,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateWorkerPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateWorkerPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1394,7 +1411,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for ListWorkerPools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListWorkerPools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1438,7 +1456,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1482,7 +1501,8 @@ pub mod cloud_build {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/devtools/cloudbuild/v2/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builders.rs
@@ -130,7 +130,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -171,7 +172,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -239,7 +241,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -345,7 +348,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -436,7 +440,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -533,7 +538,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -633,7 +639,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateRepositories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateRepositories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -674,7 +681,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -751,7 +759,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRepositories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRepositories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -842,7 +851,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRepository {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRepository {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -886,7 +896,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchReadWriteToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchReadWriteToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -927,7 +938,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchReadToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchReadToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1002,7 +1014,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchLinkableRepositories {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchLinkableRepositories {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1052,7 +1065,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for FetchGitRefs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FetchGitRefs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1111,7 +1125,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1161,7 +1176,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1216,7 +1232,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1260,7 +1277,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1304,7 +1322,8 @@ pub mod repository_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/devtools/cloudprofiler/v2/src/builders.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/builders.rs
@@ -94,7 +94,8 @@ pub mod profiler_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -147,7 +148,8 @@ pub mod profiler_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateOfflineProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateOfflineProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -200,7 +202,8 @@ pub mod profiler_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -294,7 +297,8 @@ pub mod export_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/devtools/cloudtrace/v2/src/builders.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/builders.rs
@@ -85,7 +85,8 @@ pub mod trace_service {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchWriteSpans {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchWriteSpans {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -231,7 +232,8 @@ pub mod trace_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSpan {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSpan {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/devtools/containeranalysis/v1/src/builders.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/builders.rs
@@ -92,7 +92,8 @@ pub mod container_analysis {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -142,7 +143,8 @@ pub mod container_analysis {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -197,7 +199,8 @@ pub mod container_analysis {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -249,7 +252,8 @@ pub mod container_analysis {
         }
     }
 
-    impl gax::options::RequestBuilder for GetVulnerabilityOccurrencesSummary {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetVulnerabilityOccurrencesSummary {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/firestore/admin/v1/src/builders.rs
+++ b/src/generated/firestore/admin/v1/src/builders.rs
@@ -121,7 +121,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -195,7 +196,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListIndexes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListIndexes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +238,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -277,7 +280,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteIndex {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteIndex {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -318,7 +322,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetField {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetField {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -409,7 +414,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateField {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateField {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -483,7 +489,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFields {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFields {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -602,7 +609,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ExportDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ExportDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -706,7 +714,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ImportDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ImportDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -815,7 +824,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for BulkDeleteDocuments {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BulkDeleteDocuments {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -910,7 +920,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -951,7 +962,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -998,7 +1010,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatabases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatabases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1090,7 +1103,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1176,7 +1190,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1217,7 +1232,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1264,7 +1280,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1305,7 +1322,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1408,7 +1426,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1461,7 +1480,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackupSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackupSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1505,7 +1525,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1549,7 +1570,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupSchedules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupSchedules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1605,7 +1627,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackupSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackupSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1649,7 +1672,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackupSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackupSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1726,7 +1750,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1770,7 +1795,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1814,7 +1840,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1858,7 +1885,8 @@ pub mod firestore_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/grafeas/v1/src/builders.rs
+++ b/src/generated/grafeas/v1/src/builders.rs
@@ -74,7 +74,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOccurrence {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOccurrence {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOccurrences {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOccurrences {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -192,7 +194,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOccurrence {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOccurrence {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -245,7 +248,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateOccurrence {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateOccurrence {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -300,7 +304,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateOccurrences {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateOccurrences {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -362,7 +367,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateOccurrence {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateOccurrence {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -406,7 +412,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOccurrenceNote {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOccurrenceNote {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -447,7 +454,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNote {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNote {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -520,7 +528,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNotes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNotes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -561,7 +570,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNote {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNote {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -614,7 +624,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNote {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNote {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -669,7 +680,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for BatchCreateNotes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for BatchCreateNotes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -725,7 +737,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNote {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNote {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -802,7 +815,8 @@ pub mod grafeas {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNoteOccurrences {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNoteOccurrences {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/iam/admin/v1/src/builders.rs
+++ b/src/generated/iam/admin/v1/src/builders.rs
@@ -104,7 +104,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServiceAccounts {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServiceAccounts {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -207,7 +209,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -296,7 +299,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -352,7 +356,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for PatchServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PatchServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -396,7 +401,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -440,7 +446,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -484,7 +491,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -528,7 +536,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -583,7 +592,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServiceAccountKeys {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServiceAccountKeys {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -636,7 +646,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServiceAccountKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServiceAccountKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -700,7 +711,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServiceAccountKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServiceAccountKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -752,7 +764,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for UploadServiceAccountKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UploadServiceAccountKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -798,7 +811,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteServiceAccountKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteServiceAccountKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -844,7 +858,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableServiceAccountKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableServiceAccountKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -890,7 +905,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableServiceAccountKey {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableServiceAccountKey {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -937,7 +953,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for SignBlob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SignBlob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -984,7 +1001,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for SignJwt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SignJwt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1034,7 +1052,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1093,7 +1112,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1148,7 +1168,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1225,7 +1246,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryGrantableRoles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryGrantableRoles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1304,7 +1326,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for ListRoles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListRoles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1345,7 +1368,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for GetRole {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetRole {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1398,7 +1422,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateRole {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateRole {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1454,7 +1479,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateRole {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateRole {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1501,7 +1527,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteRole {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteRole {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1548,7 +1575,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteRole {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteRole {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1623,7 +1651,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryTestablePermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryTestablePermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1667,7 +1696,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryAuditableServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryAuditableServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1717,7 +1747,8 @@ pub mod iam {
         }
     }
 
-    impl gax::options::RequestBuilder for LintPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for LintPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/iam/credentials/v1/src/builders.rs
+++ b/src/generated/iam/credentials/v1/src/builders.rs
@@ -105,7 +105,8 @@ pub mod iam_credentials {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateAccessToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateAccessToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -169,7 +170,8 @@ pub mod iam_credentials {
         }
     }
 
-    impl gax::options::RequestBuilder for GenerateIdToken {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GenerateIdToken {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -227,7 +229,8 @@ pub mod iam_credentials {
         }
     }
 
-    impl gax::options::RequestBuilder for SignBlob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SignBlob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -285,7 +288,8 @@ pub mod iam_credentials {
         }
     }
 
-    impl gax::options::RequestBuilder for SignJwt {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SignJwt {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/iam/v1/src/builders.rs
+++ b/src/generated/iam/v1/src/builders.rs
@@ -92,7 +92,8 @@ pub mod iam_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -142,7 +143,8 @@ pub mod iam_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -197,7 +199,8 @@ pub mod iam_policy {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/iam/v2/src/builders.rs
+++ b/src/generated/iam/v2/src/builders.rs
@@ -101,7 +101,8 @@ pub mod policies {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -142,7 +143,8 @@ pub mod policies {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -236,7 +238,8 @@ pub mod policies {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -318,7 +321,8 @@ pub mod policies {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -403,7 +407,8 @@ pub mod policies {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -447,7 +452,8 @@ pub mod policies {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/iam/v3/src/builders.rs
+++ b/src/generated/iam/v3/src/builders.rs
@@ -137,7 +137,8 @@ pub mod policy_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePolicyBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePolicyBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -181,7 +182,8 @@ pub mod policy_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPolicyBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPolicyBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -282,7 +284,8 @@ pub mod policy_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePolicyBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePolicyBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -373,7 +376,8 @@ pub mod policy_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePolicyBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePolicyBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -450,7 +454,8 @@ pub mod policy_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPolicyBindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPolicyBindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -531,7 +536,8 @@ pub mod policy_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchTargetPolicyBindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchTargetPolicyBindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -575,7 +581,8 @@ pub mod policy_bindings {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -718,7 +725,8 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    impl gax::options::RequestBuilder for CreatePrincipalAccessBoundaryPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreatePrincipalAccessBoundaryPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -766,7 +774,8 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    impl gax::options::RequestBuilder for GetPrincipalAccessBoundaryPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetPrincipalAccessBoundaryPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -875,7 +884,8 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdatePrincipalAccessBoundaryPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdatePrincipalAccessBoundaryPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -976,7 +986,8 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    impl gax::options::RequestBuilder for DeletePrincipalAccessBoundaryPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeletePrincipalAccessBoundaryPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1055,7 +1066,8 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    impl gax::options::RequestBuilder for ListPrincipalAccessBoundaryPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListPrincipalAccessBoundaryPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1136,7 +1148,8 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchPrincipalAccessBoundaryPolicyBindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchPrincipalAccessBoundaryPolicyBindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1182,7 +1195,8 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/identity/accesscontextmanager/v1/src/builders.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builders.rs
@@ -108,7 +108,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAccessPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAccessPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -151,7 +152,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAccessPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAccessPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -284,7 +286,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAccessPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAccessPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -385,7 +388,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAccessPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAccessPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -470,7 +474,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAccessPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAccessPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -549,7 +554,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAccessLevels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAccessLevels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -598,7 +604,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAccessLevel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAccessLevel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -696,7 +703,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAccessLevel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAccessLevel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -797,7 +805,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAccessLevel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAccessLevel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -882,7 +891,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAccessLevel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAccessLevel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -988,7 +998,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ReplaceAccessLevels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReplaceAccessLevels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1061,7 +1072,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServicePerimeters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServicePerimeters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1107,7 +1119,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServicePerimeter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServicePerimeter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1207,7 +1220,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServicePerimeter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServicePerimeter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1310,7 +1324,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateServicePerimeter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateServicePerimeter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1395,7 +1410,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteServicePerimeter {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteServicePerimeter {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1503,7 +1519,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ReplaceServicePerimeters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReplaceServicePerimeters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1600,7 +1617,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CommitServicePerimeters {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CommitServicePerimeters {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1677,7 +1695,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGcpUserAccessBindings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGcpUserAccessBindings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1725,7 +1744,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGcpUserAccessBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGcpUserAccessBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1827,7 +1847,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGcpUserAccessBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGcpUserAccessBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1932,7 +1953,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGcpUserAccessBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGcpUserAccessBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2019,7 +2041,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGcpUserAccessBinding {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGcpUserAccessBinding {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2080,7 +2103,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2132,7 +2156,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2189,7 +2214,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2235,7 +2261,8 @@ pub mod access_context_manager {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/logging/v2/src/builders.rs
+++ b/src/generated/logging/v2/src/builders.rs
@@ -74,7 +74,8 @@ pub mod logging_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLog {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLog {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -158,7 +159,8 @@ pub mod logging_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for WriteLogEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for WriteLogEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -243,7 +245,8 @@ pub mod logging_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLogEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLogEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -312,7 +315,8 @@ pub mod logging_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMonitoredResourceDescriptors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMonitoredResourceDescriptors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -376,7 +380,8 @@ pub mod logging_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLogs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLogs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -453,7 +458,8 @@ pub mod logging_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -497,7 +503,8 @@ pub mod logging_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -541,7 +548,8 @@ pub mod logging_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -635,7 +643,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBuckets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBuckets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -676,7 +685,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBucket {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBucket {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -769,7 +779,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBucketAsync {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBucketAsync {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -865,7 +876,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBucketAsync {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBucketAsync {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -921,7 +933,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBucket {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBucket {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -980,7 +993,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBucket {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBucket {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1021,7 +1035,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBucket {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBucket {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1062,7 +1077,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UndeleteBucket {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UndeleteBucket {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1129,7 +1145,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListViews {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListViews {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1170,7 +1187,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1226,7 +1244,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1285,7 +1304,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1326,7 +1346,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteView {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteView {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1393,7 +1414,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSinks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSinks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1434,7 +1456,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1490,7 +1513,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1555,7 +1579,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1596,7 +1621,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1684,7 +1710,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1760,7 +1787,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1827,7 +1855,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLinks {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLinks {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1868,7 +1897,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLink {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLink {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1936,7 +1966,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListExclusions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListExclusions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1977,7 +2008,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetExclusion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetExclusion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2027,7 +2059,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateExclusion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateExclusion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2086,7 +2119,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateExclusion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateExclusion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2127,7 +2161,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteExclusion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteExclusion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2168,7 +2203,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetCmekSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetCmekSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2230,7 +2266,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateCmekSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateCmekSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2271,7 +2308,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2330,7 +2368,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSettings {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSettings {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2424,7 +2463,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CopyLogEntries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CopyLogEntries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2501,7 +2541,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2545,7 +2586,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2589,7 +2631,8 @@ pub mod config_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2683,7 +2726,8 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLogMetrics {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLogMetrics {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2724,7 +2768,8 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLogMetric {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLogMetric {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2774,7 +2819,8 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateLogMetric {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateLogMetric {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2824,7 +2870,8 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateLogMetric {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateLogMetric {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2865,7 +2912,8 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteLogMetric {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteLogMetric {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2942,7 +2990,8 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2986,7 +3035,8 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3030,7 +3080,8 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/longrunning/src/builders.rs
+++ b/src/generated/longrunning/src/builders.rs
@@ -107,7 +107,8 @@ pub mod operations {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod operations {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -189,7 +191,8 @@ pub mod operations {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -230,7 +233,8 @@ pub mod operations {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/monitoring/dashboard/v1/src/builders.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builders.rs
@@ -89,7 +89,8 @@ pub mod dashboards_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDashboard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDashboard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -157,7 +158,8 @@ pub mod dashboards_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDashboards {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDashboards {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -198,7 +200,8 @@ pub mod dashboards_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDashboard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDashboard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -239,7 +242,8 @@ pub mod dashboards_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDashboard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDashboard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -289,7 +293,8 @@ pub mod dashboards_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDashboard {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDashboard {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/monitoring/metricsscope/v1/src/builders.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/builders.rs
@@ -74,7 +74,8 @@ pub mod metrics_scopes {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMetricsScope {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMetricsScope {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -125,7 +126,8 @@ pub mod metrics_scopes {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMetricsScopesByMonitoredProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMetricsScopesByMonitoredProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -219,7 +221,8 @@ pub mod metrics_scopes {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMonitoredProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMonitoredProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -298,7 +301,8 @@ pub mod metrics_scopes {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMonitoredProject {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMonitoredProject {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -342,7 +346,8 @@ pub mod metrics_scopes {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/monitoring/v3/src/builders.rs
+++ b/src/generated/monitoring/v3/src/builders.rs
@@ -116,7 +116,8 @@ pub mod alert_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAlertPolicies {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAlertPolicies {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -157,7 +158,8 @@ pub mod alert_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAlertPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAlertPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -210,7 +212,8 @@ pub mod alert_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAlertPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAlertPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +257,8 @@ pub mod alert_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAlertPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAlertPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -310,7 +314,8 @@ pub mod alert_policy_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAlertPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAlertPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -413,7 +418,8 @@ pub mod group_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGroups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGroups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -454,7 +460,8 @@ pub mod group_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -510,7 +517,8 @@ pub mod group_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -560,7 +568,8 @@ pub mod group_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -607,7 +616,8 @@ pub mod group_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteGroup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteGroup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -693,7 +703,8 @@ pub mod group_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListGroupMembers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListGroupMembers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -800,7 +811,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMonitoredResourceDescriptors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMonitoredResourceDescriptors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -846,7 +858,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMonitoredResourceDescriptor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMonitoredResourceDescriptor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -929,7 +942,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListMetricDescriptors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListMetricDescriptors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -973,7 +987,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetMetricDescriptor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetMetricDescriptor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1026,7 +1041,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateMetricDescriptor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateMetricDescriptor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1070,7 +1086,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteMetricDescriptor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteMetricDescriptor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1188,7 +1205,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1243,7 +1261,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1298,7 +1317,8 @@ pub mod metric_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServiceTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServiceTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1405,7 +1425,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNotificationChannelDescriptors {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNotificationChannelDescriptors {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1453,7 +1474,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNotificationChannelDescriptor {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNotificationChannelDescriptor {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1542,7 +1564,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListNotificationChannels {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListNotificationChannels {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1588,7 +1611,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNotificationChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNotificationChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1647,7 +1671,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateNotificationChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateNotificationChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1709,7 +1734,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateNotificationChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateNotificationChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1763,7 +1789,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteNotificationChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteNotificationChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1813,7 +1840,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SendNotificationChannelVerificationCode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SendNotificationChannelVerificationCode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1874,7 +1902,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetNotificationChannelVerificationCode {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetNotificationChannelVerificationCode {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1928,7 +1957,8 @@ pub mod notification_channel_service {
         }
     }
 
-    impl gax::options::RequestBuilder for VerifyNotificationChannel {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for VerifyNotificationChannel {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2028,7 +2058,8 @@ pub mod query_service {
         }
     }
 
-    impl gax::options::RequestBuilder for QueryTimeSeries {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for QueryTimeSeries {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2114,7 +2145,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2157,7 +2189,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2233,7 +2266,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServices {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServices {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2288,7 +2322,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2331,7 +2366,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteService {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteService {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2399,7 +2435,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateServiceLevelObjective {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateServiceLevelObjective {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2456,7 +2493,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetServiceLevelObjective {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetServiceLevelObjective {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2548,7 +2586,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListServiceLevelObjectives {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListServiceLevelObjectives {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2610,7 +2649,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateServiceLevelObjective {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateServiceLevelObjective {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2658,7 +2698,8 @@ pub mod service_monitoring_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteServiceLevelObjective {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteServiceLevelObjective {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2734,7 +2775,8 @@ pub mod snooze_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSnooze {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSnooze {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2808,7 +2850,8 @@ pub mod snooze_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSnoozes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSnoozes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2849,7 +2892,8 @@ pub mod snooze_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSnooze {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSnooze {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2902,7 +2946,8 @@ pub mod snooze_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSnooze {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSnooze {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3007,7 +3052,8 @@ pub mod uptime_check_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUptimeCheckConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUptimeCheckConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3051,7 +3097,8 @@ pub mod uptime_check_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetUptimeCheckConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetUptimeCheckConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3108,7 +3155,8 @@ pub mod uptime_check_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateUptimeCheckConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateUptimeCheckConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3168,7 +3216,8 @@ pub mod uptime_check_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateUptimeCheckConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateUptimeCheckConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3214,7 +3263,8 @@ pub mod uptime_check_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteUptimeCheckConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteUptimeCheckConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3279,7 +3329,8 @@ pub mod uptime_check_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListUptimeCheckIps {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListUptimeCheckIps {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/openapi-validation/src/builders.rs
+++ b/src/generated/openapi-validation/src/builders.rs
@@ -117,7 +117,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListLocations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListLocations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -166,7 +167,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -248,7 +250,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecrets {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecrets {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -306,7 +309,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -399,7 +403,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecretsByProjectAndLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecretsByProjectAndLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -468,7 +473,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateSecretByProjectAndLocation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateSecretByProjectAndLocation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -535,7 +541,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -607,7 +614,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AddSecretVersionByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddSecretVersionByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -656,7 +664,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -711,7 +720,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -775,7 +785,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -837,7 +848,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecretByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecretByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -905,7 +917,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteSecretByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteSecretByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -982,7 +995,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateSecretByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateSecretByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1073,7 +1087,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecretVersions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecretVersions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1177,7 +1192,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListSecretVersionsByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListSecretVersionsByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1235,7 +1251,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1308,7 +1325,10 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetSecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder
+        for GetSecretVersionByProjectAndLocationAndSecretAndVersion
+    {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1366,7 +1386,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AccessSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AccessSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1439,7 +1460,10 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder
+        for AccessSecretVersionByProjectAndLocationAndSecretAndVersion
+    {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1509,7 +1533,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DisableSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1584,7 +1609,10 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder
+        for DisableSecretVersionByProjectAndLocationAndSecretAndVersion
+    {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1654,7 +1682,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableSecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for EnableSecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1729,7 +1758,10 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder
+        for EnableSecretVersionByProjectAndLocationAndSecretAndVersion
+    {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1799,7 +1831,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DestroySecretVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DestroySecretVersion {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1874,7 +1907,10 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder
+        for DestroySecretVersionByProjectAndLocationAndSecretAndVersion
+    {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1947,7 +1983,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2022,7 +2059,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicyByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicyByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2080,7 +2118,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2151,7 +2190,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicyByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicyByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2220,7 +2260,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2294,7 +2335,8 @@ pub mod secret_manager_service {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissionsByProjectAndLocationAndSecret {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissionsByProjectAndLocationAndSecret {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/privacy/dlp/v2/src/builders.rs
+++ b/src/generated/privacy/dlp/v2/src/builders.rs
@@ -104,7 +104,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for InspectContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for InspectContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -186,7 +187,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RedactImage {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RedactImage {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -277,7 +279,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeidentifyContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeidentifyContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -368,7 +371,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ReidentifyContent {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ReidentifyContent {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -427,7 +431,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInfoTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInfoTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -492,7 +497,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInspectTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInspectTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -554,7 +560,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInspectTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInspectTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -598,7 +605,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInspectTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInspectTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -681,7 +689,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInspectTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInspectTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -725,7 +734,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInspectTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInspectTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -794,7 +804,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDeidentifyTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDeidentifyTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -860,7 +871,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDeidentifyTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDeidentifyTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -904,7 +916,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDeidentifyTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDeidentifyTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -991,7 +1004,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDeidentifyTemplates {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDeidentifyTemplates {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1037,7 +1051,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDeidentifyTemplate {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDeidentifyTemplate {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1102,7 +1117,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateJobTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateJobTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1164,7 +1180,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateJobTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateJobTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1219,7 +1236,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for HybridInspectJobTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for HybridInspectJobTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1260,7 +1278,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetJobTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetJobTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1352,7 +1371,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListJobTriggers {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListJobTriggers {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1396,7 +1416,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteJobTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteJobTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1440,7 +1461,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ActivateJobTrigger {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ActivateJobTrigger {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1499,7 +1521,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDiscoveryConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDiscoveryConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1561,7 +1584,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDiscoveryConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDiscoveryConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1605,7 +1629,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDiscoveryConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDiscoveryConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1682,7 +1707,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDiscoveryConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDiscoveryConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1726,7 +1752,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDiscoveryConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDiscoveryConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1788,7 +1815,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDlpJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDlpJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1880,7 +1908,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDlpJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDlpJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1921,7 +1950,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDlpJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDlpJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1962,7 +1992,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteDlpJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteDlpJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2003,7 +2034,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelDlpJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelDlpJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2068,7 +2100,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateStoredInfoType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateStoredInfoType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2130,7 +2163,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateStoredInfoType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateStoredInfoType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2174,7 +2208,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetStoredInfoType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetStoredInfoType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2257,7 +2292,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListStoredInfoTypes {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListStoredInfoTypes {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2301,7 +2337,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteStoredInfoType {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteStoredInfoType {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2388,7 +2425,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListProjectDataProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListProjectDataProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2471,7 +2509,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTableDataProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTableDataProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2556,7 +2595,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListColumnDataProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListColumnDataProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2600,7 +2640,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetProjectDataProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetProjectDataProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2687,7 +2728,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListFileStoreDataProfiles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListFileStoreDataProfiles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2733,7 +2775,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetFileStoreDataProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetFileStoreDataProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2779,7 +2822,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteFileStoreDataProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteFileStoreDataProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2823,7 +2867,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTableDataProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTableDataProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2867,7 +2912,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetColumnDataProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetColumnDataProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2911,7 +2957,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTableDataProfile {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTableDataProfile {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2964,7 +3011,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for HybridInspectDlpJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for HybridInspectDlpJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3005,7 +3053,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for FinishDlpJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for FinishDlpJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3058,7 +3107,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3099,7 +3149,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3173,7 +3224,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3250,7 +3302,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for SearchConnections {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SearchConnections {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3294,7 +3347,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -3356,7 +3410,8 @@ pub mod dlp_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateConnection {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateConnection {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/spanner/admin/database/v1/src/builders.rs
+++ b/src/generated/spanner/admin/database/v1/src/builders.rs
@@ -101,7 +101,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatabases {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatabases {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -224,7 +225,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -265,7 +267,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +360,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -461,7 +465,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateDatabaseDdl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateDatabaseDdl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -502,7 +507,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DropDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DropDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -543,7 +549,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetDatabaseDdl {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetDatabaseDdl {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -602,7 +609,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -652,7 +660,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -707,7 +716,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -812,7 +822,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -922,7 +933,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CopyBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CopyBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -963,7 +975,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1016,7 +1029,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1057,7 +1071,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackup {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackup {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1131,7 +1146,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackups {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackups {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1237,7 +1253,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for RestoreDatabase {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RestoreDatabase {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1316,7 +1333,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatabaseOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatabaseOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1393,7 +1411,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1464,7 +1483,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListDatabaseRoles {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListDatabaseRoles {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1522,7 +1542,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for AddSplitPoints {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for AddSplitPoints {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1581,7 +1602,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateBackupSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateBackupSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1625,7 +1647,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetBackupSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetBackupSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1681,7 +1704,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateBackupSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateBackupSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1725,7 +1749,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteBackupSchedule {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteBackupSchedule {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1796,7 +1821,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListBackupSchedules {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListBackupSchedules {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1873,7 +1899,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1917,7 +1944,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1961,7 +1989,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -2005,7 +2034,8 @@ pub mod database_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/spanner/admin/instance/v1/src/builders.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builders.rs
@@ -104,7 +104,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstanceConfigs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstanceConfigs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -148,7 +149,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstanceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstanceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -254,7 +256,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstanceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstanceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -357,7 +360,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstanceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstanceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -413,7 +417,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstanceConfig {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstanceConfig {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -494,7 +499,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstanceConfigOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstanceConfigOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -577,7 +583,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstances {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstances {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -659,7 +666,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstancePartitions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstancePartitions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -709,7 +717,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -804,7 +813,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -896,7 +906,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -937,7 +948,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -996,7 +1008,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for SetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for SetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1046,7 +1059,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetIamPolicy {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetIamPolicy {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1101,7 +1115,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for TestIamPermissions {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for TestIamPermissions {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1145,7 +1160,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetInstancePartition {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetInstancePartition {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1251,7 +1267,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateInstancePartition {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateInstancePartition {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1303,7 +1320,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteInstancePartition {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteInstancePartition {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1406,7 +1424,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateInstancePartition {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateInstancePartition {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1496,7 +1515,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListInstancePartitionOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListInstancePartitionOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1584,7 +1604,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for MoveInstance {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for MoveInstance {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1661,7 +1682,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1705,7 +1727,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1749,7 +1772,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1793,7 +1817,8 @@ pub mod instance_admin {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/storagetransfer/v1/src/builders.rs
+++ b/src/generated/storagetransfer/v1/src/builders.rs
@@ -83,7 +83,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetGoogleServiceAccount {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetGoogleServiceAccount {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -132,7 +133,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateTransferJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateTransferJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -202,7 +204,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateTransferJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateTransferJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -251,7 +254,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetTransferJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetTransferJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -324,7 +328,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListTransferJobs {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListTransferJobs {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -370,7 +375,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for PauseTransferOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for PauseTransferOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -418,7 +424,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ResumeTransferOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ResumeTransferOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -502,7 +509,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for RunTransferJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for RunTransferJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -554,7 +562,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteTransferJob {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteTransferJob {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -612,7 +621,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CreateAgentPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CreateAgentPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -667,7 +677,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for UpdateAgentPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for UpdateAgentPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -710,7 +721,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetAgentPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetAgentPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -786,7 +798,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListAgentPools {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListAgentPools {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -829,7 +842,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for DeleteAgentPool {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for DeleteAgentPool {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -908,7 +922,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for ListOperations {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for ListOperations {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -954,7 +969,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for GetOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for GetOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }
@@ -1000,7 +1016,8 @@ pub mod storage_transfer_service {
         }
     }
 
-    impl gax::options::RequestBuilder for CancelOperation {
+    #[doc(hidden)]
+    impl gax::options::internal::RequestBuilder for CancelOperation {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }


### PR DESCRIPTION
Part of the work for #1609 

This seals `RequestOptionsBuilder` (which is public), and hides `RequestBuilder` which was an implementation detail.

To hide `RequestBuilder`, we introduce an `internal` module which is not for applications to use. This is enforced via documentation.

Sealing the trait means that applications cannot implement it. We can add methods to the trait without fear of breaking applications.

`RequestOptionsBuilder` can only be implemented if an application utters `internal::RequestBuilder`, which they are not supposed to do.

---

A Builder still has its functions from the `RequestOptionsBuilder` blanket implementation:

![image](https://github.com/user-attachments/assets/a4dbdb94-2678-4e37-ba0d-bad569d14dd4)

But it does not have `request_options()` from `RequestBuilder`:

![image](https://github.com/user-attachments/assets/2ef4d68c-c647-4ab5-b942-340f43f2a428)

For comparison, here are the current docs: https://docs.rs/google-cloud-secretmanager-v1/latest/google_cloud_secretmanager_v1/builders/secret_manager_service/struct.ListLocations.html