### PR TITLE
docs: remove `ClientConfig` from examples

### DIFF
--- a/src/gax/src/backoff_policy.rs
+++ b/src/gax/src/backoff_policy.rs
@@ -26,6 +26,14 @@
 //! faults, something like a [RetryThrottler] may be needed to improve recovery
 //! times in larger failures.
 //!
+//! To configure the default retry backoff policy for a client, use
+//! [ClientBuilder::with_backoff_policy]. To configure the retry backoff policy
+//! used for a specific request, use
+//! [RequestOptionsBuilder::with_backoff_policy].
+//!
+//! [ClientBuilder::with_backoff_policy]: crate::client_builder::ClientBuilder::with_backoff_policy
+//! [RequestOptionsBuilder::with_backoff_policy]: crate::options::RequestOptionsBuilder::with_backoff_policy
+//!
 //! # Example
 //! ```
 //! # use google_cloud_gax::*;
@@ -33,14 +41,12 @@
 //! use exponential_backoff::ExponentialBackoffBuilder;
 //! use std::time::Duration;
 //!
-//! fn configure_backoff(config: options::ClientConfig) -> Result<options::ClientConfig> {
-//!     let policy = ExponentialBackoffBuilder::new()
-//!         .with_initial_delay(Duration::from_millis(100))
-//!         .with_maximum_delay(Duration::from_secs(5))
-//!         .with_scaling(4.0)
-//!         .build()?;
-//!     Ok(config.set_backoff_policy(policy))
-//! }
+//! let policy = ExponentialBackoffBuilder::new()
+//!     .with_initial_delay(Duration::from_millis(100))
+//!     .with_maximum_delay(Duration::from_secs(5))
+//!     .with_scaling(4.0)
+//!     .build()?;
+//! # Ok::<(), error::Error>(())
 //! ```
 //!
 //! [RetryThrottler]: crate::retry_throttler::RetryThrottler

