### PR TITLE
cleanup(auth): Remove deadcode attribute from token cache

### DIFF
--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -29,8 +29,6 @@ pub(crate) struct TokenCache {
     rx_token: watch::Receiver<Option<Result<Token>>>,
 }
 
-// TODO(#1552): Use the token cache in all creds
-#[allow(dead_code)]
 impl TokenCache {
     pub(crate) fn new<T>(inner: T) -> Self
     where


### PR DESCRIPTION
Remove  `allow(dead_code)` from token cache because all credential types now use the cache. Fixes #1552.