--- a/src/gax/src/exponential_backoff.rs
+++ b/src/gax/src/exponential_backoff.rs
@@ -41,30 +41,12 @@ impl ExponentialBackoffBuilder {
     /// # use google_cloud_gax::exponential_backoff::*;
     /// use std::time::Duration;
     ///
-    /// fn configure_retry(config: options::ClientConfig) -> Result<options::ClientConfig> {
-    ///     let policy = ExponentialBackoffBuilder::new()
+    /// let policy = ExponentialBackoffBuilder::new()
     ///         .with_initial_delay(Duration::from_millis(100))
     ///         .with_maximum_delay(Duration::from_secs(5))
     ///         .with_scaling(4.0)
     ///         .build()?;
-    ///     Ok(config.set_backoff_policy(policy))
-    /// }
-    /// ```
-    ///
-    /// # Example
-    /// ```
-    /// # use google_cloud_gax::*;
-    /// # use exponential_backoff::*;
-    /// use std::time::Duration;
-    ///
-    /// fn configure_polling(config: options::ClientConfig) -> Result<options::ClientConfig> {
-    ///     let policy = ExponentialBackoffBuilder::new()
-    ///         .with_initial_delay(Duration::from_millis(100))
-    ///         .with_maximum_delay(Duration::from_secs(5))
-    ///         .with_scaling(4.0)
-    ///         .build()?;
-    ///     Ok(config.set_polling_backoff_policy(policy))
-    /// }
+    /// # Ok::<(), error::Error>(())
     /// ```
     pub fn new() -> Self {
         Self {
@@ -123,15 +105,16 @@ impl ExponentialBackoffBuilder {
         })
     }
 
-    /// Creates a new exponential backoff policy clamping the ranges to barely
+    /// Creates a new exponential backoff policy clamping the ranges towards
     /// recommended values.
     ///
     /// The maximum delay is clamped first, to be between one second and one day
-    /// (both inclusive). The upper value is hardly useful, except maybe in
+    /// (both inclusive). The upper value is hardly useful, typically the retry
+    /// policy would expire earlier than such a long backoff. The exceptions may
     /// tests and very long running operations.
     ///
     /// Then the initial delay is clamped to be between one millisecond and the
-    /// maximum delay. One millisecond is rarely useful outside of tests, but at
+    /// maximum delay. One millisecond is rarely useful outside of tests, but it
     /// is unlikely to cause problems.
     ///
     /// Finally, the scaling factor is clamped to the `[1.0, 32.0]` range.

--- a/src/gax/src/polling_backoff_policy.rs
+++ b/src/gax/src/polling_backoff_policy.rs
@@ -27,6 +27,14 @@
 //! is reached. This works well when the expected execution time is not known
 //! in advance.
 //!
+//! To configure the default polling backoff policy for a client, use
+//! [ClientBuilder::with_polling_backoff_policy]. To configure the polling
+//! backoff policy used for a specific request, use
+//! [RequestOptionsBuilder::with_polling_backoff_policy].
+//!
+//! [ClientBuilder::with_polling_backoff_policy]: crate::client_builder::ClientBuilder::with_polling_backoff_policy
+//! [RequestOptionsBuilder::with_polling_backoff_policy]: crate::options::RequestOptionsBuilder::with_polling_backoff_policy
+//!
 //! # Example
 //! ```
 //! # use google_cloud_gax::*;
@@ -34,14 +42,13 @@
 //! use exponential_backoff::ExponentialBackoffBuilder;
 //! use std::time::Duration;
 //!
-//! fn configure_polling(config: options::ClientConfig) -> Result<options::ClientConfig> {
-//!     let policy = ExponentialBackoffBuilder::new()
-//!         .with_initial_delay(Duration::from_millis(100))
-//!         .with_maximum_delay(Duration::from_secs(5))
-//!         .with_scaling(4.0)
-//!         .build()?;
-//!     Ok(config.set_polling_backoff_policy(policy))
-//! }
+//! let policy = ExponentialBackoffBuilder::new()
+//!     .with_initial_delay(Duration::from_millis(100))
+//!     .with_maximum_delay(Duration::from_secs(5))
+//!     .with_scaling(4.0)
+//!     .build()?;
+//! // `policy` implements the `PollingBackoffPolicy` trait.
+//! # Ok::<(), error::Error>(())
 //! ```
 //!
 //! [Exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/src/gax/src/polling_error_policy.rs
+++ b/src/gax/src/polling_error_policy.rs
@@ -22,21 +22,24 @@
 //! of the polling loop, and some common implementations that should meet most
 //! needs.
 //!
+//! To configure the default polling error policy for a client, use
+//! [ClientBuilder::with_polling_error_policy]. To configure the polling error
+//! policy used for a specific request, use
+//! [RequestOptionsBuilder::with_polling_error_policy].
+//!
+//! [ClientBuilder::with_polling_error_policy]: crate::client_builder::ClientBuilder::with_polling_error_policy
+//! [RequestOptionsBuilder::with_polling_error_policy]: crate::options::RequestOptionsBuilder::with_polling_error_policy
+//!
 //! # Example:
 //! ```
 //! # use google_cloud_gax::polling_error_policy::*;
 //! # use google_cloud_gax::options;
 //! use std::time::Duration;
-//! fn customize_polling_error_policy(config: options::ClientConfig)
-//!     -> options::ClientConfig
-//! {
-//!     // Poll for at most 15 minutes or at most 50 attempts: whichever limit
-//!     // is reached first stops the polling loop.
-//!     config.set_polling_error_policy(
-//!         Aip194Strict
-//!             .with_time_limit(Duration::from_secs(15 * 60))
-//!             .with_attempt_limit(50))
-//! }
+//! // Poll for at most 15 minutes or at most 50 attempts: whichever limit is
+//! // reached first stops the polling loop.
+//! let policy = Aip194Strict
+//!     .with_time_limit(Duration::from_secs(15 * 60))
+//!     .with_attempt_limit(50);
 //! ```
 
 use crate::error::Error;


### PR DESCRIPTION
Part of the work for #1548