### PR TITLE
feat!: use builder to create all clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -706,6 +707,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -731,6 +733,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -742,6 +745,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -764,6 +768,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -775,6 +780,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -794,6 +800,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -813,6 +820,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -835,6 +843,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -856,6 +865,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -876,6 +886,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -894,6 +905,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -915,6 +927,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -935,6 +948,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -955,6 +969,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -977,6 +992,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -988,6 +1004,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -999,6 +1016,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1010,6 +1028,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1021,6 +1040,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1032,6 +1052,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1043,6 +1064,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1054,6 +1076,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1077,6 +1100,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1103,6 +1127,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1123,6 +1148,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1176,6 +1202,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1197,6 +1224,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1223,6 +1251,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1245,6 +1274,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1267,6 +1297,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1289,6 +1320,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1311,6 +1343,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1332,6 +1365,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1350,6 +1384,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1368,6 +1403,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1387,6 +1423,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1406,6 +1443,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1424,6 +1462,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1442,6 +1481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1464,6 +1504,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1483,6 +1524,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1501,6 +1543,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1522,6 +1565,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1544,6 +1588,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1565,6 +1610,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1583,6 +1629,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1606,6 +1653,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1626,6 +1674,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1637,6 +1686,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1655,6 +1705,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1678,6 +1729,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1700,6 +1752,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1722,6 +1775,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1740,6 +1794,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1759,6 +1814,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1779,6 +1835,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1801,6 +1858,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1821,6 +1879,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1843,6 +1902,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1863,6 +1923,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1884,6 +1945,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1907,6 +1969,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1928,6 +1991,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1951,6 +2015,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1974,6 +2039,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -1997,6 +2063,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2021,6 +2088,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2042,6 +2110,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2064,6 +2133,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2085,6 +2155,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2102,6 +2173,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2125,6 +2197,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2147,6 +2220,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2169,6 +2243,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2192,6 +2267,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tonic",
  "tracing",
 ]
@@ -2214,6 +2290,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2237,6 +2314,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2313,6 +2391,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2330,6 +2409,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2341,6 +2421,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -2351,6 +2432,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -2372,6 +2454,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2393,6 +2476,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2411,6 +2495,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2435,6 +2520,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2454,6 +2540,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2471,6 +2558,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2489,6 +2577,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2510,6 +2599,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2531,6 +2621,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2549,6 +2640,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2560,6 +2652,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -2582,6 +2675,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2602,6 +2696,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2620,6 +2715,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2642,6 +2738,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2659,6 +2756,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2676,6 +2774,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2687,6 +2786,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -2709,6 +2809,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2727,6 +2828,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2767,6 +2869,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2789,6 +2892,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2810,6 +2914,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2833,6 +2938,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2855,6 +2961,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2873,6 +2980,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2892,6 +3000,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2912,6 +3021,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2932,6 +3042,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2953,6 +3064,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2975,6 +3087,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2998,6 +3111,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3020,6 +3134,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3042,6 +3157,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3064,6 +3180,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3085,6 +3202,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3107,6 +3225,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3128,6 +3247,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3139,6 +3259,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -3156,6 +3277,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3177,6 +3299,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3188,6 +3311,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -3205,6 +3329,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3227,6 +3352,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3246,6 +3372,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3269,6 +3396,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3290,6 +3418,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3310,6 +3439,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3329,6 +3459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3351,6 +3482,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3368,6 +3500,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3389,6 +3522,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3407,6 +3541,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3419,6 +3554,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -3436,6 +3572,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3458,6 +3595,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3480,6 +3618,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3501,6 +3640,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3524,6 +3664,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3535,6 +3676,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -3545,6 +3687,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -3567,6 +3710,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3586,6 +3730,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3605,6 +3750,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3627,6 +3773,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3650,6 +3797,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3667,6 +3815,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3688,6 +3837,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3710,6 +3860,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3729,6 +3880,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3747,6 +3899,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3767,6 +3920,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3789,6 +3943,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3810,6 +3965,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3832,6 +3988,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3853,6 +4010,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3875,6 +4033,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3892,6 +4051,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3914,6 +4074,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3934,6 +4095,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3955,6 +4117,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3975,6 +4138,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -3993,6 +4157,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4016,6 +4181,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4034,6 +4200,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4056,6 +4223,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4067,6 +4235,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_with",
+ "tokio-test",
 ]
 
 [[package]]
@@ -4089,6 +4258,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4109,6 +4279,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4127,6 +4298,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4148,6 +4320,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4170,6 +4343,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4192,6 +4366,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4214,6 +4389,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4235,6 +4411,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4255,6 +4432,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4272,6 +4450,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4306,6 +4485,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4327,6 +4507,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -4349,6 +4530,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -5608,6 +5790,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio-test",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,3 +235,6 @@ repository   = "https://github.com/googleapis/google-cloud-rust/tree/main"
 keywords     = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
 categories   = ["network-programming"]
 rust-version = "1.85.0"
+
+[workspace.dependencies]
+tokio-test = "0.4"

--- a/generator/internal/rust/templates/common/Cargo.toml.mustache
+++ b/generator/internal/rust/templates/common/Cargo.toml.mustache
@@ -37,8 +37,9 @@ publish                = false
 {{#Codec.RequiredPackages}}
 {{{.}}}
 {{/Codec.RequiredPackages}}
-{{#Codec.HasLROs}}
 
 [dev-dependencies]
+tokio-test.workspace = true
+{{#Codec.HasLROs}}
 tokio = { version = "1", features = ["time"] }
 {{/Codec.HasLROs}}

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -23,6 +23,34 @@ pub mod {{Codec.ModuleName}} {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [{{Codec.Name}}][super::super::client::{{Codec.Name}}].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use {{Model.Codec.PackageNamespace}}::*;
+    /// # use builder::{{Codec.ModuleName}}::ClientBuilder;
+    /// # use client::{{Codec.Name}};
+    /// let builder : ClientBuilder = {{Codec.Name}}::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://{{Model.Codec.DefaultHost}}")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::{{Codec.Name}};
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = {{Codec.Name}};
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::{{Codec.Name}}] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/generator/internal/rust/templates/crate/src/client.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/client.rs.mustache
@@ -30,6 +30,15 @@ use std::sync::Arc;
 
 /// Implements a client for the {{Codec.APITitle}}.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use {{Model.Codec.PackageNamespace}}::client::{{Codec.Name}};
+/// let client = {{Codec.Name}}::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 {{#Codec.DocLines}}
@@ -38,8 +47,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `{{Codec.Name}}` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `{{Codec.Name}}` use the `with_*` methods in the type returned
+/// by [builder()][{{Codec.Name}}::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://{{Model.Codec.DefaultHost}}`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::{{Codec.ModuleName}}::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::{{Codec.ModuleName}}::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -53,24 +77,30 @@ pub struct {{Codec.Name}} {
 }
 
 impl {{Codec.Name}} {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [{{Codec.Name}}].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use {{Model.Codec.PackageNamespace}}::client::{{Codec.Name}};
+    /// let client = {{Codec.Name}}::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::{{Codec.ModuleName}}::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::{{Codec.ModuleName}}::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::{{Codec.Name}} + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::{{Codec.Name}}>> {
@@ -87,8 +117,8 @@ impl {{Codec.Name}} {
     async fn build_with_tracing(conf: gax::options::ClientConfig) -> Result<impl super::stub::{{Codec.Name}}> {
         Self::build_transport(conf).await.map(super::tracing::{{Codec.Name}}::new)
     }
-
     {{#Codec.Methods}}
+
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
@@ -116,7 +146,6 @@ impl {{Codec.Name}} {
             .set_{{Codec.SetterName}} ( {{Codec.FieldName}}.into() )
         {{/Codec.PathParams}}
     }
-
     {{/Codec.Methods}}
 }
 {{/Codec.Services}}

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -29,3 +29,6 @@ publish                = false
 
 [dependencies]
 wkt        = { path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/generator/testdata/rust/openapi/golden/src/builder.rs
+++ b/generator/testdata/rust/openapi/golden/src/builder.rs
@@ -18,6 +18,34 @@ pub mod secret_manager_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SecretManagerService][super::super::client::SecretManagerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use secretmanager_golden_openapi::*;
+    /// # use builder::secret_manager_service::ClientBuilder;
+    /// # use client::SecretManagerService;
+    /// let builder : ClientBuilder = SecretManagerService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://secretmanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SecretManagerService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SecretManagerService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -20,6 +20,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Secret Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use secretmanager_golden_openapi::client::SecretManagerService;
+/// let client = SecretManagerService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Stores sensitive data such as API keys, passwords, and certificates.
@@ -27,8 +36,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `SecretManagerService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SecretManagerService` use the `with_*` methods in the type returned
+/// by [builder()][SecretManagerService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://secretmanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::secret_manager_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::secret_manager_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,24 +66,30 @@ pub struct SecretManagerService {
 }
 
 impl SecretManagerService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SecretManagerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use secretmanager_golden_openapi::client::SecretManagerService;
+    /// let client = SecretManagerService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::secret_manager_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::secret_manager_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SecretManagerService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SecretManagerService>> {
@@ -558,5 +588,4 @@ impl SecretManagerService {
             .set_location ( location.into() )
             .set_secret ( secret.into() )
     }
-
 }

--- a/generator/testdata/rust/protobuf/golden/iam/v1/Cargo.toml
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/Cargo.toml
@@ -30,3 +30,6 @@ publish                = false
 [dependencies]
 gtype      = { path = "../../../../../../testdata/rust/protobuf/golden/type", package = "type-golden-protobuf" }
 wkt        = { path = "../../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod iam_policy {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [IAMPolicy][super::super::client::IAMPolicy].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use iam_v1_golden_protobuf::*;
+    /// # use builder::iam_policy::ClientBuilder;
+    /// # use client::IAMPolicy;
+    /// let builder : ClientBuilder = IAMPolicy::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iam-meta-api.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::IAMPolicy;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = IAMPolicy;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::IAMPolicy] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/client.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the .
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use iam_v1_golden_protobuf::client::IAMPolicy;
+/// let client = IAMPolicy::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview
@@ -51,8 +60,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `IAMPolicy` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `IAMPolicy` use the `with_*` methods in the type returned
+/// by [builder()][IAMPolicy::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iam-meta-api.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::iam_policy::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::iam_policy::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -66,24 +90,30 @@ pub struct IAMPolicy {
 }
 
 impl IAMPolicy {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [IAMPolicy].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use iam_v1_golden_protobuf::client::IAMPolicy;
+    /// let client = IAMPolicy::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::iam_policy::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::iam_policy::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::IAMPolicy + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::IAMPolicy>> {
@@ -141,5 +171,4 @@ impl IAMPolicy {
         super::builder::iam_policy::TestIamPermissions::new(self.inner.clone())
             .set_resource ( resource.into() )
     }
-
 }

--- a/generator/testdata/rust/protobuf/golden/location/Cargo.toml
+++ b/generator/testdata/rust/protobuf/golden/location/Cargo.toml
@@ -29,3 +29,6 @@ publish                = false
 
 [dependencies]
 wkt        = { path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/generator/testdata/rust/protobuf/golden/location/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builder.rs
@@ -18,6 +18,34 @@ pub mod locations {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Locations][super::super::client::Locations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use location_golden_protobuf::*;
+    /// # use builder::locations::ClientBuilder;
+    /// # use client::Locations;
+    /// let builder : ClientBuilder = Locations::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloud.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Locations;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Locations;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Locations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/generator/testdata/rust/protobuf/golden/location/src/client.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/client.rs
@@ -19,6 +19,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Metadata API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use location_golden_protobuf::client::Locations;
+/// let client = Locations::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// An abstract interface that provides location-related information for
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Locations` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Locations` use the `with_*` methods in the type returned
+/// by [builder()][Locations::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloud.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::locations::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::locations::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,24 +68,30 @@ pub struct Locations {
 }
 
 impl Locations {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [Locations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use location_golden_protobuf::client::Locations;
+    /// let client = Locations::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::locations::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::locations::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::Locations + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::Locations>> {
@@ -98,5 +128,4 @@ impl Locations {
         super::builder::locations::GetLocation::new(self.inner.clone())
             .set_name ( name.into() )
     }
-
 }

--- a/generator/testdata/rust/protobuf/golden/override/type/Cargo.toml
+++ b/generator/testdata/rust/protobuf/golden/override/type/Cargo.toml
@@ -27,3 +27,6 @@ categories.workspace   = true
 rust-version.workspace = true
 
 [dependencies]
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/generator/testdata/rust/protobuf/golden/secretmanager/Cargo.toml
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/Cargo.toml
@@ -31,3 +31,6 @@ publish                = false
 iam        = { path = "../../../../../testdata/rust/protobuf/golden/iam/v1", package = "iam-v1-golden-protobuf" }
 location   = { path = "../../../../../testdata/rust/protobuf/golden/location", package = "location-golden-protobuf" }
 wkt        = { path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builder.rs
@@ -18,6 +18,34 @@ pub mod secret_manager_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SecretManagerService][super::super::client::SecretManagerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use secretmanager_golden_protobuf::*;
+    /// # use builder::secret_manager_service::ClientBuilder;
+    /// # use client::SecretManagerService;
+    /// let builder : ClientBuilder = SecretManagerService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://secretmanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SecretManagerService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SecretManagerService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/client.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/client.rs
@@ -20,6 +20,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Secret Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use secretmanager_golden_protobuf::client::SecretManagerService;
+/// let client = SecretManagerService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Secret Manager Service
@@ -35,8 +44,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `SecretManagerService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SecretManagerService` use the `with_*` methods in the type returned
+/// by [builder()][SecretManagerService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://secretmanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::secret_manager_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::secret_manager_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -50,24 +74,30 @@ pub struct SecretManagerService {
 }
 
 impl SecretManagerService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SecretManagerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use secretmanager_golden_protobuf::client::SecretManagerService;
+    /// let client = SecretManagerService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::secret_manager_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::secret_manager_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SecretManagerService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SecretManagerService>> {
@@ -328,5 +358,4 @@ impl SecretManagerService {
         super::builder::secret_manager_service::GetLocation::new(self.inner.clone())
             .set_name ( name.into() )
     }
-
 }

--- a/generator/testdata/rust/protobuf/golden/type/Cargo.toml
+++ b/generator/testdata/rust/protobuf/golden/type/Cargo.toml
@@ -28,3 +28,6 @@ rust-version.workspace = true
 publish                = false
 
 [dependencies]
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/guide/samples/src/bin/getting_started.rs
+++ b/guide/samples/src/bin/getting_started.rs
@@ -17,7 +17,7 @@
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use google_cloud_secretmanager_v1::client::SecretManagerService;
     let project_id = std::env::args().nth(1).unwrap();
-    let client = SecretManagerService::new().await?;
+    let client = SecretManagerService::builder().build().await?;
 
     let mut items = client
         .list_secrets(format!("projects/{project_id}"))

--- a/guide/samples/src/lro.rs
+++ b/guide/samples/src/lro.rs
@@ -20,7 +20,7 @@ use google_cloud_speech_v2 as speech;
 // ANCHOR: start
 pub async fn start(project_id: &str) -> crate::Result<()> {
     // ANCHOR: client
-    let client = speech::client::Speech::new().await?;
+    let client = speech::client::Speech::builder().build().await?;
     // ANCHOR_END: client
 
     // ANCHOR: request-builder
@@ -71,7 +71,7 @@ pub async fn automatic(project_id: &str) -> crate::Result<()> {
     use speech::Poller;
     // ANCHOR_END: automatic-use
     // ANCHOR: automatic-prepare
-    let client = speech::client::Speech::new().await?;
+    let client = speech::client::Speech::builder().build().await?;
 
     let response = client
         .batch_recognize(format!(
@@ -113,7 +113,7 @@ pub async fn polling(project_id: &str) -> crate::Result<()> {
     use speech::Poller;
     // ANCHOR_END: polling-use
     // ANCHOR: polling-prepare
-    let client = speech::client::Speech::new().await?;
+    let client = speech::client::Speech::builder().build().await?;
 
     let mut poller = client
         .batch_recognize(format!(

--- a/guide/samples/src/polling_policies.rs
+++ b/guide/samples/src/polling_policies.rs
@@ -22,21 +22,20 @@ use google_cloud_speech_v2 as speech;
 pub async fn client_backoff(project_id: &str) -> crate::Result<()> {
     // ANCHOR: client-backoff-use
     use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
-    use google_cloud_gax::options::ClientConfig;
     // ANCHOR_END: client-backoff-use
     use speech::Poller;
     use std::time::Duration;
 
     // ANCHOR: client-backoff-client
-    let client = speech::client::Speech::new_with_config(
-        ClientConfig::default().set_polling_backoff_policy(
+    let client = speech::client::Speech::builder()
+        .with_polling_backoff_policy(
             ExponentialBackoffBuilder::new()
                 .with_initial_delay(Duration::from_millis(250))
                 .with_maximum_delay(Duration::from_secs(10))
                 .build()?,
-        ),
-    )
-    .await?;
+        )
+        .build()
+        .await?;
     // ANCHOR_END: client-backoff-client
 
     // ANCHOR: client-backoff-builder
@@ -86,7 +85,7 @@ pub async fn rpc_backoff(project_id: &str) -> crate::Result<()> {
     use speech::Poller;
 
     // ANCHOR: rpc-backoff-client
-    let client = speech::client::Speech::new().await?;
+    let client = speech::client::Speech::builder().build().await?;
     // ANCHOR_END: rpc-backoff-client
 
     // ANCHOR: rpc-backoff-builder
@@ -135,7 +134,6 @@ pub async fn rpc_backoff(project_id: &str) -> crate::Result<()> {
 // ANCHOR: client-errors
 pub async fn client_errors(project_id: &str) -> crate::Result<()> {
     // ANCHOR: client-errors-use
-    use google_cloud_gax::options::ClientConfig;
     use google_cloud_gax::polling_error_policy::Aip194Strict;
     use google_cloud_gax::polling_error_policy::PollingErrorPolicyExt;
     use std::time::Duration;
@@ -143,14 +141,14 @@ pub async fn client_errors(project_id: &str) -> crate::Result<()> {
     use speech::Poller;
 
     // ANCHOR: client-errors-client
-    let client = speech::client::Speech::new_with_config(
-        ClientConfig::default().set_polling_error_policy(
+    let client = speech::client::Speech::builder()
+        .with_polling_error_policy(
             Aip194Strict
                 .with_attempt_limit(100)
                 .with_time_limit(Duration::from_secs(300)),
-        ),
-    )
-    .await?;
+        )
+        .build()
+        .await?;
     // ANCHOR_END: client-errors-client
 
     // ANCHOR: client-errors-builder
@@ -201,7 +199,7 @@ pub async fn rpc_errors(project_id: &str) -> crate::Result<()> {
     use speech::Poller;
 
     // ANCHOR: rpc-errors-client
-    let client = speech::client::Speech::new().await?;
+    let client = speech::client::Speech::builder().build().await?;
     // ANCHOR_END: rpc-errors-client
 
     // ANCHOR: rpc-errors-builder

--- a/guide/samples/tests/initialize_client.rs
+++ b/guide/samples/tests/initialize_client.rs
@@ -24,7 +24,7 @@ pub async fn initialize_client(project_id: &str) -> Result {
     // asynchronous operation that may fail, as it requires acquiring an an
     // access token.
     // ANCHOR: new-client
-    let client = SecretManagerService::new().await?;
+    let client = SecretManagerService::builder().build().await?;
     // ANCHOR_END: new-client
 
     // Once initialized, use the client to make requests.

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -14,7 +14,6 @@
 
 use auth::credentials::{ApiKeyOptions, create_access_token_credential, create_api_key_credential};
 use gax::error::Error;
-use gax::options::ClientConfig as Config;
 use language::client::LanguageService;
 use language::model::Document;
 use scoped_env::ScopedEnv;
@@ -27,7 +26,7 @@ pub async fn service_account() -> Result<()> {
 
     // Create a SecretManager client. When running on GCB, this loads MDS
     // credentials for our `integration-test-runner` service account.
-    let client = SecretManagerService::new().await?;
+    let client = SecretManagerService::builder().build().await?;
 
     // Load the ADC json for the principal under test, in this case, a
     // service account.
@@ -55,8 +54,10 @@ pub async fn service_account() -> Result<()> {
         .map_err(Error::authentication)?;
 
     // Construct a new SecretManager client using the credentials.
-    let config = Config::new().set_credential(creds);
-    let client = SecretManagerService::new_with_config(config).await?;
+    let client = SecretManagerService::builder()
+        .with_credentials(creds)
+        .build()
+        .await?;
 
     // Access a secret, which only this principal has permissions to do.
     let response = client
@@ -80,7 +81,7 @@ pub async fn api_key() -> Result<()> {
 
     // Create a SecretManager client. When running on GCB, this loads MDS
     // credentials for our `integration-test-runner` service account.
-    let client = SecretManagerService::new().await?;
+    let client = SecretManagerService::builder().build().await?;
 
     // Load the API key under test.
     let response = client
@@ -102,8 +103,10 @@ pub async fn api_key() -> Result<()> {
         .map_err(Error::authentication)?;
 
     // Construct a Natural Language client using the credentials.
-    let config = Config::new().set_credential(creds);
-    let client = LanguageService::new_with_config(config).await?;
+    let client = LanguageService::builder()
+        .with_credentials(creds)
+        .build()
+        .await?;
 
     // Make a request using the API key.
     let d = Document::new()

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -51,5 +51,5 @@ rpc = { version = "0.2", path = "../generated/rpc/types", package = "google-clou
 wkt = { version = "0.3", path = "../wkt", package = "google-cloud-wkt", features = ["prost"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full", "macros"] }
+tokio                = { version = "1", features = ["full", "macros"] }
 tokio-test.workspace = true

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -52,3 +52,4 @@ wkt = { version = "0.3", path = "../wkt", package = "google-cloud-wkt", features
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "macros"] }
+tokio-test.workspace = true

--- a/src/firestore/src/generated/gapic/.sidekick.toml
+++ b/src/firestore/src/generated/gapic/.sidekick.toml
@@ -20,5 +20,6 @@ specification-source = 'google/firestore/v1'
 title-override = 'Cloud Firestore API'
 
 [codec]
-copyright-year    = '2025'
-template-override = 'templates/grpc-client'
+copyright-year        = '2025'
+template-override     = 'templates/grpc-client'
+package-name-override = 'google-cloud-firestore'

--- a/src/firestore/src/generated/gapic/builder.rs
+++ b/src/firestore/src/generated/gapic/builder.rs
@@ -18,6 +18,34 @@ pub mod firestore {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Firestore][super::super::client::Firestore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_firestore::*;
+    /// # use builder::firestore::ClientBuilder;
+    /// # use client::Firestore;
+    /// let builder : ClientBuilder = Firestore::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://firestore.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Firestore;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Firestore;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Firestore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/firestore/src/generated/gapic/client.rs
+++ b/src/firestore/src/generated/gapic/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Firestore API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_firestore::client::Firestore;
+/// let client = Firestore::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Cloud Firestore service.
@@ -34,8 +43,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Firestore` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Firestore` use the `with_*` methods in the type returned
+/// by [builder()][Firestore::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://firestore.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::firestore::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::firestore::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -49,21 +73,22 @@ pub struct Firestore {
 }
 
 impl Firestore {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Firestore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_firestore::client::Firestore;
+    /// let client = Firestore::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::firestore::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::firestore::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Firestore + 'static,
@@ -71,6 +96,11 @@ impl Firestore {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -37,7 +37,7 @@ _internal_http_client = [
   "gax/unstable-sdk-client",
 ]
 _internal_grpc_client = ["_internal_common", "dep:auth", "dep:gax", "dep:rpc", "dep:tokio", "dep:tonic"]
-_internal_common = ["dep:gax", "dep:thiserror"]
+_internal_common = ["dep:auth", "dep:gax", "dep:thiserror"]
 
 [dependencies]
 http = "1"

--- a/src/gax-internal/src/lib.rs
+++ b/src/gax-internal/src/lib.rs
@@ -39,3 +39,10 @@ pub mod http;
 #[cfg(feature = "_internal_grpc_client")]
 #[doc(hidden)]
 pub mod grpc;
+
+#[cfg(feature = "_internal_common")]
+#[doc(hidden)]
+pub mod options {
+    pub use auth::credentials::Credential as Credentials;
+    pub type ClientConfig = gax::client_builder::internal::ClientConfig<Credentials>;
+}

--- a/src/generated/api/apikeys/v2/Cargo.toml
+++ b/src/generated/api/apikeys/v2/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/api/apikeys/v2/src/builder.rs
+++ b/src/generated/api/apikeys/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod api_keys {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ApiKeys][super::super::client::ApiKeys].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apikeys_v2::*;
+    /// # use builder::api_keys::ClientBuilder;
+    /// # use client::ApiKeys;
+    /// let builder : ClientBuilder = ApiKeys::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apikeys.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ApiKeys;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ApiKeys;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ApiKeys] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/api/apikeys/v2/src/client.rs
+++ b/src/generated/api/apikeys/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the API Keys API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apikeys_v2::client::ApiKeys;
+/// let client = ApiKeys::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages the API keys associated with projects.
 ///
 /// # Configuration
 ///
-/// `ApiKeys` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ApiKeys` use the `with_*` methods in the type returned
+/// by [builder()][ApiKeys::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apikeys.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::api_keys::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::api_keys::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct ApiKeys {
 }
 
 impl ApiKeys {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ApiKeys].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apikeys_v2::client::ApiKeys;
+    /// let client = ApiKeys::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::api_keys::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::api_keys::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ApiKeys + 'static,
@@ -64,6 +89,11 @@ impl ApiKeys {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/api/servicecontrol/v1/Cargo.toml
+++ b/src/generated/api/servicecontrol/v1/Cargo.toml
@@ -41,3 +41,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/api/servicecontrol/v1/src/builder.rs
+++ b/src/generated/api/servicecontrol/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod quota_controller {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [QuotaController][super::super::client::QuotaController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_servicecontrol_v1::*;
+    /// # use builder::quota_controller::ClientBuilder;
+    /// # use client::QuotaController;
+    /// let builder : ClientBuilder = QuotaController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://servicecontrol.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::QuotaController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = QuotaController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::QuotaController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -102,6 +130,34 @@ pub mod quota_controller {
 pub mod service_controller {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ServiceController][super::super::client::ServiceController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_servicecontrol_v1::*;
+    /// # use builder::service_controller::ClientBuilder;
+    /// # use client::ServiceController;
+    /// let builder : ClientBuilder = ServiceController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://servicecontrol.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ServiceController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ServiceController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ServiceController] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/api/servicecontrol/v1/src/client.rs
+++ b/src/generated/api/servicecontrol/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Service Control API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_api_servicecontrol_v1::client::QuotaController;
+/// let client = QuotaController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// [Google Quota Control API](/service-control/overview)
@@ -30,8 +39,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `QuotaController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `QuotaController` use the `with_*` methods in the type returned
+/// by [builder()][QuotaController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://servicecontrol.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::quota_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::quota_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -45,21 +69,24 @@ pub struct QuotaController {
 }
 
 impl QuotaController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [QuotaController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_servicecontrol_v1::client::QuotaController;
+    /// let client = QuotaController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::quota_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::quota_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::QuotaController + 'static,
@@ -67,6 +94,11 @@ impl QuotaController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -114,6 +146,15 @@ impl QuotaController {
 
 /// Implements a client for the Service Control API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_api_servicecontrol_v1::client::ServiceController;
+/// let client = ServiceController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// [Google Service Control API](/service-control/overview)
@@ -123,8 +164,23 @@ impl QuotaController {
 ///
 /// # Configuration
 ///
-/// `ServiceController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ServiceController` use the `with_*` methods in the type returned
+/// by [builder()][ServiceController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://servicecontrol.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::service_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::service_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -138,21 +194,24 @@ pub struct ServiceController {
 }
 
 impl ServiceController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ServiceController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_servicecontrol_v1::client::ServiceController;
+    /// let client = ServiceController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::service_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::service_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ServiceController + 'static,
@@ -160,6 +219,11 @@ impl ServiceController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/api/servicecontrol/v2/Cargo.toml
+++ b/src/generated/api/servicecontrol/v2/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/api/servicecontrol/v2/src/builder.rs
+++ b/src/generated/api/servicecontrol/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod service_controller {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ServiceController][super::super::client::ServiceController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_servicecontrol_v2::*;
+    /// # use builder::service_controller::ClientBuilder;
+    /// # use client::ServiceController;
+    /// let builder : ClientBuilder = ServiceController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://servicecontrol.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ServiceController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ServiceController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ServiceController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/api/servicecontrol/v2/src/client.rs
+++ b/src/generated/api/servicecontrol/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Service Control API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_api_servicecontrol_v2::client::ServiceController;
+/// let client = ServiceController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// [Service Control API
@@ -34,8 +43,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ServiceController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ServiceController` use the `with_*` methods in the type returned
+/// by [builder()][ServiceController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://servicecontrol.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::service_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::service_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -49,21 +73,24 @@ pub struct ServiceController {
 }
 
 impl ServiceController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ServiceController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_servicecontrol_v2::client::ServiceController;
+    /// let client = ServiceController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::service_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::service_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ServiceController + 'static,
@@ -71,6 +98,11 @@ impl ServiceController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/api/servicemanagement/v1/Cargo.toml
+++ b/src/generated/api/servicemanagement/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/api/servicemanagement/v1/src/builder.rs
+++ b/src/generated/api/servicemanagement/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod service_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ServiceManager][super::super::client::ServiceManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_servicemanagement_v1::*;
+    /// # use builder::service_manager::ClientBuilder;
+    /// # use client::ServiceManager;
+    /// let builder : ClientBuilder = ServiceManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://servicemanagement.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ServiceManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ServiceManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ServiceManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/api/servicemanagement/v1/src/client.rs
+++ b/src/generated/api/servicemanagement/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Service Management API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+/// let client = ServiceManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// [Google Service Management
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ServiceManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ServiceManager` use the `with_*` methods in the type returned
+/// by [builder()][ServiceManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://servicemanagement.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::service_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::service_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct ServiceManager {
 }
 
 impl ServiceManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ServiceManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// let client = ServiceManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::service_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::service_manager::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ServiceManager + 'static,
@@ -65,6 +90,11 @@ impl ServiceManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/api/serviceusage/v1/Cargo.toml
+++ b/src/generated/api/serviceusage/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/api/serviceusage/v1/src/builder.rs
+++ b/src/generated/api/serviceusage/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod service_usage {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ServiceUsage][super::super::client::ServiceUsage].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_serviceusage_v1::*;
+    /// # use builder::service_usage::ClientBuilder;
+    /// # use client::ServiceUsage;
+    /// let builder : ClientBuilder = ServiceUsage::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://serviceusage.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ServiceUsage;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ServiceUsage;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ServiceUsage] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/api/serviceusage/v1/src/client.rs
+++ b/src/generated/api/serviceusage/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Service Usage API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_api_serviceusage_v1::client::ServiceUsage;
+/// let client = ServiceUsage::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Enables services that service consumers want to use on Google Cloud Platform,
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ServiceUsage` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ServiceUsage` use the `with_*` methods in the type returned
+/// by [builder()][ServiceUsage::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://serviceusage.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::service_usage::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::service_usage::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,22 @@ pub struct ServiceUsage {
 }
 
 impl ServiceUsage {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ServiceUsage].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_api_serviceusage_v1::client::ServiceUsage;
+    /// let client = ServiceUsage::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::service_usage::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::service_usage::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ServiceUsage + 'static,
@@ -68,6 +93,11 @@ impl ServiceUsage {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/api/types/Cargo.toml
+++ b/src/generated/api/types/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/appengine/v1/Cargo.toml
+++ b/src/generated/appengine/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/appengine/v1/src/builder.rs
+++ b/src/generated/appengine/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod applications {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Applications][super::super::client::Applications].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::*;
+    /// # use builder::applications::ClientBuilder;
+    /// # use client::Applications;
+    /// let builder : ClientBuilder = Applications::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://appengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Applications;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Applications;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Applications] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -482,6 +510,34 @@ pub mod services {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Services][super::super::client::Services].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::*;
+    /// # use builder::services::ClientBuilder;
+    /// # use client::Services;
+    /// let builder : ClientBuilder = Services::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://appengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Services;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Services;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Services] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -922,6 +978,34 @@ pub mod services {
 pub mod versions {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Versions][super::super::client::Versions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::*;
+    /// # use builder::versions::ClientBuilder;
+    /// # use client::Versions;
+    /// let builder : ClientBuilder = Versions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://appengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Versions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Versions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Versions] request builders.
     #[derive(Clone, Debug)]
@@ -1460,6 +1544,34 @@ pub mod instances {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Instances][super::super::client::Instances].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::*;
+    /// # use builder::instances::ClientBuilder;
+    /// # use client::Instances;
+    /// let builder : ClientBuilder = Instances::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://appengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Instances;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Instances;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Instances] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1882,6 +1994,34 @@ pub mod instances {
 pub mod firewall {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Firewall][super::super::client::Firewall].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::*;
+    /// # use builder::firewall::ClientBuilder;
+    /// # use client::Firewall;
+    /// let builder : ClientBuilder = Firewall::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://appengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Firewall;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Firewall;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Firewall] request builders.
     #[derive(Clone, Debug)]
@@ -2372,6 +2512,34 @@ pub mod authorized_domains {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AuthorizedDomains][super::super::client::AuthorizedDomains].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::*;
+    /// # use builder::authorized_domains::ClientBuilder;
+    /// # use client::AuthorizedDomains;
+    /// let builder : ClientBuilder = AuthorizedDomains::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://appengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AuthorizedDomains;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AuthorizedDomains;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AuthorizedDomains] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2592,6 +2760,34 @@ pub mod authorized_domains {
 pub mod authorized_certificates {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [AuthorizedCertificates][super::super::client::AuthorizedCertificates].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::*;
+    /// # use builder::authorized_certificates::ClientBuilder;
+    /// # use client::AuthorizedCertificates;
+    /// let builder : ClientBuilder = AuthorizedCertificates::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://appengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AuthorizedCertificates;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AuthorizedCertificates;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::AuthorizedCertificates] request builders.
     #[derive(Clone, Debug)]
@@ -3064,6 +3260,34 @@ pub mod authorized_certificates {
 pub mod domain_mappings {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [DomainMappings][super::super::client::DomainMappings].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::*;
+    /// # use builder::domain_mappings::ClientBuilder;
+    /// # use client::DomainMappings;
+    /// let builder : ClientBuilder = DomainMappings::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://appengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DomainMappings;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DomainMappings;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::DomainMappings] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/appengine/v1/src/client.rs
+++ b/src/generated/appengine/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the App Engine Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_appengine_v1::client::Applications;
+/// let client = Applications::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages App Engine applications.
 ///
 /// # Configuration
 ///
-/// `Applications` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Applications` use the `with_*` methods in the type returned
+/// by [builder()][Applications::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://appengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::applications::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::applications::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Applications {
 }
 
 impl Applications {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Applications].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::client::Applications;
+    /// let client = Applications::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::applications::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::applications::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Applications + 'static,
@@ -64,6 +89,11 @@ impl Applications {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -193,14 +223,38 @@ impl Applications {
 
 /// Implements a client for the App Engine Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_appengine_v1::client::Services;
+/// let client = Services::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages services of an application.
 ///
 /// # Configuration
 ///
-/// `Services` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Services` use the `with_*` methods in the type returned
+/// by [builder()][Services::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://appengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::services::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::services::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -214,21 +268,22 @@ pub struct Services {
 }
 
 impl Services {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Services].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::client::Services;
+    /// let client = Services::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::services::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::services::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Services + 'static,
@@ -236,6 +291,11 @@ impl Services {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -336,14 +396,38 @@ impl Services {
 
 /// Implements a client for the App Engine Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_appengine_v1::client::Versions;
+/// let client = Versions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages versions of a service.
 ///
 /// # Configuration
 ///
-/// `Versions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Versions` use the `with_*` methods in the type returned
+/// by [builder()][Versions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://appengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::versions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::versions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -357,21 +441,22 @@ pub struct Versions {
 }
 
 impl Versions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Versions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::client::Versions;
+    /// let client = Versions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::versions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::versions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Versions + 'static,
@@ -379,6 +464,11 @@ impl Versions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -534,14 +624,38 @@ impl Versions {
 
 /// Implements a client for the App Engine Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_appengine_v1::client::Instances;
+/// let client = Instances::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages instances of a version.
 ///
 /// # Configuration
 ///
-/// `Instances` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Instances` use the `with_*` methods in the type returned
+/// by [builder()][Instances::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://appengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::instances::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::instances::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -555,21 +669,22 @@ pub struct Instances {
 }
 
 impl Instances {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Instances].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::client::Instances;
+    /// let client = Instances::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::instances::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::instances::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Instances + 'static,
@@ -577,6 +692,11 @@ impl Instances {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -698,6 +818,15 @@ impl Instances {
 
 /// Implements a client for the App Engine Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_appengine_v1::client::Firewall;
+/// let client = Firewall::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Firewall resources are used to define a collection of access control rules
@@ -713,8 +842,23 @@ impl Instances {
 ///
 /// # Configuration
 ///
-/// `Firewall` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Firewall` use the `with_*` methods in the type returned
+/// by [builder()][Firewall::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://appengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::firewall::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::firewall::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -728,21 +872,22 @@ pub struct Firewall {
 }
 
 impl Firewall {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Firewall].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::client::Firewall;
+    /// let client = Firewall::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::firewall::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::firewall::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Firewall + 'static,
@@ -750,6 +895,11 @@ impl Firewall {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -853,6 +1003,15 @@ impl Firewall {
 
 /// Implements a client for the App Engine Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_appengine_v1::client::AuthorizedDomains;
+/// let client = AuthorizedDomains::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages domains a user is authorized to administer. To authorize use of a
@@ -861,8 +1020,23 @@ impl Firewall {
 ///
 /// # Configuration
 ///
-/// `AuthorizedDomains` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AuthorizedDomains` use the `with_*` methods in the type returned
+/// by [builder()][AuthorizedDomains::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://appengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::authorized_domains::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::authorized_domains::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -876,21 +1050,24 @@ pub struct AuthorizedDomains {
 }
 
 impl AuthorizedDomains {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AuthorizedDomains].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::client::AuthorizedDomains;
+    /// let client = AuthorizedDomains::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::authorized_domains::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::authorized_domains::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AuthorizedDomains + 'static,
@@ -898,6 +1075,11 @@ impl AuthorizedDomains {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -957,6 +1139,15 @@ impl AuthorizedDomains {
 
 /// Implements a client for the App Engine Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_appengine_v1::client::AuthorizedCertificates;
+/// let client = AuthorizedCertificates::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages SSL certificates a user is authorized to administer. A user can
@@ -964,8 +1155,23 @@ impl AuthorizedDomains {
 ///
 /// # Configuration
 ///
-/// `AuthorizedCertificates` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AuthorizedCertificates` use the `with_*` methods in the type returned
+/// by [builder()][AuthorizedCertificates::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://appengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::authorized_certificates::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::authorized_certificates::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -979,21 +1185,24 @@ pub struct AuthorizedCertificates {
 }
 
 impl AuthorizedCertificates {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AuthorizedCertificates].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::client::AuthorizedCertificates;
+    /// let client = AuthorizedCertificates::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::authorized_certificates::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::authorized_certificates::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AuthorizedCertificates + 'static,
@@ -1001,6 +1210,11 @@ impl AuthorizedCertificates {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1106,14 +1320,38 @@ impl AuthorizedCertificates {
 
 /// Implements a client for the App Engine Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_appengine_v1::client::DomainMappings;
+/// let client = DomainMappings::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages domains serving an application.
 ///
 /// # Configuration
 ///
-/// `DomainMappings` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DomainMappings` use the `with_*` methods in the type returned
+/// by [builder()][DomainMappings::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://appengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::domain_mappings::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::domain_mappings::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1127,21 +1365,22 @@ pub struct DomainMappings {
 }
 
 impl DomainMappings {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DomainMappings].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_appengine_v1::client::DomainMappings;
+    /// let client = DomainMappings::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::domain_mappings::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::domain_mappings::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DomainMappings + 'static,
@@ -1149,6 +1388,11 @@ impl DomainMappings {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/apps/script/calendar/Cargo.toml
+++ b/src/generated/apps/script/calendar/Cargo.toml
@@ -32,3 +32,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/apps/script/docs/Cargo.toml
+++ b/src/generated/apps/script/docs/Cargo.toml
@@ -32,3 +32,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/apps/script/drive/Cargo.toml
+++ b/src/generated/apps/script/drive/Cargo.toml
@@ -32,3 +32,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/apps/script/gmail/Cargo.toml
+++ b/src/generated/apps/script/gmail/Cargo.toml
@@ -32,3 +32,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/apps/script/gtype/Cargo.toml
+++ b/src/generated/apps/script/gtype/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/apps/script/sheets/Cargo.toml
+++ b/src/generated/apps/script/sheets/Cargo.toml
@@ -32,3 +32,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/apps/script/slides/Cargo.toml
+++ b/src/generated/apps/script/slides/Cargo.toml
@@ -32,3 +32,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/bigtable/admin/v2/Cargo.toml
+++ b/src/generated/bigtable/admin/v2/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/bigtable/admin/v2/src/builder.rs
+++ b/src/generated/bigtable/admin/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod bigtable_instance_admin {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [BigtableInstanceAdmin][super::super::client::BigtableInstanceAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigtable_admin_v2::*;
+    /// # use builder::bigtable_instance_admin::ClientBuilder;
+    /// # use client::BigtableInstanceAdmin;
+    /// let builder : ClientBuilder = BigtableInstanceAdmin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigtableadmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::BigtableInstanceAdmin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = BigtableInstanceAdmin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::BigtableInstanceAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2523,6 +2551,34 @@ pub mod bigtable_instance_admin {
 pub mod bigtable_table_admin {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [BigtableTableAdmin][super::super::client::BigtableTableAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigtable_admin_v2::*;
+    /// # use builder::bigtable_table_admin::ClientBuilder;
+    /// # use client::BigtableTableAdmin;
+    /// let builder : ClientBuilder = BigtableTableAdmin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigtableadmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::BigtableTableAdmin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = BigtableTableAdmin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::BigtableTableAdmin] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/bigtable/admin/v2/src/client.rs
+++ b/src/generated/bigtable/admin/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Bigtable Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+/// let client = BigtableInstanceAdmin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for creating, configuring, and deleting Cloud Bigtable Instances and
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `BigtableInstanceAdmin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `BigtableInstanceAdmin` use the `with_*` methods in the type returned
+/// by [builder()][BigtableInstanceAdmin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigtableadmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::bigtable_instance_admin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::bigtable_instance_admin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,24 @@ pub struct BigtableInstanceAdmin {
 }
 
 impl BigtableInstanceAdmin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [BigtableInstanceAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// let client = BigtableInstanceAdmin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::bigtable_instance_admin::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::bigtable_instance_admin::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::BigtableInstanceAdmin + 'static,
@@ -66,6 +93,11 @@ impl BigtableInstanceAdmin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -550,6 +582,15 @@ impl BigtableInstanceAdmin {
 
 /// Implements a client for the Cloud Bigtable Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+/// let client = BigtableTableAdmin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for creating, configuring, and deleting Cloud Bigtable tables.
@@ -559,8 +600,23 @@ impl BigtableInstanceAdmin {
 ///
 /// # Configuration
 ///
-/// `BigtableTableAdmin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `BigtableTableAdmin` use the `with_*` methods in the type returned
+/// by [builder()][BigtableTableAdmin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigtableadmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::bigtable_table_admin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::bigtable_table_admin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -574,21 +630,24 @@ pub struct BigtableTableAdmin {
 }
 
 impl BigtableTableAdmin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [BigtableTableAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// let client = BigtableTableAdmin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::bigtable_table_admin::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::bigtable_table_admin::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::BigtableTableAdmin + 'static,
@@ -596,6 +655,11 @@ impl BigtableTableAdmin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/accessapproval/v1/Cargo.toml
+++ b/src/generated/cloud/accessapproval/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/accessapproval/v1/src/builder.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod access_approval {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AccessApproval][super::super::client::AccessApproval].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_accessapproval_v1::*;
+    /// # use builder::access_approval::ClientBuilder;
+    /// # use client::AccessApproval;
+    /// let builder : ClientBuilder = AccessApproval::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://accessapproval.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AccessApproval;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AccessApproval;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AccessApproval] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/accessapproval/v1/src/client.rs
+++ b/src/generated/cloud/accessapproval/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Access Approval API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_accessapproval_v1::client::AccessApproval;
+/// let client = AccessApproval::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This API allows a customer to manage accesses to cloud resources by
@@ -61,8 +70,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AccessApproval` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AccessApproval` use the `with_*` methods in the type returned
+/// by [builder()][AccessApproval::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://accessapproval.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::access_approval::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::access_approval::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -76,21 +100,22 @@ pub struct AccessApproval {
 }
 
 impl AccessApproval {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AccessApproval].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// let client = AccessApproval::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::access_approval::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::access_approval::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AccessApproval + 'static,
@@ -98,6 +123,11 @@ impl AccessApproval {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/advisorynotifications/v1/Cargo.toml
+++ b/src/generated/cloud/advisorynotifications/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/advisorynotifications/v1/src/builder.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod advisory_notifications_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AdvisoryNotificationsService][super::super::client::AdvisoryNotificationsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_advisorynotifications_v1::*;
+    /// # use builder::advisory_notifications_service::ClientBuilder;
+    /// # use client::AdvisoryNotificationsService;
+    /// let builder : ClientBuilder = AdvisoryNotificationsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://advisorynotifications.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AdvisoryNotificationsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AdvisoryNotificationsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AdvisoryNotificationsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/advisorynotifications/v1/src/client.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Advisory Notifications API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_advisorynotifications_v1::client::AdvisoryNotificationsService;
+/// let client = AdvisoryNotificationsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service to manage Security and Privacy Notifications.
 ///
 /// # Configuration
 ///
-/// `AdvisoryNotificationsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AdvisoryNotificationsService` use the `with_*` methods in the type returned
+/// by [builder()][AdvisoryNotificationsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://advisorynotifications.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::advisory_notifications_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::advisory_notifications_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct AdvisoryNotificationsService {
 }
 
 impl AdvisoryNotificationsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AdvisoryNotificationsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_advisorynotifications_v1::client::AdvisoryNotificationsService;
+    /// let client = AdvisoryNotificationsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::advisory_notifications_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::advisory_notifications_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AdvisoryNotificationsService + 'static,
@@ -64,6 +91,11 @@ impl AdvisoryNotificationsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -47,4 +47,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/aiplatform/v1/src/builder.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod dataset_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DatasetService][super::super::client::DatasetService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::dataset_service::ClientBuilder;
+    /// # use client::DatasetService;
+    /// let builder : ClientBuilder = DatasetService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DatasetService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DatasetService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DatasetService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2129,6 +2157,34 @@ pub mod deployment_resource_pool_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DeploymentResourcePoolService][super::super::client::DeploymentResourcePoolService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::deployment_resource_pool_service::ClientBuilder;
+    /// # use client::DeploymentResourcePoolService;
+    /// let builder : ClientBuilder = DeploymentResourcePoolService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DeploymentResourcePoolService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DeploymentResourcePoolService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DeploymentResourcePoolService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -3230,6 +3286,34 @@ pub mod deployment_resource_pool_service {
 pub mod endpoint_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [EndpointService][super::super::client::EndpointService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::endpoint_service::ClientBuilder;
+    /// # use client::EndpointService;
+    /// let builder : ClientBuilder = EndpointService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EndpointService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EndpointService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::EndpointService] request builders.
     #[derive(Clone, Debug)]
@@ -4572,6 +4656,34 @@ pub mod evaluation_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [EvaluationService][super::super::client::EvaluationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::evaluation_service::ClientBuilder;
+    /// # use client::EvaluationService;
+    /// let builder : ClientBuilder = EvaluationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EvaluationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EvaluationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::EvaluationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -5204,6 +5316,34 @@ pub mod evaluation_service {
 pub mod feature_online_store_admin_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [FeatureOnlineStoreAdminService][super::super::client::FeatureOnlineStoreAdminService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::feature_online_store_admin_service::ClientBuilder;
+    /// # use client::FeatureOnlineStoreAdminService;
+    /// let builder : ClientBuilder = FeatureOnlineStoreAdminService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::FeatureOnlineStoreAdminService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = FeatureOnlineStoreAdminService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::FeatureOnlineStoreAdminService] request builders.
     #[derive(Clone, Debug)]
@@ -6844,6 +6984,34 @@ pub mod feature_online_store_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [FeatureOnlineStoreService][super::super::client::FeatureOnlineStoreService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::feature_online_store_service::ClientBuilder;
+    /// # use client::FeatureOnlineStoreService;
+    /// let builder : ClientBuilder = FeatureOnlineStoreService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::FeatureOnlineStoreService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = FeatureOnlineStoreService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::FeatureOnlineStoreService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -7569,6 +7737,34 @@ pub mod feature_online_store_service {
 pub mod feature_registry_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [FeatureRegistryService][super::super::client::FeatureRegistryService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::feature_registry_service::ClientBuilder;
+    /// # use client::FeatureRegistryService;
+    /// let builder : ClientBuilder = FeatureRegistryService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::FeatureRegistryService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = FeatureRegistryService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::FeatureRegistryService] request builders.
     #[derive(Clone, Debug)]
@@ -9106,6 +9302,34 @@ pub mod featurestore_online_serving_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [FeaturestoreOnlineServingService][super::super::client::FeaturestoreOnlineServingService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::featurestore_online_serving_service::ClientBuilder;
+    /// # use client::FeaturestoreOnlineServingService;
+    /// let builder : ClientBuilder = FeaturestoreOnlineServingService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::FeaturestoreOnlineServingService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = FeaturestoreOnlineServingService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::FeaturestoreOnlineServingService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -9824,6 +10048,34 @@ pub mod featurestore_online_serving_service {
 pub mod featurestore_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [FeaturestoreService][super::super::client::FeaturestoreService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::featurestore_service::ClientBuilder;
+    /// # use client::FeaturestoreService;
+    /// let builder : ClientBuilder = FeaturestoreService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::FeaturestoreService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = FeaturestoreService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::FeaturestoreService] request builders.
     #[derive(Clone, Debug)]
@@ -12245,6 +12497,34 @@ pub mod gen_ai_cache_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [GenAiCacheService][super::super::client::GenAiCacheService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::gen_ai_cache_service::ClientBuilder;
+    /// # use client::GenAiCacheService;
+    /// let builder : ClientBuilder = GenAiCacheService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::GenAiCacheService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = GenAiCacheService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::GenAiCacheService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -13094,6 +13374,34 @@ pub mod gen_ai_cache_service {
 pub mod gen_ai_tuning_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [GenAiTuningService][super::super::client::GenAiTuningService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::gen_ai_tuning_service::ClientBuilder;
+    /// # use client::GenAiTuningService;
+    /// let builder : ClientBuilder = GenAiTuningService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::GenAiTuningService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = GenAiTuningService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::GenAiTuningService] request builders.
     #[derive(Clone, Debug)]
@@ -14002,6 +14310,34 @@ pub mod gen_ai_tuning_service {
 pub mod index_endpoint_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [IndexEndpointService][super::super::client::IndexEndpointService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::index_endpoint_service::ClientBuilder;
+    /// # use client::IndexEndpointService;
+    /// let builder : ClientBuilder = IndexEndpointService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::IndexEndpointService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = IndexEndpointService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::IndexEndpointService] request builders.
     #[derive(Clone, Debug)]
@@ -15263,6 +15599,34 @@ pub mod index_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [IndexService][super::super::client::IndexService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::index_service::ClientBuilder;
+    /// # use client::IndexService;
+    /// let builder : ClientBuilder = IndexService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::IndexService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = IndexService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::IndexService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -16343,6 +16707,34 @@ pub mod index_service {
 pub mod job_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [JobService][super::super::client::JobService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::job_service::ClientBuilder;
+    /// # use client::JobService;
+    /// let builder : ClientBuilder = JobService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::JobService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = JobService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::JobService] request builders.
     #[derive(Clone, Debug)]
@@ -19176,6 +19568,34 @@ pub mod llm_utility_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [LlmUtilityService][super::super::client::LlmUtilityService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::llm_utility_service::ClientBuilder;
+    /// # use client::LlmUtilityService;
+    /// let builder : ClientBuilder = LlmUtilityService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::LlmUtilityService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = LlmUtilityService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::LlmUtilityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -19924,6 +20344,34 @@ pub mod match_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [MatchService][super::super::client::MatchService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::match_service::ClientBuilder;
+    /// # use client::MatchService;
+    /// let builder : ClientBuilder = MatchService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::MatchService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = MatchService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::MatchService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -20627,6 +21075,34 @@ pub mod match_service {
 pub mod metadata_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [MetadataService][super::super::client::MetadataService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::metadata_service::ClientBuilder;
+    /// # use client::MetadataService;
+    /// let builder : ClientBuilder = MetadataService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::MetadataService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = MetadataService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::MetadataService] request builders.
     #[derive(Clone, Debug)]
@@ -23348,6 +23824,34 @@ pub mod migration_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [MigrationService][super::super::client::MigrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::migration_service::ClientBuilder;
+    /// # use client::MigrationService;
+    /// let builder : ClientBuilder = MigrationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::MigrationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = MigrationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::MigrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -24106,6 +24610,34 @@ pub mod model_garden_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ModelGardenService][super::super::client::ModelGardenService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::model_garden_service::ClientBuilder;
+    /// # use client::ModelGardenService;
+    /// let builder : ClientBuilder = ModelGardenService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ModelGardenService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ModelGardenService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ModelGardenService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -24751,6 +25283,34 @@ pub mod model_garden_service {
 pub mod model_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ModelService][super::super::client::ModelService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::model_service::ClientBuilder;
+    /// # use client::ModelService;
+    /// let builder : ClientBuilder = ModelService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ModelService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ModelService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ModelService] request builders.
     #[derive(Clone, Debug)]
@@ -26741,6 +27301,34 @@ pub mod notebook_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [NotebookService][super::super::client::NotebookService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::notebook_service::ClientBuilder;
+    /// # use client::NotebookService;
+    /// let builder : ClientBuilder = NotebookService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::NotebookService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = NotebookService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::NotebookService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -28636,6 +29224,34 @@ pub mod persistent_resource_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [PersistentResourceService][super::super::client::PersistentResourceService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::persistent_resource_service::ClientBuilder;
+    /// # use client::PersistentResourceService;
+    /// let builder : ClientBuilder = PersistentResourceService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PersistentResourceService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PersistentResourceService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::PersistentResourceService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -29750,6 +30366,34 @@ pub mod persistent_resource_service {
 pub mod pipeline_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [PipelineService][super::super::client::PipelineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::pipeline_service::ClientBuilder;
+    /// # use client::PipelineService;
+    /// let builder : ClientBuilder = PipelineService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PipelineService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PipelineService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::PipelineService] request builders.
     #[derive(Clone, Debug)]
@@ -31157,6 +31801,34 @@ pub mod prediction_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [PredictionService][super::super::client::PredictionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::prediction_service::ClientBuilder;
+    /// # use client::PredictionService;
+    /// let builder : ClientBuilder = PredictionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PredictionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PredictionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::PredictionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -32156,6 +32828,34 @@ pub mod reasoning_engine_execution_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ReasoningEngineExecutionService][super::super::client::ReasoningEngineExecutionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::reasoning_engine_execution_service::ClientBuilder;
+    /// # use client::ReasoningEngineExecutionService;
+    /// let builder : ClientBuilder = ReasoningEngineExecutionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ReasoningEngineExecutionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ReasoningEngineExecutionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ReasoningEngineExecutionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -32813,6 +33513,34 @@ pub mod reasoning_engine_execution_service {
 pub mod reasoning_engine_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ReasoningEngineService][super::super::client::ReasoningEngineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::reasoning_engine_service::ClientBuilder;
+    /// # use client::ReasoningEngineService;
+    /// let builder : ClientBuilder = ReasoningEngineService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ReasoningEngineService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ReasoningEngineService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ReasoningEngineService] request builders.
     #[derive(Clone, Debug)]
@@ -33823,6 +34551,34 @@ pub mod schedule_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ScheduleService][super::super::client::ScheduleService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::schedule_service::ClientBuilder;
+    /// # use client::ScheduleService;
+    /// let builder : ClientBuilder = ScheduleService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ScheduleService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ScheduleService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ScheduleService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -34794,6 +35550,34 @@ pub mod schedule_service {
 pub mod specialist_pool_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SpecialistPoolService][super::super::client::SpecialistPoolService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::specialist_pool_service::ClientBuilder;
+    /// # use client::SpecialistPoolService;
+    /// let builder : ClientBuilder = SpecialistPoolService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SpecialistPoolService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SpecialistPoolService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SpecialistPoolService] request builders.
     #[derive(Clone, Debug)]
@@ -35809,6 +36593,34 @@ pub mod specialist_pool_service {
 pub mod tensorboard_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [TensorboardService][super::super::client::TensorboardService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::tensorboard_service::ClientBuilder;
+    /// # use client::TensorboardService;
+    /// let builder : ClientBuilder = TensorboardService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TensorboardService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TensorboardService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::TensorboardService] request builders.
     #[derive(Clone, Debug)]
@@ -38352,6 +39164,34 @@ pub mod vertex_rag_data_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [VertexRagDataService][super::super::client::VertexRagDataService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::vertex_rag_data_service::ClientBuilder;
+    /// # use client::VertexRagDataService;
+    /// let builder : ClientBuilder = VertexRagDataService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VertexRagDataService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VertexRagDataService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::VertexRagDataService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -39689,6 +40529,34 @@ pub mod vertex_rag_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [VertexRagService][super::super::client::VertexRagService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::vertex_rag_service::ClientBuilder;
+    /// # use client::VertexRagService;
+    /// let builder : ClientBuilder = VertexRagService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VertexRagService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VertexRagService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::VertexRagService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -40481,6 +41349,34 @@ pub mod vertex_rag_service {
 pub mod vizier_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [VizierService][super::super::client::VizierService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::*;
+    /// # use builder::vizier_service::ClientBuilder;
+    /// # use client::VizierService;
+    /// let builder : ClientBuilder = VizierService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://aiplatform.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VizierService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VizierService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::VizierService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/aiplatform/v1/src/client.rs
+++ b/src/generated/cloud/aiplatform/v1/src/client.rs
@@ -22,14 +22,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::DatasetService;
+/// let client = DatasetService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The service that manages Vertex AI Dataset and its child resources.
 ///
 /// # Configuration
 ///
-/// `DatasetService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DatasetService` use the `with_*` methods in the type returned
+/// by [builder()][DatasetService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::dataset_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::dataset_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct DatasetService {
 }
 
 impl DatasetService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DatasetService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// let client = DatasetService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::dataset_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::dataset_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DatasetService + 'static,
@@ -65,6 +90,11 @@ impl DatasetService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -452,14 +482,38 @@ impl DatasetService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+/// let client = DeploymentResourcePoolService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service that manages the DeploymentResourcePool resource.
 ///
 /// # Configuration
 ///
-/// `DeploymentResourcePoolService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DeploymentResourcePoolService` use the `with_*` methods in the type returned
+/// by [builder()][DeploymentResourcePoolService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::deployment_resource_pool_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::deployment_resource_pool_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -473,21 +527,24 @@ pub struct DeploymentResourcePoolService {
 }
 
 impl DeploymentResourcePoolService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DeploymentResourcePoolService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// let client = DeploymentResourcePoolService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::deployment_resource_pool_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::deployment_resource_pool_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DeploymentResourcePoolService + 'static,
@@ -495,6 +552,11 @@ impl DeploymentResourcePoolService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -732,14 +794,38 @@ impl DeploymentResourcePoolService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::EndpointService;
+/// let client = EndpointService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for managing Vertex AI's Endpoints.
 ///
 /// # Configuration
 ///
-/// `EndpointService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EndpointService` use the `with_*` methods in the type returned
+/// by [builder()][EndpointService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::endpoint_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::endpoint_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -753,21 +839,24 @@ pub struct EndpointService {
 }
 
 impl EndpointService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EndpointService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// let client = EndpointService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::endpoint_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::endpoint_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EndpointService + 'static,
@@ -775,6 +864,11 @@ impl EndpointService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1057,14 +1151,38 @@ impl EndpointService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::EvaluationService;
+/// let client = EvaluationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Vertex AI Online Evaluation Service.
 ///
 /// # Configuration
 ///
-/// `EvaluationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EvaluationService` use the `with_*` methods in the type returned
+/// by [builder()][EvaluationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::evaluation_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::evaluation_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1078,21 +1196,24 @@ pub struct EvaluationService {
 }
 
 impl EvaluationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EvaluationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// let client = EvaluationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::evaluation_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::evaluation_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EvaluationService + 'static,
@@ -1100,6 +1221,11 @@ impl EvaluationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1248,6 +1374,15 @@ impl EvaluationService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+/// let client = FeatureOnlineStoreAdminService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The service that handles CRUD and List for resources for
@@ -1255,8 +1390,23 @@ impl EvaluationService {
 ///
 /// # Configuration
 ///
-/// `FeatureOnlineStoreAdminService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `FeatureOnlineStoreAdminService` use the `with_*` methods in the type returned
+/// by [builder()][FeatureOnlineStoreAdminService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::feature_online_store_admin_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::feature_online_store_admin_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1270,21 +1420,24 @@ pub struct FeatureOnlineStoreAdminService {
 }
 
 impl FeatureOnlineStoreAdminService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [FeatureOnlineStoreAdminService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// let client = FeatureOnlineStoreAdminService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::feature_online_store_admin_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::feature_online_store_admin_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::FeatureOnlineStoreAdminService + 'static,
@@ -1292,6 +1445,11 @@ impl FeatureOnlineStoreAdminService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1633,14 +1791,38 @@ impl FeatureOnlineStoreAdminService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+/// let client = FeatureOnlineStoreService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for fetching feature values from the online store.
 ///
 /// # Configuration
 ///
-/// `FeatureOnlineStoreService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `FeatureOnlineStoreService` use the `with_*` methods in the type returned
+/// by [builder()][FeatureOnlineStoreService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::feature_online_store_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::feature_online_store_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1654,21 +1836,24 @@ pub struct FeatureOnlineStoreService {
 }
 
 impl FeatureOnlineStoreService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [FeatureOnlineStoreService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// let client = FeatureOnlineStoreService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::feature_online_store_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::feature_online_store_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::FeatureOnlineStoreService + 'static,
@@ -1676,6 +1861,11 @@ impl FeatureOnlineStoreService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1835,6 +2025,15 @@ impl FeatureOnlineStoreService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+/// let client = FeatureRegistryService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The service that handles CRUD and List for resources for
@@ -1842,8 +2041,23 @@ impl FeatureOnlineStoreService {
 ///
 /// # Configuration
 ///
-/// `FeatureRegistryService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `FeatureRegistryService` use the `with_*` methods in the type returned
+/// by [builder()][FeatureRegistryService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::feature_registry_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::feature_registry_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1857,21 +2071,24 @@ pub struct FeatureRegistryService {
 }
 
 impl FeatureRegistryService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [FeatureRegistryService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// let client = FeatureRegistryService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::feature_registry_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::feature_registry_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::FeatureRegistryService + 'static,
@@ -1879,6 +2096,11 @@ impl FeatureRegistryService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2187,14 +2409,38 @@ impl FeatureRegistryService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+/// let client = FeaturestoreOnlineServingService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for serving online feature values.
 ///
 /// # Configuration
 ///
-/// `FeaturestoreOnlineServingService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `FeaturestoreOnlineServingService` use the `with_*` methods in the type returned
+/// by [builder()][FeaturestoreOnlineServingService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::featurestore_online_serving_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::featurestore_online_serving_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2208,21 +2454,24 @@ pub struct FeaturestoreOnlineServingService {
 }
 
 impl FeaturestoreOnlineServingService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [FeaturestoreOnlineServingService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// let client = FeaturestoreOnlineServingService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::featurestore_online_serving_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::featurestore_online_serving_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::FeaturestoreOnlineServingService + 'static,
@@ -2230,6 +2479,11 @@ impl FeaturestoreOnlineServingService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2403,14 +2657,38 @@ impl FeaturestoreOnlineServingService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+/// let client = FeaturestoreService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The service that handles CRUD and List for resources for Featurestore.
 ///
 /// # Configuration
 ///
-/// `FeaturestoreService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `FeaturestoreService` use the `with_*` methods in the type returned
+/// by [builder()][FeaturestoreService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::featurestore_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::featurestore_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2424,21 +2702,24 @@ pub struct FeaturestoreService {
 }
 
 impl FeaturestoreService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [FeaturestoreService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// let client = FeaturestoreService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::featurestore_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::featurestore_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::FeaturestoreService + 'static,
@@ -2446,6 +2727,11 @@ impl FeaturestoreService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2929,14 +3215,38 @@ impl FeaturestoreService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+/// let client = GenAiCacheService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing Vertex AI's CachedContent resource.
 ///
 /// # Configuration
 ///
-/// `GenAiCacheService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `GenAiCacheService` use the `with_*` methods in the type returned
+/// by [builder()][GenAiCacheService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::gen_ai_cache_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::gen_ai_cache_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2950,21 +3260,24 @@ pub struct GenAiCacheService {
 }
 
 impl GenAiCacheService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [GenAiCacheService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// let client = GenAiCacheService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::gen_ai_cache_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::gen_ai_cache_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::GenAiCacheService + 'static,
@@ -2972,6 +3285,11 @@ impl GenAiCacheService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3157,14 +3475,38 @@ impl GenAiCacheService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+/// let client = GenAiTuningService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for creating and managing GenAI Tuning Jobs.
 ///
 /// # Configuration
 ///
-/// `GenAiTuningService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `GenAiTuningService` use the `with_*` methods in the type returned
+/// by [builder()][GenAiTuningService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::gen_ai_tuning_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::gen_ai_tuning_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3178,21 +3520,24 @@ pub struct GenAiTuningService {
 }
 
 impl GenAiTuningService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [GenAiTuningService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// let client = GenAiTuningService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::gen_ai_tuning_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::gen_ai_tuning_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::GenAiTuningService + 'static,
@@ -3200,6 +3545,11 @@ impl GenAiTuningService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3411,14 +3761,38 @@ impl GenAiTuningService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+/// let client = IndexEndpointService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for managing Vertex AI's IndexEndpoints.
 ///
 /// # Configuration
 ///
-/// `IndexEndpointService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `IndexEndpointService` use the `with_*` methods in the type returned
+/// by [builder()][IndexEndpointService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::index_endpoint_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::index_endpoint_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3432,21 +3806,24 @@ pub struct IndexEndpointService {
 }
 
 impl IndexEndpointService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [IndexEndpointService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// let client = IndexEndpointService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::index_endpoint_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::index_endpoint_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::IndexEndpointService + 'static,
@@ -3454,6 +3831,11 @@ impl IndexEndpointService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3718,14 +4100,38 @@ impl IndexEndpointService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::IndexService;
+/// let client = IndexService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for creating and managing Vertex AI's Index resources.
 ///
 /// # Configuration
 ///
-/// `IndexService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `IndexService` use the `with_*` methods in the type returned
+/// by [builder()][IndexService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::index_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::index_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3739,21 +4145,22 @@ pub struct IndexService {
 }
 
 impl IndexService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [IndexService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// let client = IndexService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::index_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::index_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::IndexService + 'static,
@@ -3761,6 +4168,11 @@ impl IndexService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3990,14 +4402,38 @@ impl IndexService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::JobService;
+/// let client = JobService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for creating and managing Vertex AI's jobs.
 ///
 /// # Configuration
 ///
-/// `JobService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `JobService` use the `with_*` methods in the type returned
+/// by [builder()][JobService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::job_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::job_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -4011,21 +4447,22 @@ pub struct JobService {
 }
 
 impl JobService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [JobService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// let client = JobService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::job_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::job_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::JobService + 'static,
@@ -4033,6 +4470,11 @@ impl JobService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -4621,14 +5063,38 @@ impl JobService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+/// let client = LlmUtilityService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for LLM related utility functions.
 ///
 /// # Configuration
 ///
-/// `LlmUtilityService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `LlmUtilityService` use the `with_*` methods in the type returned
+/// by [builder()][LlmUtilityService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::llm_utility_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::llm_utility_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -4642,21 +5108,24 @@ pub struct LlmUtilityService {
 }
 
 impl LlmUtilityService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [LlmUtilityService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// let client = LlmUtilityService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::llm_utility_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::llm_utility_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::LlmUtilityService + 'static,
@@ -4664,6 +5133,11 @@ impl LlmUtilityService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -4821,6 +5295,15 @@ impl LlmUtilityService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::MatchService;
+/// let client = MatchService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// MatchService is a Google managed service for efficient vector similarity
@@ -4828,8 +5311,23 @@ impl LlmUtilityService {
 ///
 /// # Configuration
 ///
-/// `MatchService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `MatchService` use the `with_*` methods in the type returned
+/// by [builder()][MatchService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::match_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::match_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -4843,21 +5341,22 @@ pub struct MatchService {
 }
 
 impl MatchService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [MatchService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// let client = MatchService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::match_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::match_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::MatchService + 'static,
@@ -4865,6 +5364,11 @@ impl MatchService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -5018,14 +5522,38 @@ impl MatchService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::MetadataService;
+/// let client = MetadataService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for reading and writing metadata entries.
 ///
 /// # Configuration
 ///
-/// `MetadataService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `MetadataService` use the `with_*` methods in the type returned
+/// by [builder()][MetadataService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::metadata_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::metadata_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -5039,21 +5567,24 @@ pub struct MetadataService {
 }
 
 impl MetadataService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [MetadataService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// let client = MetadataService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::metadata_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::metadata_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::MetadataService + 'static,
@@ -5061,6 +5592,11 @@ impl MetadataService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -5581,6 +6117,15 @@ impl MetadataService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::MigrationService;
+/// let client = MigrationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service that migrates resources from automl.googleapis.com,
@@ -5588,8 +6133,23 @@ impl MetadataService {
 ///
 /// # Configuration
 ///
-/// `MigrationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `MigrationService` use the `with_*` methods in the type returned
+/// by [builder()][MigrationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::migration_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::migration_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -5603,21 +6163,24 @@ pub struct MigrationService {
 }
 
 impl MigrationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [MigrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// let client = MigrationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::migration_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::migration_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::MigrationService + 'static,
@@ -5625,6 +6188,11 @@ impl MigrationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -5795,14 +6363,38 @@ impl MigrationService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+/// let client = ModelGardenService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The interface of Model Garden Service.
 ///
 /// # Configuration
 ///
-/// `ModelGardenService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ModelGardenService` use the `with_*` methods in the type returned
+/// by [builder()][ModelGardenService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::model_garden_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::model_garden_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -5816,21 +6408,24 @@ pub struct ModelGardenService {
 }
 
 impl ModelGardenService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ModelGardenService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// let client = ModelGardenService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::model_garden_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::model_garden_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ModelGardenService + 'static,
@@ -5838,6 +6433,11 @@ impl ModelGardenService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -5986,14 +6586,38 @@ impl ModelGardenService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::ModelService;
+/// let client = ModelService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for managing Vertex AI's machine learning Models.
 ///
 /// # Configuration
 ///
-/// `ModelService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ModelService` use the `with_*` methods in the type returned
+/// by [builder()][ModelService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::model_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::model_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -6007,21 +6631,22 @@ pub struct ModelService {
 }
 
 impl ModelService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ModelService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// let client = ModelService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::model_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::model_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ModelService + 'static,
@@ -6029,6 +6654,11 @@ impl ModelService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -6420,14 +7050,38 @@ impl ModelService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::NotebookService;
+/// let client = NotebookService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The interface for Vertex Notebook service (a.k.a. Colab on Workbench).
 ///
 /// # Configuration
 ///
-/// `NotebookService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `NotebookService` use the `with_*` methods in the type returned
+/// by [builder()][NotebookService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::notebook_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::notebook_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -6441,21 +7095,24 @@ pub struct NotebookService {
 }
 
 impl NotebookService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [NotebookService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// let client = NotebookService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::notebook_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::notebook_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::NotebookService + 'static,
@@ -6463,6 +7120,11 @@ impl NotebookService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -6836,14 +7498,38 @@ impl NotebookService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+/// let client = PersistentResourceService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for managing Vertex AI's machine learning PersistentResource.
 ///
 /// # Configuration
 ///
-/// `PersistentResourceService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PersistentResourceService` use the `with_*` methods in the type returned
+/// by [builder()][PersistentResourceService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::persistent_resource_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::persistent_resource_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -6857,21 +7543,24 @@ pub struct PersistentResourceService {
 }
 
 impl PersistentResourceService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PersistentResourceService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// let client = PersistentResourceService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::persistent_resource_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::persistent_resource_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PersistentResourceService + 'static,
@@ -6879,6 +7568,11 @@ impl PersistentResourceService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -7122,6 +7816,15 @@ impl PersistentResourceService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::PipelineService;
+/// let client = PipelineService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for creating and managing Vertex AI's pipelines. This includes both
@@ -7130,8 +7833,23 @@ impl PersistentResourceService {
 ///
 /// # Configuration
 ///
-/// `PipelineService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PipelineService` use the `with_*` methods in the type returned
+/// by [builder()][PipelineService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::pipeline_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::pipeline_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -7145,21 +7863,24 @@ pub struct PipelineService {
 }
 
 impl PipelineService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PipelineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// let client = PipelineService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::pipeline_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::pipeline_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PipelineService + 'static,
@@ -7167,6 +7888,11 @@ impl PipelineService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -7497,14 +8223,38 @@ impl PipelineService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::PredictionService;
+/// let client = PredictionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for online predictions and explanations.
 ///
 /// # Configuration
 ///
-/// `PredictionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PredictionService` use the `with_*` methods in the type returned
+/// by [builder()][PredictionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::prediction_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::prediction_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -7518,21 +8268,24 @@ pub struct PredictionService {
 }
 
 impl PredictionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PredictionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// let client = PredictionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::prediction_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::prediction_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PredictionService + 'static,
@@ -7540,6 +8293,11 @@ impl PredictionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -7762,14 +8520,38 @@ impl PredictionService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+/// let client = ReasoningEngineExecutionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for executing queries on Reasoning Engine.
 ///
 /// # Configuration
 ///
-/// `ReasoningEngineExecutionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ReasoningEngineExecutionService` use the `with_*` methods in the type returned
+/// by [builder()][ReasoningEngineExecutionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::reasoning_engine_execution_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::reasoning_engine_execution_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -7783,21 +8565,24 @@ pub struct ReasoningEngineExecutionService {
 }
 
 impl ReasoningEngineExecutionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ReasoningEngineExecutionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// let client = ReasoningEngineExecutionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::reasoning_engine_execution_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::reasoning_engine_execution_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ReasoningEngineExecutionService + 'static,
@@ -7805,6 +8590,11 @@ impl ReasoningEngineExecutionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -7957,14 +8747,38 @@ impl ReasoningEngineExecutionService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+/// let client = ReasoningEngineService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for managing Vertex AI's Reasoning Engines.
 ///
 /// # Configuration
 ///
-/// `ReasoningEngineService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ReasoningEngineService` use the `with_*` methods in the type returned
+/// by [builder()][ReasoningEngineService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::reasoning_engine_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::reasoning_engine_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -7978,21 +8792,24 @@ pub struct ReasoningEngineService {
 }
 
 impl ReasoningEngineService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ReasoningEngineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// let client = ReasoningEngineService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::reasoning_engine_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::reasoning_engine_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ReasoningEngineService + 'static,
@@ -8000,6 +8817,11 @@ impl ReasoningEngineService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -8214,6 +9036,15 @@ impl ReasoningEngineService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::ScheduleService;
+/// let client = ScheduleService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for creating and managing Vertex AI's Schedule resources to
@@ -8221,8 +9052,23 @@ impl ReasoningEngineService {
 ///
 /// # Configuration
 ///
-/// `ScheduleService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ScheduleService` use the `with_*` methods in the type returned
+/// by [builder()][ScheduleService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::schedule_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::schedule_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -8236,21 +9082,24 @@ pub struct ScheduleService {
 }
 
 impl ScheduleService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ScheduleService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// let client = ScheduleService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::schedule_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::schedule_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ScheduleService + 'static,
@@ -8258,6 +9107,11 @@ impl ScheduleService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -8490,6 +9344,15 @@ impl ScheduleService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+/// let client = SpecialistPoolService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for creating and managing Customer SpecialistPools.
@@ -8501,8 +9364,23 @@ impl ScheduleService {
 ///
 /// # Configuration
 ///
-/// `SpecialistPoolService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SpecialistPoolService` use the `with_*` methods in the type returned
+/// by [builder()][SpecialistPoolService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::specialist_pool_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::specialist_pool_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -8516,21 +9394,24 @@ pub struct SpecialistPoolService {
 }
 
 impl SpecialistPoolService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SpecialistPoolService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// let client = SpecialistPoolService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::specialist_pool_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::specialist_pool_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SpecialistPoolService + 'static,
@@ -8538,6 +9419,11 @@ impl SpecialistPoolService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -8752,14 +9638,38 @@ impl SpecialistPoolService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::TensorboardService;
+/// let client = TensorboardService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// TensorboardService
 ///
 /// # Configuration
 ///
-/// `TensorboardService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TensorboardService` use the `with_*` methods in the type returned
+/// by [builder()][TensorboardService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::tensorboard_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::tensorboard_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -8773,21 +9683,24 @@ pub struct TensorboardService {
 }
 
 impl TensorboardService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TensorboardService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// let client = TensorboardService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::tensorboard_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::tensorboard_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TensorboardService + 'static,
@@ -8795,6 +9708,11 @@ impl TensorboardService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -9272,14 +10190,38 @@ impl TensorboardService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+/// let client = VertexRagDataService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for managing user data for RAG.
 ///
 /// # Configuration
 ///
-/// `VertexRagDataService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VertexRagDataService` use the `with_*` methods in the type returned
+/// by [builder()][VertexRagDataService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::vertex_rag_data_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::vertex_rag_data_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -9293,21 +10235,24 @@ pub struct VertexRagDataService {
 }
 
 impl VertexRagDataService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VertexRagDataService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// let client = VertexRagDataService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::vertex_rag_data_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::vertex_rag_data_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VertexRagDataService + 'static,
@@ -9315,6 +10260,11 @@ impl VertexRagDataService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -9594,14 +10544,38 @@ impl VertexRagDataService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::VertexRagService;
+/// let client = VertexRagService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for retrieving relevant contexts.
 ///
 /// # Configuration
 ///
-/// `VertexRagService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VertexRagService` use the `with_*` methods in the type returned
+/// by [builder()][VertexRagService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::vertex_rag_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::vertex_rag_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -9615,21 +10589,24 @@ pub struct VertexRagService {
 }
 
 impl VertexRagService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VertexRagService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// let client = VertexRagService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::vertex_rag_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::vertex_rag_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VertexRagService + 'static,
@@ -9637,6 +10614,11 @@ impl VertexRagService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -9806,6 +10788,15 @@ impl VertexRagService {
 
 /// Implements a client for the Vertex AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_aiplatform_v1::client::VizierService;
+/// let client = VizierService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Vertex AI Vizier API.
@@ -9816,8 +10807,23 @@ impl VertexRagService {
 ///
 /// # Configuration
 ///
-/// `VizierService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VizierService` use the `with_*` methods in the type returned
+/// by [builder()][VizierService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://aiplatform.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::vizier_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::vizier_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -9831,21 +10837,22 @@ pub struct VizierService {
 }
 
 impl VizierService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VizierService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// let client = VizierService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::vizier_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::vizier_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VizierService + 'static,
@@ -9853,6 +10860,11 @@ impl VizierService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/alloydb/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/connectors/v1/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/alloydb/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/alloydb/v1/src/builder.rs
+++ b/src/generated/cloud/alloydb/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod alloy_db_admin {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AlloyDBAdmin][super::super::client::AlloyDBAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_alloydb_v1::*;
+    /// # use builder::alloy_db_admin::ClientBuilder;
+    /// # use client::AlloyDBAdmin;
+    /// let builder : ClientBuilder = AlloyDBAdmin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://alloydb.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AlloyDBAdmin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AlloyDBAdmin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AlloyDBAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/alloydb/v1/src/client.rs
+++ b/src/generated/cloud/alloydb/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the AlloyDB API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+/// let client = AlloyDBAdmin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `AlloyDBAdmin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AlloyDBAdmin` use the `with_*` methods in the type returned
+/// by [builder()][AlloyDBAdmin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://alloydb.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::alloy_db_admin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::alloy_db_admin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct AlloyDBAdmin {
 }
 
 impl AlloyDBAdmin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AlloyDBAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// let client = AlloyDBAdmin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::alloy_db_admin::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::alloy_db_admin::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AlloyDBAdmin + 'static,
@@ -64,6 +89,11 @@ impl AlloyDBAdmin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/apigateway/v1/Cargo.toml
+++ b/src/generated/cloud/apigateway/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/apigateway/v1/src/builder.rs
+++ b/src/generated/cloud/apigateway/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod api_gateway_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ApiGatewayService][super::super::client::ApiGatewayService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apigateway_v1::*;
+    /// # use builder::api_gateway_service::ClientBuilder;
+    /// # use client::ApiGatewayService;
+    /// let builder : ClientBuilder = ApiGatewayService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apigateway.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ApiGatewayService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ApiGatewayService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ApiGatewayService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/apigateway/v1/src/client.rs
+++ b/src/generated/cloud/apigateway/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the API Gateway API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+/// let client = ApiGatewayService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The API Gateway Service is the interface for managing API Gateways.
 ///
 /// # Configuration
 ///
-/// `ApiGatewayService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ApiGatewayService` use the `with_*` methods in the type returned
+/// by [builder()][ApiGatewayService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apigateway.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::api_gateway_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::api_gateway_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct ApiGatewayService {
 }
 
 impl ApiGatewayService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ApiGatewayService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+    /// let client = ApiGatewayService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::api_gateway_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::api_gateway_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ApiGatewayService + 'static,
@@ -64,6 +91,11 @@ impl ApiGatewayService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/apigeeconnect/v1/Cargo.toml
+++ b/src/generated/cloud/apigeeconnect/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/apigeeconnect/v1/src/builder.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod connection_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ConnectionService][super::super::client::ConnectionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apigeeconnect_v1::*;
+    /// # use builder::connection_service::ClientBuilder;
+    /// # use client::ConnectionService;
+    /// let builder : ClientBuilder = ConnectionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apigeeconnect.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConnectionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConnectionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ConnectionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/apigeeconnect/v1/src/client.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Apigee Connect API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apigeeconnect_v1::client::ConnectionService;
+/// let client = ConnectionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service Interface for the Apigee Connect connection management APIs.
 ///
 /// # Configuration
 ///
-/// `ConnectionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConnectionService` use the `with_*` methods in the type returned
+/// by [builder()][ConnectionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apigeeconnect.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::connection_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::connection_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct ConnectionService {
 }
 
 impl ConnectionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConnectionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apigeeconnect_v1::client::ConnectionService;
+    /// let client = ConnectionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::connection_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::connection_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConnectionService + 'static,
@@ -64,6 +91,11 @@ impl ConnectionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/apihub/v1/src/builder.rs
+++ b/src/generated/cloud/apihub/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod api_hub {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ApiHub][super::super::client::ApiHub].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::*;
+    /// # use builder::api_hub::ClientBuilder;
+    /// # use client::ApiHub;
+    /// let builder : ClientBuilder = ApiHub::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apihub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ApiHub;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ApiHub;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ApiHub] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2293,6 +2321,34 @@ pub mod api_hub_dependencies {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ApiHubDependencies][super::super::client::ApiHubDependencies].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::*;
+    /// # use builder::api_hub_dependencies::ClientBuilder;
+    /// # use client::ApiHubDependencies;
+    /// let builder : ClientBuilder = ApiHubDependencies::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apihub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ApiHubDependencies;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ApiHubDependencies;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ApiHubDependencies] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2934,6 +2990,34 @@ pub mod host_project_registration_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [HostProjectRegistrationService][super::super::client::HostProjectRegistrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::*;
+    /// # use builder::host_project_registration_service::ClientBuilder;
+    /// # use client::HostProjectRegistrationService;
+    /// let builder : ClientBuilder = HostProjectRegistrationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apihub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::HostProjectRegistrationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = HostProjectRegistrationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::HostProjectRegistrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -3515,6 +3599,34 @@ pub mod linting_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [LintingService][super::super::client::LintingService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::*;
+    /// # use builder::linting_service::ClientBuilder;
+    /// # use client::LintingService;
+    /// let builder : ClientBuilder = LintingService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apihub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::LintingService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = LintingService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::LintingService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -4060,6 +4172,34 @@ pub mod api_hub_plugin {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ApiHubPlugin][super::super::client::ApiHubPlugin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::*;
+    /// # use builder::api_hub_plugin::ClientBuilder;
+    /// # use client::ApiHubPlugin;
+    /// let builder : ClientBuilder = ApiHubPlugin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apihub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ApiHubPlugin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ApiHubPlugin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ApiHubPlugin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -4544,6 +4684,34 @@ pub mod api_hub_plugin {
 pub mod provisioning {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Provisioning][super::super::client::Provisioning].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::*;
+    /// # use builder::provisioning::ClientBuilder;
+    /// # use client::Provisioning;
+    /// let builder : ClientBuilder = Provisioning::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apihub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Provisioning;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Provisioning;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Provisioning] request builders.
     #[derive(Clone, Debug)]
@@ -5092,6 +5260,34 @@ pub mod provisioning {
 pub mod runtime_project_attachment_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [RuntimeProjectAttachmentService][super::super::client::RuntimeProjectAttachmentService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::*;
+    /// # use builder::runtime_project_attachment_service::ClientBuilder;
+    /// # use client::RuntimeProjectAttachmentService;
+    /// let builder : ClientBuilder = RuntimeProjectAttachmentService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apihub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RuntimeProjectAttachmentService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RuntimeProjectAttachmentService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::RuntimeProjectAttachmentService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/apihub/v1/src/client.rs
+++ b/src/generated/cloud/apihub/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the API hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apihub_v1::client::ApiHub;
+/// let client = ApiHub::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This service provides all methods related to the API hub.
 ///
 /// # Configuration
 ///
-/// `ApiHub` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ApiHub` use the `with_*` methods in the type returned
+/// by [builder()][ApiHub::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apihub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::api_hub::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::api_hub::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct ApiHub {
 }
 
 impl ApiHub {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ApiHub].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// let client = ApiHub::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::api_hub::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::api_hub::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ApiHub + 'static,
@@ -64,6 +89,11 @@ impl ApiHub {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -640,6 +670,15 @@ impl ApiHub {
 
 /// Implements a client for the API hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+/// let client = ApiHubDependencies::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This service provides methods for various operations related to a
@@ -649,8 +688,23 @@ impl ApiHub {
 ///
 /// # Configuration
 ///
-/// `ApiHubDependencies` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ApiHubDependencies` use the `with_*` methods in the type returned
+/// by [builder()][ApiHubDependencies::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apihub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::api_hub_dependencies::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::api_hub_dependencies::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -664,21 +718,24 @@ pub struct ApiHubDependencies {
 }
 
 impl ApiHubDependencies {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ApiHubDependencies].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// let client = ApiHubDependencies::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::api_hub_dependencies::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::api_hub_dependencies::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ApiHubDependencies + 'static,
@@ -686,6 +743,11 @@ impl ApiHubDependencies {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -832,14 +894,38 @@ impl ApiHubDependencies {
 
 /// Implements a client for the API hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
+/// let client = HostProjectRegistrationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This service is used for managing the host project registrations.
 ///
 /// # Configuration
 ///
-/// `HostProjectRegistrationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `HostProjectRegistrationService` use the `with_*` methods in the type returned
+/// by [builder()][HostProjectRegistrationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apihub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::host_project_registration_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::host_project_registration_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -853,21 +939,24 @@ pub struct HostProjectRegistrationService {
 }
 
 impl HostProjectRegistrationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [HostProjectRegistrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
+    /// let client = HostProjectRegistrationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::host_project_registration_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::host_project_registration_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::HostProjectRegistrationService + 'static,
@@ -875,6 +964,11 @@ impl HostProjectRegistrationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1002,14 +1096,38 @@ impl HostProjectRegistrationService {
 
 /// Implements a client for the API hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apihub_v1::client::LintingService;
+/// let client = LintingService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This service provides all methods related to the 1p Linter.
 ///
 /// # Configuration
 ///
-/// `LintingService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `LintingService` use the `with_*` methods in the type returned
+/// by [builder()][LintingService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apihub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::linting_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::linting_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1023,21 +1141,22 @@ pub struct LintingService {
 }
 
 impl LintingService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [LintingService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// let client = LintingService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::linting_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::linting_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::LintingService + 'static,
@@ -1045,6 +1164,11 @@ impl LintingService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1170,14 +1294,38 @@ impl LintingService {
 
 /// Implements a client for the API hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+/// let client = ApiHubPlugin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This service is used for managing plugins inside the API Hub.
 ///
 /// # Configuration
 ///
-/// `ApiHubPlugin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ApiHubPlugin` use the `with_*` methods in the type returned
+/// by [builder()][ApiHubPlugin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apihub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::api_hub_plugin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::api_hub_plugin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1191,21 +1339,22 @@ pub struct ApiHubPlugin {
 }
 
 impl ApiHubPlugin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ApiHubPlugin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// let client = ApiHubPlugin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::api_hub_plugin::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::api_hub_plugin::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ApiHubPlugin + 'static,
@@ -1213,6 +1362,11 @@ impl ApiHubPlugin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1326,14 +1480,38 @@ impl ApiHubPlugin {
 
 /// Implements a client for the API hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apihub_v1::client::Provisioning;
+/// let client = Provisioning::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This service is used for managing the data plane provisioning of the API hub.
 ///
 /// # Configuration
 ///
-/// `Provisioning` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Provisioning` use the `with_*` methods in the type returned
+/// by [builder()][Provisioning::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apihub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::provisioning::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::provisioning::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1347,21 +1525,22 @@ pub struct Provisioning {
 }
 
 impl Provisioning {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Provisioning].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::client::Provisioning;
+    /// let client = Provisioning::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::provisioning::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::provisioning::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Provisioning + 'static,
@@ -1369,6 +1548,11 @@ impl Provisioning {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1491,14 +1675,38 @@ impl Provisioning {
 
 /// Implements a client for the API hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+/// let client = RuntimeProjectAttachmentService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This service is used for managing the runtime project attachments.
 ///
 /// # Configuration
 ///
-/// `RuntimeProjectAttachmentService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RuntimeProjectAttachmentService` use the `with_*` methods in the type returned
+/// by [builder()][RuntimeProjectAttachmentService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apihub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::runtime_project_attachment_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::runtime_project_attachment_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1512,21 +1720,24 @@ pub struct RuntimeProjectAttachmentService {
 }
 
 impl RuntimeProjectAttachmentService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RuntimeProjectAttachmentService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// let client = RuntimeProjectAttachmentService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::runtime_project_attachment_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::runtime_project_attachment_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RuntimeProjectAttachmentService + 'static,
@@ -1534,6 +1745,11 @@ impl RuntimeProjectAttachmentService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/apphub/v1/Cargo.toml
+++ b/src/generated/cloud/apphub/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/apphub/v1/src/builder.rs
+++ b/src/generated/cloud/apphub/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod app_hub {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AppHub][super::super::client::AppHub].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apphub_v1::*;
+    /// # use builder::app_hub::ClientBuilder;
+    /// # use client::AppHub;
+    /// let builder : ClientBuilder = AppHub::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://apphub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AppHub;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AppHub;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AppHub] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/apphub/v1/src/client.rs
+++ b/src/generated/cloud/apphub/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the App Hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_apphub_v1::client::AppHub;
+/// let client = AppHub::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The App Hub API allows you to manage App Hub resources.
 ///
 /// # Configuration
 ///
-/// `AppHub` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AppHub` use the `with_*` methods in the type returned
+/// by [builder()][AppHub::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://apphub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::app_hub::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::app_hub::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct AppHub {
 }
 
 impl AppHub {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AppHub].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// let client = AppHub::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::app_hub::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::app_hub::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AppHub + 'static,
@@ -64,6 +89,11 @@ impl AppHub {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/asset/v1/Cargo.toml
+++ b/src/generated/cloud/asset/v1/Cargo.toml
@@ -48,4 +48,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/asset/v1/src/builder.rs
+++ b/src/generated/cloud/asset/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod asset_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AssetService][super::super::client::AssetService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_asset_v1::*;
+    /// # use builder::asset_service::ClientBuilder;
+    /// # use client::AssetService;
+    /// let builder : ClientBuilder = AssetService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudasset.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AssetService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AssetService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AssetService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/asset/v1/src/client.rs
+++ b/src/generated/cloud/asset/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Asset API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_asset_v1::client::AssetService;
+/// let client = AssetService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Asset service definition.
 ///
 /// # Configuration
 ///
-/// `AssetService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AssetService` use the `with_*` methods in the type returned
+/// by [builder()][AssetService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudasset.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::asset_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::asset_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct AssetService {
 }
 
 impl AssetService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AssetService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// let client = AssetService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::asset_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::asset_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AssetService + 'static,
@@ -64,6 +89,11 @@ impl AssetService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/assuredworkloads/v1/Cargo.toml
+++ b/src/generated/cloud/assuredworkloads/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/assuredworkloads/v1/src/builder.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod assured_workloads_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AssuredWorkloadsService][super::super::client::AssuredWorkloadsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_assuredworkloads_v1::*;
+    /// # use builder::assured_workloads_service::ClientBuilder;
+    /// # use client::AssuredWorkloadsService;
+    /// let builder : ClientBuilder = AssuredWorkloadsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://assuredworkloads.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AssuredWorkloadsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AssuredWorkloadsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AssuredWorkloadsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/assuredworkloads/v1/src/client.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Assured Workloads API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
+/// let client = AssuredWorkloadsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service to manage AssuredWorkloads.
 ///
 /// # Configuration
 ///
-/// `AssuredWorkloadsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AssuredWorkloadsService` use the `with_*` methods in the type returned
+/// by [builder()][AssuredWorkloadsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://assuredworkloads.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::assured_workloads_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::assured_workloads_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct AssuredWorkloadsService {
 }
 
 impl AssuredWorkloadsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AssuredWorkloadsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
+    /// let client = AssuredWorkloadsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::assured_workloads_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::assured_workloads_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AssuredWorkloadsService + 'static,
@@ -64,6 +91,11 @@ impl AssuredWorkloadsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/backupdr/v1/Cargo.toml
+++ b/src/generated/cloud/backupdr/v1/Cargo.toml
@@ -46,4 +46,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/backupdr/v1/src/builder.rs
+++ b/src/generated/cloud/backupdr/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod backup_dr {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [BackupDR][super::super::client::BackupDR].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_backupdr_v1::*;
+    /// # use builder::backup_dr::ClientBuilder;
+    /// # use client::BackupDR;
+    /// let builder : ClientBuilder = BackupDR::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://backupdr.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::BackupDR;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = BackupDR;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::BackupDR] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/backupdr/v1/src/client.rs
+++ b/src/generated/cloud/backupdr/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Backup and DR Service API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_backupdr_v1::client::BackupDR;
+/// let client = BackupDR::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The BackupDR Service
 ///
 /// # Configuration
 ///
-/// `BackupDR` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `BackupDR` use the `with_*` methods in the type returned
+/// by [builder()][BackupDR::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://backupdr.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::backup_dr::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::backup_dr::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct BackupDR {
 }
 
 impl BackupDR {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [BackupDR].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// let client = BackupDR::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::backup_dr::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::backup_dr::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::BackupDR + 'static,
@@ -64,6 +89,11 @@ impl BackupDR {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/baremetalsolution/v2/Cargo.toml
+++ b/src/generated/cloud/baremetalsolution/v2/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/baremetalsolution/v2/src/builder.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod bare_metal_solution {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [BareMetalSolution][super::super::client::BareMetalSolution].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_baremetalsolution_v2::*;
+    /// # use builder::bare_metal_solution::ClientBuilder;
+    /// # use client::BareMetalSolution;
+    /// let builder : ClientBuilder = BareMetalSolution::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://baremetalsolution.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::BareMetalSolution;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = BareMetalSolution;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::BareMetalSolution] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/baremetalsolution/v2/src/client.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Bare Metal Solution API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+/// let client = BareMetalSolution::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Performs management operations on Bare Metal Solution servers.
@@ -34,8 +43,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `BareMetalSolution` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `BareMetalSolution` use the `with_*` methods in the type returned
+/// by [builder()][BareMetalSolution::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://baremetalsolution.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::bare_metal_solution::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::bare_metal_solution::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -49,21 +73,24 @@ pub struct BareMetalSolution {
 }
 
 impl BareMetalSolution {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [BareMetalSolution].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// let client = BareMetalSolution::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::bare_metal_solution::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::bare_metal_solution::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::BareMetalSolution + 'static,
@@ -71,6 +98,11 @@ impl BareMetalSolution {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod app_connections_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AppConnectionsService][super::super::client::AppConnectionsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_appconnections_v1::*;
+    /// # use builder::app_connections_service::ClientBuilder;
+    /// # use client::AppConnectionsService;
+    /// let builder : ClientBuilder = AppConnectionsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://beyondcorp.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AppConnectionsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AppConnectionsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AppConnectionsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the BeyondCorp API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+/// let client = AppConnectionsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview:
@@ -40,8 +49,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AppConnectionsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AppConnectionsService` use the `with_*` methods in the type returned
+/// by [builder()][AppConnectionsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://beyondcorp.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::app_connections_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::app_connections_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -55,21 +79,24 @@ pub struct AppConnectionsService {
 }
 
 impl AppConnectionsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AppConnectionsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// let client = AppConnectionsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::app_connections_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::app_connections_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AppConnectionsService + 'static,
@@ -77,6 +104,11 @@ impl AppConnectionsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod app_connectors_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AppConnectorsService][super::super::client::AppConnectorsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_appconnectors_v1::*;
+    /// # use builder::app_connectors_service::ClientBuilder;
+    /// # use client::AppConnectorsService;
+    /// let builder : ClientBuilder = AppConnectorsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://beyondcorp.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AppConnectorsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AppConnectorsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AppConnectorsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the BeyondCorp API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+/// let client = AppConnectorsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview:
@@ -40,8 +49,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AppConnectorsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AppConnectorsService` use the `with_*` methods in the type returned
+/// by [builder()][AppConnectorsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://beyondcorp.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::app_connectors_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::app_connectors_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -55,21 +79,24 @@ pub struct AppConnectorsService {
 }
 
 impl AppConnectorsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AppConnectorsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// let client = AppConnectorsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::app_connectors_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::app_connectors_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AppConnectorsService + 'static,
@@ -77,6 +104,11 @@ impl AppConnectorsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod app_gateways_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AppGatewaysService][super::super::client::AppGatewaysService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_appgateways_v1::*;
+    /// # use builder::app_gateways_service::ClientBuilder;
+    /// # use client::AppGatewaysService;
+    /// let builder : ClientBuilder = AppGatewaysService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://beyondcorp.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AppGatewaysService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AppGatewaysService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AppGatewaysService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the BeyondCorp API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+/// let client = AppGatewaysService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview:
@@ -40,8 +49,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AppGatewaysService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AppGatewaysService` use the `with_*` methods in the type returned
+/// by [builder()][AppGatewaysService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://beyondcorp.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::app_gateways_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::app_gateways_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -55,21 +79,24 @@ pub struct AppGatewaysService {
 }
 
 impl AppGatewaysService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AppGatewaysService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// let client = AppGatewaysService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::app_gateways_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::app_gateways_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AppGatewaysService + 'static,
@@ -77,6 +104,11 @@ impl AppGatewaysService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod client_connector_services_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ClientConnectorServicesService][super::super::client::ClientConnectorServicesService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::*;
+    /// # use builder::client_connector_services_service::ClientBuilder;
+    /// # use client::ClientConnectorServicesService;
+    /// let builder : ClientBuilder = ClientConnectorServicesService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://beyondcorp.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ClientConnectorServicesService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ClientConnectorServicesService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ClientConnectorServicesService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the BeyondCorp API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+/// let client = ClientConnectorServicesService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview:
@@ -37,8 +46,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ClientConnectorServicesService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ClientConnectorServicesService` use the `with_*` methods in the type returned
+/// by [builder()][ClientConnectorServicesService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://beyondcorp.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::client_connector_services_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::client_connector_services_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -52,21 +76,24 @@ pub struct ClientConnectorServicesService {
 }
 
 impl ClientConnectorServicesService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ClientConnectorServicesService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// let client = ClientConnectorServicesService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::client_connector_services_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::client_connector_services_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ClientConnectorServicesService + 'static,
@@ -74,6 +101,11 @@ impl ClientConnectorServicesService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod client_gateways_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ClientGatewaysService][super::super::client::ClientGatewaysService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_clientgateways_v1::*;
+    /// # use builder::client_gateways_service::ClientBuilder;
+    /// # use client::ClientGatewaysService;
+    /// let builder : ClientBuilder = ClientGatewaysService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://beyondcorp.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ClientGatewaysService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ClientGatewaysService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ClientGatewaysService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the BeyondCorp API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+/// let client = ClientGatewaysService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview:
@@ -37,8 +46,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ClientGatewaysService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ClientGatewaysService` use the `with_*` methods in the type returned
+/// by [builder()][ClientGatewaysService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://beyondcorp.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::client_gateways_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::client_gateways_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -52,21 +76,24 @@ pub struct ClientGatewaysService {
 }
 
 impl ClientGatewaysService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ClientGatewaysService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// let client = ClientGatewaysService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::client_gateways_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::client_gateways_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ClientGatewaysService + 'static,
@@ -74,6 +101,11 @@ impl ClientGatewaysService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod analytics_hub_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AnalyticsHubService][super::super::client::AnalyticsHubService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_analyticshub_v1::*;
+    /// # use builder::analytics_hub_service::ClientBuilder;
+    /// # use client::AnalyticsHubService;
+    /// let builder : ClientBuilder = AnalyticsHubService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://analyticshub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AnalyticsHubService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AnalyticsHubService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AnalyticsHubService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Analytics Hub API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+/// let client = AnalyticsHubService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The `AnalyticsHubService` API facilitates data sharing within and across
@@ -32,8 +41,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AnalyticsHubService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AnalyticsHubService` use the `with_*` methods in the type returned
+/// by [builder()][AnalyticsHubService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://analyticshub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::analytics_hub_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::analytics_hub_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -47,21 +71,24 @@ pub struct AnalyticsHubService {
 }
 
 impl AnalyticsHubService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AnalyticsHubService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// let client = AnalyticsHubService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::analytics_hub_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::analytics_hub_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AnalyticsHubService + 'static,
@@ -69,6 +96,11 @@ impl AnalyticsHubService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/bigquery/connection/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/connection/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/bigquery/connection/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod connection_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ConnectionService][super::super::client::ConnectionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_connection_v1::*;
+    /// # use builder::connection_service::ClientBuilder;
+    /// # use client::ConnectionService;
+    /// let builder : ClientBuilder = ConnectionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigqueryconnection.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConnectionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConnectionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ConnectionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/bigquery/connection/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the BigQuery Connection API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+/// let client = ConnectionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages external data source connections and credentials.
 ///
 /// # Configuration
 ///
-/// `ConnectionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConnectionService` use the `with_*` methods in the type returned
+/// by [builder()][ConnectionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigqueryconnection.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::connection_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::connection_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct ConnectionService {
 }
 
 impl ConnectionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConnectionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+    /// let client = ConnectionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::connection_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::connection_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConnectionService + 'static,
@@ -64,6 +91,11 @@ impl ConnectionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod data_policy_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DataPolicyService][super::super::client::DataPolicyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_datapolicies_v1::*;
+    /// # use builder::data_policy_service::ClientBuilder;
+    /// # use client::DataPolicyService;
+    /// let builder : ClientBuilder = DataPolicyService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquerydatapolicy.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DataPolicyService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DataPolicyService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DataPolicyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the BigQuery Data Policy API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+/// let client = DataPolicyService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Data Policy Service provides APIs for managing the label-policy bindings.
 ///
 /// # Configuration
 ///
-/// `DataPolicyService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DataPolicyService` use the `with_*` methods in the type returned
+/// by [builder()][DataPolicyService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquerydatapolicy.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::data_policy_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::data_policy_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct DataPolicyService {
 }
 
 impl DataPolicyService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DataPolicyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// let client = DataPolicyService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::data_policy_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::data_policy_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DataPolicyService + 'static,
@@ -64,6 +91,11 @@ impl DataPolicyService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod data_transfer_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DataTransferService][super::super::client::DataTransferService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_datatransfer_v1::*;
+    /// # use builder::data_transfer_service::ClientBuilder;
+    /// # use client::DataTransferService;
+    /// let builder : ClientBuilder = DataTransferService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquerydatatransfer.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DataTransferService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DataTransferService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DataTransferService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the BigQuery Data Transfer API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+/// let client = DataTransferService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This API allows users to manage their data transfers into BigQuery.
 ///
 /// # Configuration
 ///
-/// `DataTransferService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DataTransferService` use the `with_*` methods in the type returned
+/// by [builder()][DataTransferService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquerydatatransfer.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::data_transfer_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::data_transfer_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct DataTransferService {
 }
 
 impl DataTransferService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DataTransferService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// let client = DataTransferService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::data_transfer_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::data_transfer_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DataTransferService + 'static,
@@ -64,6 +91,11 @@ impl DataTransferService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/bigquery/migration/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/migration/v2/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/bigquery/migration/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod migration_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [MigrationService][super::super::client::MigrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_migration_v2::*;
+    /// # use builder::migration_service::ClientBuilder;
+    /// # use client::MigrationService;
+    /// let builder : ClientBuilder = MigrationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquerymigration.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::MigrationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = MigrationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::MigrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/bigquery/migration/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the BigQuery Migration API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_migration_v2::client::MigrationService;
+/// let client = MigrationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service to handle EDW migrations.
 ///
 /// # Configuration
 ///
-/// `MigrationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `MigrationService` use the `with_*` methods in the type returned
+/// by [builder()][MigrationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquerymigration.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::migration_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::migration_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct MigrationService {
 }
 
 impl MigrationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [MigrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_migration_v2::client::MigrationService;
+    /// let client = MigrationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::migration_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::migration_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::MigrationService + 'static,
@@ -64,6 +91,11 @@ impl MigrationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/bigquery/reservation/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod reservation_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ReservationService][super::super::client::ReservationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_reservation_v1::*;
+    /// # use builder::reservation_service::ClientBuilder;
+    /// # use client::ReservationService;
+    /// let builder : ClientBuilder = ReservationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigqueryreservation.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ReservationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ReservationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ReservationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/bigquery/reservation/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the BigQuery Reservation API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+/// let client = ReservationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This API allows users to manage their BigQuery reservations.
@@ -41,8 +50,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ReservationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ReservationService` use the `with_*` methods in the type returned
+/// by [builder()][ReservationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigqueryreservation.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::reservation_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::reservation_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -56,21 +80,24 @@ pub struct ReservationService {
 }
 
 impl ReservationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ReservationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// let client = ReservationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::reservation_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::reservation_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ReservationService + 'static,
@@ -78,6 +105,11 @@ impl ReservationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/bigquery/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/v2/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/bigquery/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod dataset_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DatasetService][super::super::client::DatasetService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::*;
+    /// # use builder::dataset_service::ClientBuilder;
+    /// # use client::DatasetService;
+    /// let builder : ClientBuilder = DatasetService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquery.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DatasetService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DatasetService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DatasetService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -476,6 +504,34 @@ pub mod model_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ModelService][super::super::client::ModelService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::*;
+    /// # use builder::model_service::ClientBuilder;
+    /// # use client::ModelService;
+    /// let builder : ClientBuilder = ModelService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquery.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ModelService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ModelService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ModelService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -736,6 +792,34 @@ pub mod project_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ProjectService][super::super::client::ProjectService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::*;
+    /// # use builder::project_service::ClientBuilder;
+    /// # use client::ProjectService;
+    /// let builder : ClientBuilder = ProjectService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquery.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ProjectService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ProjectService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ProjectService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -806,6 +890,34 @@ pub mod project_service {
 pub mod routine_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [RoutineService][super::super::client::RoutineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::*;
+    /// # use builder::routine_service::ClientBuilder;
+    /// # use client::RoutineService;
+    /// let builder : ClientBuilder = RoutineService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquery.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RoutineService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RoutineService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::RoutineService] request builders.
     #[derive(Clone, Debug)]
@@ -1129,6 +1241,34 @@ pub mod routine_service {
 pub mod row_access_policy_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [RowAccessPolicyService][super::super::client::RowAccessPolicyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::*;
+    /// # use builder::row_access_policy_service::ClientBuilder;
+    /// # use client::RowAccessPolicyService;
+    /// let builder : ClientBuilder = RowAccessPolicyService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquery.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RowAccessPolicyService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RowAccessPolicyService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::RowAccessPolicyService] request builders.
     #[derive(Clone, Debug)]
@@ -1603,6 +1743,34 @@ pub mod row_access_policy_service {
 pub mod table_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [TableService][super::super::client::TableService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::*;
+    /// # use builder::table_service::ClientBuilder;
+    /// # use client::TableService;
+    /// let builder : ClientBuilder = TableService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://bigquery.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TableService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TableService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::TableService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/bigquery/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the BigQuery API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_v2::client::DatasetService;
+/// let client = DatasetService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// DatasetService provides methods for managing BigQuery datasets.
 ///
 /// # Configuration
 ///
-/// `DatasetService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DatasetService` use the `with_*` methods in the type returned
+/// by [builder()][DatasetService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquery.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::dataset_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::dataset_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct DatasetService {
 }
 
 impl DatasetService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DatasetService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::client::DatasetService;
+    /// let client = DatasetService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::dataset_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::dataset_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DatasetService + 'static,
@@ -64,6 +89,11 @@ impl DatasetService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -176,14 +206,38 @@ impl DatasetService {
 
 /// Implements a client for the BigQuery API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_v2::client::ModelService;
+/// let client = ModelService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Model Service for BigQuery ML
 ///
 /// # Configuration
 ///
-/// `ModelService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ModelService` use the `with_*` methods in the type returned
+/// by [builder()][ModelService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquery.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::model_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::model_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -197,21 +251,22 @@ pub struct ModelService {
 }
 
 impl ModelService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ModelService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::client::ModelService;
+    /// let client = ModelService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::model_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::model_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ModelService + 'static,
@@ -219,6 +274,11 @@ impl ModelService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -299,14 +359,38 @@ impl ModelService {
 
 /// Implements a client for the BigQuery API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_v2::client::ProjectService;
+/// let client = ProjectService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This service provides access to BigQuery functionality related to projects.
 ///
 /// # Configuration
 ///
-/// `ProjectService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ProjectService` use the `with_*` methods in the type returned
+/// by [builder()][ProjectService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquery.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::project_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::project_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -320,21 +404,22 @@ pub struct ProjectService {
 }
 
 impl ProjectService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ProjectService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::client::ProjectService;
+    /// let client = ProjectService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::project_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::project_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ProjectService + 'static,
@@ -342,6 +427,11 @@ impl ProjectService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -380,14 +470,38 @@ impl ProjectService {
 
 /// Implements a client for the BigQuery API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_v2::client::RoutineService;
+/// let client = RoutineService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// RoutineService provides management access to BigQuery routines.
 ///
 /// # Configuration
 ///
-/// `RoutineService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RoutineService` use the `with_*` methods in the type returned
+/// by [builder()][RoutineService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquery.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::routine_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::routine_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -401,21 +515,22 @@ pub struct RoutineService {
 }
 
 impl RoutineService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RoutineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::client::RoutineService;
+    /// let client = RoutineService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::routine_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::routine_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RoutineService + 'static,
@@ -423,6 +538,11 @@ impl RoutineService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -514,14 +634,38 @@ impl RoutineService {
 
 /// Implements a client for the BigQuery API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_v2::client::RowAccessPolicyService;
+/// let client = RowAccessPolicyService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for interacting with row access policies.
 ///
 /// # Configuration
 ///
-/// `RowAccessPolicyService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RowAccessPolicyService` use the `with_*` methods in the type returned
+/// by [builder()][RowAccessPolicyService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquery.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::row_access_policy_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::row_access_policy_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -535,21 +679,24 @@ pub struct RowAccessPolicyService {
 }
 
 impl RowAccessPolicyService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RowAccessPolicyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::client::RowAccessPolicyService;
+    /// let client = RowAccessPolicyService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::row_access_policy_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::row_access_policy_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RowAccessPolicyService + 'static,
@@ -557,6 +704,11 @@ impl RowAccessPolicyService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -671,6 +823,15 @@ impl RowAccessPolicyService {
 
 /// Implements a client for the BigQuery API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_bigquery_v2::client::TableService;
+/// let client = TableService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// TableService provides methods for managing BigQuery tables and table-like
@@ -678,8 +839,23 @@ impl RowAccessPolicyService {
 ///
 /// # Configuration
 ///
-/// `TableService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TableService` use the `with_*` methods in the type returned
+/// by [builder()][TableService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://bigquery.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::table_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::table_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -693,21 +869,22 @@ pub struct TableService {
 }
 
 impl TableService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TableService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_bigquery_v2::client::TableService;
+    /// let client = TableService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::table_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::table_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TableService + 'static,
@@ -715,6 +892,11 @@ impl TableService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/billing/v1/Cargo.toml
+++ b/src/generated/cloud/billing/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/billing/v1/src/builder.rs
+++ b/src/generated/cloud/billing/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_billing {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudBilling][super::super::client::CloudBilling].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_billing_v1::*;
+    /// # use builder::cloud_billing::ClientBuilder;
+    /// # use client::CloudBilling;
+    /// let builder : ClientBuilder = CloudBilling::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudbilling.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudBilling;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudBilling;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudBilling] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -678,6 +706,34 @@ pub mod cloud_billing {
 pub mod cloud_catalog {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [CloudCatalog][super::super::client::CloudCatalog].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_billing_v1::*;
+    /// # use builder::cloud_catalog::ClientBuilder;
+    /// # use client::CloudCatalog;
+    /// let builder : ClientBuilder = CloudCatalog::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudbilling.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudCatalog;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudCatalog;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::CloudCatalog] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/billing/v1/src/client.rs
+++ b/src/generated/cloud/billing/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Billing API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_billing_v1::client::CloudBilling;
+/// let client = CloudBilling::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Retrieves the Google Cloud Console billing accounts and associates them with
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudBilling` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudBilling` use the `with_*` methods in the type returned
+/// by [builder()][CloudBilling::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudbilling.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_billing::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_billing::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct CloudBilling {
 }
 
 impl CloudBilling {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudBilling].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// let client = CloudBilling::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_billing::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cloud_billing::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudBilling + 'static,
@@ -65,6 +90,11 @@ impl CloudBilling {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -254,6 +284,15 @@ impl CloudBilling {
 
 /// Implements a client for the Cloud Billing API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_billing_v1::client::CloudCatalog;
+/// let client = CloudCatalog::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A catalog of Google Cloud Platform services and SKUs.
@@ -262,8 +301,23 @@ impl CloudBilling {
 ///
 /// # Configuration
 ///
-/// `CloudCatalog` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudCatalog` use the `with_*` methods in the type returned
+/// by [builder()][CloudCatalog::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudbilling.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_catalog::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_catalog::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -277,21 +331,22 @@ pub struct CloudCatalog {
 }
 
 impl CloudCatalog {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudCatalog].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_billing_v1::client::CloudCatalog;
+    /// let client = CloudCatalog::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_catalog::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cloud_catalog::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudCatalog + 'static,
@@ -299,6 +354,11 @@ impl CloudCatalog {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/binaryauthorization/v1/Cargo.toml
+++ b/src/generated/cloud/binaryauthorization/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/binaryauthorization/v1/src/builder.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod binauthz_management_service_v_1 {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [BinauthzManagementServiceV1][super::super::client::BinauthzManagementServiceV1].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_binaryauthorization_v1::*;
+    /// # use builder::binauthz_management_service_v_1::ClientBuilder;
+    /// # use client::BinauthzManagementServiceV1;
+    /// let builder : ClientBuilder = BinauthzManagementServiceV1::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://binaryauthorization.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::BinauthzManagementServiceV1;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = BinauthzManagementServiceV1;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::BinauthzManagementServiceV1] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -402,6 +430,34 @@ pub mod system_policy_v_1 {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SystemPolicyV1][super::super::client::SystemPolicyV1].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_binaryauthorization_v1::*;
+    /// # use builder::system_policy_v_1::ClientBuilder;
+    /// # use client::SystemPolicyV1;
+    /// let builder : ClientBuilder = SystemPolicyV1::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://binaryauthorization.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SystemPolicyV1;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SystemPolicyV1;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SystemPolicyV1] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -469,6 +525,34 @@ pub mod system_policy_v_1 {
 pub mod validation_helper_v_1 {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ValidationHelperV1][super::super::client::ValidationHelperV1].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_binaryauthorization_v1::*;
+    /// # use builder::validation_helper_v_1::ClientBuilder;
+    /// # use client::ValidationHelperV1;
+    /// let builder : ClientBuilder = ValidationHelperV1::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://binaryauthorization.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ValidationHelperV1;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ValidationHelperV1;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ValidationHelperV1] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/binaryauthorization/v1/src/client.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Binary Authorization API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+/// let client = BinauthzManagementServiceV1::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Google Cloud Management Service for Binary Authorization admission policies
@@ -36,8 +45,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `BinauthzManagementServiceV1` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `BinauthzManagementServiceV1` use the `with_*` methods in the type returned
+/// by [builder()][BinauthzManagementServiceV1::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://binaryauthorization.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::binauthz_management_service_v_1::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::binauthz_management_service_v_1::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -51,21 +75,24 @@ pub struct BinauthzManagementServiceV1 {
 }
 
 impl BinauthzManagementServiceV1 {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [BinauthzManagementServiceV1].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+    /// let client = BinauthzManagementServiceV1::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::binauthz_management_service_v_1::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::binauthz_management_service_v_1::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::BinauthzManagementServiceV1 + 'static,
@@ -73,6 +100,11 @@ impl BinauthzManagementServiceV1 {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -196,14 +228,38 @@ impl BinauthzManagementServiceV1 {
 
 /// Implements a client for the Binary Authorization API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_binaryauthorization_v1::client::SystemPolicyV1;
+/// let client = SystemPolicyV1::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API for working with the system policy.
 ///
 /// # Configuration
 ///
-/// `SystemPolicyV1` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SystemPolicyV1` use the `with_*` methods in the type returned
+/// by [builder()][SystemPolicyV1::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://binaryauthorization.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::system_policy_v_1::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::system_policy_v_1::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -217,21 +273,24 @@ pub struct SystemPolicyV1 {
 }
 
 impl SystemPolicyV1 {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SystemPolicyV1].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_binaryauthorization_v1::client::SystemPolicyV1;
+    /// let client = SystemPolicyV1::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::system_policy_v_1::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::system_policy_v_1::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SystemPolicyV1 + 'static,
@@ -239,6 +298,11 @@ impl SystemPolicyV1 {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -276,14 +340,38 @@ impl SystemPolicyV1 {
 
 /// Implements a client for the Binary Authorization API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_binaryauthorization_v1::client::ValidationHelperV1;
+/// let client = ValidationHelperV1::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// BinAuthz Attestor verification
 ///
 /// # Configuration
 ///
-/// `ValidationHelperV1` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ValidationHelperV1` use the `with_*` methods in the type returned
+/// by [builder()][ValidationHelperV1::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://binaryauthorization.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::validation_helper_v_1::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::validation_helper_v_1::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -297,21 +385,24 @@ pub struct ValidationHelperV1 {
 }
 
 impl ValidationHelperV1 {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ValidationHelperV1].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_binaryauthorization_v1::client::ValidationHelperV1;
+    /// let client = ValidationHelperV1::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::validation_helper_v_1::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::validation_helper_v_1::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ValidationHelperV1 + 'static,
@@ -319,6 +410,11 @@ impl ValidationHelperV1 {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/certificatemanager/v1/Cargo.toml
+++ b/src/generated/cloud/certificatemanager/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/certificatemanager/v1/src/builder.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod certificate_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CertificateManager][super::super::client::CertificateManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_certificatemanager_v1::*;
+    /// # use builder::certificate_manager::ClientBuilder;
+    /// # use client::CertificateManager;
+    /// let builder : ClientBuilder = CertificateManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://certificatemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CertificateManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CertificateManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CertificateManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/certificatemanager/v1/src/client.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Certificate Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+/// let client = CertificateManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview
@@ -53,8 +62,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CertificateManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CertificateManager` use the `with_*` methods in the type returned
+/// by [builder()][CertificateManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://certificatemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::certificate_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::certificate_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -68,21 +92,24 @@ pub struct CertificateManager {
 }
 
 impl CertificateManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CertificateManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// let client = CertificateManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::certificate_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::certificate_manager::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CertificateManager + 'static,
@@ -90,6 +117,11 @@ impl CertificateManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
+++ b/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/builder.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_controls_partner_core {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudControlsPartnerCore][super::super::client::CloudControlsPartnerCore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_cloudcontrolspartner_v1::*;
+    /// # use builder::cloud_controls_partner_core::ClientBuilder;
+    /// # use client::CloudControlsPartnerCore;
+    /// let builder : ClientBuilder = CloudControlsPartnerCore::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudcontrolspartner.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudControlsPartnerCore;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudControlsPartnerCore;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudControlsPartnerCore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -527,6 +555,34 @@ pub mod cloud_controls_partner_core {
 pub mod cloud_controls_partner_monitoring {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [CloudControlsPartnerMonitoring][super::super::client::CloudControlsPartnerMonitoring].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_cloudcontrolspartner_v1::*;
+    /// # use builder::cloud_controls_partner_monitoring::ClientBuilder;
+    /// # use client::CloudControlsPartnerMonitoring;
+    /// let builder : ClientBuilder = CloudControlsPartnerMonitoring::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudcontrolspartner.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudControlsPartnerMonitoring;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudControlsPartnerMonitoring;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::CloudControlsPartnerMonitoring] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Controls Partner API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+/// let client = CloudControlsPartnerCore::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `CloudControlsPartnerCore` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudControlsPartnerCore` use the `with_*` methods in the type returned
+/// by [builder()][CloudControlsPartnerCore::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudcontrolspartner.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_controls_partner_core::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_controls_partner_core::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct CloudControlsPartnerCore {
 }
 
 impl CloudControlsPartnerCore {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudControlsPartnerCore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// let client = CloudControlsPartnerCore::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_controls_partner_core::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::cloud_controls_partner_core::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudControlsPartnerCore + 'static,
@@ -64,6 +91,11 @@ impl CloudControlsPartnerCore {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -167,14 +199,38 @@ impl CloudControlsPartnerCore {
 
 /// Implements a client for the Cloud Controls Partner API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerMonitoring;
+/// let client = CloudControlsPartnerMonitoring::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `CloudControlsPartnerMonitoring` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudControlsPartnerMonitoring` use the `with_*` methods in the type returned
+/// by [builder()][CloudControlsPartnerMonitoring::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudcontrolspartner.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_controls_partner_monitoring::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_controls_partner_monitoring::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -188,21 +244,24 @@ pub struct CloudControlsPartnerMonitoring {
 }
 
 impl CloudControlsPartnerMonitoring {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudControlsPartnerMonitoring].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerMonitoring;
+    /// let client = CloudControlsPartnerMonitoring::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_controls_partner_monitoring::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::cloud_controls_partner_monitoring::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudControlsPartnerMonitoring + 'static,
@@ -210,6 +269,11 @@ impl CloudControlsPartnerMonitoring {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/clouddms/v1/Cargo.toml
+++ b/src/generated/cloud/clouddms/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/clouddms/v1/src/builder.rs
+++ b/src/generated/cloud/clouddms/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod data_migration_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DataMigrationService][super::super::client::DataMigrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_clouddms_v1::*;
+    /// # use builder::data_migration_service::ClientBuilder;
+    /// # use client::DataMigrationService;
+    /// let builder : ClientBuilder = DataMigrationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://datamigration.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DataMigrationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DataMigrationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DataMigrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/clouddms/v1/src/client.rs
+++ b/src/generated/cloud/clouddms/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Database Migration API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_clouddms_v1::client::DataMigrationService;
+/// let client = DataMigrationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Database Migration service
 ///
 /// # Configuration
 ///
-/// `DataMigrationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DataMigrationService` use the `with_*` methods in the type returned
+/// by [builder()][DataMigrationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://datamigration.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::data_migration_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::data_migration_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct DataMigrationService {
 }
 
 impl DataMigrationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DataMigrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// let client = DataMigrationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::data_migration_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::data_migration_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DataMigrationService + 'static,
@@ -64,6 +91,11 @@ impl DataMigrationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod license_management_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [LicenseManagementService][super::super::client::LicenseManagementService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_commerce_consumer_procurement_v1::*;
+    /// # use builder::license_management_service::ClientBuilder;
+    /// # use client::LicenseManagementService;
+    /// let builder : ClientBuilder = LicenseManagementService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudcommerceconsumerprocurement.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::LicenseManagementService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = LicenseManagementService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::LicenseManagementService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -379,6 +407,34 @@ pub mod license_management_service {
 pub mod consumer_procurement_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ConsumerProcurementService][super::super::client::ConsumerProcurementService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_commerce_consumer_procurement_v1::*;
+    /// # use builder::consumer_procurement_service::ClientBuilder;
+    /// # use client::ConsumerProcurementService;
+    /// let builder : ClientBuilder = ConsumerProcurementService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudcommerceconsumerprocurement.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConsumerProcurementService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConsumerProcurementService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ConsumerProcurementService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/client.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Commerce Consumer Procurement API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
+/// let client = LicenseManagementService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing licenses.
 ///
 /// # Configuration
 ///
-/// `LicenseManagementService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `LicenseManagementService` use the `with_*` methods in the type returned
+/// by [builder()][LicenseManagementService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudcommerceconsumerprocurement.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::license_management_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::license_management_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct LicenseManagementService {
 }
 
 impl LicenseManagementService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [LicenseManagementService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
+    /// let client = LicenseManagementService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::license_management_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::license_management_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::LicenseManagementService + 'static,
@@ -64,6 +91,11 @@ impl LicenseManagementService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -148,6 +180,15 @@ impl LicenseManagementService {
 
 /// Implements a client for the Cloud Commerce Consumer Procurement API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_commerce_consumer_procurement_v1::client::ConsumerProcurementService;
+/// let client = ConsumerProcurementService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// ConsumerProcurementService allows customers to make purchases of products
@@ -163,8 +204,23 @@ impl LicenseManagementService {
 ///
 /// # Configuration
 ///
-/// `ConsumerProcurementService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConsumerProcurementService` use the `with_*` methods in the type returned
+/// by [builder()][ConsumerProcurementService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudcommerceconsumerprocurement.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::consumer_procurement_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::consumer_procurement_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -178,21 +234,24 @@ pub struct ConsumerProcurementService {
 }
 
 impl ConsumerProcurementService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConsumerProcurementService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::ConsumerProcurementService;
+    /// let client = ConsumerProcurementService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::consumer_procurement_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::consumer_procurement_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConsumerProcurementService + 'static,
@@ -200,6 +259,11 @@ impl ConsumerProcurementService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/common/Cargo.toml
+++ b/src/generated/cloud/common/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
+++ b/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod confidential_computing {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ConfidentialComputing][super::super::client::ConfidentialComputing].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_confidentialcomputing_v1::*;
+    /// # use builder::confidential_computing::ClientBuilder;
+    /// # use client::ConfidentialComputing;
+    /// let builder : ClientBuilder = ConfidentialComputing::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://confidentialcomputing.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConfidentialComputing;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConfidentialComputing;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ConfidentialComputing] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/confidentialcomputing/v1/src/client.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Confidential Computing API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
+/// let client = ConfidentialComputing::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `ConfidentialComputing` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConfidentialComputing` use the `with_*` methods in the type returned
+/// by [builder()][ConfidentialComputing::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://confidentialcomputing.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::confidential_computing::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::confidential_computing::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct ConfidentialComputing {
 }
 
 impl ConfidentialComputing {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConfidentialComputing].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
+    /// let client = ConfidentialComputing::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::confidential_computing::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::confidential_computing::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConfidentialComputing + 'static,
@@ -64,6 +91,11 @@ impl ConfidentialComputing {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/config/v1/Cargo.toml
+++ b/src/generated/cloud/config/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/config/v1/src/builder.rs
+++ b/src/generated/cloud/config/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod config {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Config][super::super::client::Config].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_config_v1::*;
+    /// # use builder::config::ClientBuilder;
+    /// # use client::Config;
+    /// let builder : ClientBuilder = Config::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://config.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Config;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Config;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Config] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/config/v1/src/client.rs
+++ b/src/generated/cloud/config/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Infrastructure Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_config_v1::client::Config;
+/// let client = Config::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Infrastructure Manager is a managed service that automates the deployment and
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Config` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Config` use the `with_*` methods in the type returned
+/// by [builder()][Config::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://config.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::config::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::config::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct Config {
 }
 
 impl Config {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Config].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_config_v1::client::Config;
+    /// let client = Config::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::config::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::config::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Config + 'static,
@@ -65,6 +90,11 @@ impl Config {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/connectors/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/connectors/v1/src/builder.rs
+++ b/src/generated/cloud/connectors/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod connectors {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Connectors][super::super::client::Connectors].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_connectors_v1::*;
+    /// # use builder::connectors::ClientBuilder;
+    /// # use client::Connectors;
+    /// let builder : ClientBuilder = Connectors::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://connectors.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Connectors;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Connectors;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Connectors] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/connectors/v1/src/client.rs
+++ b/src/generated/cloud/connectors/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Connectors API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_connectors_v1::client::Connectors;
+/// let client = Connectors::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Connectors is the interface for managing Connectors.
 ///
 /// # Configuration
 ///
-/// `Connectors` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Connectors` use the `with_*` methods in the type returned
+/// by [builder()][Connectors::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://connectors.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::connectors::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::connectors::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Connectors {
 }
 
 impl Connectors {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Connectors].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// let client = Connectors::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::connectors::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::connectors::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Connectors + 'static,
@@ -64,6 +89,11 @@ impl Connectors {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod contact_center_insights {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ContactCenterInsights][super::super::client::ContactCenterInsights].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_contactcenterinsights_v1::*;
+    /// # use builder::contact_center_insights::ClientBuilder;
+    /// # use client::ContactCenterInsights;
+    /// let builder : ClientBuilder = ContactCenterInsights::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://contactcenterinsights.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ContactCenterInsights;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ContactCenterInsights;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ContactCenterInsights] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/contactcenterinsights/v1/src/client.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Contact Center AI Insights API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+/// let client = ContactCenterInsights::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// An API that lets users analyze and explore their business conversation data.
 ///
 /// # Configuration
 ///
-/// `ContactCenterInsights` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ContactCenterInsights` use the `with_*` methods in the type returned
+/// by [builder()][ContactCenterInsights::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://contactcenterinsights.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::contact_center_insights::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::contact_center_insights::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct ContactCenterInsights {
 }
 
 impl ContactCenterInsights {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ContactCenterInsights].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// let client = ContactCenterInsights::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::contact_center_insights::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::contact_center_insights::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ContactCenterInsights + 'static,
@@ -64,6 +91,11 @@ impl ContactCenterInsights {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod lineage {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Lineage][super::super::client::Lineage].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datacatalog_lineage_v1::*;
+    /// # use builder::lineage::ClientBuilder;
+    /// # use client::Lineage;
+    /// let builder : ClientBuilder = Lineage::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://datalineage.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Lineage;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Lineage;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Lineage] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/datacatalog/lineage/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Data Lineage API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+/// let client = Lineage::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Lineage is used to track data flows between assets over time. You can
@@ -32,8 +41,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Lineage` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Lineage` use the `with_*` methods in the type returned
+/// by [builder()][Lineage::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://datalineage.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::lineage::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::lineage::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -47,21 +71,22 @@ pub struct Lineage {
 }
 
 impl Lineage {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Lineage].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// let client = Lineage::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::lineage::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::lineage::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Lineage + 'static,
@@ -69,6 +94,11 @@ impl Lineage {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/datacatalog/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/datacatalog/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod data_catalog {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DataCatalog][super::super::client::DataCatalog].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datacatalog_v1::*;
+    /// # use builder::data_catalog::ClientBuilder;
+    /// # use client::DataCatalog;
+    /// let builder : ClientBuilder = DataCatalog::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://datacatalog.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DataCatalog;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DataCatalog;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DataCatalog] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2370,6 +2398,34 @@ pub mod policy_tag_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [PolicyTagManager][super::super::client::PolicyTagManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datacatalog_v1::*;
+    /// # use builder::policy_tag_manager::ClientBuilder;
+    /// # use client::PolicyTagManager;
+    /// let builder : ClientBuilder = PolicyTagManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://datacatalog.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PolicyTagManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PolicyTagManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::PolicyTagManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -3297,6 +3353,34 @@ pub mod policy_tag_manager {
 pub mod policy_tag_manager_serialization {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [PolicyTagManagerSerialization][super::super::client::PolicyTagManagerSerialization].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datacatalog_v1::*;
+    /// # use builder::policy_tag_manager_serialization::ClientBuilder;
+    /// # use client::PolicyTagManagerSerialization;
+    /// let builder : ClientBuilder = PolicyTagManagerSerialization::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://datacatalog.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PolicyTagManagerSerialization;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PolicyTagManagerSerialization;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::PolicyTagManagerSerialization] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/datacatalog/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Google Cloud Data Catalog API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_datacatalog_v1::client::DataCatalog;
+/// let client = DataCatalog::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Deprecated: Please use Dataplex Catalog instead.
@@ -30,8 +39,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `DataCatalog` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DataCatalog` use the `with_*` methods in the type returned
+/// by [builder()][DataCatalog::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://datacatalog.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::data_catalog::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::data_catalog::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -45,21 +69,22 @@ pub struct DataCatalog {
 }
 
 impl DataCatalog {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DataCatalog].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// let client = DataCatalog::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::data_catalog::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::data_catalog::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DataCatalog + 'static,
@@ -67,6 +92,11 @@ impl DataCatalog {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -716,6 +746,15 @@ impl DataCatalog {
 
 /// Implements a client for the Google Cloud Data Catalog API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+/// let client = PolicyTagManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Policy Tag Manager API service allows you to manage your policy tags and
@@ -727,8 +766,23 @@ impl DataCatalog {
 ///
 /// # Configuration
 ///
-/// `PolicyTagManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PolicyTagManager` use the `with_*` methods in the type returned
+/// by [builder()][PolicyTagManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://datacatalog.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::policy_tag_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::policy_tag_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -742,21 +796,24 @@ pub struct PolicyTagManager {
 }
 
 impl PolicyTagManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PolicyTagManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// let client = PolicyTagManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::policy_tag_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::policy_tag_manager::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PolicyTagManager + 'static,
@@ -764,6 +821,11 @@ impl PolicyTagManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -966,6 +1028,15 @@ impl PolicyTagManager {
 
 /// Implements a client for the Google Cloud Data Catalog API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
+/// let client = PolicyTagManagerSerialization::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Policy Tag Manager Serialization API service allows you to manipulate
@@ -975,8 +1046,23 @@ impl PolicyTagManager {
 ///
 /// # Configuration
 ///
-/// `PolicyTagManagerSerialization` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PolicyTagManagerSerialization` use the `with_*` methods in the type returned
+/// by [builder()][PolicyTagManagerSerialization::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://datacatalog.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::policy_tag_manager_serialization::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::policy_tag_manager_serialization::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -990,21 +1076,24 @@ pub struct PolicyTagManagerSerialization {
 }
 
 impl PolicyTagManagerSerialization {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PolicyTagManagerSerialization].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
+    /// let client = PolicyTagManagerSerialization::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::policy_tag_manager_serialization::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::policy_tag_manager_serialization::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PolicyTagManagerSerialization + 'static,
@@ -1012,6 +1101,11 @@ impl PolicyTagManagerSerialization {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/datafusion/v1/Cargo.toml
+++ b/src/generated/cloud/datafusion/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/datafusion/v1/src/builder.rs
+++ b/src/generated/cloud/datafusion/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod data_fusion {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DataFusion][super::super::client::DataFusion].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datafusion_v1::*;
+    /// # use builder::data_fusion::ClientBuilder;
+    /// # use client::DataFusion;
+    /// let builder : ClientBuilder = DataFusion::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://datafusion.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DataFusion;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DataFusion;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DataFusion] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/datafusion/v1/src/client.rs
+++ b/src/generated/cloud/datafusion/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Data Fusion API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_datafusion_v1::client::DataFusion;
+/// let client = DataFusion::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for creating and managing Data Fusion instances.
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `DataFusion` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DataFusion` use the `with_*` methods in the type returned
+/// by [builder()][DataFusion::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://datafusion.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::data_fusion::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::data_fusion::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,22 @@ pub struct DataFusion {
 }
 
 impl DataFusion {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DataFusion].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datafusion_v1::client::DataFusion;
+    /// let client = DataFusion::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::data_fusion::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::data_fusion::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DataFusion + 'static,
@@ -66,6 +91,11 @@ impl DataFusion {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/dataproc/v1/Cargo.toml
+++ b/src/generated/cloud/dataproc/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/dataproc/v1/src/builder.rs
+++ b/src/generated/cloud/dataproc/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod autoscaling_policy_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AutoscalingPolicyService][super::super::client::AutoscalingPolicyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::*;
+    /// # use builder::autoscaling_policy_service::ClientBuilder;
+    /// # use client::AutoscalingPolicyService;
+    /// let builder : ClientBuilder = AutoscalingPolicyService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dataproc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AutoscalingPolicyService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AutoscalingPolicyService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AutoscalingPolicyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -724,6 +752,34 @@ pub mod batch_controller {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [BatchController][super::super::client::BatchController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::*;
+    /// # use builder::batch_controller::ClientBuilder;
+    /// # use client::BatchController;
+    /// let builder : ClientBuilder = BatchController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dataproc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::BatchController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = BatchController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::BatchController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1395,6 +1451,34 @@ pub mod batch_controller {
 pub mod cluster_controller {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ClusterController][super::super::client::ClusterController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::*;
+    /// # use builder::cluster_controller::ClientBuilder;
+    /// # use client::ClusterController;
+    /// let builder : ClientBuilder = ClusterController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dataproc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ClusterController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ClusterController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ClusterController] request builders.
     #[derive(Clone, Debug)]
@@ -2630,6 +2714,34 @@ pub mod job_controller {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [JobController][super::super::client::JobController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::*;
+    /// # use builder::job_controller::ClientBuilder;
+    /// # use client::JobController;
+    /// let builder : ClientBuilder = JobController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dataproc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::JobController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = JobController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::JobController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -3515,6 +3627,34 @@ pub mod node_group_controller {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [NodeGroupController][super::super::client::NodeGroupController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::*;
+    /// # use builder::node_group_controller::ClientBuilder;
+    /// # use client::NodeGroupController;
+    /// let builder : ClientBuilder = NodeGroupController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dataproc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::NodeGroupController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = NodeGroupController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::NodeGroupController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -4166,6 +4306,34 @@ pub mod node_group_controller {
 pub mod session_template_controller {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SessionTemplateController][super::super::client::SessionTemplateController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::*;
+    /// # use builder::session_template_controller::ClientBuilder;
+    /// # use client::SessionTemplateController;
+    /// let builder : ClientBuilder = SessionTemplateController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dataproc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SessionTemplateController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SessionTemplateController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SessionTemplateController] request builders.
     #[derive(Clone, Debug)]
@@ -4868,6 +5036,34 @@ pub mod session_template_controller {
 pub mod session_controller {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SessionController][super::super::client::SessionController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::*;
+    /// # use builder::session_controller::ClientBuilder;
+    /// # use client::SessionController;
+    /// let builder : ClientBuilder = SessionController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dataproc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SessionController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SessionController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SessionController] request builders.
     #[derive(Clone, Debug)]
@@ -5670,6 +5866,34 @@ pub mod session_controller {
 pub mod workflow_template_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [WorkflowTemplateService][super::super::client::WorkflowTemplateService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::*;
+    /// # use builder::workflow_template_service::ClientBuilder;
+    /// # use client::WorkflowTemplateService;
+    /// let builder : ClientBuilder = WorkflowTemplateService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dataproc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::WorkflowTemplateService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = WorkflowTemplateService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::WorkflowTemplateService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/dataproc/v1/src/client.rs
+++ b/src/generated/cloud/dataproc/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Dataproc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+/// let client = AutoscalingPolicyService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The API interface for managing autoscaling policies in the
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AutoscalingPolicyService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AutoscalingPolicyService` use the `with_*` methods in the type returned
+/// by [builder()][AutoscalingPolicyService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dataproc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::autoscaling_policy_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::autoscaling_policy_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,24 @@ pub struct AutoscalingPolicyService {
 }
 
 impl AutoscalingPolicyService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AutoscalingPolicyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// let client = AutoscalingPolicyService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::autoscaling_policy_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::autoscaling_policy_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AutoscalingPolicyService + 'static,
@@ -65,6 +92,11 @@ impl AutoscalingPolicyService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -224,14 +256,38 @@ impl AutoscalingPolicyService {
 
 /// Implements a client for the Cloud Dataproc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dataproc_v1::client::BatchController;
+/// let client = BatchController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The BatchController provides methods to manage batch workloads.
 ///
 /// # Configuration
 ///
-/// `BatchController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `BatchController` use the `with_*` methods in the type returned
+/// by [builder()][BatchController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dataproc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::batch_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::batch_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -245,21 +301,24 @@ pub struct BatchController {
 }
 
 impl BatchController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [BatchController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// let client = BatchController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::batch_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::batch_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::BatchController + 'static,
@@ -267,6 +326,11 @@ impl BatchController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -422,6 +486,15 @@ impl BatchController {
 
 /// Implements a client for the Cloud Dataproc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dataproc_v1::client::ClusterController;
+/// let client = ClusterController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The ClusterControllerService provides methods to manage clusters
@@ -429,8 +502,23 @@ impl BatchController {
 ///
 /// # Configuration
 ///
-/// `ClusterController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ClusterController` use the `with_*` methods in the type returned
+/// by [builder()][ClusterController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dataproc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cluster_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cluster_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -444,21 +532,24 @@ pub struct ClusterController {
 }
 
 impl ClusterController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ClusterController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::client::ClusterController;
+    /// let client = ClusterController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cluster_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::cluster_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ClusterController + 'static,
@@ -466,6 +557,11 @@ impl ClusterController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -761,14 +857,38 @@ impl ClusterController {
 
 /// Implements a client for the Cloud Dataproc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dataproc_v1::client::JobController;
+/// let client = JobController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The JobController provides methods to manage jobs.
 ///
 /// # Configuration
 ///
-/// `JobController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `JobController` use the `with_*` methods in the type returned
+/// by [builder()][JobController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dataproc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::job_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::job_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -782,21 +902,22 @@ pub struct JobController {
 }
 
 impl JobController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [JobController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// let client = JobController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::job_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::job_controller::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::JobController + 'static,
@@ -804,6 +925,11 @@ impl JobController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1013,6 +1139,15 @@ impl JobController {
 
 /// Implements a client for the Cloud Dataproc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dataproc_v1::client::NodeGroupController;
+/// let client = NodeGroupController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The `NodeGroupControllerService` provides methods to manage node groups
@@ -1020,8 +1155,23 @@ impl JobController {
 ///
 /// # Configuration
 ///
-/// `NodeGroupController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `NodeGroupController` use the `with_*` methods in the type returned
+/// by [builder()][NodeGroupController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dataproc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::node_group_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::node_group_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1035,21 +1185,24 @@ pub struct NodeGroupController {
 }
 
 impl NodeGroupController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [NodeGroupController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::client::NodeGroupController;
+    /// let client = NodeGroupController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::node_group_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::node_group_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::NodeGroupController + 'static,
@@ -1057,6 +1210,11 @@ impl NodeGroupController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1223,14 +1381,38 @@ impl NodeGroupController {
 
 /// Implements a client for the Cloud Dataproc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+/// let client = SessionTemplateController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The SessionTemplateController provides methods to manage session templates.
 ///
 /// # Configuration
 ///
-/// `SessionTemplateController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SessionTemplateController` use the `with_*` methods in the type returned
+/// by [builder()][SessionTemplateController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dataproc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::session_template_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::session_template_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1244,21 +1426,24 @@ pub struct SessionTemplateController {
 }
 
 impl SessionTemplateController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SessionTemplateController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// let client = SessionTemplateController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::session_template_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::session_template_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SessionTemplateController + 'static,
@@ -1266,6 +1451,11 @@ impl SessionTemplateController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1421,14 +1611,38 @@ impl SessionTemplateController {
 
 /// Implements a client for the Cloud Dataproc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dataproc_v1::client::SessionController;
+/// let client = SessionController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The `SessionController` provides methods to manage interactive sessions.
 ///
 /// # Configuration
 ///
-/// `SessionController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SessionController` use the `with_*` methods in the type returned
+/// by [builder()][SessionController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dataproc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::session_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::session_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1442,21 +1656,24 @@ pub struct SessionController {
 }
 
 impl SessionController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SessionController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::client::SessionController;
+    /// let client = SessionController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::session_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::session_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SessionController + 'static,
@@ -1464,6 +1681,11 @@ impl SessionController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1650,6 +1872,15 @@ impl SessionController {
 
 /// Implements a client for the Cloud Dataproc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+/// let client = WorkflowTemplateService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The API interface for managing Workflow Templates in the
@@ -1657,8 +1888,23 @@ impl SessionController {
 ///
 /// # Configuration
 ///
-/// `WorkflowTemplateService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `WorkflowTemplateService` use the `with_*` methods in the type returned
+/// by [builder()][WorkflowTemplateService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dataproc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::workflow_template_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::workflow_template_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1672,21 +1918,24 @@ pub struct WorkflowTemplateService {
 }
 
 impl WorkflowTemplateService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [WorkflowTemplateService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// let client = WorkflowTemplateService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::workflow_template_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::workflow_template_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::WorkflowTemplateService + 'static,
@@ -1694,6 +1943,11 @@ impl WorkflowTemplateService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/datastream/v1/Cargo.toml
+++ b/src/generated/cloud/datastream/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/datastream/v1/src/builder.rs
+++ b/src/generated/cloud/datastream/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod datastream {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Datastream][super::super::client::Datastream].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datastream_v1::*;
+    /// # use builder::datastream::ClientBuilder;
+    /// # use client::Datastream;
+    /// let builder : ClientBuilder = Datastream::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://datastream.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Datastream;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Datastream;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Datastream] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/datastream/v1/src/client.rs
+++ b/src/generated/cloud/datastream/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Datastream API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_datastream_v1::client::Datastream;
+/// let client = Datastream::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Datastream service
 ///
 /// # Configuration
 ///
-/// `Datastream` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Datastream` use the `with_*` methods in the type returned
+/// by [builder()][Datastream::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://datastream.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::datastream::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::datastream::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Datastream {
 }
 
 impl Datastream {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Datastream].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// let client = Datastream::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::datastream::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::datastream::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Datastream + 'static,
@@ -64,6 +89,11 @@ impl Datastream {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/deploy/v1/Cargo.toml
+++ b/src/generated/cloud/deploy/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/deploy/v1/src/builder.rs
+++ b/src/generated/cloud/deploy/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_deploy {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudDeploy][super::super::client::CloudDeploy].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_deploy_v1::*;
+    /// # use builder::cloud_deploy::ClientBuilder;
+    /// # use client::CloudDeploy;
+    /// let builder : ClientBuilder = CloudDeploy::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://clouddeploy.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudDeploy;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudDeploy;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudDeploy] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/deploy/v1/src/client.rs
+++ b/src/generated/cloud/deploy/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Deploy API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_deploy_v1::client::CloudDeploy;
+/// let client = CloudDeploy::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// CloudDeploy service creates and manages Continuous Delivery operations
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudDeploy` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudDeploy` use the `with_*` methods in the type returned
+/// by [builder()][CloudDeploy::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://clouddeploy.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_deploy::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_deploy::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct CloudDeploy {
 }
 
 impl CloudDeploy {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudDeploy].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// let client = CloudDeploy::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_deploy::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cloud_deploy::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudDeploy + 'static,
@@ -65,6 +90,11 @@ impl CloudDeploy {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/developerconnect/v1/Cargo.toml
+++ b/src/generated/cloud/developerconnect/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/developerconnect/v1/src/builder.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod developer_connect {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DeveloperConnect][super::super::client::DeveloperConnect].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_developerconnect_v1::*;
+    /// # use builder::developer_connect::ClientBuilder;
+    /// # use client::DeveloperConnect;
+    /// let builder : ClientBuilder = DeveloperConnect::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://developerconnect.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DeveloperConnect;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DeveloperConnect;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DeveloperConnect] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/developerconnect/v1/src/client.rs
+++ b/src/generated/cloud/developerconnect/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Developer Connect API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+/// let client = DeveloperConnect::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `DeveloperConnect` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DeveloperConnect` use the `with_*` methods in the type returned
+/// by [builder()][DeveloperConnect::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://developerconnect.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::developer_connect::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::developer_connect::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct DeveloperConnect {
 }
 
 impl DeveloperConnect {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DeveloperConnect].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// let client = DeveloperConnect::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::developer_connect::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::developer_connect::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DeveloperConnect + 'static,
@@ -64,6 +91,11 @@ impl DeveloperConnect {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
@@ -18,6 +18,34 @@ pub mod agents {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Agents][super::super::client::Agents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::agents::ClientBuilder;
+    /// # use client::Agents;
+    /// let builder : ClientBuilder = Agents::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Agents;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Agents;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Agents] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1013,6 +1041,34 @@ pub mod changelogs {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Changelogs][super::super::client::Changelogs].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::changelogs::ClientBuilder;
+    /// # use client::Changelogs;
+    /// let builder : ClientBuilder = Changelogs::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Changelogs;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Changelogs;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Changelogs] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1444,6 +1500,34 @@ pub mod deployments {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Deployments][super::super::client::Deployments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::deployments::ClientBuilder;
+    /// # use client::Deployments;
+    /// let builder : ClientBuilder = Deployments::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Deployments;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Deployments;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Deployments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1868,6 +1952,34 @@ pub mod deployments {
 pub mod entity_types {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [EntityTypes][super::super::client::EntityTypes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::entity_types::ClientBuilder;
+    /// # use client::EntityTypes;
+    /// let builder : ClientBuilder = EntityTypes::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EntityTypes;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EntityTypes;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::EntityTypes] request builders.
     #[derive(Clone, Debug)]
@@ -2718,6 +2830,34 @@ pub mod entity_types {
 pub mod environments {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Environments][super::super::client::Environments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::environments::ClientBuilder;
+    /// # use client::Environments;
+    /// let builder : ClientBuilder = Environments::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Environments;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Environments;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Environments] request builders.
     #[derive(Clone, Debug)]
@@ -3700,6 +3840,34 @@ pub mod experiments {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Experiments][super::super::client::Experiments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::experiments::ClientBuilder;
+    /// # use client::Experiments;
+    /// let builder : ClientBuilder = Experiments::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Experiments;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Experiments;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Experiments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -4364,6 +4532,34 @@ pub mod experiments {
 pub mod flows {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Flows][super::super::client::Flows].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::flows::ClientBuilder;
+    /// # use client::Flows;
+    /// let builder : ClientBuilder = Flows::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Flows;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Flows;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Flows] request builders.
     #[derive(Clone, Debug)]
@@ -5333,6 +5529,34 @@ pub mod generators {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Generators][super::super::client::Generators].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::generators::ClientBuilder;
+    /// # use client::Generators;
+    /// let builder : ClientBuilder = Generators::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Generators;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Generators;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Generators] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -5934,6 +6158,34 @@ pub mod generators {
 pub mod intents {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Intents][super::super::client::Intents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::intents::ClientBuilder;
+    /// # use client::Intents;
+    /// let builder : ClientBuilder = Intents::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Intents;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Intents;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Intents] request builders.
     #[derive(Clone, Debug)]
@@ -6752,6 +7004,34 @@ pub mod pages {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Pages][super::super::client::Pages].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::pages::ClientBuilder;
+    /// # use client::Pages;
+    /// let builder : ClientBuilder = Pages::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Pages;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Pages;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Pages] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -7346,6 +7626,34 @@ pub mod pages {
 pub mod security_settings_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SecuritySettingsService][super::super::client::SecuritySettingsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::security_settings_service::ClientBuilder;
+    /// # use client::SecuritySettingsService;
+    /// let builder : ClientBuilder = SecuritySettingsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SecuritySettingsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SecuritySettingsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SecuritySettingsService] request builders.
     #[derive(Clone, Debug)]
@@ -7960,6 +8268,34 @@ pub mod sessions {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Sessions][super::super::client::Sessions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::sessions::ClientBuilder;
+    /// # use client::Sessions;
+    /// let builder : ClientBuilder = Sessions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Sessions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Sessions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Sessions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -8546,6 +8882,34 @@ pub mod sessions {
 pub mod session_entity_types {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SessionEntityTypes][super::super::client::SessionEntityTypes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::session_entity_types::ClientBuilder;
+    /// # use client::SessionEntityTypes;
+    /// let builder : ClientBuilder = SessionEntityTypes::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SessionEntityTypes;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SessionEntityTypes;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SessionEntityTypes] request builders.
     #[derive(Clone, Debug)]
@@ -9145,6 +9509,34 @@ pub mod session_entity_types {
 pub mod test_cases {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [TestCases][super::super::client::TestCases].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::test_cases::ClientBuilder;
+    /// # use client::TestCases;
+    /// let builder : ClientBuilder = TestCases::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TestCases;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TestCases;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::TestCases] request builders.
     #[derive(Clone, Debug)]
@@ -10313,6 +10705,34 @@ pub mod transition_route_groups {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TransitionRouteGroups][super::super::client::TransitionRouteGroups].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::transition_route_groups::ClientBuilder;
+    /// # use client::TransitionRouteGroups;
+    /// let builder : ClientBuilder = TransitionRouteGroups::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TransitionRouteGroups;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TransitionRouteGroups;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TransitionRouteGroups] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -10967,6 +11387,34 @@ pub mod transition_route_groups {
 pub mod versions {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Versions][super::super::client::Versions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::versions::ClientBuilder;
+    /// # use client::Versions;
+    /// let builder : ClientBuilder = Versions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Versions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Versions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Versions] request builders.
     #[derive(Clone, Debug)]
@@ -11715,6 +12163,34 @@ pub mod versions {
 pub mod webhooks {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Webhooks][super::super::client::Webhooks].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::*;
+    /// # use builder::webhooks::ClientBuilder;
+    /// # use client::Webhooks;
+    /// let builder : ClientBuilder = Webhooks::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Webhooks;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Webhooks;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Webhooks] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/dialogflow/cx/v3/src/client.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Agents;
+/// let client = Agents::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Agents][google.cloud.dialogflow.cx.v3.Agent].
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Agents` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Agents` use the `with_*` methods in the type returned
+/// by [builder()][Agents::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::agents::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::agents::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,22 @@ pub struct Agents {
 }
 
 impl Agents {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Agents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// let client = Agents::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::agents::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::agents::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Agents + 'static,
@@ -66,6 +91,11 @@ impl Agents {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -286,6 +316,15 @@ impl Agents {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Changelogs;
+/// let client = Changelogs::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Changelogs][google.cloud.dialogflow.cx.v3.Changelog].
@@ -294,8 +333,23 @@ impl Agents {
 ///
 /// # Configuration
 ///
-/// `Changelogs` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Changelogs` use the `with_*` methods in the type returned
+/// by [builder()][Changelogs::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::changelogs::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::changelogs::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -309,21 +363,22 @@ pub struct Changelogs {
 }
 
 impl Changelogs {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Changelogs].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Changelogs;
+    /// let client = Changelogs::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::changelogs::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::changelogs::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Changelogs + 'static,
@@ -331,6 +386,11 @@ impl Changelogs {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -422,6 +482,15 @@ impl Changelogs {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Deployments;
+/// let client = Deployments::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Deployments][google.cloud.dialogflow.cx.v3.Deployment].
@@ -430,8 +499,23 @@ impl Changelogs {
 ///
 /// # Configuration
 ///
-/// `Deployments` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Deployments` use the `with_*` methods in the type returned
+/// by [builder()][Deployments::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::deployments::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::deployments::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -445,21 +529,22 @@ pub struct Deployments {
 }
 
 impl Deployments {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Deployments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Deployments;
+    /// let client = Deployments::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::deployments::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::deployments::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Deployments + 'static,
@@ -467,6 +552,11 @@ impl Deployments {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -564,6 +654,15 @@ impl Deployments {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+/// let client = EntityTypes::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [EntityTypes][google.cloud.dialogflow.cx.v3.EntityType].
@@ -572,8 +671,23 @@ impl Deployments {
 ///
 /// # Configuration
 ///
-/// `EntityTypes` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EntityTypes` use the `with_*` methods in the type returned
+/// by [builder()][EntityTypes::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::entity_types::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::entity_types::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -587,21 +701,22 @@ pub struct EntityTypes {
 }
 
 impl EntityTypes {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EntityTypes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+    /// let client = EntityTypes::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::entity_types::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::entity_types::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EntityTypes + 'static,
@@ -609,6 +724,11 @@ impl EntityTypes {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -777,6 +897,15 @@ impl EntityTypes {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Environments;
+/// let client = Environments::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing
@@ -786,8 +915,23 @@ impl EntityTypes {
 ///
 /// # Configuration
 ///
-/// `Environments` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Environments` use the `with_*` methods in the type returned
+/// by [builder()][Environments::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::environments::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::environments::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -801,21 +945,22 @@ pub struct Environments {
 }
 
 impl Environments {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Environments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Environments;
+    /// let client = Environments::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::environments::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::environments::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Environments + 'static,
@@ -823,6 +968,11 @@ impl Environments {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1080,6 +1230,15 @@ impl Environments {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+/// let client = Experiments::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Experiments][google.cloud.dialogflow.cx.v3.Experiment].
@@ -1088,8 +1247,23 @@ impl Environments {
 ///
 /// # Configuration
 ///
-/// `Experiments` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Experiments` use the `with_*` methods in the type returned
+/// by [builder()][Experiments::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::experiments::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::experiments::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1103,21 +1277,22 @@ pub struct Experiments {
 }
 
 impl Experiments {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Experiments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// let client = Experiments::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::experiments::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::experiments::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Experiments + 'static,
@@ -1125,6 +1300,11 @@ impl Experiments {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1281,6 +1461,15 @@ impl Experiments {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Flows;
+/// let client = Flows::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Flows][google.cloud.dialogflow.cx.v3.Flow].
@@ -1289,8 +1478,23 @@ impl Experiments {
 ///
 /// # Configuration
 ///
-/// `Flows` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Flows` use the `with_*` methods in the type returned
+/// by [builder()][Flows::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::flows::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::flows::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1304,21 +1508,22 @@ pub struct Flows {
 }
 
 impl Flows {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Flows].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// let client = Flows::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::flows::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::flows::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Flows + 'static,
@@ -1326,6 +1531,11 @@ impl Flows {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1560,6 +1770,15 @@ impl Flows {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Generators;
+/// let client = Generators::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Generators][google.cloud.dialogflow.cx.v3.Generator]
@@ -1568,8 +1787,23 @@ impl Flows {
 ///
 /// # Configuration
 ///
-/// `Generators` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Generators` use the `with_*` methods in the type returned
+/// by [builder()][Generators::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::generators::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::generators::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1583,21 +1817,22 @@ pub struct Generators {
 }
 
 impl Generators {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Generators].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Generators;
+    /// let client = Generators::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::generators::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::generators::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Generators + 'static,
@@ -1605,6 +1840,11 @@ impl Generators {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1722,6 +1962,15 @@ impl Generators {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Intents;
+/// let client = Intents::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Intents][google.cloud.dialogflow.cx.v3.Intent].
@@ -1730,8 +1979,23 @@ impl Generators {
 ///
 /// # Configuration
 ///
-/// `Intents` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Intents` use the `with_*` methods in the type returned
+/// by [builder()][Intents::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::intents::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::intents::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1745,21 +2009,22 @@ pub struct Intents {
 }
 
 impl Intents {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Intents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Intents;
+    /// let client = Intents::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::intents::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::intents::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Intents + 'static,
@@ -1767,6 +2032,11 @@ impl Intents {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1953,6 +2223,15 @@ impl Intents {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Pages;
+/// let client = Pages::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Pages][google.cloud.dialogflow.cx.v3.Page].
@@ -1961,8 +2240,23 @@ impl Intents {
 ///
 /// # Configuration
 ///
-/// `Pages` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Pages` use the `with_*` methods in the type returned
+/// by [builder()][Pages::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::pages::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::pages::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1976,21 +2270,22 @@ pub struct Pages {
 }
 
 impl Pages {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Pages].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Pages;
+    /// let client = Pages::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::pages::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::pages::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Pages + 'static,
@@ -1998,6 +2293,11 @@ impl Pages {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2119,14 +2419,38 @@ impl Pages {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+/// let client = SecuritySettingsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing security settings for Dialogflow.
 ///
 /// # Configuration
 ///
-/// `SecuritySettingsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SecuritySettingsService` use the `with_*` methods in the type returned
+/// by [builder()][SecuritySettingsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::security_settings_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::security_settings_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2140,21 +2464,24 @@ pub struct SecuritySettingsService {
 }
 
 impl SecuritySettingsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SecuritySettingsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+    /// let client = SecuritySettingsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::security_settings_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::security_settings_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SecuritySettingsService + 'static,
@@ -2162,6 +2489,11 @@ impl SecuritySettingsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2296,6 +2628,15 @@ impl SecuritySettingsService {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+/// let client = Sessions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A session represents an interaction with a user. You retrieve user input
@@ -2307,8 +2648,23 @@ impl SecuritySettingsService {
 ///
 /// # Configuration
 ///
-/// `Sessions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Sessions` use the `with_*` methods in the type returned
+/// by [builder()][Sessions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sessions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sessions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2322,21 +2678,22 @@ pub struct Sessions {
 }
 
 impl Sessions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Sessions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+    /// let client = Sessions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sessions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sessions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Sessions + 'static,
@@ -2344,6 +2701,11 @@ impl Sessions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2470,6 +2832,15 @@ impl Sessions {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+/// let client = SessionEntityTypes::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing
@@ -2479,8 +2850,23 @@ impl Sessions {
 ///
 /// # Configuration
 ///
-/// `SessionEntityTypes` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SessionEntityTypes` use the `with_*` methods in the type returned
+/// by [builder()][SessionEntityTypes::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::session_entity_types::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::session_entity_types::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2494,21 +2880,24 @@ pub struct SessionEntityTypes {
 }
 
 impl SessionEntityTypes {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SessionEntityTypes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+    /// let client = SessionEntityTypes::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::session_entity_types::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::session_entity_types::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SessionEntityTypes + 'static,
@@ -2516,6 +2905,11 @@ impl SessionEntityTypes {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2640,6 +3034,15 @@ impl SessionEntityTypes {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+/// let client = TestCases::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Test Cases][google.cloud.dialogflow.cx.v3.TestCase] and
@@ -2650,8 +3053,23 @@ impl SessionEntityTypes {
 ///
 /// # Configuration
 ///
-/// `TestCases` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TestCases` use the `with_*` methods in the type returned
+/// by [builder()][TestCases::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::test_cases::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::test_cases::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2665,21 +3083,22 @@ pub struct TestCases {
 }
 
 impl TestCases {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TestCases].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// let client = TestCases::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::test_cases::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::test_cases::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TestCases + 'static,
@@ -2687,6 +3106,11 @@ impl TestCases {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2957,6 +3381,15 @@ impl TestCases {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+/// let client = TransitionRouteGroups::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing
@@ -2966,8 +3399,23 @@ impl TestCases {
 ///
 /// # Configuration
 ///
-/// `TransitionRouteGroups` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TransitionRouteGroups` use the `with_*` methods in the type returned
+/// by [builder()][TransitionRouteGroups::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::transition_route_groups::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::transition_route_groups::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2981,21 +3429,24 @@ pub struct TransitionRouteGroups {
 }
 
 impl TransitionRouteGroups {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TransitionRouteGroups].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+    /// let client = TransitionRouteGroups::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::transition_route_groups::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::transition_route_groups::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TransitionRouteGroups + 'static,
@@ -3003,6 +3454,11 @@ impl TransitionRouteGroups {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3152,6 +3608,15 @@ impl TransitionRouteGroups {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Versions;
+/// let client = Versions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Versions][google.cloud.dialogflow.cx.v3.Version].
@@ -3160,8 +3625,23 @@ impl TransitionRouteGroups {
 ///
 /// # Configuration
 ///
-/// `Versions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Versions` use the `with_*` methods in the type returned
+/// by [builder()][Versions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::versions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::versions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3175,21 +3655,22 @@ pub struct Versions {
 }
 
 impl Versions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Versions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Versions;
+    /// let client = Versions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::versions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::versions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Versions + 'static,
@@ -3197,6 +3678,11 @@ impl Versions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3379,6 +3865,15 @@ impl Versions {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+/// let client = Webhooks::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Webhooks][google.cloud.dialogflow.cx.v3.Webhook].
@@ -3387,8 +3882,23 @@ impl Versions {
 ///
 /// # Configuration
 ///
-/// `Webhooks` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Webhooks` use the `with_*` methods in the type returned
+/// by [builder()][Webhooks::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::webhooks::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::webhooks::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3402,21 +3912,22 @@ pub struct Webhooks {
 }
 
 impl Webhooks {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Webhooks].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+    /// let client = Webhooks::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::webhooks::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::webhooks::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Webhooks + 'static,
@@ -3424,6 +3935,11 @@ impl Webhooks {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/dialogflow/v2/src/builder.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod agents {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Agents][super::super::client::Agents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::agents::ClientBuilder;
+    /// # use client::Agents;
+    /// let builder : ClientBuilder = Agents::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Agents;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Agents;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Agents] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -922,6 +950,34 @@ pub mod answer_records {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AnswerRecords][super::super::client::AnswerRecords].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::answer_records::ClientBuilder;
+    /// # use client::AnswerRecords;
+    /// let builder : ClientBuilder = AnswerRecords::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AnswerRecords;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AnswerRecords;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AnswerRecords] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1370,6 +1426,34 @@ pub mod answer_records {
 pub mod contexts {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Contexts][super::super::client::Contexts].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::contexts::ClientBuilder;
+    /// # use client::Contexts;
+    /// let builder : ClientBuilder = Contexts::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Contexts;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Contexts;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Contexts] request builders.
     #[derive(Clone, Debug)]
@@ -1987,6 +2071,34 @@ pub mod contexts {
 pub mod conversations {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Conversations][super::super::client::Conversations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::conversations::ClientBuilder;
+    /// # use client::Conversations;
+    /// let builder : ClientBuilder = Conversations::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Conversations;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Conversations;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Conversations] request builders.
     #[derive(Clone, Debug)]
@@ -3074,6 +3186,34 @@ pub mod conversation_datasets {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ConversationDatasets][super::super::client::ConversationDatasets].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::conversation_datasets::ClientBuilder;
+    /// # use client::ConversationDatasets;
+    /// let builder : ClientBuilder = ConversationDatasets::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConversationDatasets;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConversationDatasets;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ConversationDatasets] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -3816,6 +3956,34 @@ pub mod conversation_datasets {
 pub mod conversation_models {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ConversationModels][super::super::client::ConversationModels].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::conversation_models::ClientBuilder;
+    /// # use client::ConversationModels;
+    /// let builder : ClientBuilder = ConversationModels::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConversationModels;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConversationModels;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ConversationModels] request builders.
     #[derive(Clone, Debug)]
@@ -4835,6 +5003,34 @@ pub mod conversation_profiles {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ConversationProfiles][super::super::client::ConversationProfiles].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::conversation_profiles::ClientBuilder;
+    /// # use client::ConversationProfiles;
+    /// let builder : ClientBuilder = ConversationProfiles::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConversationProfiles;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConversationProfiles;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ConversationProfiles] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -5683,6 +5879,34 @@ pub mod conversation_profiles {
 pub mod documents {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Documents][super::super::client::Documents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::documents::ClientBuilder;
+    /// # use client::Documents;
+    /// let builder : ClientBuilder = Documents::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Documents;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Documents;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Documents] request builders.
     #[derive(Clone, Debug)]
@@ -6694,6 +6918,34 @@ pub mod encryption_spec_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [EncryptionSpecService][super::super::client::EncryptionSpecService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::encryption_spec_service::ClientBuilder;
+    /// # use client::EncryptionSpecService;
+    /// let builder : ClientBuilder = EncryptionSpecService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EncryptionSpecService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EncryptionSpecService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::EncryptionSpecService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -7161,6 +7413,34 @@ pub mod encryption_spec_service {
 pub mod entity_types {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [EntityTypes][super::super::client::EntityTypes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::entity_types::ClientBuilder;
+    /// # use client::EntityTypes;
+    /// let builder : ClientBuilder = EntityTypes::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EntityTypes;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EntityTypes;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::EntityTypes] request builders.
     #[derive(Clone, Debug)]
@@ -8267,6 +8547,34 @@ pub mod environments {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Environments][super::super::client::Environments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::environments::ClientBuilder;
+    /// # use client::Environments;
+    /// let builder : ClientBuilder = Environments::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Environments;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Environments;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Environments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -8935,6 +9243,34 @@ pub mod fulfillments {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Fulfillments][super::super::client::Fulfillments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::fulfillments::ClientBuilder;
+    /// # use client::Fulfillments;
+    /// let builder : ClientBuilder = Fulfillments::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Fulfillments;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Fulfillments;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Fulfillments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -9347,6 +9683,34 @@ pub mod fulfillments {
 pub mod generators {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Generators][super::super::client::Generators].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::generators::ClientBuilder;
+    /// # use client::Generators;
+    /// let builder : ClientBuilder = Generators::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Generators;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Generators;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Generators] request builders.
     #[derive(Clone, Debug)]
@@ -9925,6 +10289,34 @@ pub mod generators {
 pub mod intents {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Intents][super::super::client::Intents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::intents::ClientBuilder;
+    /// # use client::Intents;
+    /// let builder : ClientBuilder = Intents::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Intents;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Intents;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Intents] request builders.
     #[derive(Clone, Debug)]
@@ -10751,6 +11143,34 @@ pub mod knowledge_bases {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [KnowledgeBases][super::super::client::KnowledgeBases].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::knowledge_bases::ClientBuilder;
+    /// # use client::KnowledgeBases;
+    /// let builder : ClientBuilder = KnowledgeBases::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::KnowledgeBases;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = KnowledgeBases;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::KnowledgeBases] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -11349,6 +11769,34 @@ pub mod knowledge_bases {
 pub mod participants {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Participants][super::super::client::Participants].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::participants::ClientBuilder;
+    /// # use client::Participants;
+    /// let builder : ClientBuilder = Participants::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Participants;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Participants;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Participants] request builders.
     #[derive(Clone, Debug)]
@@ -12248,6 +12696,34 @@ pub mod sessions {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Sessions][super::super::client::Sessions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::sessions::ClientBuilder;
+    /// # use client::Sessions;
+    /// let builder : ClientBuilder = Sessions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Sessions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Sessions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Sessions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -12647,6 +13123,34 @@ pub mod sessions {
 pub mod session_entity_types {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SessionEntityTypes][super::super::client::SessionEntityTypes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::session_entity_types::ClientBuilder;
+    /// # use client::SessionEntityTypes;
+    /// let builder : ClientBuilder = SessionEntityTypes::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SessionEntityTypes;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SessionEntityTypes;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SessionEntityTypes] request builders.
     #[derive(Clone, Debug)]
@@ -13246,6 +13750,34 @@ pub mod session_entity_types {
 pub mod versions {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Versions][super::super::client::Versions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::*;
+    /// # use builder::versions::ClientBuilder;
+    /// # use client::Versions;
+    /// let builder : ClientBuilder = Versions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dialogflow.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Versions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Versions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Versions] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/dialogflow/v2/src/client.rs
+++ b/src/generated/cloud/dialogflow/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Agents;
+/// let client = Agents::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Agents][google.cloud.dialogflow.v2.Agent].
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Agents` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Agents` use the `with_*` methods in the type returned
+/// by [builder()][Agents::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::agents::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::agents::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,22 @@ pub struct Agents {
 }
 
 impl Agents {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Agents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Agents;
+    /// let client = Agents::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::agents::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::agents::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Agents + 'static,
@@ -66,6 +91,11 @@ impl Agents {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -341,6 +371,15 @@ impl Agents {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::AnswerRecords;
+/// let client = AnswerRecords::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing
@@ -350,8 +389,23 @@ impl Agents {
 ///
 /// # Configuration
 ///
-/// `AnswerRecords` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AnswerRecords` use the `with_*` methods in the type returned
+/// by [builder()][AnswerRecords::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::answer_records::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::answer_records::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -365,21 +419,22 @@ pub struct AnswerRecords {
 }
 
 impl AnswerRecords {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AnswerRecords].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::AnswerRecords;
+    /// let client = AnswerRecords::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::answer_records::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::answer_records::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AnswerRecords + 'static,
@@ -387,6 +442,11 @@ impl AnswerRecords {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -482,6 +542,15 @@ impl AnswerRecords {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Contexts;
+/// let client = Contexts::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Contexts][google.cloud.dialogflow.v2.Context].
@@ -490,8 +559,23 @@ impl AnswerRecords {
 ///
 /// # Configuration
 ///
-/// `Contexts` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Contexts` use the `with_*` methods in the type returned
+/// by [builder()][Contexts::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::contexts::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::contexts::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -505,21 +589,22 @@ pub struct Contexts {
 }
 
 impl Contexts {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Contexts].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// let client = Contexts::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::contexts::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::contexts::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Contexts + 'static,
@@ -527,6 +612,11 @@ impl Contexts {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -652,6 +742,15 @@ impl Contexts {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Conversations;
+/// let client = Conversations::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing
@@ -661,8 +760,23 @@ impl Contexts {
 ///
 /// # Configuration
 ///
-/// `Conversations` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Conversations` use the `with_*` methods in the type returned
+/// by [builder()][Conversations::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::conversations::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::conversations::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -676,21 +790,22 @@ pub struct Conversations {
 }
 
 impl Conversations {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Conversations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// let client = Conversations::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::conversations::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::conversations::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Conversations + 'static,
@@ -698,6 +813,11 @@ impl Conversations {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -910,6 +1030,15 @@ impl Conversations {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::ConversationDatasets;
+/// let client = ConversationDatasets::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Conversation datasets.
@@ -919,8 +1048,23 @@ impl Conversations {
 ///
 /// # Configuration
 ///
-/// `ConversationDatasets` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConversationDatasets` use the `with_*` methods in the type returned
+/// by [builder()][ConversationDatasets::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::conversation_datasets::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::conversation_datasets::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -934,21 +1078,24 @@ pub struct ConversationDatasets {
 }
 
 impl ConversationDatasets {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConversationDatasets].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::ConversationDatasets;
+    /// let client = ConversationDatasets::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::conversation_datasets::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::conversation_datasets::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConversationDatasets + 'static,
@@ -956,6 +1103,11 @@ impl ConversationDatasets {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1148,14 +1300,38 @@ impl ConversationDatasets {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::ConversationModels;
+/// let client = ConversationModels::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages a collection of models for human agent assistant.
 ///
 /// # Configuration
 ///
-/// `ConversationModels` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConversationModels` use the `with_*` methods in the type returned
+/// by [builder()][ConversationModels::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::conversation_models::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::conversation_models::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1169,21 +1345,24 @@ pub struct ConversationModels {
 }
 
 impl ConversationModels {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConversationModels].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::ConversationModels;
+    /// let client = ConversationModels::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::conversation_models::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::conversation_models::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConversationModels + 'static,
@@ -1191,6 +1370,11 @@ impl ConversationModels {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1457,6 +1641,15 @@ impl ConversationModels {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+/// let client = ConversationProfiles::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing
@@ -1466,8 +1659,23 @@ impl ConversationModels {
 ///
 /// # Configuration
 ///
-/// `ConversationProfiles` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConversationProfiles` use the `with_*` methods in the type returned
+/// by [builder()][ConversationProfiles::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::conversation_profiles::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::conversation_profiles::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1481,21 +1689,24 @@ pub struct ConversationProfiles {
 }
 
 impl ConversationProfiles {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConversationProfiles].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+    /// let client = ConversationProfiles::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::conversation_profiles::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::conversation_profiles::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConversationProfiles + 'static,
@@ -1503,6 +1714,11 @@ impl ConversationProfiles {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1720,6 +1936,15 @@ impl ConversationProfiles {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Documents;
+/// let client = Documents::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing knowledge
@@ -1729,8 +1954,23 @@ impl ConversationProfiles {
 ///
 /// # Configuration
 ///
-/// `Documents` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Documents` use the `with_*` methods in the type returned
+/// by [builder()][Documents::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::documents::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::documents::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1744,21 +1984,22 @@ pub struct Documents {
 }
 
 impl Documents {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Documents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Documents;
+    /// let client = Documents::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::documents::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::documents::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Documents + 'static,
@@ -1766,6 +2007,11 @@ impl Documents {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2042,14 +2288,38 @@ impl Documents {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::EncryptionSpecService;
+/// let client = EncryptionSpecService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages encryption spec settings for Dialogflow and Agent Assist.
 ///
 /// # Configuration
 ///
-/// `EncryptionSpecService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EncryptionSpecService` use the `with_*` methods in the type returned
+/// by [builder()][EncryptionSpecService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::encryption_spec_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::encryption_spec_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2063,21 +2333,24 @@ pub struct EncryptionSpecService {
 }
 
 impl EncryptionSpecService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EncryptionSpecService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::EncryptionSpecService;
+    /// let client = EncryptionSpecService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::encryption_spec_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::encryption_spec_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EncryptionSpecService + 'static,
@@ -2085,6 +2358,11 @@ impl EncryptionSpecService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2196,6 +2474,15 @@ impl EncryptionSpecService {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::EntityTypes;
+/// let client = EntityTypes::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [EntityTypes][google.cloud.dialogflow.v2.EntityType].
@@ -2204,8 +2491,23 @@ impl EncryptionSpecService {
 ///
 /// # Configuration
 ///
-/// `EntityTypes` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EntityTypes` use the `with_*` methods in the type returned
+/// by [builder()][EntityTypes::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::entity_types::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::entity_types::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2219,21 +2521,22 @@ pub struct EntityTypes {
 }
 
 impl EntityTypes {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EntityTypes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::EntityTypes;
+    /// let client = EntityTypes::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::entity_types::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::entity_types::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EntityTypes + 'static,
@@ -2241,6 +2544,11 @@ impl EntityTypes {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2535,6 +2843,15 @@ impl EntityTypes {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Environments;
+/// let client = Environments::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Environments][google.cloud.dialogflow.v2.Environment].
@@ -2543,8 +2860,23 @@ impl EntityTypes {
 ///
 /// # Configuration
 ///
-/// `Environments` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Environments` use the `with_*` methods in the type returned
+/// by [builder()][Environments::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::environments::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::environments::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2558,21 +2890,22 @@ pub struct Environments {
 }
 
 impl Environments {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Environments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Environments;
+    /// let client = Environments::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::environments::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::environments::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Environments + 'static,
@@ -2580,6 +2913,11 @@ impl Environments {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2718,6 +3056,15 @@ impl Environments {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Fulfillments;
+/// let client = Fulfillments::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Fulfillments][google.cloud.dialogflow.v2.Fulfillment].
@@ -2726,8 +3073,23 @@ impl Environments {
 ///
 /// # Configuration
 ///
-/// `Fulfillments` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Fulfillments` use the `with_*` methods in the type returned
+/// by [builder()][Fulfillments::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::fulfillments::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::fulfillments::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2741,21 +3103,22 @@ pub struct Fulfillments {
 }
 
 impl Fulfillments {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Fulfillments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Fulfillments;
+    /// let client = Fulfillments::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::fulfillments::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::fulfillments::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Fulfillments + 'static,
@@ -2763,6 +3126,11 @@ impl Fulfillments {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2854,6 +3222,15 @@ impl Fulfillments {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Generators;
+/// let client = Generators::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Generator Service for LLM powered Agent Assist. This service manages the
@@ -2864,8 +3241,23 @@ impl Fulfillments {
 ///
 /// # Configuration
 ///
-/// `Generators` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Generators` use the `with_*` methods in the type returned
+/// by [builder()][Generators::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::generators::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::generators::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2879,21 +3271,22 @@ pub struct Generators {
 }
 
 impl Generators {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Generators].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Generators;
+    /// let client = Generators::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::generators::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::generators::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Generators + 'static,
@@ -2901,6 +3294,11 @@ impl Generators {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3018,6 +3416,15 @@ impl Generators {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Intents;
+/// let client = Intents::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Intents][google.cloud.dialogflow.v2.Intent].
@@ -3026,8 +3433,23 @@ impl Generators {
 ///
 /// # Configuration
 ///
-/// `Intents` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Intents` use the `with_*` methods in the type returned
+/// by [builder()][Intents::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::intents::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::intents::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3041,21 +3463,22 @@ pub struct Intents {
 }
 
 impl Intents {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Intents].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Intents;
+    /// let client = Intents::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::intents::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::intents::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Intents + 'static,
@@ -3063,6 +3486,11 @@ impl Intents {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3255,6 +3683,15 @@ impl Intents {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+/// let client = KnowledgeBases::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing
@@ -3264,8 +3701,23 @@ impl Intents {
 ///
 /// # Configuration
 ///
-/// `KnowledgeBases` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `KnowledgeBases` use the `with_*` methods in the type returned
+/// by [builder()][KnowledgeBases::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::knowledge_bases::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::knowledge_bases::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3279,21 +3731,22 @@ pub struct KnowledgeBases {
 }
 
 impl KnowledgeBases {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [KnowledgeBases].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+    /// let client = KnowledgeBases::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::knowledge_bases::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::knowledge_bases::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::KnowledgeBases + 'static,
@@ -3301,6 +3754,11 @@ impl KnowledgeBases {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3423,6 +3881,15 @@ impl KnowledgeBases {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Participants;
+/// let client = Participants::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Participants][google.cloud.dialogflow.v2.Participant].
@@ -3431,8 +3898,23 @@ impl KnowledgeBases {
 ///
 /// # Configuration
 ///
-/// `Participants` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Participants` use the `with_*` methods in the type returned
+/// by [builder()][Participants::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::participants::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::participants::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3446,21 +3928,22 @@ pub struct Participants {
 }
 
 impl Participants {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Participants].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// let client = Participants::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::participants::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::participants::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Participants + 'static,
@@ -3468,6 +3951,11 @@ impl Participants {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3630,6 +4118,15 @@ impl Participants {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Sessions;
+/// let client = Sessions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service used for session interactions.
@@ -3639,8 +4136,23 @@ impl Participants {
 ///
 /// # Configuration
 ///
-/// `Sessions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Sessions` use the `with_*` methods in the type returned
+/// by [builder()][Sessions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sessions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sessions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3654,21 +4166,22 @@ pub struct Sessions {
 }
 
 impl Sessions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Sessions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Sessions;
+    /// let client = Sessions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sessions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sessions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Sessions + 'static,
@@ -3676,6 +4189,11 @@ impl Sessions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3774,6 +4292,15 @@ impl Sessions {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+/// let client = SessionEntityTypes::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing
@@ -3783,8 +4310,23 @@ impl Sessions {
 ///
 /// # Configuration
 ///
-/// `SessionEntityTypes` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SessionEntityTypes` use the `with_*` methods in the type returned
+/// by [builder()][SessionEntityTypes::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::session_entity_types::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::session_entity_types::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3798,21 +4340,24 @@ pub struct SessionEntityTypes {
 }
 
 impl SessionEntityTypes {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SessionEntityTypes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+    /// let client = SessionEntityTypes::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::session_entity_types::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::session_entity_types::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SessionEntityTypes + 'static,
@@ -3820,6 +4365,11 @@ impl SessionEntityTypes {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -3967,6 +4517,15 @@ impl SessionEntityTypes {
 
 /// Implements a client for the Dialogflow API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_dialogflow_v2::client::Versions;
+/// let client = Versions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Versions][google.cloud.dialogflow.v2.Version].
@@ -3975,8 +4534,23 @@ impl SessionEntityTypes {
 ///
 /// # Configuration
 ///
-/// `Versions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Versions` use the `with_*` methods in the type returned
+/// by [builder()][Versions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dialogflow.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::versions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::versions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -3990,21 +4564,22 @@ pub struct Versions {
 }
 
 impl Versions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Versions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_dialogflow_v2::client::Versions;
+    /// let client = Versions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::versions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::versions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Versions + 'static,
@@ -4012,6 +4587,11 @@ impl Versions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/discoveryengine/v1/src/builder.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod completion_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CompletionService][super::super::client::CompletionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::completion_service::ClientBuilder;
+    /// # use client::CompletionService;
+    /// let builder : ClientBuilder = CompletionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CompletionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CompletionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CompletionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -669,6 +697,34 @@ pub mod control_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ControlService][super::super::client::ControlService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::control_service::ClientBuilder;
+    /// # use client::ControlService;
+    /// let builder : ClientBuilder = ControlService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ControlService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ControlService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ControlService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1132,6 +1188,34 @@ pub mod control_service {
 pub mod conversational_search_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ConversationalSearchService][super::super::client::ConversationalSearchService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::conversational_search_service::ClientBuilder;
+    /// # use client::ConversationalSearchService;
+    /// let builder : ClientBuilder = ConversationalSearchService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConversationalSearchService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConversationalSearchService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ConversationalSearchService] request builders.
     #[derive(Clone, Debug)]
@@ -2206,6 +2290,34 @@ pub mod data_store_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DataStoreService][super::super::client::DataStoreService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::data_store_service::ClientBuilder;
+    /// # use client::DataStoreService;
+    /// let builder : ClientBuilder = DataStoreService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DataStoreService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DataStoreService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DataStoreService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2755,6 +2867,34 @@ pub mod data_store_service {
 pub mod document_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [DocumentService][super::super::client::DocumentService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::document_service::ClientBuilder;
+    /// # use client::DocumentService;
+    /// let builder : ClientBuilder = DocumentService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DocumentService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DocumentService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::DocumentService] request builders.
     #[derive(Clone, Debug)]
@@ -3524,6 +3664,34 @@ pub mod engine_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [EngineService][super::super::client::EngineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::engine_service::ClientBuilder;
+    /// # use client::EngineService;
+    /// let builder : ClientBuilder = EngineService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EngineService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EngineService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::EngineService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -4061,6 +4229,34 @@ pub mod grounded_generation_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [GroundedGenerationService][super::super::client::GroundedGenerationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::grounded_generation_service::ClientBuilder;
+    /// # use client::GroundedGenerationService;
+    /// let builder : ClientBuilder = GroundedGenerationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::GroundedGenerationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = GroundedGenerationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::GroundedGenerationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -4456,6 +4652,34 @@ pub mod project_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ProjectService][super::super::client::ProjectService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::project_service::ClientBuilder;
+    /// # use client::ProjectService;
+    /// let builder : ClientBuilder = ProjectService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ProjectService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ProjectService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ProjectService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -4746,6 +4970,34 @@ pub mod rank_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [RankService][super::super::client::RankService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::rank_service::ClientBuilder;
+    /// # use client::RankService;
+    /// let builder : ClientBuilder = RankService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RankService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RankService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::RankService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -5025,6 +5277,34 @@ pub mod rank_service {
 pub mod recommendation_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [RecommendationService][super::super::client::RecommendationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::recommendation_service::ClientBuilder;
+    /// # use client::RecommendationService;
+    /// let builder : ClientBuilder = RecommendationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RecommendationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RecommendationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::RecommendationService] request builders.
     #[derive(Clone, Debug)]
@@ -5320,6 +5600,34 @@ pub mod recommendation_service {
 pub mod schema_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SchemaService][super::super::client::SchemaService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::schema_service::ClientBuilder;
+    /// # use client::SchemaService;
+    /// let builder : ClientBuilder = SchemaService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SchemaService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SchemaService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SchemaService] request builders.
     #[derive(Clone, Debug)]
@@ -5886,6 +6194,34 @@ pub mod schema_service {
 pub mod search_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SearchService][super::super::client::SearchService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::search_service::ClientBuilder;
+    /// # use client::SearchService;
+    /// let builder : ClientBuilder = SearchService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SearchService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SearchService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SearchService] request builders.
     #[derive(Clone, Debug)]
@@ -6607,6 +6943,34 @@ pub mod search_tuning_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SearchTuningService][super::super::client::SearchTuningService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::search_tuning_service::ClientBuilder;
+    /// # use client::SearchTuningService;
+    /// let builder : ClientBuilder = SearchTuningService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SearchTuningService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SearchTuningService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SearchTuningService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -6965,6 +7329,34 @@ pub mod search_tuning_service {
 pub mod site_search_engine_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SiteSearchEngineService][super::super::client::SiteSearchEngineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::site_search_engine_service::ClientBuilder;
+    /// # use client::SiteSearchEngineService;
+    /// let builder : ClientBuilder = SiteSearchEngineService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SiteSearchEngineService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SiteSearchEngineService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SiteSearchEngineService] request builders.
     #[derive(Clone, Debug)]
@@ -8152,6 +8544,34 @@ pub mod site_search_engine_service {
 pub mod user_event_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [UserEventService][super::super::client::UserEventService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::*;
+    /// # use builder::user_event_service::ClientBuilder;
+    /// # use client::UserEventService;
+    /// let builder : ClientBuilder = UserEventService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://discoveryengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::UserEventService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = UserEventService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::UserEventService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/discoveryengine/v1/src/client.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::CompletionService;
+/// let client = CompletionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for Auto-Completion.
 ///
 /// # Configuration
 ///
-/// `CompletionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CompletionService` use the `with_*` methods in the type returned
+/// by [builder()][CompletionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::completion_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::completion_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct CompletionService {
 }
 
 impl CompletionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CompletionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::CompletionService;
+    /// let client = CompletionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::completion_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::completion_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CompletionService + 'static,
@@ -64,6 +91,11 @@ impl CompletionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -226,6 +258,15 @@ impl CompletionService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::ControlService;
+/// let client = ControlService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for performing CRUD operations on Controls.
@@ -235,8 +276,23 @@ impl CompletionService {
 ///
 /// # Configuration
 ///
-/// `ControlService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ControlService` use the `with_*` methods in the type returned
+/// by [builder()][ControlService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::control_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::control_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -250,21 +306,22 @@ pub struct ControlService {
 }
 
 impl ControlService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ControlService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::ControlService;
+    /// let client = ControlService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::control_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::control_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ControlService + 'static,
@@ -272,6 +329,11 @@ impl ControlService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -397,14 +459,38 @@ impl ControlService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+/// let client = ConversationalSearchService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for conversational search.
 ///
 /// # Configuration
 ///
-/// `ConversationalSearchService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConversationalSearchService` use the `with_*` methods in the type returned
+/// by [builder()][ConversationalSearchService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::conversational_search_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::conversational_search_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -418,21 +504,24 @@ pub struct ConversationalSearchService {
 }
 
 impl ConversationalSearchService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConversationalSearchService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// let client = ConversationalSearchService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::conversational_search_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::conversational_search_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConversationalSearchService + 'static,
@@ -440,6 +529,11 @@ impl ConversationalSearchService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -657,6 +751,15 @@ impl ConversationalSearchService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::DataStoreService;
+/// let client = DataStoreService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [DataStore][google.cloud.discoveryengine.v1.DataStore]
@@ -666,8 +769,23 @@ impl ConversationalSearchService {
 ///
 /// # Configuration
 ///
-/// `DataStoreService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DataStoreService` use the `with_*` methods in the type returned
+/// by [builder()][DataStoreService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::data_store_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::data_store_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -681,21 +799,24 @@ pub struct DataStoreService {
 }
 
 impl DataStoreService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DataStoreService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::DataStoreService;
+    /// let client = DataStoreService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::data_store_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::data_store_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DataStoreService + 'static,
@@ -703,6 +824,11 @@ impl DataStoreService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -848,6 +974,15 @@ impl DataStoreService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::DocumentService;
+/// let client = DocumentService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for ingesting [Document][google.cloud.discoveryengine.v1.Document]
@@ -857,8 +992,23 @@ impl DataStoreService {
 ///
 /// # Configuration
 ///
-/// `DocumentService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DocumentService` use the `with_*` methods in the type returned
+/// by [builder()][DocumentService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::document_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::document_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -872,21 +1022,24 @@ pub struct DocumentService {
 }
 
 impl DocumentService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DocumentService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::DocumentService;
+    /// let client = DocumentService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::document_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::document_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DocumentService + 'static,
@@ -894,6 +1047,11 @@ impl DocumentService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1088,6 +1246,15 @@ impl DocumentService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::EngineService;
+/// let client = EngineService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Engine][google.cloud.discoveryengine.v1.Engine]
@@ -1097,8 +1264,23 @@ impl DocumentService {
 ///
 /// # Configuration
 ///
-/// `EngineService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EngineService` use the `with_*` methods in the type returned
+/// by [builder()][EngineService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::engine_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::engine_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1112,21 +1294,22 @@ pub struct EngineService {
 }
 
 impl EngineService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EngineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::EngineService;
+    /// let client = EngineService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::engine_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::engine_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EngineService + 'static,
@@ -1134,6 +1317,11 @@ impl EngineService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1268,14 +1456,38 @@ impl EngineService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::GroundedGenerationService;
+/// let client = GroundedGenerationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for grounded generation.
 ///
 /// # Configuration
 ///
-/// `GroundedGenerationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `GroundedGenerationService` use the `with_*` methods in the type returned
+/// by [builder()][GroundedGenerationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::grounded_generation_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::grounded_generation_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1289,21 +1501,24 @@ pub struct GroundedGenerationService {
 }
 
 impl GroundedGenerationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [GroundedGenerationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::GroundedGenerationService;
+    /// let client = GroundedGenerationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::grounded_generation_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::grounded_generation_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::GroundedGenerationService + 'static,
@@ -1311,6 +1526,11 @@ impl GroundedGenerationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1392,6 +1612,15 @@ impl GroundedGenerationService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::ProjectService;
+/// let client = ProjectService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for operations on the
@@ -1401,8 +1630,23 @@ impl GroundedGenerationService {
 ///
 /// # Configuration
 ///
-/// `ProjectService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ProjectService` use the `with_*` methods in the type returned
+/// by [builder()][ProjectService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::project_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::project_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1416,21 +1660,22 @@ pub struct ProjectService {
 }
 
 impl ProjectService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ProjectService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::ProjectService;
+    /// let client = ProjectService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::project_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::project_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ProjectService + 'static,
@@ -1438,6 +1683,11 @@ impl ProjectService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1522,14 +1772,38 @@ impl ProjectService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::RankService;
+/// let client = RankService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for ranking text records.
 ///
 /// # Configuration
 ///
-/// `RankService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RankService` use the `with_*` methods in the type returned
+/// by [builder()][RankService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::rank_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::rank_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1543,21 +1817,22 @@ pub struct RankService {
 }
 
 impl RankService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RankService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::RankService;
+    /// let client = RankService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::rank_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::rank_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RankService + 'static,
@@ -1565,6 +1840,11 @@ impl RankService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1632,14 +1912,38 @@ impl RankService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::RecommendationService;
+/// let client = RecommendationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for making recommendations.
 ///
 /// # Configuration
 ///
-/// `RecommendationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RecommendationService` use the `with_*` methods in the type returned
+/// by [builder()][RecommendationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::recommendation_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::recommendation_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1653,21 +1957,24 @@ pub struct RecommendationService {
 }
 
 impl RecommendationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RecommendationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::RecommendationService;
+    /// let client = RecommendationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::recommendation_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::recommendation_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RecommendationService + 'static,
@@ -1675,6 +1982,11 @@ impl RecommendationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1745,6 +2057,15 @@ impl RecommendationService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::SchemaService;
+/// let client = SchemaService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing [Schema][google.cloud.discoveryengine.v1.Schema]s.
@@ -1753,8 +2074,23 @@ impl RecommendationService {
 ///
 /// # Configuration
 ///
-/// `SchemaService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SchemaService` use the `with_*` methods in the type returned
+/// by [builder()][SchemaService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::schema_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::schema_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1768,21 +2104,22 @@ pub struct SchemaService {
 }
 
 impl SchemaService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SchemaService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::SchemaService;
+    /// let client = SchemaService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::schema_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::schema_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SchemaService + 'static,
@@ -1790,6 +2127,11 @@ impl SchemaService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1933,14 +2275,38 @@ impl SchemaService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::SearchService;
+/// let client = SearchService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for search.
 ///
 /// # Configuration
 ///
-/// `SearchService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SearchService` use the `with_*` methods in the type returned
+/// by [builder()][SearchService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::search_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::search_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1954,21 +2320,22 @@ pub struct SearchService {
 }
 
 impl SearchService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SearchService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::SearchService;
+    /// let client = SearchService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::search_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::search_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SearchService + 'static,
@@ -1976,6 +2343,11 @@ impl SearchService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2068,14 +2440,38 @@ impl SearchService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::SearchTuningService;
+/// let client = SearchTuningService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for search tuning.
 ///
 /// # Configuration
 ///
-/// `SearchTuningService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SearchTuningService` use the `with_*` methods in the type returned
+/// by [builder()][SearchTuningService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::search_tuning_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::search_tuning_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2089,21 +2485,24 @@ pub struct SearchTuningService {
 }
 
 impl SearchTuningService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SearchTuningService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::SearchTuningService;
+    /// let client = SearchTuningService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::search_tuning_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::search_tuning_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SearchTuningService + 'static,
@@ -2111,6 +2510,11 @@ impl SearchTuningService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2200,14 +2604,38 @@ impl SearchTuningService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::SiteSearchEngineService;
+/// let client = SiteSearchEngineService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing site search related resources.
 ///
 /// # Configuration
 ///
-/// `SiteSearchEngineService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SiteSearchEngineService` use the `with_*` methods in the type returned
+/// by [builder()][SiteSearchEngineService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::site_search_engine_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::site_search_engine_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2221,21 +2649,24 @@ pub struct SiteSearchEngineService {
 }
 
 impl SiteSearchEngineService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SiteSearchEngineService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::SiteSearchEngineService;
+    /// let client = SiteSearchEngineService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::site_search_engine_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::site_search_engine_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SiteSearchEngineService + 'static,
@@ -2243,6 +2674,11 @@ impl SiteSearchEngineService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -2518,14 +2954,38 @@ impl SiteSearchEngineService {
 
 /// Implements a client for the Discovery Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_discoveryengine_v1::client::UserEventService;
+/// let client = UserEventService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for ingesting end user actions on a website to Discovery Engine API.
 ///
 /// # Configuration
 ///
-/// `UserEventService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `UserEventService` use the `with_*` methods in the type returned
+/// by [builder()][UserEventService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://discoveryengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::user_event_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::user_event_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -2539,21 +2999,24 @@ pub struct UserEventService {
 }
 
 impl UserEventService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [UserEventService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_discoveryengine_v1::client::UserEventService;
+    /// let client = UserEventService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::user_event_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::user_event_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::UserEventService + 'static,
@@ -2561,6 +3024,11 @@ impl UserEventService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -46,4 +46,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/documentai/v1/src/builder.rs
+++ b/src/generated/cloud/documentai/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod document_processor_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DocumentProcessorService][super::super::client::DocumentProcessorService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_documentai_v1::*;
+    /// # use builder::document_processor_service::ClientBuilder;
+    /// # use client::DocumentProcessorService;
+    /// let builder : ClientBuilder = DocumentProcessorService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://documentai.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DocumentProcessorService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DocumentProcessorService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DocumentProcessorService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/documentai/v1/src/client.rs
+++ b/src/generated/cloud/documentai/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Document AI API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+/// let client = DocumentProcessorService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service to call Document AI to process documents according to the
@@ -30,8 +39,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `DocumentProcessorService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DocumentProcessorService` use the `with_*` methods in the type returned
+/// by [builder()][DocumentProcessorService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://documentai.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::document_processor_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::document_processor_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -45,21 +69,24 @@ pub struct DocumentProcessorService {
 }
 
 impl DocumentProcessorService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DocumentProcessorService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// let client = DocumentProcessorService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::document_processor_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::document_processor_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DocumentProcessorService + 'static,
@@ -67,6 +94,11 @@ impl DocumentProcessorService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/domains/v1/Cargo.toml
+++ b/src/generated/cloud/domains/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/domains/v1/src/builder.rs
+++ b/src/generated/cloud/domains/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod domains {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Domains][super::super::client::Domains].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_domains_v1::*;
+    /// # use builder::domains::ClientBuilder;
+    /// # use client::Domains;
+    /// let builder : ClientBuilder = Domains::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://domains.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Domains;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Domains;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Domains] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/domains/v1/src/client.rs
+++ b/src/generated/cloud/domains/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Domains API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_domains_v1::client::Domains;
+/// let client = Domains::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Cloud Domains API enables management and configuration of domain names.
 ///
 /// # Configuration
 ///
-/// `Domains` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Domains` use the `with_*` methods in the type returned
+/// by [builder()][Domains::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://domains.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::domains::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::domains::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Domains {
 }
 
 impl Domains {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Domains].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_domains_v1::client::Domains;
+    /// let client = Domains::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::domains::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::domains::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Domains + 'static,
@@ -64,6 +89,11 @@ impl Domains {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/edgecontainer/v1/Cargo.toml
+++ b/src/generated/cloud/edgecontainer/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/edgecontainer/v1/src/builder.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod edge_container {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [EdgeContainer][super::super::client::EdgeContainer].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_edgecontainer_v1::*;
+    /// # use builder::edge_container::ClientBuilder;
+    /// # use client::EdgeContainer;
+    /// let builder : ClientBuilder = EdgeContainer::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://edgecontainer.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EdgeContainer;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EdgeContainer;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::EdgeContainer] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/edgecontainer/v1/src/client.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Distributed Cloud Edge Container API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+/// let client = EdgeContainer::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// EdgeContainer API provides management of Kubernetes Clusters on Google Edge
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `EdgeContainer` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EdgeContainer` use the `with_*` methods in the type returned
+/// by [builder()][EdgeContainer::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://edgecontainer.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::edge_container::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::edge_container::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct EdgeContainer {
 }
 
 impl EdgeContainer {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EdgeContainer].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// let client = EdgeContainer::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::edge_container::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::edge_container::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EdgeContainer + 'static,
@@ -65,6 +90,11 @@ impl EdgeContainer {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/edgenetwork/v1/Cargo.toml
+++ b/src/generated/cloud/edgenetwork/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/edgenetwork/v1/src/builder.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod edge_network {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [EdgeNetwork][super::super::client::EdgeNetwork].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_edgenetwork_v1::*;
+    /// # use builder::edge_network::ClientBuilder;
+    /// # use client::EdgeNetwork;
+    /// let builder : ClientBuilder = EdgeNetwork::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://edgenetwork.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EdgeNetwork;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EdgeNetwork;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::EdgeNetwork] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/edgenetwork/v1/src/client.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Distributed Cloud Edge Network API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+/// let client = EdgeNetwork::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// EdgeNetwork API provides managed, highly available cloud dynamic network
@@ -30,8 +39,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `EdgeNetwork` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EdgeNetwork` use the `with_*` methods in the type returned
+/// by [builder()][EdgeNetwork::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://edgenetwork.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::edge_network::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::edge_network::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -45,21 +69,22 @@ pub struct EdgeNetwork {
 }
 
 impl EdgeNetwork {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EdgeNetwork].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// let client = EdgeNetwork::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::edge_network::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::edge_network::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EdgeNetwork + 'static,
@@ -67,6 +92,11 @@ impl EdgeNetwork {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/essentialcontacts/v1/Cargo.toml
+++ b/src/generated/cloud/essentialcontacts/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/essentialcontacts/v1/src/builder.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod essential_contacts_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [EssentialContactsService][super::super::client::EssentialContactsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_essentialcontacts_v1::*;
+    /// # use builder::essential_contacts_service::ClientBuilder;
+    /// # use client::EssentialContactsService;
+    /// let builder : ClientBuilder = EssentialContactsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://essentialcontacts.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EssentialContactsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EssentialContactsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::EssentialContactsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/essentialcontacts/v1/src/client.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Essential Contacts API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
+/// let client = EssentialContactsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages contacts for important Google Cloud notifications.
 ///
 /// # Configuration
 ///
-/// `EssentialContactsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EssentialContactsService` use the `with_*` methods in the type returned
+/// by [builder()][EssentialContactsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://essentialcontacts.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::essential_contacts_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::essential_contacts_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct EssentialContactsService {
 }
 
 impl EssentialContactsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EssentialContactsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
+    /// let client = EssentialContactsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::essential_contacts_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::essential_contacts_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EssentialContactsService + 'static,
@@ -64,6 +91,11 @@ impl EssentialContactsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/eventarc/v1/Cargo.toml
+++ b/src/generated/cloud/eventarc/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/eventarc/v1/src/builder.rs
+++ b/src/generated/cloud/eventarc/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod eventarc {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Eventarc][super::super::client::Eventarc].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_eventarc_v1::*;
+    /// # use builder::eventarc::ClientBuilder;
+    /// # use client::Eventarc;
+    /// let builder : ClientBuilder = Eventarc::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://eventarc.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Eventarc;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Eventarc;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Eventarc] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/eventarc/v1/src/client.rs
+++ b/src/generated/cloud/eventarc/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Eventarc API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_eventarc_v1::client::Eventarc;
+/// let client = Eventarc::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Eventarc allows users to subscribe to various events that are provided by
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Eventarc` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Eventarc` use the `with_*` methods in the type returned
+/// by [builder()][Eventarc::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://eventarc.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::eventarc::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::eventarc::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct Eventarc {
 }
 
 impl Eventarc {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Eventarc].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// let client = Eventarc::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::eventarc::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::eventarc::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Eventarc + 'static,
@@ -65,6 +90,11 @@ impl Eventarc {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/filestore/v1/Cargo.toml
+++ b/src/generated/cloud/filestore/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/filestore/v1/src/builder.rs
+++ b/src/generated/cloud/filestore/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_filestore_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudFilestoreManager][super::super::client::CloudFilestoreManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_filestore_v1::*;
+    /// # use builder::cloud_filestore_manager::ClientBuilder;
+    /// # use client::CloudFilestoreManager;
+    /// let builder : ClientBuilder = CloudFilestoreManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://file.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudFilestoreManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudFilestoreManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudFilestoreManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/filestore/v1/src/client.rs
+++ b/src/generated/cloud/filestore/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Filestore API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+/// let client = CloudFilestoreManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Configures and manages Filestore resources.
@@ -47,8 +56,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudFilestoreManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudFilestoreManager` use the `with_*` methods in the type returned
+/// by [builder()][CloudFilestoreManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://file.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_filestore_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_filestore_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -62,21 +86,24 @@ pub struct CloudFilestoreManager {
 }
 
 impl CloudFilestoreManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudFilestoreManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+    /// let client = CloudFilestoreManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_filestore_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::cloud_filestore_manager::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudFilestoreManager + 'static,
@@ -84,6 +111,11 @@ impl CloudFilestoreManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/financialservices/v1/Cargo.toml
+++ b/src/generated/cloud/financialservices/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/financialservices/v1/src/builder.rs
+++ b/src/generated/cloud/financialservices/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod aml {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Aml][super::super::client::Aml].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_financialservices_v1::*;
+    /// # use builder::aml::ClientBuilder;
+    /// # use client::Aml;
+    /// let builder : ClientBuilder = Aml::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://financialservices.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Aml;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Aml;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Aml] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/financialservices/v1/src/client.rs
+++ b/src/generated/cloud/financialservices/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Financial Services API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_financialservices_v1::client::Aml;
+/// let client = Aml::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The AML (Anti Money Laundering) service allows users to perform REST
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Aml` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Aml` use the `with_*` methods in the type returned
+/// by [builder()][Aml::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://financialservices.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::aml::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::aml::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct Aml {
 }
 
 impl Aml {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Aml].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// let client = Aml::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::aml::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::aml::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Aml + 'static,
@@ -65,6 +90,11 @@ impl Aml {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/functions/v2/Cargo.toml
+++ b/src/generated/cloud/functions/v2/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/functions/v2/src/builder.rs
+++ b/src/generated/cloud/functions/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod function_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [FunctionService][super::super::client::FunctionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_functions_v2::*;
+    /// # use builder::function_service::ClientBuilder;
+    /// # use client::FunctionService;
+    /// let builder : ClientBuilder = FunctionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudfunctions.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::FunctionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = FunctionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::FunctionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/functions/v2/src/client.rs
+++ b/src/generated/cloud/functions/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Functions API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_functions_v2::client::FunctionService;
+/// let client = FunctionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Google Cloud Functions is used to deploy functions that are executed by
@@ -32,8 +41,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `FunctionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `FunctionService` use the `with_*` methods in the type returned
+/// by [builder()][FunctionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudfunctions.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::function_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::function_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -47,21 +71,24 @@ pub struct FunctionService {
 }
 
 impl FunctionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [FunctionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// let client = FunctionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::function_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::function_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::FunctionService + 'static,
@@ -69,6 +96,11 @@ impl FunctionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/gkebackup/v1/Cargo.toml
+++ b/src/generated/cloud/gkebackup/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/gkebackup/v1/src/builder.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod backup_for_gke {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [BackupForGKE][super::super::client::BackupForGKE].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkebackup_v1::*;
+    /// # use builder::backup_for_gke::ClientBuilder;
+    /// # use client::BackupForGKE;
+    /// let builder : ClientBuilder = BackupForGKE::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://gkebackup.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::BackupForGKE;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = BackupForGKE;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::BackupForGKE] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/gkebackup/v1/src/client.rs
+++ b/src/generated/cloud/gkebackup/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Backup for GKE API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+/// let client = BackupForGKE::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// BackupForGKE allows Kubernetes administrators to configure, execute, and
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `BackupForGKE` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `BackupForGKE` use the `with_*` methods in the type returned
+/// by [builder()][BackupForGKE::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://gkebackup.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::backup_for_gke::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::backup_for_gke::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct BackupForGKE {
 }
 
 impl BackupForGKE {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [BackupForGKE].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// let client = BackupForGKE::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::backup_for_gke::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::backup_for_gke::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::BackupForGKE + 'static,
@@ -65,6 +90,11 @@ impl BackupForGKE {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
+++ b/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/builder.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod gateway_control {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [GatewayControl][super::super::client::GatewayControl].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkeconnect_gateway_v1::*;
+    /// # use builder::gateway_control::ClientBuilder;
+    /// # use client::GatewayControl;
+    /// let builder : ClientBuilder = GatewayControl::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://connectgateway.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::GatewayControl;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = GatewayControl;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::GatewayControl] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/client.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Connect Gateway API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_gkeconnect_gateway_v1::client::GatewayControl;
+/// let client = GatewayControl::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// GatewayControl is the control plane API for Connect Gateway.
 ///
 /// # Configuration
 ///
-/// `GatewayControl` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `GatewayControl` use the `with_*` methods in the type returned
+/// by [builder()][GatewayControl::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://connectgateway.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::gateway_control::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::gateway_control::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct GatewayControl {
 }
 
 impl GatewayControl {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [GatewayControl].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkeconnect_gateway_v1::client::GatewayControl;
+    /// let client = GatewayControl::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::gateway_control::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::gateway_control::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::GatewayControl + 'static,
@@ -64,6 +89,11 @@ impl GatewayControl {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/gkehub/configmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/configmanagement/v1/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/gkehub/multiclusteringress/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/multiclusteringress/v1/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/gkehub/v1/src/builder.rs
+++ b/src/generated/cloud/gkehub/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod gke_hub {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [GkeHub][super::super::client::GkeHub].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkehub_v1::*;
+    /// # use builder::gke_hub::ClientBuilder;
+    /// # use client::GkeHub;
+    /// let builder : ClientBuilder = GkeHub::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://gkehub.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::GkeHub;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = GkeHub;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::GkeHub] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/gkehub/v1/src/client.rs
+++ b/src/generated/cloud/gkehub/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the GKE Hub.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_gkehub_v1::client::GkeHub;
+/// let client = GkeHub::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The GKE Hub service handles the registration of many Kubernetes clusters to
@@ -46,8 +55,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `GkeHub` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `GkeHub` use the `with_*` methods in the type returned
+/// by [builder()][GkeHub::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://gkehub.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::gke_hub::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::gke_hub::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -61,21 +85,22 @@ pub struct GkeHub {
 }
 
 impl GkeHub {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [GkeHub].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkehub_v1::client::GkeHub;
+    /// let client = GkeHub::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::gke_hub::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::gke_hub::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::GkeHub + 'static,
@@ -83,6 +108,11 @@ impl GkeHub {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/gkemulticloud/v1/Cargo.toml
+++ b/src/generated/cloud/gkemulticloud/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/gkemulticloud/v1/src/builder.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod attached_clusters {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AttachedClusters][super::super::client::AttachedClusters].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkemulticloud_v1::*;
+    /// # use builder::attached_clusters::ClientBuilder;
+    /// # use client::AttachedClusters;
+    /// let builder : ClientBuilder = AttachedClusters::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://gkemulticloud.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AttachedClusters;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AttachedClusters;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AttachedClusters] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1015,6 +1043,34 @@ pub mod attached_clusters {
 pub mod aws_clusters {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [AwsClusters][super::super::client::AwsClusters].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkemulticloud_v1::*;
+    /// # use builder::aws_clusters::ClientBuilder;
+    /// # use client::AwsClusters;
+    /// let builder : ClientBuilder = AwsClusters::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://gkemulticloud.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AwsClusters;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AwsClusters;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::AwsClusters] request builders.
     #[derive(Clone, Debug)]
@@ -2469,6 +2525,34 @@ pub mod aws_clusters {
 pub mod azure_clusters {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [AzureClusters][super::super::client::AzureClusters].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkemulticloud_v1::*;
+    /// # use builder::azure_clusters::ClientBuilder;
+    /// # use client::AzureClusters;
+    /// let builder : ClientBuilder = AzureClusters::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://gkemulticloud.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AzureClusters;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AzureClusters;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::AzureClusters] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/gkemulticloud/v1/src/client.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the GKE Multi-Cloud API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+/// let client = AttachedClusters::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The AttachedClusters API provides a single centrally managed service
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AttachedClusters` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AttachedClusters` use the `with_*` methods in the type returned
+/// by [builder()][AttachedClusters::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://gkemulticloud.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::attached_clusters::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::attached_clusters::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,24 @@ pub struct AttachedClusters {
 }
 
 impl AttachedClusters {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AttachedClusters].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+    /// let client = AttachedClusters::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::attached_clusters::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::attached_clusters::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AttachedClusters + 'static,
@@ -66,6 +93,11 @@ impl AttachedClusters {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -302,6 +334,15 @@ impl AttachedClusters {
 
 /// Implements a client for the GKE Multi-Cloud API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+/// let client = AwsClusters::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The AwsClusters API provides a single centrally managed service
@@ -309,8 +350,23 @@ impl AttachedClusters {
 ///
 /// # Configuration
 ///
-/// `AwsClusters` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AwsClusters` use the `with_*` methods in the type returned
+/// by [builder()][AwsClusters::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://gkemulticloud.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::aws_clusters::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::aws_clusters::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -324,21 +380,22 @@ pub struct AwsClusters {
 }
 
 impl AwsClusters {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AwsClusters].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// let client = AwsClusters::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::aws_clusters::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::aws_clusters::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AwsClusters + 'static,
@@ -346,6 +403,11 @@ impl AwsClusters {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -697,6 +759,15 @@ impl AwsClusters {
 
 /// Implements a client for the GKE Multi-Cloud API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+/// let client = AzureClusters::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The AzureClusters API provides a single centrally managed service
@@ -704,8 +775,23 @@ impl AwsClusters {
 ///
 /// # Configuration
 ///
-/// `AzureClusters` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AzureClusters` use the `with_*` methods in the type returned
+/// by [builder()][AzureClusters::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://gkemulticloud.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::azure_clusters::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::azure_clusters::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -719,21 +805,22 @@ pub struct AzureClusters {
 }
 
 impl AzureClusters {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AzureClusters].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// let client = AzureClusters::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::azure_clusters::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::azure_clusters::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AzureClusters + 'static,
@@ -741,6 +828,11 @@ impl AzureClusters {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
+++ b/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
@@ -45,3 +45,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/gsuiteaddons/v1/src/builder.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod g_suite_add_ons {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [GSuiteAddOns][super::super::client::GSuiteAddOns].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gsuiteaddons_v1::*;
+    /// # use builder::g_suite_add_ons::ClientBuilder;
+    /// # use client::GSuiteAddOns;
+    /// let builder : ClientBuilder = GSuiteAddOns::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://gsuiteaddons.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::GSuiteAddOns;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = GSuiteAddOns;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::GSuiteAddOns] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/gsuiteaddons/v1/src/client.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Google Workspace add-ons API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+/// let client = GSuiteAddOns::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for managing Google Workspace add-ons deployments.
@@ -54,8 +63,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `GSuiteAddOns` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `GSuiteAddOns` use the `with_*` methods in the type returned
+/// by [builder()][GSuiteAddOns::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://gsuiteaddons.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::g_suite_add_ons::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::g_suite_add_ons::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -69,21 +93,22 @@ pub struct GSuiteAddOns {
 }
 
 impl GSuiteAddOns {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [GSuiteAddOns].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// let client = GSuiteAddOns::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::g_suite_add_ons::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::g_suite_add_ons::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::GSuiteAddOns + 'static,
@@ -91,6 +116,11 @@ impl GSuiteAddOns {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/iap/v1/Cargo.toml
+++ b/src/generated/cloud/iap/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/iap/v1/src/builder.rs
+++ b/src/generated/cloud/iap/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod identity_aware_proxy_admin_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [IdentityAwareProxyAdminService][super::super::client::IdentityAwareProxyAdminService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iap_v1::*;
+    /// # use builder::identity_aware_proxy_admin_service::ClientBuilder;
+    /// # use client::IdentityAwareProxyAdminService;
+    /// let builder : ClientBuilder = IdentityAwareProxyAdminService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iap.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::IdentityAwareProxyAdminService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = IdentityAwareProxyAdminService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::IdentityAwareProxyAdminService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -614,6 +642,34 @@ pub mod identity_aware_proxy_admin_service {
 pub mod identity_aware_proxy_o_auth_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [IdentityAwareProxyOAuthService][super::super::client::IdentityAwareProxyOAuthService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iap_v1::*;
+    /// # use builder::identity_aware_proxy_o_auth_service::ClientBuilder;
+    /// # use client::IdentityAwareProxyOAuthService;
+    /// let builder : ClientBuilder = IdentityAwareProxyOAuthService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iap.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::IdentityAwareProxyOAuthService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = IdentityAwareProxyOAuthService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::IdentityAwareProxyOAuthService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/iap/v1/src/client.rs
+++ b/src/generated/cloud/iap/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Identity-Aware Proxy API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+/// let client = IdentityAwareProxyAdminService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// APIs for Identity-Aware Proxy Admin configurations.
 ///
 /// # Configuration
 ///
-/// `IdentityAwareProxyAdminService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `IdentityAwareProxyAdminService` use the `with_*` methods in the type returned
+/// by [builder()][IdentityAwareProxyAdminService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iap.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::identity_aware_proxy_admin_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::identity_aware_proxy_admin_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct IdentityAwareProxyAdminService {
 }
 
 impl IdentityAwareProxyAdminService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [IdentityAwareProxyAdminService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// let client = IdentityAwareProxyAdminService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::identity_aware_proxy_admin_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::identity_aware_proxy_admin_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::IdentityAwareProxyAdminService + 'static,
@@ -64,6 +91,11 @@ impl IdentityAwareProxyAdminService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -208,6 +240,15 @@ impl IdentityAwareProxyAdminService {
 
 /// Implements a client for the Cloud Identity-Aware Proxy API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+/// let client = IdentityAwareProxyOAuthService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API to programmatically create, list and retrieve Identity Aware Proxy (IAP)
@@ -216,8 +257,23 @@ impl IdentityAwareProxyAdminService {
 ///
 /// # Configuration
 ///
-/// `IdentityAwareProxyOAuthService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `IdentityAwareProxyOAuthService` use the `with_*` methods in the type returned
+/// by [builder()][IdentityAwareProxyOAuthService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iap.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::identity_aware_proxy_o_auth_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::identity_aware_proxy_o_auth_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -231,21 +287,24 @@ pub struct IdentityAwareProxyOAuthService {
 }
 
 impl IdentityAwareProxyOAuthService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [IdentityAwareProxyOAuthService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+    /// let client = IdentityAwareProxyOAuthService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::identity_aware_proxy_o_auth_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::identity_aware_proxy_o_auth_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::IdentityAwareProxyOAuthService + 'static,
@@ -253,6 +312,11 @@ impl IdentityAwareProxyOAuthService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/ids/v1/Cargo.toml
+++ b/src/generated/cloud/ids/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/ids/v1/src/builder.rs
+++ b/src/generated/cloud/ids/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod ids {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Ids][super::super::client::Ids].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_ids_v1::*;
+    /// # use builder::ids::ClientBuilder;
+    /// # use client::Ids;
+    /// let builder : ClientBuilder = Ids::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://ids.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Ids;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Ids;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Ids] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/ids/v1/src/client.rs
+++ b/src/generated/cloud/ids/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud IDS API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_ids_v1::client::Ids;
+/// let client = Ids::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The IDS Service
 ///
 /// # Configuration
 ///
-/// `Ids` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Ids` use the `with_*` methods in the type returned
+/// by [builder()][Ids::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://ids.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::ids::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::ids::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Ids {
 }
 
 impl Ids {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Ids].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_ids_v1::client::Ids;
+    /// let client = Ids::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::ids::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::ids::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Ids + 'static,
@@ -64,6 +89,11 @@ impl Ids {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/kms/inventory/v1/Cargo.toml
+++ b/src/generated/cloud/kms/inventory/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/kms/inventory/v1/src/builder.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod key_dashboard_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [KeyDashboardService][super::super::client::KeyDashboardService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_inventory_v1::*;
+    /// # use builder::key_dashboard_service::ClientBuilder;
+    /// # use client::KeyDashboardService;
+    /// let builder : ClientBuilder = KeyDashboardService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://kmsinventory.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::KeyDashboardService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = KeyDashboardService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::KeyDashboardService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -112,6 +140,34 @@ pub mod key_dashboard_service {
 pub mod key_tracking_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [KeyTrackingService][super::super::client::KeyTrackingService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_inventory_v1::*;
+    /// # use builder::key_tracking_service::ClientBuilder;
+    /// # use client::KeyTrackingService;
+    /// let builder : ClientBuilder = KeyTrackingService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://kmsinventory.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::KeyTrackingService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = KeyTrackingService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::KeyTrackingService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/kms/inventory/v1/src/client.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the KMS Inventory API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_kms_inventory_v1::client::KeyDashboardService;
+/// let client = KeyDashboardService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Provides a cross-region view of all Cloud KMS keys in a given Cloud project.
 ///
 /// # Configuration
 ///
-/// `KeyDashboardService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `KeyDashboardService` use the `with_*` methods in the type returned
+/// by [builder()][KeyDashboardService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://kmsinventory.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::key_dashboard_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::key_dashboard_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct KeyDashboardService {
 }
 
 impl KeyDashboardService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [KeyDashboardService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_inventory_v1::client::KeyDashboardService;
+    /// let client = KeyDashboardService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::key_dashboard_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::key_dashboard_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::KeyDashboardService + 'static,
@@ -64,6 +91,11 @@ impl KeyDashboardService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -103,6 +135,15 @@ impl KeyDashboardService {
 
 /// Implements a client for the KMS Inventory API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_kms_inventory_v1::client::KeyTrackingService;
+/// let client = KeyTrackingService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Returns information about the resources in an org that are protected by a
@@ -110,8 +151,23 @@ impl KeyDashboardService {
 ///
 /// # Configuration
 ///
-/// `KeyTrackingService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `KeyTrackingService` use the `with_*` methods in the type returned
+/// by [builder()][KeyTrackingService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://kmsinventory.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::key_tracking_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::key_tracking_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -125,21 +181,24 @@ pub struct KeyTrackingService {
 }
 
 impl KeyTrackingService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [KeyTrackingService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_inventory_v1::client::KeyTrackingService;
+    /// let client = KeyTrackingService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::key_tracking_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::key_tracking_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::KeyTrackingService + 'static,
@@ -147,6 +206,11 @@ impl KeyTrackingService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/kms/v1/src/builder.rs
+++ b/src/generated/cloud/kms/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod autokey {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Autokey][super::super::client::Autokey].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_v1::*;
+    /// # use builder::autokey::ClientBuilder;
+    /// # use client::Autokey;
+    /// let builder : ClientBuilder = Autokey::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudkms.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Autokey;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Autokey;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Autokey] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -589,6 +617,34 @@ pub mod autokey_admin {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AutokeyAdmin][super::super::client::AutokeyAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_v1::*;
+    /// # use builder::autokey_admin::ClientBuilder;
+    /// # use client::AutokeyAdmin;
+    /// let builder : ClientBuilder = AutokeyAdmin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudkms.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AutokeyAdmin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AutokeyAdmin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AutokeyAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1095,6 +1151,34 @@ pub mod autokey_admin {
 pub mod ekm_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [EkmService][super::super::client::EkmService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_v1::*;
+    /// # use builder::ekm_service::ClientBuilder;
+    /// # use client::EkmService;
+    /// let builder : ClientBuilder = EkmService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudkms.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EkmService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EkmService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::EkmService] request builders.
     #[derive(Clone, Debug)]
@@ -1840,6 +1924,34 @@ pub mod ekm_service {
 pub mod key_management_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [KeyManagementService][super::super::client::KeyManagementService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_v1::*;
+    /// # use builder::key_management_service::ClientBuilder;
+    /// # use client::KeyManagementService;
+    /// let builder : ClientBuilder = KeyManagementService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudkms.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::KeyManagementService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = KeyManagementService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::KeyManagementService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/kms/v1/src/client.rs
+++ b/src/generated/cloud/kms/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Key Management Service (KMS) API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_kms_v1::client::Autokey;
+/// let client = Autokey::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Provides interfaces for using [Cloud KMS
@@ -49,8 +58,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Autokey` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Autokey` use the `with_*` methods in the type returned
+/// by [builder()][Autokey::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudkms.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::autokey::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::autokey::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -64,21 +88,22 @@ pub struct Autokey {
 }
 
 impl Autokey {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Autokey].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_v1::client::Autokey;
+    /// let client = Autokey::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::autokey::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::autokey::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Autokey + 'static,
@@ -86,6 +111,11 @@ impl Autokey {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -223,6 +253,15 @@ impl Autokey {
 
 /// Implements a client for the Cloud Key Management Service (KMS) API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_kms_v1::client::AutokeyAdmin;
+/// let client = AutokeyAdmin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Provides interfaces for managing [Cloud KMS
@@ -238,8 +277,23 @@ impl Autokey {
 ///
 /// # Configuration
 ///
-/// `AutokeyAdmin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AutokeyAdmin` use the `with_*` methods in the type returned
+/// by [builder()][AutokeyAdmin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudkms.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::autokey_admin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::autokey_admin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -253,21 +307,22 @@ pub struct AutokeyAdmin {
 }
 
 impl AutokeyAdmin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AutokeyAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// let client = AutokeyAdmin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::autokey_admin::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::autokey_admin::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AutokeyAdmin + 'static,
@@ -275,6 +330,11 @@ impl AutokeyAdmin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -407,6 +467,15 @@ impl AutokeyAdmin {
 
 /// Implements a client for the Cloud Key Management Service (KMS) API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_kms_v1::client::EkmService;
+/// let client = EkmService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Google Cloud Key Management EKM Service
@@ -420,8 +489,23 @@ impl AutokeyAdmin {
 ///
 /// # Configuration
 ///
-/// `EkmService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EkmService` use the `with_*` methods in the type returned
+/// by [builder()][EkmService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudkms.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::ekm_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::ekm_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -435,21 +519,22 @@ pub struct EkmService {
 }
 
 impl EkmService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EkmService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// let client = EkmService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::ekm_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::ekm_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EkmService + 'static,
@@ -457,6 +542,11 @@ impl EkmService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -632,6 +722,15 @@ impl EkmService {
 
 /// Implements a client for the Cloud Key Management Service (KMS) API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_kms_v1::client::KeyManagementService;
+/// let client = KeyManagementService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Google Cloud Key Management Service
@@ -654,8 +753,23 @@ impl EkmService {
 ///
 /// # Configuration
 ///
-/// `KeyManagementService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `KeyManagementService` use the `with_*` methods in the type returned
+/// by [builder()][KeyManagementService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudkms.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::key_management_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::key_management_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -669,21 +783,24 @@ pub struct KeyManagementService {
 }
 
 impl KeyManagementService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [KeyManagementService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// let client = KeyManagementService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::key_management_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::key_management_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::KeyManagementService + 'static,
@@ -691,6 +808,11 @@ impl KeyManagementService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/language/v2/Cargo.toml
+++ b/src/generated/cloud/language/v2/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/language/v2/src/builder.rs
+++ b/src/generated/cloud/language/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod language_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [LanguageService][super::super::client::LanguageService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_language_v2::*;
+    /// # use builder::language_service::ClientBuilder;
+    /// # use client::LanguageService;
+    /// let builder : ClientBuilder = LanguageService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://language.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::LanguageService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = LanguageService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::LanguageService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/language/v2/src/client.rs
+++ b/src/generated/cloud/language/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Natural Language API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_language_v2::client::LanguageService;
+/// let client = LanguageService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Provides text analysis operations such as sentiment analysis and entity
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `LanguageService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `LanguageService` use the `with_*` methods in the type returned
+/// by [builder()][LanguageService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://language.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::language_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::language_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,24 @@ pub struct LanguageService {
 }
 
 impl LanguageService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [LanguageService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_language_v2::client::LanguageService;
+    /// let client = LanguageService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::language_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::language_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::LanguageService + 'static,
@@ -65,6 +92,11 @@ impl LanguageService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/location/src/builder.rs
+++ b/src/generated/cloud/location/src/builder.rs
@@ -18,6 +18,34 @@ pub mod locations {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Locations][super::super::client::Locations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_location::*;
+    /// # use builder::locations::ClientBuilder;
+    /// # use client::Locations;
+    /// let builder : ClientBuilder = Locations::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloud.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Locations;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Locations;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Locations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Metadata API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_location::client::Locations;
+/// let client = Locations::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// An abstract interface that provides location-related information for
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Locations` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Locations` use the `with_*` methods in the type returned
+/// by [builder()][Locations::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloud.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::locations::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::locations::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,22 @@ pub struct Locations {
 }
 
 impl Locations {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Locations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_location::client::Locations;
+    /// let client = Locations::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::locations::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::locations::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Locations + 'static,
@@ -68,6 +93,11 @@ impl Locations {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/managedidentities/v1/Cargo.toml
+++ b/src/generated/cloud/managedidentities/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/managedidentities/v1/src/builder.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod managed_identities_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ManagedIdentitiesService][super::super::client::ManagedIdentitiesService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_managedidentities_v1::*;
+    /// # use builder::managed_identities_service::ClientBuilder;
+    /// # use client::ManagedIdentitiesService;
+    /// let builder : ClientBuilder = ManagedIdentitiesService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://managedidentities.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ManagedIdentitiesService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ManagedIdentitiesService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ManagedIdentitiesService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/managedidentities/v1/src/client.rs
+++ b/src/generated/cloud/managedidentities/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Managed Service for Microsoft Active Directory API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
+/// let client = ManagedIdentitiesService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview
@@ -59,8 +68,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ManagedIdentitiesService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ManagedIdentitiesService` use the `with_*` methods in the type returned
+/// by [builder()][ManagedIdentitiesService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://managedidentities.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::managed_identities_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::managed_identities_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -74,21 +98,24 @@ pub struct ManagedIdentitiesService {
 }
 
 impl ManagedIdentitiesService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ManagedIdentitiesService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
+    /// let client = ManagedIdentitiesService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::managed_identities_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::managed_identities_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ManagedIdentitiesService + 'static,
@@ -96,6 +123,11 @@ impl ManagedIdentitiesService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/memcache/v1/Cargo.toml
+++ b/src/generated/cloud/memcache/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/memcache/v1/src/builder.rs
+++ b/src/generated/cloud/memcache/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_memcache {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudMemcache][super::super::client::CloudMemcache].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_memcache_v1::*;
+    /// # use builder::cloud_memcache::ClientBuilder;
+    /// # use client::CloudMemcache;
+    /// let builder : ClientBuilder = CloudMemcache::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://memcache.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudMemcache;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudMemcache;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudMemcache] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/memcache/v1/src/client.rs
+++ b/src/generated/cloud/memcache/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Memorystore for Memcached API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_memcache_v1::client::CloudMemcache;
+/// let client = CloudMemcache::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Configures and manages Cloud Memorystore for Memcached instances.
@@ -42,8 +51,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudMemcache` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudMemcache` use the `with_*` methods in the type returned
+/// by [builder()][CloudMemcache::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://memcache.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_memcache::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_memcache::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -57,21 +81,22 @@ pub struct CloudMemcache {
 }
 
 impl CloudMemcache {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudMemcache].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_memcache_v1::client::CloudMemcache;
+    /// let client = CloudMemcache::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_memcache::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cloud_memcache::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudMemcache + 'static,
@@ -79,6 +104,11 @@ impl CloudMemcache {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/memorystore/v1/Cargo.toml
+++ b/src/generated/cloud/memorystore/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/memorystore/v1/src/builder.rs
+++ b/src/generated/cloud/memorystore/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod memorystore {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Memorystore][super::super::client::Memorystore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_memorystore_v1::*;
+    /// # use builder::memorystore::ClientBuilder;
+    /// # use client::Memorystore;
+    /// let builder : ClientBuilder = Memorystore::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://memorystore.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Memorystore;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Memorystore;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Memorystore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/memorystore/v1/src/client.rs
+++ b/src/generated/cloud/memorystore/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Memorystore API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_memorystore_v1::client::Memorystore;
+/// let client = Memorystore::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `Memorystore` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Memorystore` use the `with_*` methods in the type returned
+/// by [builder()][Memorystore::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://memorystore.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::memorystore::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::memorystore::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Memorystore {
 }
 
 impl Memorystore {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Memorystore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// let client = Memorystore::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::memorystore::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::memorystore::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Memorystore + 'static,
@@ -64,6 +89,11 @@ impl Memorystore {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/metastore/v1/Cargo.toml
+++ b/src/generated/cloud/metastore/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/metastore/v1/src/builder.rs
+++ b/src/generated/cloud/metastore/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod dataproc_metastore {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DataprocMetastore][super::super::client::DataprocMetastore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_metastore_v1::*;
+    /// # use builder::dataproc_metastore::ClientBuilder;
+    /// # use client::DataprocMetastore;
+    /// let builder : ClientBuilder = DataprocMetastore::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://metastore.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DataprocMetastore;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DataprocMetastore;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DataprocMetastore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2090,6 +2118,34 @@ pub mod dataproc_metastore {
 pub mod dataproc_metastore_federation {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [DataprocMetastoreFederation][super::super::client::DataprocMetastoreFederation].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_metastore_v1::*;
+    /// # use builder::dataproc_metastore_federation::ClientBuilder;
+    /// # use client::DataprocMetastoreFederation;
+    /// let builder : ClientBuilder = DataprocMetastoreFederation::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://metastore.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DataprocMetastoreFederation;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DataprocMetastoreFederation;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::DataprocMetastoreFederation] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/metastore/v1/src/client.rs
+++ b/src/generated/cloud/metastore/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Dataproc Metastore API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_metastore_v1::client::DataprocMetastore;
+/// let client = DataprocMetastore::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Configures and manages metastore services.
@@ -47,8 +56,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `DataprocMetastore` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DataprocMetastore` use the `with_*` methods in the type returned
+/// by [builder()][DataprocMetastore::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://metastore.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::dataproc_metastore::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::dataproc_metastore::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -62,21 +86,24 @@ pub struct DataprocMetastore {
 }
 
 impl DataprocMetastore {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DataprocMetastore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// let client = DataprocMetastore::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::dataproc_metastore::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::dataproc_metastore::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DataprocMetastore + 'static,
@@ -84,6 +111,11 @@ impl DataprocMetastore {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -497,6 +529,15 @@ impl DataprocMetastore {
 
 /// Implements a client for the Dataproc Metastore API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+/// let client = DataprocMetastoreFederation::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Configures and manages metastore federation services.
@@ -516,8 +557,23 @@ impl DataprocMetastore {
 ///
 /// # Configuration
 ///
-/// `DataprocMetastoreFederation` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DataprocMetastoreFederation` use the `with_*` methods in the type returned
+/// by [builder()][DataprocMetastoreFederation::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://metastore.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::dataproc_metastore_federation::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::dataproc_metastore_federation::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -531,21 +587,24 @@ pub struct DataprocMetastoreFederation {
 }
 
 impl DataprocMetastoreFederation {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DataprocMetastoreFederation].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// let client = DataprocMetastoreFederation::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::dataproc_metastore_federation::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::dataproc_metastore_federation::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DataprocMetastoreFederation + 'static,
@@ -553,6 +612,11 @@ impl DataprocMetastoreFederation {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/migrationcenter/v1/Cargo.toml
+++ b/src/generated/cloud/migrationcenter/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/migrationcenter/v1/src/builder.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod migration_center {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [MigrationCenter][super::super::client::MigrationCenter].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_migrationcenter_v1::*;
+    /// # use builder::migration_center::ClientBuilder;
+    /// # use client::MigrationCenter;
+    /// let builder : ClientBuilder = MigrationCenter::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://migrationcenter.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::MigrationCenter;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = MigrationCenter;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::MigrationCenter] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/migrationcenter/v1/src/client.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Migration Center API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+/// let client = MigrationCenter::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources.
 ///
 /// # Configuration
 ///
-/// `MigrationCenter` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `MigrationCenter` use the `with_*` methods in the type returned
+/// by [builder()][MigrationCenter::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://migrationcenter.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::migration_center::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::migration_center::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct MigrationCenter {
 }
 
 impl MigrationCenter {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [MigrationCenter].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// let client = MigrationCenter::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::migration_center::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::migration_center::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::MigrationCenter + 'static,
@@ -64,6 +91,11 @@ impl MigrationCenter {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/modelarmor/v1/Cargo.toml
+++ b/src/generated/cloud/modelarmor/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/modelarmor/v1/src/builder.rs
+++ b/src/generated/cloud/modelarmor/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod model_armor {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ModelArmor][super::super::client::ModelArmor].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_modelarmor_v1::*;
+    /// # use builder::model_armor::ClientBuilder;
+    /// # use client::ModelArmor;
+    /// let builder : ClientBuilder = ModelArmor::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://modelarmor.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ModelArmor;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ModelArmor;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ModelArmor] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/modelarmor/v1/src/client.rs
+++ b/src/generated/cloud/modelarmor/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Model Armor API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_modelarmor_v1::client::ModelArmor;
+/// let client = ModelArmor::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `ModelArmor` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ModelArmor` use the `with_*` methods in the type returned
+/// by [builder()][ModelArmor::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://modelarmor.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::model_armor::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::model_armor::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct ModelArmor {
 }
 
 impl ModelArmor {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ModelArmor].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// let client = ModelArmor::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::model_armor::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::model_armor::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ModelArmor + 'static,
@@ -64,6 +89,11 @@ impl ModelArmor {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/netapp/v1/src/builder.rs
+++ b/src/generated/cloud/netapp/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod net_app {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [NetApp][super::super::client::NetApp].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_netapp_v1::*;
+    /// # use builder::net_app::ClientBuilder;
+    /// # use client::NetApp;
+    /// let builder : ClientBuilder = NetApp::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://netapp.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::NetApp;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = NetApp;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::NetApp] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/netapp/v1/src/client.rs
+++ b/src/generated/cloud/netapp/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the NetApp API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_netapp_v1::client::NetApp;
+/// let client = NetApp::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// NetApp Files Google Cloud Service
 ///
 /// # Configuration
 ///
-/// `NetApp` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `NetApp` use the `with_*` methods in the type returned
+/// by [builder()][NetApp::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://netapp.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::net_app::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::net_app::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct NetApp {
 }
 
 impl NetApp {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [NetApp].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// let client = NetApp::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::net_app::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::net_app::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::NetApp + 'static,
@@ -64,6 +89,11 @@ impl NetApp {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/networkconnectivity/v1/Cargo.toml
+++ b/src/generated/cloud/networkconnectivity/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/networkconnectivity/v1/src/builder.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod hub_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [HubService][super::super::client::HubService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkconnectivity_v1::*;
+    /// # use builder::hub_service::ClientBuilder;
+    /// # use client::HubService;
+    /// let builder : ClientBuilder = HubService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://networkconnectivity.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::HubService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = HubService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::HubService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2190,6 +2218,34 @@ pub mod hub_service {
 pub mod policy_based_routing_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [PolicyBasedRoutingService][super::super::client::PolicyBasedRoutingService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkconnectivity_v1::*;
+    /// # use builder::policy_based_routing_service::ClientBuilder;
+    /// # use client::PolicyBasedRoutingService;
+    /// let builder : ClientBuilder = PolicyBasedRoutingService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://networkconnectivity.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PolicyBasedRoutingService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PolicyBasedRoutingService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::PolicyBasedRoutingService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/networkconnectivity/v1/src/client.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Network Connectivity API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_networkconnectivity_v1::client::HubService;
+/// let client = HubService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Network Connectivity Center is a hub-and-spoke abstraction for network
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `HubService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `HubService` use the `with_*` methods in the type returned
+/// by [builder()][HubService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://networkconnectivity.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::hub_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::hub_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,22 @@ pub struct HubService {
 }
 
 impl HubService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [HubService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// let client = HubService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::hub_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::hub_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::HubService + 'static,
@@ -66,6 +91,11 @@ impl HubService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -456,6 +486,15 @@ impl HubService {
 
 /// Implements a client for the Network Connectivity API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+/// let client = PolicyBasedRoutingService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Policy-Based Routing allows GCP customers to specify flexibile routing
@@ -463,8 +502,23 @@ impl HubService {
 ///
 /// # Configuration
 ///
-/// `PolicyBasedRoutingService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PolicyBasedRoutingService` use the `with_*` methods in the type returned
+/// by [builder()][PolicyBasedRoutingService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://networkconnectivity.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::policy_based_routing_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::policy_based_routing_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -478,21 +532,24 @@ pub struct PolicyBasedRoutingService {
 }
 
 impl PolicyBasedRoutingService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PolicyBasedRoutingService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// let client = PolicyBasedRoutingService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::policy_based_routing_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::policy_based_routing_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PolicyBasedRoutingService + 'static,
@@ -500,6 +557,11 @@ impl PolicyBasedRoutingService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/networkmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/networkmanagement/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/networkmanagement/v1/src/builder.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod reachability_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ReachabilityService][super::super::client::ReachabilityService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkmanagement_v1::*;
+    /// # use builder::reachability_service::ClientBuilder;
+    /// # use client::ReachabilityService;
+    /// let builder : ClientBuilder = ReachabilityService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://networkmanagement.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ReachabilityService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ReachabilityService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ReachabilityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1031,6 +1059,34 @@ pub mod reachability_service {
 pub mod vpc_flow_logs_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [VpcFlowLogsService][super::super::client::VpcFlowLogsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkmanagement_v1::*;
+    /// # use builder::vpc_flow_logs_service::ClientBuilder;
+    /// # use client::VpcFlowLogsService;
+    /// let builder : ClientBuilder = VpcFlowLogsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://networkmanagement.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VpcFlowLogsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VpcFlowLogsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::VpcFlowLogsService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/networkmanagement/v1/src/client.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Network Management API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+/// let client = ReachabilityService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Reachability service in the Google Cloud Network Management API provides
@@ -34,8 +43,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ReachabilityService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ReachabilityService` use the `with_*` methods in the type returned
+/// by [builder()][ReachabilityService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://networkmanagement.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::reachability_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::reachability_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -49,21 +73,24 @@ pub struct ReachabilityService {
 }
 
 impl ReachabilityService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ReachabilityService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// let client = ReachabilityService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::reachability_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::reachability_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ReachabilityService + 'static,
@@ -71,6 +98,11 @@ impl ReachabilityService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -329,6 +361,15 @@ impl ReachabilityService {
 
 /// Implements a client for the Network Management API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+/// let client = VpcFlowLogsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The VPC Flow Logs service in the Google Cloud Network Management API provides
@@ -337,8 +378,23 @@ impl ReachabilityService {
 ///
 /// # Configuration
 ///
-/// `VpcFlowLogsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VpcFlowLogsService` use the `with_*` methods in the type returned
+/// by [builder()][VpcFlowLogsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://networkmanagement.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::vpc_flow_logs_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::vpc_flow_logs_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -352,21 +408,24 @@ pub struct VpcFlowLogsService {
 }
 
 impl VpcFlowLogsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VpcFlowLogsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// let client = VpcFlowLogsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::vpc_flow_logs_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::vpc_flow_logs_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VpcFlowLogsService + 'static,
@@ -374,6 +433,11 @@ impl VpcFlowLogsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/networksecurity/v1/Cargo.toml
+++ b/src/generated/cloud/networksecurity/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/networksecurity/v1/src/builder.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod network_security {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [NetworkSecurity][super::super::client::NetworkSecurity].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networksecurity_v1::*;
+    /// # use builder::network_security::ClientBuilder;
+    /// # use client::NetworkSecurity;
+    /// let builder : ClientBuilder = NetworkSecurity::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://networksecurity.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::NetworkSecurity;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = NetworkSecurity;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::NetworkSecurity] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/networksecurity/v1/src/client.rs
+++ b/src/generated/cloud/networksecurity/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Network Security API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+/// let client = NetworkSecurity::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Network Security API provides resources to configure authentication and
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `NetworkSecurity` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `NetworkSecurity` use the `with_*` methods in the type returned
+/// by [builder()][NetworkSecurity::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://networksecurity.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::network_security::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::network_security::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,24 @@ pub struct NetworkSecurity {
 }
 
 impl NetworkSecurity {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [NetworkSecurity].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// let client = NetworkSecurity::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::network_security::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::network_security::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::NetworkSecurity + 'static,
@@ -66,6 +93,11 @@ impl NetworkSecurity {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/networkservices/v1/Cargo.toml
+++ b/src/generated/cloud/networkservices/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/networkservices/v1/src/builder.rs
+++ b/src/generated/cloud/networkservices/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod dep_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DepService][super::super::client::DepService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkservices_v1::*;
+    /// # use builder::dep_service::ClientBuilder;
+    /// # use client::DepService;
+    /// let builder : ClientBuilder = DepService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://networkservices.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DepService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DepService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DepService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1405,6 +1433,34 @@ pub mod dep_service {
 pub mod network_services {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [NetworkServices][super::super::client::NetworkServices].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkservices_v1::*;
+    /// # use builder::network_services::ClientBuilder;
+    /// # use client::NetworkServices;
+    /// let builder : ClientBuilder = NetworkServices::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://networkservices.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::NetworkServices;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = NetworkServices;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::NetworkServices] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/networkservices/v1/src/client.rs
+++ b/src/generated/cloud/networkservices/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Network Services API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_networkservices_v1::client::DepService;
+/// let client = DepService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources.
 ///
 /// # Configuration
 ///
-/// `DepService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DepService` use the `with_*` methods in the type returned
+/// by [builder()][DepService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://networkservices.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::dep_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::dep_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct DepService {
 }
 
 impl DepService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DepService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// let client = DepService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::dep_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::dep_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DepService + 'static,
@@ -64,6 +89,11 @@ impl DepService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -337,14 +367,38 @@ impl DepService {
 
 /// Implements a client for the Network Services API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_networkservices_v1::client::NetworkServices;
+/// let client = NetworkServices::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources.
 ///
 /// # Configuration
 ///
-/// `NetworkServices` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `NetworkServices` use the `with_*` methods in the type returned
+/// by [builder()][NetworkServices::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://networkservices.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::network_services::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::network_services::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -358,21 +412,24 @@ pub struct NetworkServices {
 }
 
 impl NetworkServices {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [NetworkServices].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// let client = NetworkServices::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::network_services::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::network_services::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::NetworkServices + 'static,
@@ -380,6 +437,11 @@ impl NetworkServices {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/notebooks/v2/Cargo.toml
+++ b/src/generated/cloud/notebooks/v2/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/notebooks/v2/src/builder.rs
+++ b/src/generated/cloud/notebooks/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod notebook_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [NotebookService][super::super::client::NotebookService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_notebooks_v2::*;
+    /// # use builder::notebook_service::ClientBuilder;
+    /// # use client::NotebookService;
+    /// let builder : ClientBuilder = NotebookService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://notebooks.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::NotebookService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = NotebookService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::NotebookService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/notebooks/v2/src/client.rs
+++ b/src/generated/cloud/notebooks/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Notebooks API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_notebooks_v2::client::NotebookService;
+/// let client = NotebookService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API v2 service for Workbench Notebooks Instances.
 ///
 /// # Configuration
 ///
-/// `NotebookService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `NotebookService` use the `with_*` methods in the type returned
+/// by [builder()][NotebookService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://notebooks.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::notebook_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::notebook_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct NotebookService {
 }
 
 impl NotebookService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [NotebookService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// let client = NotebookService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::notebook_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::notebook_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::NotebookService + 'static,
@@ -64,6 +91,11 @@ impl NotebookService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/optimization/v1/Cargo.toml
+++ b/src/generated/cloud/optimization/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/optimization/v1/src/builder.rs
+++ b/src/generated/cloud/optimization/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod fleet_routing {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [FleetRouting][super::super::client::FleetRouting].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_optimization_v1::*;
+    /// # use builder::fleet_routing::ClientBuilder;
+    /// # use client::FleetRouting;
+    /// let builder : ClientBuilder = FleetRouting::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudoptimization.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::FleetRouting;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = FleetRouting;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::FleetRouting] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/optimization/v1/src/client.rs
+++ b/src/generated/cloud/optimization/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Optimization API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_optimization_v1::client::FleetRouting;
+/// let client = FleetRouting::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service for optimizing vehicle tours.
@@ -43,8 +52,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `FleetRouting` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `FleetRouting` use the `with_*` methods in the type returned
+/// by [builder()][FleetRouting::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudoptimization.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::fleet_routing::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::fleet_routing::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -58,21 +82,22 @@ pub struct FleetRouting {
 }
 
 impl FleetRouting {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [FleetRouting].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_optimization_v1::client::FleetRouting;
+    /// let client = FleetRouting::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::fleet_routing::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::fleet_routing::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::FleetRouting + 'static,
@@ -80,6 +105,11 @@ impl FleetRouting {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/oracledatabase/v1/Cargo.toml
+++ b/src/generated/cloud/oracledatabase/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/oracledatabase/v1/src/builder.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod oracle_database {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [OracleDatabase][super::super::client::OracleDatabase].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_oracledatabase_v1::*;
+    /// # use builder::oracle_database::ClientBuilder;
+    /// # use client::OracleDatabase;
+    /// let builder : ClientBuilder = OracleDatabase::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://oracledatabase.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::OracleDatabase;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = OracleDatabase;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::OracleDatabase] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/oracledatabase/v1/src/client.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Oracle Database@Google Cloud API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+/// let client = OracleDatabase::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `OracleDatabase` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `OracleDatabase` use the `with_*` methods in the type returned
+/// by [builder()][OracleDatabase::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://oracledatabase.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::oracle_database::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::oracle_database::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct OracleDatabase {
 }
 
 impl OracleDatabase {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [OracleDatabase].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// let client = OracleDatabase::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::oracle_database::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::oracle_database::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::OracleDatabase + 'static,
@@ -64,6 +89,11 @@ impl OracleDatabase {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod environments {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Environments][super::super::client::Environments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_orchestration_airflow_service_v1::*;
+    /// # use builder::environments::ClientBuilder;
+    /// # use client::Environments;
+    /// let builder : ClientBuilder = Environments::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://composer.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Environments;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Environments;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Environments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1855,6 +1883,34 @@ pub mod environments {
 pub mod image_versions {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ImageVersions][super::super::client::ImageVersions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_orchestration_airflow_service_v1::*;
+    /// # use builder::image_versions::ClientBuilder;
+    /// # use client::ImageVersions;
+    /// let builder : ClientBuilder = ImageVersions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://composer.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ImageVersions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ImageVersions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ImageVersions] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/client.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Composer API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+/// let client = Environments::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Managed Apache Airflow Environments.
 ///
 /// # Configuration
 ///
-/// `Environments` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Environments` use the `with_*` methods in the type returned
+/// by [builder()][Environments::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://composer.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::environments::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::environments::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Environments {
 }
 
 impl Environments {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Environments].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// let client = Environments::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::environments::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::environments::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Environments + 'static,
@@ -64,6 +89,11 @@ impl Environments {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -450,14 +480,38 @@ impl Environments {
 
 /// Implements a client for the Cloud Composer API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_orchestration_airflow_service_v1::client::ImageVersions;
+/// let client = ImageVersions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Readonly service to query available ImageVersions.
 ///
 /// # Configuration
 ///
-/// `ImageVersions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ImageVersions` use the `with_*` methods in the type returned
+/// by [builder()][ImageVersions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://composer.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::image_versions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::image_versions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -471,21 +525,22 @@ pub struct ImageVersions {
 }
 
 impl ImageVersions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ImageVersions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_orchestration_airflow_service_v1::client::ImageVersions;
+    /// let client = ImageVersions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::image_versions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::image_versions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ImageVersions + 'static,
@@ -493,6 +548,11 @@ impl ImageVersions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/orgpolicy/v1/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v1/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/orgpolicy/v2/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v2/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/orgpolicy/v2/src/builder.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod org_policy {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [OrgPolicy][super::super::client::OrgPolicy].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_orgpolicy_v2::*;
+    /// # use builder::org_policy::ClientBuilder;
+    /// # use client::OrgPolicy;
+    /// let builder : ClientBuilder = OrgPolicy::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://orgpolicy.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::OrgPolicy;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = OrgPolicy;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::OrgPolicy] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/orgpolicy/v2/src/client.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Organization Policy API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+/// let client = OrgPolicy::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// An interface for managing organization policies.
@@ -46,8 +55,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `OrgPolicy` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `OrgPolicy` use the `with_*` methods in the type returned
+/// by [builder()][OrgPolicy::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://orgpolicy.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::org_policy::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::org_policy::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -61,21 +85,22 @@ pub struct OrgPolicy {
 }
 
 impl OrgPolicy {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [OrgPolicy].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// let client = OrgPolicy::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::org_policy::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::org_policy::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::OrgPolicy + 'static,
@@ -83,6 +108,11 @@ impl OrgPolicy {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/osconfig/v1/Cargo.toml
+++ b/src/generated/cloud/osconfig/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/osconfig/v1/src/builder.rs
+++ b/src/generated/cloud/osconfig/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod os_config_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [OsConfigService][super::super::client::OsConfigService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_osconfig_v1::*;
+    /// # use builder::os_config_service::ClientBuilder;
+    /// # use client::OsConfigService;
+    /// let builder : ClientBuilder = OsConfigService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://osconfig.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::OsConfigService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = OsConfigService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::OsConfigService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -838,6 +866,34 @@ pub mod os_config_service {
 pub mod os_config_zonal_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [OsConfigZonalService][super::super::client::OsConfigZonalService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_osconfig_v1::*;
+    /// # use builder::os_config_zonal_service::ClientBuilder;
+    /// # use client::OsConfigZonalService;
+    /// let builder : ClientBuilder = OsConfigZonalService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://osconfig.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::OsConfigZonalService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = OsConfigZonalService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::OsConfigZonalService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/osconfig/v1/src/client.rs
+++ b/src/generated/cloud/osconfig/v1/src/client.rs
@@ -23,6 +23,15 @@ use std::sync::Arc;
 
 /// Implements a client for the OS Config API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_osconfig_v1::client::OsConfigService;
+/// let client = OsConfigService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// OS Config API
@@ -32,8 +41,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `OsConfigService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `OsConfigService` use the `with_*` methods in the type returned
+/// by [builder()][OsConfigService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://osconfig.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::os_config_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::os_config_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -47,21 +71,24 @@ pub struct OsConfigService {
 }
 
 impl OsConfigService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [OsConfigService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// let client = OsConfigService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::os_config_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::os_config_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::OsConfigService + 'static,
@@ -69,6 +96,11 @@ impl OsConfigService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -231,6 +263,15 @@ impl OsConfigService {
 
 /// Implements a client for the OS Config API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
+/// let client = OsConfigZonalService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Zonal OS Config API
@@ -240,8 +281,23 @@ impl OsConfigService {
 ///
 /// # Configuration
 ///
-/// `OsConfigZonalService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `OsConfigZonalService` use the `with_*` methods in the type returned
+/// by [builder()][OsConfigZonalService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://osconfig.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::os_config_zonal_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::os_config_zonal_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -255,21 +311,24 @@ pub struct OsConfigZonalService {
 }
 
 impl OsConfigZonalService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [OsConfigZonalService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
+    /// let client = OsConfigZonalService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::os_config_zonal_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::os_config_zonal_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::OsConfigZonalService + 'static,
@@ -277,6 +336,11 @@ impl OsConfigZonalService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/oslogin/v1/Cargo.toml
+++ b/src/generated/cloud/oslogin/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/oslogin/v1/src/builder.rs
+++ b/src/generated/cloud/oslogin/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod os_login_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [OsLoginService][super::super::client::OsLoginService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_oslogin_v1::*;
+    /// # use builder::os_login_service::ClientBuilder;
+    /// # use client::OsLoginService;
+    /// let builder : ClientBuilder = OsLoginService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://oslogin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::OsLoginService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = OsLoginService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::OsLoginService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/oslogin/v1/src/client.rs
+++ b/src/generated/cloud/oslogin/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud OS Login API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_oslogin_v1::client::OsLoginService;
+/// let client = OsLoginService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud OS Login API
@@ -30,8 +39,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `OsLoginService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `OsLoginService` use the `with_*` methods in the type returned
+/// by [builder()][OsLoginService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://oslogin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::os_login_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::os_login_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -45,21 +69,24 @@ pub struct OsLoginService {
 }
 
 impl OsLoginService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [OsLoginService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_oslogin_v1::client::OsLoginService;
+    /// let client = OsLoginService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::os_login_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::os_login_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::OsLoginService + 'static,
@@ -67,6 +94,11 @@ impl OsLoginService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/parallelstore/v1/Cargo.toml
+++ b/src/generated/cloud/parallelstore/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/parallelstore/v1/src/builder.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod parallelstore {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Parallelstore][super::super::client::Parallelstore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_parallelstore_v1::*;
+    /// # use builder::parallelstore::ClientBuilder;
+    /// # use client::Parallelstore;
+    /// let builder : ClientBuilder = Parallelstore::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://parallelstore.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Parallelstore;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Parallelstore;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Parallelstore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/parallelstore/v1/src/client.rs
+++ b/src/generated/cloud/parallelstore/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Parallelstore API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_parallelstore_v1::client::Parallelstore;
+/// let client = Parallelstore::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
@@ -43,8 +52,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Parallelstore` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Parallelstore` use the `with_*` methods in the type returned
+/// by [builder()][Parallelstore::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://parallelstore.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::parallelstore::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::parallelstore::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -58,21 +82,22 @@ pub struct Parallelstore {
 }
 
 impl Parallelstore {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Parallelstore].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_parallelstore_v1::client::Parallelstore;
+    /// let client = Parallelstore::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::parallelstore::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::parallelstore::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Parallelstore + 'static,
@@ -80,6 +105,11 @@ impl Parallelstore {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/parametermanager/v1/Cargo.toml
+++ b/src/generated/cloud/parametermanager/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/parametermanager/v1/src/builder.rs
+++ b/src/generated/cloud/parametermanager/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod parameter_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ParameterManager][super::super::client::ParameterManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_parametermanager_v1::*;
+    /// # use builder::parameter_manager::ClientBuilder;
+    /// # use client::ParameterManager;
+    /// let builder : ClientBuilder = ParameterManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://parametermanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ParameterManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ParameterManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ParameterManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/parametermanager/v1/src/client.rs
+++ b/src/generated/cloud/parametermanager/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Parameter Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_parametermanager_v1::client::ParameterManager;
+/// let client = ParameterManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `ParameterManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ParameterManager` use the `with_*` methods in the type returned
+/// by [builder()][ParameterManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://parametermanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::parameter_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::parameter_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct ParameterManager {
 }
 
 impl ParameterManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ParameterManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// let client = ParameterManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::parameter_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::parameter_manager::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ParameterManager + 'static,
@@ -64,6 +91,11 @@ impl ParameterManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/policysimulator/v1/Cargo.toml
+++ b/src/generated/cloud/policysimulator/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/policysimulator/v1/src/builder.rs
+++ b/src/generated/cloud/policysimulator/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod simulator {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Simulator][super::super::client::Simulator].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_policysimulator_v1::*;
+    /// # use builder::simulator::ClientBuilder;
+    /// # use client::Simulator;
+    /// let builder : ClientBuilder = Simulator::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://policysimulator.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Simulator;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Simulator;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Simulator] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/policysimulator/v1/src/client.rs
+++ b/src/generated/cloud/policysimulator/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Policy Simulator API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_policysimulator_v1::client::Simulator;
+/// let client = Simulator::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Policy Simulator API service.
@@ -40,8 +49,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Simulator` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Simulator` use the `with_*` methods in the type returned
+/// by [builder()][Simulator::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://policysimulator.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::simulator::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::simulator::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -55,21 +79,22 @@ pub struct Simulator {
 }
 
 impl Simulator {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Simulator].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_policysimulator_v1::client::Simulator;
+    /// let client = Simulator::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::simulator::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::simulator::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Simulator + 'static,
@@ -77,6 +102,11 @@ impl Simulator {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
@@ -42,3 +42,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/builder.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/builder.rs
@@ -18,6 +18,34 @@ pub mod policy_troubleshooter {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [PolicyTroubleshooter][super::super::client::PolicyTroubleshooter].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_policytroubleshooter_iam_v3::*;
+    /// # use builder::policy_troubleshooter::ClientBuilder;
+    /// # use client::PolicyTroubleshooter;
+    /// let builder : ClientBuilder = PolicyTroubleshooter::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://policytroubleshooter.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PolicyTroubleshooter;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PolicyTroubleshooter;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::PolicyTroubleshooter] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/client.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Policy Troubleshooter API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_policytroubleshooter_iam_v3::client::PolicyTroubleshooter;
+/// let client = PolicyTroubleshooter::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// IAM Policy Troubleshooter service.
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `PolicyTroubleshooter` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PolicyTroubleshooter` use the `with_*` methods in the type returned
+/// by [builder()][PolicyTroubleshooter::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://policytroubleshooter.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::policy_troubleshooter::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::policy_troubleshooter::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,24 @@ pub struct PolicyTroubleshooter {
 }
 
 impl PolicyTroubleshooter {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PolicyTroubleshooter].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_policytroubleshooter_iam_v3::client::PolicyTroubleshooter;
+    /// let client = PolicyTroubleshooter::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::policy_troubleshooter::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::policy_troubleshooter::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PolicyTroubleshooter + 'static,
@@ -66,6 +93,11 @@ impl PolicyTroubleshooter {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
@@ -41,3 +41,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/policytroubleshooter/v1/src/builder.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod iam_checker {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [IamChecker][super::super::client::IamChecker].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_policytroubleshooter_v1::*;
+    /// # use builder::iam_checker::ClientBuilder;
+    /// # use client::IamChecker;
+    /// let builder : ClientBuilder = IamChecker::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://policytroubleshooter.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::IamChecker;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = IamChecker;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::IamChecker] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/policytroubleshooter/v1/src/client.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Policy Troubleshooter API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_policytroubleshooter_v1::client::IamChecker;
+/// let client = IamChecker::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// IAM Policy Troubleshooter service.
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `IamChecker` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `IamChecker` use the `with_*` methods in the type returned
+/// by [builder()][IamChecker::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://policytroubleshooter.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::iam_checker::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::iam_checker::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,22 @@ pub struct IamChecker {
 }
 
 impl IamChecker {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [IamChecker].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_policytroubleshooter_v1::client::IamChecker;
+    /// let client = IamChecker::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::iam_checker::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::iam_checker::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::IamChecker + 'static,
@@ -66,6 +91,11 @@ impl IamChecker {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/builder.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod privileged_access_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [PrivilegedAccessManager][super::super::client::PrivilegedAccessManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_privilegedaccessmanager_v1::*;
+    /// # use builder::privileged_access_manager::ClientBuilder;
+    /// # use client::PrivilegedAccessManager;
+    /// let builder : ClientBuilder = PrivilegedAccessManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://privilegedaccessmanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PrivilegedAccessManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PrivilegedAccessManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::PrivilegedAccessManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Privileged Access Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+/// let client = PrivilegedAccessManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// This API allows customers to manage temporary, request based privileged
@@ -46,8 +55,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `PrivilegedAccessManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PrivilegedAccessManager` use the `with_*` methods in the type returned
+/// by [builder()][PrivilegedAccessManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://privilegedaccessmanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::privileged_access_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::privileged_access_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -61,21 +85,24 @@ pub struct PrivilegedAccessManager {
 }
 
 impl PrivilegedAccessManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PrivilegedAccessManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// let client = PrivilegedAccessManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::privileged_access_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::privileged_access_manager::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PrivilegedAccessManager + 'static,
@@ -83,6 +110,11 @@ impl PrivilegedAccessManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/builder.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod rapid_migration_assessment {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [RapidMigrationAssessment][super::super::client::RapidMigrationAssessment].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_rapidmigrationassessment_v1::*;
+    /// # use builder::rapid_migration_assessment::ClientBuilder;
+    /// # use client::RapidMigrationAssessment;
+    /// let builder : ClientBuilder = RapidMigrationAssessment::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://rapidmigrationassessment.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RapidMigrationAssessment;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RapidMigrationAssessment;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::RapidMigrationAssessment] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/client.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Rapid Migration Assessment API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+/// let client = RapidMigrationAssessment::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources.
 ///
 /// # Configuration
 ///
-/// `RapidMigrationAssessment` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RapidMigrationAssessment` use the `with_*` methods in the type returned
+/// by [builder()][RapidMigrationAssessment::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://rapidmigrationassessment.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::rapid_migration_assessment::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::rapid_migration_assessment::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct RapidMigrationAssessment {
 }
 
 impl RapidMigrationAssessment {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RapidMigrationAssessment].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+    /// let client = RapidMigrationAssessment::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::rapid_migration_assessment::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::rapid_migration_assessment::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RapidMigrationAssessment + 'static,
@@ -64,6 +91,11 @@ impl RapidMigrationAssessment {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
+++ b/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod recaptcha_enterprise_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [RecaptchaEnterpriseService][super::super::client::RecaptchaEnterpriseService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_recaptchaenterprise_v1::*;
+    /// # use builder::recaptcha_enterprise_service::ClientBuilder;
+    /// # use client::RecaptchaEnterpriseService;
+    /// let builder : ClientBuilder = RecaptchaEnterpriseService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://recaptchaenterprise.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RecaptchaEnterpriseService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RecaptchaEnterpriseService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::RecaptchaEnterpriseService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/recaptchaenterprise/v1/src/client.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the reCAPTCHA Enterprise API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+/// let client = RecaptchaEnterpriseService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service to determine the likelihood an event is legitimate.
 ///
 /// # Configuration
 ///
-/// `RecaptchaEnterpriseService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RecaptchaEnterpriseService` use the `with_*` methods in the type returned
+/// by [builder()][RecaptchaEnterpriseService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://recaptchaenterprise.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::recaptcha_enterprise_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::recaptcha_enterprise_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct RecaptchaEnterpriseService {
 }
 
 impl RecaptchaEnterpriseService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RecaptchaEnterpriseService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// let client = RecaptchaEnterpriseService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::recaptcha_enterprise_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::recaptcha_enterprise_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RecaptchaEnterpriseService + 'static,
@@ -64,6 +91,11 @@ impl RecaptchaEnterpriseService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/recommender/logging/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/logging/v1/Cargo.toml
@@ -32,3 +32,6 @@ recommender = { version = "0.2", path = "../../../../../../src/generated/cloud/r
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/recommender/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/recommender/v1/src/builder.rs
+++ b/src/generated/cloud/recommender/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod recommender {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Recommender][super::super::client::Recommender].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_recommender_v1::*;
+    /// # use builder::recommender::ClientBuilder;
+    /// # use client::Recommender;
+    /// let builder : ClientBuilder = Recommender::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://recommender.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Recommender;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Recommender;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Recommender] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/recommender/v1/src/client.rs
+++ b/src/generated/cloud/recommender/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Recommender API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_recommender_v1::client::Recommender;
+/// let client = Recommender::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Provides insights and recommendations for cloud customers for various
@@ -30,8 +39,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Recommender` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Recommender` use the `with_*` methods in the type returned
+/// by [builder()][Recommender::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://recommender.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::recommender::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::recommender::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -45,21 +69,22 @@ pub struct Recommender {
 }
 
 impl Recommender {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Recommender].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// let client = Recommender::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::recommender::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::recommender::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Recommender + 'static,
@@ -67,6 +92,11 @@ impl Recommender {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/redis/cluster/v1/Cargo.toml
+++ b/src/generated/cloud/redis/cluster/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/redis/cluster/v1/src/builder.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_redis_cluster {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudRedisCluster][super::super::client::CloudRedisCluster].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_redis_cluster_v1::*;
+    /// # use builder::cloud_redis_cluster::ClientBuilder;
+    /// # use client::CloudRedisCluster;
+    /// let builder : ClientBuilder = CloudRedisCluster::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://redis.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudRedisCluster;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudRedisCluster;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudRedisCluster] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/redis/cluster/v1/src/client.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Google Cloud Memorystore for Redis API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+/// let client = CloudRedisCluster::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Configures and manages Cloud Memorystore for Redis clusters
@@ -43,8 +52,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudRedisCluster` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudRedisCluster` use the `with_*` methods in the type returned
+/// by [builder()][CloudRedisCluster::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://redis.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_redis_cluster::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_redis_cluster::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -58,21 +82,24 @@ pub struct CloudRedisCluster {
 }
 
 impl CloudRedisCluster {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudRedisCluster].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// let client = CloudRedisCluster::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_redis_cluster::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::cloud_redis_cluster::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudRedisCluster + 'static,
@@ -80,6 +107,11 @@ impl CloudRedisCluster {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/redis/v1/Cargo.toml
+++ b/src/generated/cloud/redis/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/redis/v1/src/builder.rs
+++ b/src/generated/cloud/redis/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_redis {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudRedis][super::super::client::CloudRedis].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_redis_v1::*;
+    /// # use builder::cloud_redis::ClientBuilder;
+    /// # use client::CloudRedis;
+    /// let builder : ClientBuilder = CloudRedis::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://redis.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudRedis;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudRedis;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudRedis] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/redis/v1/src/client.rs
+++ b/src/generated/cloud/redis/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Google Cloud Memorystore for Redis API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_redis_v1::client::CloudRedis;
+/// let client = CloudRedis::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Configures and manages Cloud Memorystore for Redis instances
@@ -43,8 +52,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudRedis` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudRedis` use the `with_*` methods in the type returned
+/// by [builder()][CloudRedis::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://redis.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_redis::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_redis::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -58,21 +82,22 @@ pub struct CloudRedis {
 }
 
 impl CloudRedis {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudRedis].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_redis_v1::client::CloudRedis;
+    /// let client = CloudRedis::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_redis::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cloud_redis::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudRedis + 'static,
@@ -80,6 +105,11 @@ impl CloudRedis {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/resourcemanager/v3/Cargo.toml
+++ b/src/generated/cloud/resourcemanager/v3/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/resourcemanager/v3/src/builder.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builder.rs
@@ -18,6 +18,34 @@ pub mod folders {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Folders][super::super::client::Folders].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::*;
+    /// # use builder::folders::ClientBuilder;
+    /// # use client::Folders;
+    /// let builder : ClientBuilder = Folders::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudresourcemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Folders;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Folders;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Folders] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -862,6 +890,34 @@ pub mod organizations {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Organizations][super::super::client::Organizations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::*;
+    /// # use builder::organizations::ClientBuilder;
+    /// # use client::Organizations;
+    /// let builder : ClientBuilder = Organizations::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudresourcemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Organizations;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Organizations;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Organizations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1213,6 +1269,34 @@ pub mod organizations {
 pub mod projects {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Projects][super::super::client::Projects].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::*;
+    /// # use builder::projects::ClientBuilder;
+    /// # use client::Projects;
+    /// let builder : ClientBuilder = Projects::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudresourcemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Projects;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Projects;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Projects] request builders.
     #[derive(Clone, Debug)]
@@ -2060,6 +2144,34 @@ pub mod tag_bindings {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TagBindings][super::super::client::TagBindings].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::*;
+    /// # use builder::tag_bindings::ClientBuilder;
+    /// # use client::TagBindings;
+    /// let builder : ClientBuilder = TagBindings::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudresourcemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TagBindings;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TagBindings;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TagBindings] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2447,6 +2559,34 @@ pub mod tag_holds {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TagHolds][super::super::client::TagHolds].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::*;
+    /// # use builder::tag_holds::ClientBuilder;
+    /// # use client::TagHolds;
+    /// let builder : ClientBuilder = TagHolds::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudresourcemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TagHolds;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TagHolds;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TagHolds] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2770,6 +2910,34 @@ pub mod tag_holds {
 pub mod tag_keys {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [TagKeys][super::super::client::TagKeys].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::*;
+    /// # use builder::tag_keys::ClientBuilder;
+    /// # use client::TagKeys;
+    /// let builder : ClientBuilder = TagKeys::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudresourcemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TagKeys;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TagKeys;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::TagKeys] request builders.
     #[derive(Clone, Debug)]
@@ -3443,6 +3611,34 @@ pub mod tag_keys {
 pub mod tag_values {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [TagValues][super::super::client::TagValues].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::*;
+    /// # use builder::tag_values::ClientBuilder;
+    /// # use client::TagValues;
+    /// let builder : ClientBuilder = TagValues::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudresourcemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TagValues;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TagValues;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::TagValues] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/resourcemanager/v3/src/client.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Resource Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_resourcemanager_v3::client::Folders;
+/// let client = Folders::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages Cloud Platform folder resources.
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Folders` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Folders` use the `with_*` methods in the type returned
+/// by [builder()][Folders::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudresourcemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::folders::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::folders::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,22 @@ pub struct Folders {
 }
 
 impl Folders {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Folders].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::client::Folders;
+    /// let client = Folders::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::folders::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::folders::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Folders + 'static,
@@ -66,6 +91,11 @@ impl Folders {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -349,14 +379,38 @@ impl Folders {
 
 /// Implements a client for the Cloud Resource Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_resourcemanager_v3::client::Organizations;
+/// let client = Organizations::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Allows users to manage their organization resources.
 ///
 /// # Configuration
 ///
-/// `Organizations` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Organizations` use the `with_*` methods in the type returned
+/// by [builder()][Organizations::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudresourcemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::organizations::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::organizations::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -370,21 +424,22 @@ pub struct Organizations {
 }
 
 impl Organizations {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Organizations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::client::Organizations;
+    /// let client = Organizations::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::organizations::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::organizations::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Organizations + 'static,
@@ -392,6 +447,11 @@ impl Organizations {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -491,14 +551,38 @@ impl Organizations {
 
 /// Implements a client for the Cloud Resource Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_resourcemanager_v3::client::Projects;
+/// let client = Projects::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages Google Cloud Projects.
 ///
 /// # Configuration
 ///
-/// `Projects` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Projects` use the `with_*` methods in the type returned
+/// by [builder()][Projects::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudresourcemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::projects::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::projects::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -512,21 +596,22 @@ pub struct Projects {
 }
 
 impl Projects {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Projects].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::client::Projects;
+    /// let client = Projects::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::projects::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::projects::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Projects + 'static,
@@ -534,6 +619,11 @@ impl Projects {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -834,6 +924,15 @@ impl Projects {
 
 /// Implements a client for the Cloud Resource Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_resourcemanager_v3::client::TagBindings;
+/// let client = TagBindings::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Allow users to create and manage TagBindings between TagValues and
@@ -841,8 +940,23 @@ impl Projects {
 ///
 /// # Configuration
 ///
-/// `TagBindings` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TagBindings` use the `with_*` methods in the type returned
+/// by [builder()][TagBindings::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudresourcemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::tag_bindings::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::tag_bindings::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -856,21 +970,22 @@ pub struct TagBindings {
 }
 
 impl TagBindings {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TagBindings].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::client::TagBindings;
+    /// let client = TagBindings::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::tag_bindings::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::tag_bindings::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TagBindings + 'static,
@@ -878,6 +993,11 @@ impl TagBindings {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -965,6 +1085,15 @@ impl TagBindings {
 
 /// Implements a client for the Cloud Resource Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_resourcemanager_v3::client::TagHolds;
+/// let client = TagHolds::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Allow users to create and manage TagHolds for TagValues. TagHolds represent
@@ -975,8 +1104,23 @@ impl TagBindings {
 ///
 /// # Configuration
 ///
-/// `TagHolds` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TagHolds` use the `with_*` methods in the type returned
+/// by [builder()][TagHolds::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudresourcemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::tag_holds::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::tag_holds::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -990,21 +1134,22 @@ pub struct TagHolds {
 }
 
 impl TagHolds {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TagHolds].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::client::TagHolds;
+    /// let client = TagHolds::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::tag_holds::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::tag_holds::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TagHolds + 'static,
@@ -1012,6 +1157,11 @@ impl TagHolds {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1095,14 +1245,38 @@ impl TagHolds {
 
 /// Implements a client for the Cloud Resource Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_resourcemanager_v3::client::TagKeys;
+/// let client = TagKeys::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Allow users to create and manage tag keys.
 ///
 /// # Configuration
 ///
-/// `TagKeys` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TagKeys` use the `with_*` methods in the type returned
+/// by [builder()][TagKeys::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudresourcemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::tag_keys::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::tag_keys::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1116,21 +1290,22 @@ pub struct TagKeys {
 }
 
 impl TagKeys {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TagKeys].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::client::TagKeys;
+    /// let client = TagKeys::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::tag_keys::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::tag_keys::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TagKeys + 'static,
@@ -1138,6 +1313,11 @@ impl TagKeys {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1292,14 +1472,38 @@ impl TagKeys {
 
 /// Implements a client for the Cloud Resource Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_resourcemanager_v3::client::TagValues;
+/// let client = TagValues::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Allow users to create and manage tag values.
 ///
 /// # Configuration
 ///
-/// `TagValues` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TagValues` use the `with_*` methods in the type returned
+/// by [builder()][TagValues::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudresourcemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::tag_values::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::tag_values::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1313,21 +1517,22 @@ pub struct TagValues {
 }
 
 impl TagValues {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TagValues].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_resourcemanager_v3::client::TagValues;
+    /// let client = TagValues::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::tag_values::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::tag_values::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TagValues + 'static,
@@ -1335,6 +1540,11 @@ impl TagValues {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/retail/v2/Cargo.toml
+++ b/src/generated/cloud/retail/v2/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/retail/v2/src/builder.rs
+++ b/src/generated/cloud/retail/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod analytics_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AnalyticsService][super::super::client::AnalyticsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::analytics_service::ClientBuilder;
+    /// # use client::AnalyticsService;
+    /// let builder : ClientBuilder = AnalyticsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AnalyticsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AnalyticsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AnalyticsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -267,6 +295,34 @@ pub mod analytics_service {
 pub mod catalog_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [CatalogService][super::super::client::CatalogService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::catalog_service::ClientBuilder;
+    /// # use client::CatalogService;
+    /// let builder : ClientBuilder = CatalogService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CatalogService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CatalogService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::CatalogService] request builders.
     #[derive(Clone, Debug)]
@@ -1030,6 +1086,34 @@ pub mod completion_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CompletionService][super::super::client::CompletionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::completion_service::ClientBuilder;
+    /// # use client::CompletionService;
+    /// let builder : ClientBuilder = CompletionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CompletionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CompletionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CompletionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -1376,6 +1460,34 @@ pub mod completion_service {
 pub mod control_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ControlService][super::super::client::ControlService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::control_service::ClientBuilder;
+    /// # use client::ControlService;
+    /// let builder : ClientBuilder = ControlService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ControlService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ControlService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ControlService] request builders.
     #[derive(Clone, Debug)]
@@ -1795,6 +1907,34 @@ pub mod control_service {
 pub mod generative_question_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [GenerativeQuestionService][super::super::client::GenerativeQuestionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::generative_question_service::ClientBuilder;
+    /// # use client::GenerativeQuestionService;
+    /// let builder : ClientBuilder = GenerativeQuestionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::GenerativeQuestionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = GenerativeQuestionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::GenerativeQuestionService] request builders.
     #[derive(Clone, Debug)]
@@ -2238,6 +2378,34 @@ pub mod generative_question_service {
 pub mod model_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ModelService][super::super::client::ModelService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::model_service::ClientBuilder;
+    /// # use client::ModelService;
+    /// let builder : ClientBuilder = ModelService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ModelService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ModelService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ModelService] request builders.
     #[derive(Clone, Debug)]
@@ -2854,6 +3022,34 @@ pub mod prediction_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [PredictionService][super::super::client::PredictionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::prediction_service::ClientBuilder;
+    /// # use client::PredictionService;
+    /// let builder : ClientBuilder = PredictionService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PredictionService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PredictionService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::PredictionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -3097,6 +3293,34 @@ pub mod prediction_service {
 pub mod product_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ProductService][super::super::client::ProductService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::product_service::ClientBuilder;
+    /// # use client::ProductService;
+    /// let builder : ClientBuilder = ProductService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ProductService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ProductService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ProductService] request builders.
     #[derive(Clone, Debug)]
@@ -4329,6 +4553,34 @@ pub mod search_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SearchService][super::super::client::SearchService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::search_service::ClientBuilder;
+    /// # use client::SearchService;
+    /// let builder : ClientBuilder = SearchService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SearchService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SearchService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SearchService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -4730,6 +4982,34 @@ pub mod search_service {
 pub mod serving_config_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ServingConfigService][super::super::client::ServingConfigService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::serving_config_service::ClientBuilder;
+    /// # use client::ServingConfigService;
+    /// let builder : ClientBuilder = ServingConfigService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ServingConfigService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ServingConfigService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ServingConfigService] request builders.
     #[derive(Clone, Debug)]
@@ -5274,6 +5554,34 @@ pub mod serving_config_service {
 pub mod user_event_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [UserEventService][super::super::client::UserEventService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::*;
+    /// # use builder::user_event_service::ClientBuilder;
+    /// # use client::UserEventService;
+    /// let builder : ClientBuilder = UserEventService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://retail.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::UserEventService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = UserEventService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::UserEventService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/retail/v2/src/client.rs
+++ b/src/generated/cloud/retail/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::AnalyticsService;
+/// let client = AnalyticsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing & accessing retail search business metric.
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AnalyticsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AnalyticsService` use the `with_*` methods in the type returned
+/// by [builder()][AnalyticsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::analytics_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::analytics_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,24 @@ pub struct AnalyticsService {
 }
 
 impl AnalyticsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AnalyticsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::AnalyticsService;
+    /// let client = AnalyticsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::analytics_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::analytics_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AnalyticsService + 'static,
@@ -65,6 +92,11 @@ impl AnalyticsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -137,14 +169,38 @@ impl AnalyticsService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::CatalogService;
+/// let client = CatalogService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing catalog configuration.
 ///
 /// # Configuration
 ///
-/// `CatalogService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CatalogService` use the `with_*` methods in the type returned
+/// by [builder()][CatalogService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::catalog_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::catalog_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -158,21 +214,22 @@ pub struct CatalogService {
 }
 
 impl CatalogService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CatalogService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// let client = CatalogService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::catalog_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::catalog_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CatalogService + 'static,
@@ -180,6 +237,11 @@ impl CatalogService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -416,6 +478,15 @@ impl CatalogService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::CompletionService;
+/// let client = CompletionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Autocomplete service for retail.
@@ -425,8 +496,23 @@ impl CatalogService {
 ///
 /// # Configuration
 ///
-/// `CompletionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CompletionService` use the `with_*` methods in the type returned
+/// by [builder()][CompletionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::completion_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::completion_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -440,21 +526,24 @@ pub struct CompletionService {
 }
 
 impl CompletionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CompletionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::CompletionService;
+    /// let client = CompletionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::completion_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::completion_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CompletionService + 'static,
@@ -462,6 +551,11 @@ impl CompletionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -551,14 +645,38 @@ impl CompletionService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::ControlService;
+/// let client = ControlService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for modifying Control.
 ///
 /// # Configuration
 ///
-/// `ControlService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ControlService` use the `with_*` methods in the type returned
+/// by [builder()][ControlService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::control_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::control_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -572,21 +690,22 @@ pub struct ControlService {
 }
 
 impl ControlService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ControlService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::ControlService;
+    /// let client = ControlService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::control_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::control_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ControlService + 'static,
@@ -594,6 +713,11 @@ impl ControlService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -707,14 +831,38 @@ impl ControlService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::GenerativeQuestionService;
+/// let client = GenerativeQuestionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing LLM generated questions in search serving.
 ///
 /// # Configuration
 ///
-/// `GenerativeQuestionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `GenerativeQuestionService` use the `with_*` methods in the type returned
+/// by [builder()][GenerativeQuestionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::generative_question_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::generative_question_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -728,21 +876,24 @@ pub struct GenerativeQuestionService {
 }
 
 impl GenerativeQuestionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [GenerativeQuestionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::GenerativeQuestionService;
+    /// let client = GenerativeQuestionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::generative_question_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::generative_question_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::GenerativeQuestionService + 'static,
@@ -750,6 +901,11 @@ impl GenerativeQuestionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -857,6 +1013,15 @@ impl GenerativeQuestionService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::ModelService;
+/// let client = ModelService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for performing CRUD operations on models.
@@ -874,8 +1039,23 @@ impl GenerativeQuestionService {
 ///
 /// # Configuration
 ///
-/// `ModelService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ModelService` use the `with_*` methods in the type returned
+/// by [builder()][ModelService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::model_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::model_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -889,21 +1069,22 @@ pub struct ModelService {
 }
 
 impl ModelService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ModelService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::ModelService;
+    /// let client = ModelService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::model_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::model_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ModelService + 'static,
@@ -911,6 +1092,11 @@ impl ModelService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1047,14 +1233,38 @@ impl ModelService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::PredictionService;
+/// let client = PredictionService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for making recommendation prediction.
 ///
 /// # Configuration
 ///
-/// `PredictionService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PredictionService` use the `with_*` methods in the type returned
+/// by [builder()][PredictionService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::prediction_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::prediction_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1068,21 +1278,24 @@ pub struct PredictionService {
 }
 
 impl PredictionService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PredictionService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::PredictionService;
+    /// let client = PredictionService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::prediction_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::prediction_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PredictionService + 'static,
@@ -1090,6 +1303,11 @@ impl PredictionService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1149,6 +1367,15 @@ impl PredictionService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::ProductService;
+/// let client = ProductService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for ingesting [Product][google.cloud.retail.v2.Product] information
@@ -1158,8 +1385,23 @@ impl PredictionService {
 ///
 /// # Configuration
 ///
-/// `ProductService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ProductService` use the `with_*` methods in the type returned
+/// by [builder()][ProductService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::product_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::product_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1173,21 +1415,22 @@ pub struct ProductService {
 }
 
 impl ProductService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ProductService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::ProductService;
+    /// let client = ProductService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::product_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::product_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ProductService + 'static,
@@ -1195,6 +1438,11 @@ impl ProductService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1665,6 +1913,15 @@ impl ProductService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::SearchService;
+/// let client = SearchService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for search.
@@ -1674,8 +1931,23 @@ impl ProductService {
 ///
 /// # Configuration
 ///
-/// `SearchService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SearchService` use the `with_*` methods in the type returned
+/// by [builder()][SearchService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::search_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::search_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1689,21 +1961,22 @@ pub struct SearchService {
 }
 
 impl SearchService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SearchService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::SearchService;
+    /// let client = SearchService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::search_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::search_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SearchService + 'static,
@@ -1711,6 +1984,11 @@ impl SearchService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1772,14 +2050,38 @@ impl SearchService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::ServingConfigService;
+/// let client = ServingConfigService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for modifying ServingConfig.
 ///
 /// # Configuration
 ///
-/// `ServingConfigService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ServingConfigService` use the `with_*` methods in the type returned
+/// by [builder()][ServingConfigService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::serving_config_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::serving_config_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1793,21 +2095,24 @@ pub struct ServingConfigService {
 }
 
 impl ServingConfigService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ServingConfigService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::ServingConfigService;
+    /// let client = ServingConfigService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::serving_config_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::serving_config_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ServingConfigService + 'static,
@@ -1815,6 +2120,11 @@ impl ServingConfigService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1948,14 +2258,38 @@ impl ServingConfigService {
 
 /// Implements a client for the Vertex AI Search for Retail API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_retail_v2::client::UserEventService;
+/// let client = UserEventService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for ingesting end user actions on the customer website.
 ///
 /// # Configuration
 ///
-/// `UserEventService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `UserEventService` use the `with_*` methods in the type returned
+/// by [builder()][UserEventService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://retail.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::user_event_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::user_event_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1969,21 +2303,24 @@ pub struct UserEventService {
 }
 
 impl UserEventService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [UserEventService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_retail_v2::client::UserEventService;
+    /// let client = UserEventService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::user_event_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::user_event_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::UserEventService + 'static,
@@ -1991,6 +2328,11 @@ impl UserEventService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/run/v2/src/builder.rs
+++ b/src/generated/cloud/run/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod builds {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Builds][super::super::client::Builds].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::*;
+    /// # use builder::builds::ClientBuilder;
+    /// # use client::Builds;
+    /// let builder : ClientBuilder = Builds::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://run.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Builds;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Builds;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Builds] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -351,6 +379,34 @@ pub mod builds {
 pub mod executions {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Executions][super::super::client::Executions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::*;
+    /// # use builder::executions::ClientBuilder;
+    /// # use client::Executions;
+    /// let builder : ClientBuilder = Executions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://run.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Executions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Executions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Executions] request builders.
     #[derive(Clone, Debug)]
@@ -891,6 +947,34 @@ pub mod executions {
 pub mod jobs {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Jobs][super::super::client::Jobs].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::*;
+    /// # use builder::jobs::ClientBuilder;
+    /// # use client::Jobs;
+    /// let builder : ClientBuilder = Jobs::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://run.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Jobs;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Jobs;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Jobs] request builders.
     #[derive(Clone, Debug)]
@@ -1789,6 +1873,34 @@ pub mod revisions {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Revisions][super::super::client::Revisions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::*;
+    /// # use builder::revisions::ClientBuilder;
+    /// # use client::Revisions;
+    /// let builder : ClientBuilder = Revisions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://run.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Revisions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Revisions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Revisions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2239,6 +2351,34 @@ pub mod revisions {
 pub mod services {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Services][super::super::client::Services].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::*;
+    /// # use builder::services::ClientBuilder;
+    /// # use client::Services;
+    /// let builder : ClientBuilder = Services::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://run.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Services;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Services;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Services] request builders.
     #[derive(Clone, Debug)]
@@ -3056,6 +3196,34 @@ pub mod services {
 pub mod tasks {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [Tasks][super::super::client::Tasks].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::*;
+    /// # use builder::tasks::ClientBuilder;
+    /// # use client::Tasks;
+    /// let builder : ClientBuilder = Tasks::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://run.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Tasks;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Tasks;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::Tasks] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/run/v2/src/client.rs
+++ b/src/generated/cloud/run/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Run Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_run_v2::client::Builds;
+/// let client = Builds::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Run Build Control Plane API
 ///
 /// # Configuration
 ///
-/// `Builds` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Builds` use the `with_*` methods in the type returned
+/// by [builder()][Builds::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://run.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::builds::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::builds::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Builds {
 }
 
 impl Builds {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Builds].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::client::Builds;
+    /// let client = Builds::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::builds::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::builds::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Builds + 'static,
@@ -64,6 +89,11 @@ impl Builds {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -138,14 +168,38 @@ impl Builds {
 
 /// Implements a client for the Cloud Run Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_run_v2::client::Executions;
+/// let client = Executions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Run Execution Control Plane API.
 ///
 /// # Configuration
 ///
-/// `Executions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Executions` use the `with_*` methods in the type returned
+/// by [builder()][Executions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://run.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::executions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::executions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -159,21 +213,22 @@ pub struct Executions {
 }
 
 impl Executions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Executions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::client::Executions;
+    /// let client = Executions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::executions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::executions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Executions + 'static,
@@ -181,6 +236,11 @@ impl Executions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -303,14 +363,38 @@ impl Executions {
 
 /// Implements a client for the Cloud Run Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_run_v2::client::Jobs;
+/// let client = Jobs::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Run Job Control Plane API.
 ///
 /// # Configuration
 ///
-/// `Jobs` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Jobs` use the `with_*` methods in the type returned
+/// by [builder()][Jobs::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://run.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::jobs::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::jobs::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -324,21 +408,22 @@ pub struct Jobs {
 }
 
 impl Jobs {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Jobs].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::client::Jobs;
+    /// let client = Jobs::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::jobs::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::jobs::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Jobs + 'static,
@@ -346,6 +431,11 @@ impl Jobs {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -520,14 +610,38 @@ impl Jobs {
 
 /// Implements a client for the Cloud Run Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_run_v2::client::Revisions;
+/// let client = Revisions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Run Revision Control Plane API.
 ///
 /// # Configuration
 ///
-/// `Revisions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Revisions` use the `with_*` methods in the type returned
+/// by [builder()][Revisions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://run.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::revisions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::revisions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -541,21 +655,22 @@ pub struct Revisions {
 }
 
 impl Revisions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Revisions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::client::Revisions;
+    /// let client = Revisions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::revisions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::revisions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Revisions + 'static,
@@ -563,6 +678,11 @@ impl Revisions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -666,14 +786,38 @@ impl Revisions {
 
 /// Implements a client for the Cloud Run Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_run_v2::client::Services;
+/// let client = Services::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Run Service Control Plane API
 ///
 /// # Configuration
 ///
-/// `Services` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Services` use the `with_*` methods in the type returned
+/// by [builder()][Services::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://run.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::services::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::services::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -687,21 +831,22 @@ pub struct Services {
 }
 
 impl Services {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Services].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::client::Services;
+    /// let client = Services::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::services::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::services::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Services + 'static,
@@ -709,6 +854,11 @@ impl Services {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -880,14 +1030,38 @@ impl Services {
 
 /// Implements a client for the Cloud Run Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_run_v2::client::Tasks;
+/// let client = Tasks::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Run Task Control Plane API.
 ///
 /// # Configuration
 ///
-/// `Tasks` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Tasks` use the `with_*` methods in the type returned
+/// by [builder()][Tasks::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://run.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::tasks::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::tasks::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -901,21 +1075,22 @@ pub struct Tasks {
 }
 
 impl Tasks {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Tasks].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_run_v2::client::Tasks;
+    /// let client = Tasks::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::tasks::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::tasks::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Tasks + 'static,
@@ -923,6 +1098,11 @@ impl Tasks {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/scheduler/v1/Cargo.toml
+++ b/src/generated/cloud/scheduler/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/scheduler/v1/src/builder.rs
+++ b/src/generated/cloud/scheduler/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_scheduler {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudScheduler][super::super::client::CloudScheduler].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_scheduler_v1::*;
+    /// # use builder::cloud_scheduler::ClientBuilder;
+    /// # use client::CloudScheduler;
+    /// let builder : ClientBuilder = CloudScheduler::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudscheduler.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudScheduler;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudScheduler;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudScheduler] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/scheduler/v1/src/client.rs
+++ b/src/generated/cloud/scheduler/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Scheduler API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_scheduler_v1::client::CloudScheduler;
+/// let client = CloudScheduler::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Cloud Scheduler API allows external entities to reliably
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudScheduler` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudScheduler` use the `with_*` methods in the type returned
+/// by [builder()][CloudScheduler::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudscheduler.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_scheduler::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_scheduler::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct CloudScheduler {
 }
 
 impl CloudScheduler {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudScheduler].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// let client = CloudScheduler::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_scheduler::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cloud_scheduler::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudScheduler + 'static,
@@ -65,6 +90,11 @@ impl CloudScheduler {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/secretmanager/v1/src/builder.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod secret_manager_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SecretManagerService][super::super::client::SecretManagerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_secretmanager_v1::*;
+    /// # use builder::secret_manager_service::ClientBuilder;
+    /// # use client::SecretManagerService;
+    /// let builder : ClientBuilder = SecretManagerService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://secretmanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SecretManagerService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SecretManagerService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Secret Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+/// let client = SecretManagerService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Secret Manager Service
@@ -36,8 +45,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `SecretManagerService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SecretManagerService` use the `with_*` methods in the type returned
+/// by [builder()][SecretManagerService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://secretmanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::secret_manager_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::secret_manager_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -51,21 +75,24 @@ pub struct SecretManagerService {
 }
 
 impl SecretManagerService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SecretManagerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// let client = SecretManagerService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::secret_manager_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::secret_manager_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SecretManagerService + 'static,
@@ -73,6 +100,11 @@ impl SecretManagerService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/securesourcemanager/v1/Cargo.toml
+++ b/src/generated/cloud/securesourcemanager/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/securesourcemanager/v1/src/builder.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod secure_source_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SecureSourceManager][super::super::client::SecureSourceManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_securesourcemanager_v1::*;
+    /// # use builder::secure_source_manager::ClientBuilder;
+    /// # use client::SecureSourceManager;
+    /// let builder : ClientBuilder = SecureSourceManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://securesourcemanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SecureSourceManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SecureSourceManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SecureSourceManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/securesourcemanager/v1/src/client.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Secure Source Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+/// let client = SecureSourceManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Secure Source Manager API
@@ -46,8 +55,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `SecureSourceManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SecureSourceManager` use the `with_*` methods in the type returned
+/// by [builder()][SecureSourceManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://securesourcemanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::secure_source_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::secure_source_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -61,21 +85,24 @@ pub struct SecureSourceManager {
 }
 
 impl SecureSourceManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SecureSourceManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// let client = SecureSourceManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::secure_source_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::secure_source_manager::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SecureSourceManager + 'static,
@@ -83,6 +110,11 @@ impl SecureSourceManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/security/privateca/v1/Cargo.toml
+++ b/src/generated/cloud/security/privateca/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/security/privateca/v1/src/builder.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod certificate_authority_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CertificateAuthorityService][super::super::client::CertificateAuthorityService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_security_privateca_v1::*;
+    /// # use builder::certificate_authority_service::ClientBuilder;
+    /// # use client::CertificateAuthorityService;
+    /// let builder : ClientBuilder = CertificateAuthorityService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://privateca.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CertificateAuthorityService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CertificateAuthorityService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CertificateAuthorityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/security/privateca/v1/src/client.rs
+++ b/src/generated/cloud/security/privateca/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Certificate Authority API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+/// let client = CertificateAuthorityService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// [Certificate Authority
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CertificateAuthorityService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CertificateAuthorityService` use the `with_*` methods in the type returned
+/// by [builder()][CertificateAuthorityService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://privateca.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::certificate_authority_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::certificate_authority_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,24 @@ pub struct CertificateAuthorityService {
 }
 
 impl CertificateAuthorityService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CertificateAuthorityService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// let client = CertificateAuthorityService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::certificate_authority_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::certificate_authority_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CertificateAuthorityService + 'static,
@@ -68,6 +95,11 @@ impl CertificateAuthorityService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/security/publicca/v1/Cargo.toml
+++ b/src/generated/cloud/security/publicca/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/security/publicca/v1/src/builder.rs
+++ b/src/generated/cloud/security/publicca/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod public_certificate_authority_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [PublicCertificateAuthorityService][super::super::client::PublicCertificateAuthorityService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_security_publicca_v1::*;
+    /// # use builder::public_certificate_authority_service::ClientBuilder;
+    /// # use client::PublicCertificateAuthorityService;
+    /// let builder : ClientBuilder = PublicCertificateAuthorityService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://publicca.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PublicCertificateAuthorityService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PublicCertificateAuthorityService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::PublicCertificateAuthorityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/security/publicca/v1/src/client.rs
+++ b/src/generated/cloud/security/publicca/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Public Certificate Authority API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_security_publicca_v1::client::PublicCertificateAuthorityService;
+/// let client = PublicCertificateAuthorityService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages the resources required for ACME [external account
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `PublicCertificateAuthorityService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PublicCertificateAuthorityService` use the `with_*` methods in the type returned
+/// by [builder()][PublicCertificateAuthorityService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://publicca.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::public_certificate_authority_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::public_certificate_authority_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,24 @@ pub struct PublicCertificateAuthorityService {
 }
 
 impl PublicCertificateAuthorityService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PublicCertificateAuthorityService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_security_publicca_v1::client::PublicCertificateAuthorityService;
+    /// let client = PublicCertificateAuthorityService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::public_certificate_authority_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::public_certificate_authority_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PublicCertificateAuthorityService + 'static,
@@ -66,6 +93,11 @@ impl PublicCertificateAuthorityService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/securitycenter/v2/src/builder.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod security_center {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SecurityCenter][super::super::client::SecurityCenter].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_securitycenter_v2::*;
+    /// # use builder::security_center::ClientBuilder;
+    /// # use client::SecurityCenter;
+    /// let builder : ClientBuilder = SecurityCenter::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://securitycenter.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SecurityCenter;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SecurityCenter;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SecurityCenter] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/securitycenter/v2/src/client.rs
+++ b/src/generated/cloud/securitycenter/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Security Command Center API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+/// let client = SecurityCenter::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// V2 APIs for Security Center service.
 ///
 /// # Configuration
 ///
-/// `SecurityCenter` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SecurityCenter` use the `with_*` methods in the type returned
+/// by [builder()][SecurityCenter::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://securitycenter.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::security_center::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::security_center::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct SecurityCenter {
 }
 
 impl SecurityCenter {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SecurityCenter].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// let client = SecurityCenter::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::security_center::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::security_center::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SecurityCenter + 'static,
@@ -64,6 +89,11 @@ impl SecurityCenter {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/securityposture/v1/Cargo.toml
+++ b/src/generated/cloud/securityposture/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/securityposture/v1/src/builder.rs
+++ b/src/generated/cloud/securityposture/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod security_posture {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SecurityPosture][super::super::client::SecurityPosture].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_securityposture_v1::*;
+    /// # use builder::security_posture::ClientBuilder;
+    /// # use client::SecurityPosture;
+    /// let builder : ClientBuilder = SecurityPosture::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://securityposture.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SecurityPosture;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SecurityPosture;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SecurityPosture] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/securityposture/v1/src/client.rs
+++ b/src/generated/cloud/securityposture/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Security Posture API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_securityposture_v1::client::SecurityPosture;
+/// let client = SecurityPosture::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources.
 ///
 /// # Configuration
 ///
-/// `SecurityPosture` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SecurityPosture` use the `with_*` methods in the type returned
+/// by [builder()][SecurityPosture::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://securityposture.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::security_posture::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::security_posture::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct SecurityPosture {
 }
 
 impl SecurityPosture {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SecurityPosture].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_securityposture_v1::client::SecurityPosture;
+    /// let client = SecurityPosture::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::security_posture::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::security_posture::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SecurityPosture + 'static,
@@ -64,6 +91,11 @@ impl SecurityPosture {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/servicedirectory/v1/Cargo.toml
+++ b/src/generated/cloud/servicedirectory/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/servicedirectory/v1/src/builder.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod lookup_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [LookupService][super::super::client::LookupService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_servicedirectory_v1::*;
+    /// # use builder::lookup_service::ClientBuilder;
+    /// # use client::LookupService;
+    /// let builder : ClientBuilder = LookupService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://servicedirectory.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::LookupService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = LookupService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::LookupService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -217,6 +245,34 @@ pub mod lookup_service {
 pub mod registration_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [RegistrationService][super::super::client::RegistrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_servicedirectory_v1::*;
+    /// # use builder::registration_service::ClientBuilder;
+    /// # use client::RegistrationService;
+    /// let builder : ClientBuilder = RegistrationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://servicedirectory.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RegistrationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RegistrationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::RegistrationService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/servicedirectory/v1/src/client.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Service Directory API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_servicedirectory_v1::client::LookupService;
+/// let client = LookupService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service Directory API for looking up service data at runtime.
 ///
 /// # Configuration
 ///
-/// `LookupService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `LookupService` use the `with_*` methods in the type returned
+/// by [builder()][LookupService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://servicedirectory.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::lookup_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::lookup_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct LookupService {
 }
 
 impl LookupService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [LookupService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_servicedirectory_v1::client::LookupService;
+    /// let client = LookupService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::lookup_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::lookup_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::LookupService + 'static,
@@ -64,6 +89,11 @@ impl LookupService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -121,6 +151,15 @@ impl LookupService {
 
 /// Implements a client for the Service Directory API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+/// let client = RegistrationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service Directory API for registering services. It defines the following
@@ -146,8 +185,23 @@ impl LookupService {
 ///
 /// # Configuration
 ///
-/// `RegistrationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RegistrationService` use the `with_*` methods in the type returned
+/// by [builder()][RegistrationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://servicedirectory.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::registration_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::registration_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -161,21 +215,24 @@ pub struct RegistrationService {
 }
 
 impl RegistrationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RegistrationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// let client = RegistrationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::registration_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::registration_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RegistrationService + 'static,
@@ -183,6 +240,11 @@ impl RegistrationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/servicehealth/v1/Cargo.toml
+++ b/src/generated/cloud/servicehealth/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/servicehealth/v1/src/builder.rs
+++ b/src/generated/cloud/servicehealth/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod service_health {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ServiceHealth][super::super::client::ServiceHealth].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_servicehealth_v1::*;
+    /// # use builder::service_health::ClientBuilder;
+    /// # use client::ServiceHealth;
+    /// let builder : ClientBuilder = ServiceHealth::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://servicehealth.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ServiceHealth;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ServiceHealth;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ServiceHealth] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/servicehealth/v1/src/client.rs
+++ b/src/generated/cloud/servicehealth/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Service Health API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_servicehealth_v1::client::ServiceHealth;
+/// let client = ServiceHealth::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Request service health events relevant to your Google Cloud project.
 ///
 /// # Configuration
 ///
-/// `ServiceHealth` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ServiceHealth` use the `with_*` methods in the type returned
+/// by [builder()][ServiceHealth::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://servicehealth.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::service_health::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::service_health::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct ServiceHealth {
 }
 
 impl ServiceHealth {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ServiceHealth].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_servicehealth_v1::client::ServiceHealth;
+    /// let client = ServiceHealth::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::service_health::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::service_health::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ServiceHealth + 'static,
@@ -64,6 +89,11 @@ impl ServiceHealth {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/shell/v1/Cargo.toml
+++ b/src/generated/cloud/shell/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/shell/v1/src/builder.rs
+++ b/src/generated/cloud/shell/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_shell_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudShellService][super::super::client::CloudShellService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_shell_v1::*;
+    /// # use builder::cloud_shell_service::ClientBuilder;
+    /// # use client::CloudShellService;
+    /// let builder : ClientBuilder = CloudShellService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudshell.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudShellService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudShellService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudShellService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/shell/v1/src/client.rs
+++ b/src/generated/cloud/shell/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Shell API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_shell_v1::client::CloudShellService;
+/// let client = CloudShellService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API for interacting with Google Cloud Shell. Each user of Cloud Shell has at
@@ -33,8 +42,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudShellService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudShellService` use the `with_*` methods in the type returned
+/// by [builder()][CloudShellService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudshell.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_shell_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_shell_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -48,21 +72,24 @@ pub struct CloudShellService {
 }
 
 impl CloudShellService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudShellService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_shell_v1::client::CloudShellService;
+    /// let client = CloudShellService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_shell_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::cloud_shell_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudShellService + 'static,
@@ -70,6 +97,11 @@ impl CloudShellService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/speech/v2/Cargo.toml
+++ b/src/generated/cloud/speech/v2/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/speech/v2/src/builder.rs
+++ b/src/generated/cloud/speech/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod speech {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Speech][super::super::client::Speech].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_speech_v2::*;
+    /// # use builder::speech::ClientBuilder;
+    /// # use client::Speech;
+    /// let builder : ClientBuilder = Speech::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://speech.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Speech;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Speech;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Speech] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/speech/v2/src/client.rs
+++ b/src/generated/cloud/speech/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Speech-to-Text API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_speech_v2::client::Speech;
+/// let client = Speech::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Enables speech transcription and resource management.
 ///
 /// # Configuration
 ///
-/// `Speech` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Speech` use the `with_*` methods in the type returned
+/// by [builder()][Speech::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://speech.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::speech::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::speech::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Speech {
 }
 
 impl Speech {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Speech].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// let client = Speech::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::speech::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::speech::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Speech + 'static,
@@ -64,6 +89,11 @@ impl Speech {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/sql/v1/Cargo.toml
+++ b/src/generated/cloud/sql/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/sql/v1/src/builder.rs
+++ b/src/generated/cloud/sql/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod sql_backup_runs_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SqlBackupRunsService][super::super::client::SqlBackupRunsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_backup_runs_service::ClientBuilder;
+    /// # use client::SqlBackupRunsService;
+    /// let builder : ClientBuilder = SqlBackupRunsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlBackupRunsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlBackupRunsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SqlBackupRunsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -265,6 +293,34 @@ pub mod sql_connect_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SqlConnectService][super::super::client::SqlConnectService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_connect_service::ClientBuilder;
+    /// # use client::SqlConnectService;
+    /// let builder : ClientBuilder = SqlConnectService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlConnectService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlConnectService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SqlConnectService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -415,6 +471,34 @@ pub mod sql_connect_service {
 pub mod sql_databases_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SqlDatabasesService][super::super::client::SqlDatabasesService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_databases_service::ClientBuilder;
+    /// # use client::SqlDatabasesService;
+    /// let builder : ClientBuilder = SqlDatabasesService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlDatabasesService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlDatabasesService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SqlDatabasesService] request builders.
     #[derive(Clone, Debug)]
@@ -771,6 +855,34 @@ pub mod sql_flags_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SqlFlagsService][super::super::client::SqlFlagsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_flags_service::ClientBuilder;
+    /// # use client::SqlFlagsService;
+    /// let builder : ClientBuilder = SqlFlagsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlFlagsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlFlagsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SqlFlagsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -837,6 +949,34 @@ pub mod sql_flags_service {
 pub mod sql_instances_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SqlInstancesService][super::super::client::SqlInstancesService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_instances_service::ClientBuilder;
+    /// # use client::SqlInstancesService;
+    /// let builder : ClientBuilder = SqlInstancesService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlInstancesService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlInstancesService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SqlInstancesService] request builders.
     #[derive(Clone, Debug)]
@@ -2681,6 +2821,34 @@ pub mod sql_operations_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SqlOperationsService][super::super::client::SqlOperationsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_operations_service::ClientBuilder;
+    /// # use client::SqlOperationsService;
+    /// let builder : ClientBuilder = SqlOperationsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlOperationsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlOperationsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SqlOperationsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2861,6 +3029,34 @@ pub mod sql_operations_service {
 pub mod sql_ssl_certs_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SqlSslCertsService][super::super::client::SqlSslCertsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_ssl_certs_service::ClientBuilder;
+    /// # use client::SqlSslCertsService;
+    /// let builder : ClientBuilder = SqlSslCertsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlSslCertsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlSslCertsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SqlSslCertsService] request builders.
     #[derive(Clone, Debug)]
@@ -3097,6 +3293,34 @@ pub mod sql_tiers_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SqlTiersService][super::super::client::SqlTiersService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_tiers_service::ClientBuilder;
+    /// # use client::SqlTiersService;
+    /// let builder : ClientBuilder = SqlTiersService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlTiersService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlTiersService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SqlTiersService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -3163,6 +3387,34 @@ pub mod sql_tiers_service {
 pub mod sql_users_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [SqlUsersService][super::super::client::SqlUsersService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::*;
+    /// # use builder::sql_users_service::ClientBuilder;
+    /// # use client::SqlUsersService;
+    /// let builder : ClientBuilder = SqlUsersService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://sqladmin.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SqlUsersService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SqlUsersService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::SqlUsersService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/sql/v1/src/client.rs
+++ b/src/generated/cloud/sql/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud SQL Admin API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlBackupRunsService;
+/// let client = SqlBackupRunsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for managing database backups.
 ///
 /// # Configuration
 ///
-/// `SqlBackupRunsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlBackupRunsService` use the `with_*` methods in the type returned
+/// by [builder()][SqlBackupRunsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_backup_runs_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_backup_runs_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,24 +66,30 @@ pub struct SqlBackupRunsService {
 }
 
 impl SqlBackupRunsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlBackupRunsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlBackupRunsService;
+    /// let client = SqlBackupRunsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_backup_runs_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_backup_runs_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlBackupRunsService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlBackupRunsService>> {
@@ -130,10 +160,18 @@ impl SqlBackupRunsService {
             .set_project ( project.into() )
             .set_instance ( instance.into() )
     }
-
 }
 
 /// Implements a client for the Cloud SQL Admin API.
+///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlConnectService;
+/// let client = SqlConnectService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
 ///
 /// # Service Description
 ///
@@ -141,8 +179,23 @@ impl SqlBackupRunsService {
 ///
 /// # Configuration
 ///
-/// `SqlConnectService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlConnectService` use the `with_*` methods in the type returned
+/// by [builder()][SqlConnectService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_connect_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_connect_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -156,24 +209,30 @@ pub struct SqlConnectService {
 }
 
 impl SqlConnectService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlConnectService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlConnectService;
+    /// let client = SqlConnectService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_connect_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_connect_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlConnectService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlConnectService>> {
@@ -217,10 +276,18 @@ impl SqlConnectService {
             .set_project ( project.into() )
             .set_instance ( instance.into() )
     }
-
 }
 
 /// Implements a client for the Cloud SQL Admin API.
+///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlDatabasesService;
+/// let client = SqlDatabasesService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
 ///
 /// # Service Description
 ///
@@ -228,8 +295,23 @@ impl SqlConnectService {
 ///
 /// # Configuration
 ///
-/// `SqlDatabasesService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlDatabasesService` use the `with_*` methods in the type returned
+/// by [builder()][SqlDatabasesService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_databases_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_databases_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -243,24 +325,30 @@ pub struct SqlDatabasesService {
 }
 
 impl SqlDatabasesService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlDatabasesService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlDatabasesService;
+    /// let client = SqlDatabasesService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_databases_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_databases_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlDatabasesService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlDatabasesService>> {
@@ -363,10 +451,18 @@ impl SqlDatabasesService {
             .set_instance ( instance.into() )
             .set_database ( database.into() )
     }
-
 }
 
 /// Implements a client for the Cloud SQL Admin API.
+///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlFlagsService;
+/// let client = SqlFlagsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
 ///
 /// # Service Description
 ///
@@ -374,8 +470,23 @@ impl SqlDatabasesService {
 ///
 /// # Configuration
 ///
-/// `SqlFlagsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlFlagsService` use the `with_*` methods in the type returned
+/// by [builder()][SqlFlagsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_flags_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_flags_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -389,24 +500,30 @@ pub struct SqlFlagsService {
 }
 
 impl SqlFlagsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlFlagsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlFlagsService;
+    /// let client = SqlFlagsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_flags_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_flags_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlFlagsService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlFlagsService>> {
@@ -431,10 +548,18 @@ impl SqlFlagsService {
     {
         super::builder::sql_flags_service::List::new(self.inner.clone())
     }
-
 }
 
 /// Implements a client for the Cloud SQL Admin API.
+///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlInstancesService;
+/// let client = SqlInstancesService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
 ///
 /// # Service Description
 ///
@@ -442,8 +567,23 @@ impl SqlFlagsService {
 ///
 /// # Configuration
 ///
-/// `SqlInstancesService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlInstancesService` use the `with_*` methods in the type returned
+/// by [builder()][SqlInstancesService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_instances_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_instances_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -457,24 +597,30 @@ pub struct SqlInstancesService {
 }
 
 impl SqlInstancesService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlInstancesService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// let client = SqlInstancesService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_instances_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_instances_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlInstancesService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlInstancesService>> {
@@ -931,10 +1077,18 @@ impl SqlInstancesService {
             .set_project ( project.into() )
             .set_instance ( instance.into() )
     }
-
 }
 
 /// Implements a client for the Cloud SQL Admin API.
+///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlOperationsService;
+/// let client = SqlOperationsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
 ///
 /// # Service Description
 ///
@@ -942,8 +1096,23 @@ impl SqlInstancesService {
 ///
 /// # Configuration
 ///
-/// `SqlOperationsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlOperationsService` use the `with_*` methods in the type returned
+/// by [builder()][SqlOperationsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_operations_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_operations_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -957,24 +1126,30 @@ pub struct SqlOperationsService {
 }
 
 impl SqlOperationsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlOperationsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlOperationsService;
+    /// let client = SqlOperationsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_operations_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_operations_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlOperationsService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlOperationsService>> {
@@ -1026,10 +1201,18 @@ impl SqlOperationsService {
             .set_project ( project.into() )
             .set_operation ( operation.into() )
     }
-
 }
 
 /// Implements a client for the Cloud SQL Admin API.
+///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlSslCertsService;
+/// let client = SqlSslCertsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
 ///
 /// # Service Description
 ///
@@ -1037,8 +1220,23 @@ impl SqlOperationsService {
 ///
 /// # Configuration
 ///
-/// `SqlSslCertsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlSslCertsService` use the `with_*` methods in the type returned
+/// by [builder()][SqlSslCertsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_ssl_certs_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_ssl_certs_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1052,24 +1250,30 @@ pub struct SqlSslCertsService {
 }
 
 impl SqlSslCertsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlSslCertsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlSslCertsService;
+    /// let client = SqlSslCertsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_ssl_certs_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_ssl_certs_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlSslCertsService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlSslCertsService>> {
@@ -1143,10 +1347,18 @@ impl SqlSslCertsService {
             .set_project ( project.into() )
             .set_instance ( instance.into() )
     }
-
 }
 
 /// Implements a client for the Cloud SQL Admin API.
+///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlTiersService;
+/// let client = SqlTiersService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
 ///
 /// # Service Description
 ///
@@ -1154,8 +1366,23 @@ impl SqlSslCertsService {
 ///
 /// # Configuration
 ///
-/// `SqlTiersService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlTiersService` use the `with_*` methods in the type returned
+/// by [builder()][SqlTiersService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_tiers_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_tiers_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1169,24 +1396,30 @@ pub struct SqlTiersService {
 }
 
 impl SqlTiersService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlTiersService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlTiersService;
+    /// let client = SqlTiersService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_tiers_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_tiers_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlTiersService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlTiersService>> {
@@ -1215,10 +1448,18 @@ impl SqlTiersService {
         super::builder::sql_tiers_service::List::new(self.inner.clone())
             .set_project ( project.into() )
     }
-
 }
 
 /// Implements a client for the Cloud SQL Admin API.
+///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_sql_v1::client::SqlUsersService;
+/// let client = SqlUsersService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
 ///
 /// # Service Description
 ///
@@ -1226,8 +1467,23 @@ impl SqlTiersService {
 ///
 /// # Configuration
 ///
-/// `SqlUsersService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SqlUsersService` use the `with_*` methods in the type returned
+/// by [builder()][SqlUsersService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://sqladmin.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::sql_users_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::sql_users_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1241,24 +1497,30 @@ pub struct SqlUsersService {
 }
 
 impl SqlUsersService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner }) 
+    /// Returns a builder for [SqlUsersService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_sql_v1::client::SqlUsersService;
+    /// let client = SqlUsersService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::sql_users_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::sql_users_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where T: super::stub::SqlUsersService + 'static {
         Self { inner: Arc::new(stub) }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn super::stub::dynamic::SqlUsersService>> {
@@ -1337,5 +1599,4 @@ impl SqlUsersService {
             .set_project ( project.into() )
             .set_instance ( instance.into() )
     }
-
 }

--- a/src/generated/cloud/storageinsights/v1/Cargo.toml
+++ b/src/generated/cloud/storageinsights/v1/Cargo.toml
@@ -42,3 +42,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/storageinsights/v1/src/builder.rs
+++ b/src/generated/cloud/storageinsights/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod storage_insights {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [StorageInsights][super::super::client::StorageInsights].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_storageinsights_v1::*;
+    /// # use builder::storage_insights::ClientBuilder;
+    /// # use client::StorageInsights;
+    /// let builder : ClientBuilder = StorageInsights::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://storageinsights.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::StorageInsights;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = StorageInsights;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::StorageInsights] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/storageinsights/v1/src/client.rs
+++ b/src/generated/cloud/storageinsights/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Storage Insights API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_storageinsights_v1::client::StorageInsights;
+/// let client = StorageInsights::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service describing handlers for resources
 ///
 /// # Configuration
 ///
-/// `StorageInsights` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `StorageInsights` use the `with_*` methods in the type returned
+/// by [builder()][StorageInsights::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://storageinsights.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::storage_insights::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::storage_insights::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct StorageInsights {
 }
 
 impl StorageInsights {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [StorageInsights].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// let client = StorageInsights::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::storage_insights::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::storage_insights::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::StorageInsights + 'static,
@@ -64,6 +91,11 @@ impl StorageInsights {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/support/v2/Cargo.toml
+++ b/src/generated/cloud/support/v2/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/support/v2/src/builder.rs
+++ b/src/generated/cloud/support/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod case_attachment_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CaseAttachmentService][super::super::client::CaseAttachmentService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_support_v2::*;
+    /// # use builder::case_attachment_service::ClientBuilder;
+    /// # use client::CaseAttachmentService;
+    /// let builder : ClientBuilder = CaseAttachmentService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudsupport.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CaseAttachmentService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CaseAttachmentService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CaseAttachmentService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -116,6 +144,34 @@ pub mod case_attachment_service {
 pub mod case_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [CaseService][super::super::client::CaseService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_support_v2::*;
+    /// # use builder::case_service::ClientBuilder;
+    /// # use client::CaseService;
+    /// let builder : ClientBuilder = CaseService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudsupport.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CaseService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CaseService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::CaseService] request builders.
     #[derive(Clone, Debug)]
@@ -601,6 +657,34 @@ pub mod case_service {
 pub mod comment_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [CommentService][super::super::client::CommentService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_support_v2::*;
+    /// # use builder::comment_service::ClientBuilder;
+    /// # use client::CommentService;
+    /// let builder : ClientBuilder = CommentService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudsupport.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CommentService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CommentService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::CommentService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/support/v2/src/client.rs
+++ b/src/generated/cloud/support/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Google Cloud Support API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_support_v2::client::CaseAttachmentService;
+/// let client = CaseAttachmentService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service to manage file attachment for Google Cloud support cases.
 ///
 /// # Configuration
 ///
-/// `CaseAttachmentService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CaseAttachmentService` use the `with_*` methods in the type returned
+/// by [builder()][CaseAttachmentService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudsupport.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::case_attachment_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::case_attachment_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct CaseAttachmentService {
 }
 
 impl CaseAttachmentService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CaseAttachmentService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_support_v2::client::CaseAttachmentService;
+    /// let client = CaseAttachmentService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::case_attachment_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::case_attachment_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CaseAttachmentService + 'static,
@@ -64,6 +91,11 @@ impl CaseAttachmentService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -101,14 +133,38 @@ impl CaseAttachmentService {
 
 /// Implements a client for the Google Cloud Support API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_support_v2::client::CaseService;
+/// let client = CaseService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service to manage Google Cloud support cases.
 ///
 /// # Configuration
 ///
-/// `CaseService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CaseService` use the `with_*` methods in the type returned
+/// by [builder()][CaseService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudsupport.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::case_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::case_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -122,21 +178,22 @@ pub struct CaseService {
 }
 
 impl CaseService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CaseService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_support_v2::client::CaseService;
+    /// let client = CaseService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::case_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::case_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CaseService + 'static,
@@ -144,6 +201,11 @@ impl CaseService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -251,14 +313,38 @@ impl CaseService {
 
 /// Implements a client for the Google Cloud Support API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_support_v2::client::CommentService;
+/// let client = CommentService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service to manage comments on cases.
 ///
 /// # Configuration
 ///
-/// `CommentService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CommentService` use the `with_*` methods in the type returned
+/// by [builder()][CommentService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudsupport.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::comment_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::comment_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -272,21 +358,22 @@ pub struct CommentService {
 }
 
 impl CommentService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CommentService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_support_v2::client::CommentService;
+    /// let client = CommentService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::comment_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::comment_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CommentService + 'static,
@@ -294,6 +381,11 @@ impl CommentService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/talent/v4/Cargo.toml
+++ b/src/generated/cloud/talent/v4/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/talent/v4/src/builder.rs
+++ b/src/generated/cloud/talent/v4/src/builder.rs
@@ -18,6 +18,34 @@ pub mod company_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CompanyService][super::super::client::CompanyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::*;
+    /// # use builder::company_service::ClientBuilder;
+    /// # use client::CompanyService;
+    /// let builder : ClientBuilder = CompanyService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://jobs.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CompanyService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CompanyService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CompanyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -353,6 +381,34 @@ pub mod completion {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Completion][super::super::client::Completion].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::*;
+    /// # use builder::completion::ClientBuilder;
+    /// # use client::Completion;
+    /// let builder : ClientBuilder = Completion::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://jobs.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Completion;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Completion;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Completion] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -513,6 +569,34 @@ pub mod event_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [EventService][super::super::client::EventService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::*;
+    /// # use builder::event_service::ClientBuilder;
+    /// # use client::EventService;
+    /// let builder : ClientBuilder = EventService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://jobs.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::EventService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = EventService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::EventService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -637,6 +721,34 @@ pub mod event_service {
 pub mod job_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [JobService][super::super::client::JobService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::*;
+    /// # use builder::job_service::ClientBuilder;
+    /// # use client::JobService;
+    /// let builder : ClientBuilder = JobService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://jobs.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::JobService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = JobService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::JobService] request builders.
     #[derive(Clone, Debug)]
@@ -1592,6 +1704,34 @@ pub mod job_service {
 pub mod tenant_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [TenantService][super::super::client::TenantService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::*;
+    /// # use builder::tenant_service::ClientBuilder;
+    /// # use client::TenantService;
+    /// let builder : ClientBuilder = TenantService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://jobs.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TenantService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TenantService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::TenantService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/talent/v4/src/client.rs
+++ b/src/generated/cloud/talent/v4/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Talent Solution API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_talent_v4::client::CompanyService;
+/// let client = CompanyService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service that handles company management, including CRUD and enumeration.
 ///
 /// # Configuration
 ///
-/// `CompanyService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CompanyService` use the `with_*` methods in the type returned
+/// by [builder()][CompanyService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://jobs.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::company_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::company_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct CompanyService {
 }
 
 impl CompanyService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CompanyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::client::CompanyService;
+    /// let client = CompanyService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::company_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::company_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CompanyService + 'static,
@@ -64,6 +89,11 @@ impl CompanyService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -147,14 +177,38 @@ impl CompanyService {
 
 /// Implements a client for the Cloud Talent Solution API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_talent_v4::client::Completion;
+/// let client = Completion::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service handles auto completion.
 ///
 /// # Configuration
 ///
-/// `Completion` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Completion` use the `with_*` methods in the type returned
+/// by [builder()][Completion::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://jobs.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::completion::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::completion::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -168,21 +222,22 @@ pub struct Completion {
 }
 
 impl Completion {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Completion].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::client::Completion;
+    /// let client = Completion::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::completion::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::completion::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Completion + 'static,
@@ -190,6 +245,11 @@ impl Completion {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -237,14 +297,38 @@ impl Completion {
 
 /// Implements a client for the Cloud Talent Solution API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_talent_v4::client::EventService;
+/// let client = EventService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service handles client event report.
 ///
 /// # Configuration
 ///
-/// `EventService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `EventService` use the `with_*` methods in the type returned
+/// by [builder()][EventService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://jobs.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::event_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::event_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -258,21 +342,22 @@ pub struct EventService {
 }
 
 impl EventService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [EventService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::client::EventService;
+    /// let client = EventService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::event_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::event_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::EventService + 'static,
@@ -280,6 +365,11 @@ impl EventService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -333,14 +423,38 @@ impl EventService {
 
 /// Implements a client for the Cloud Talent Solution API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_talent_v4::client::JobService;
+/// let client = JobService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service handles job management, including job CRUD, enumeration and search.
 ///
 /// # Configuration
 ///
-/// `JobService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `JobService` use the `with_*` methods in the type returned
+/// by [builder()][JobService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://jobs.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::job_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::job_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -354,21 +468,22 @@ pub struct JobService {
 }
 
 impl JobService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [JobService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::client::JobService;
+    /// let client = JobService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::job_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::job_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::JobService + 'static,
@@ -376,6 +491,11 @@ impl JobService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -561,14 +681,38 @@ impl JobService {
 
 /// Implements a client for the Cloud Talent Solution API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_talent_v4::client::TenantService;
+/// let client = TenantService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service that handles tenant management, including CRUD and enumeration.
 ///
 /// # Configuration
 ///
-/// `TenantService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TenantService` use the `with_*` methods in the type returned
+/// by [builder()][TenantService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://jobs.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::tenant_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::tenant_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -582,21 +726,22 @@ pub struct TenantService {
 }
 
 impl TenantService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TenantService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_talent_v4::client::TenantService;
+    /// let client = TenantService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::tenant_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::tenant_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TenantService + 'static,
@@ -604,6 +749,11 @@ impl TenantService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/tasks/v2/Cargo.toml
+++ b/src/generated/cloud/tasks/v2/Cargo.toml
@@ -41,3 +41,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/tasks/v2/src/builder.rs
+++ b/src/generated/cloud/tasks/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_tasks {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudTasks][super::super::client::CloudTasks].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_tasks_v2::*;
+    /// # use builder::cloud_tasks::ClientBuilder;
+    /// # use client::CloudTasks;
+    /// let builder : ClientBuilder = CloudTasks::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudtasks.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudTasks;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudTasks;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudTasks] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/tasks/v2/src/client.rs
+++ b/src/generated/cloud/tasks/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Tasks API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_tasks_v2::client::CloudTasks;
+/// let client = CloudTasks::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Tasks allows developers to manage the execution of background
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudTasks` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudTasks` use the `with_*` methods in the type returned
+/// by [builder()][CloudTasks::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudtasks.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_tasks::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_tasks::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct CloudTasks {
 }
 
 impl CloudTasks {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudTasks].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// let client = CloudTasks::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_tasks::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cloud_tasks::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudTasks + 'static,
@@ -65,6 +90,11 @@ impl CloudTasks {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/telcoautomation/v1/Cargo.toml
+++ b/src/generated/cloud/telcoautomation/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/telcoautomation/v1/src/builder.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod telco_automation {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TelcoAutomation][super::super::client::TelcoAutomation].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_telcoautomation_v1::*;
+    /// # use builder::telco_automation::ClientBuilder;
+    /// # use client::TelcoAutomation;
+    /// let builder : ClientBuilder = TelcoAutomation::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://telcoautomation.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TelcoAutomation;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TelcoAutomation;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TelcoAutomation] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/telcoautomation/v1/src/client.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Telco Automation API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+/// let client = TelcoAutomation::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// TelcoAutomation Service manages the control plane cluster a.k.a.
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `TelcoAutomation` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TelcoAutomation` use the `with_*` methods in the type returned
+/// by [builder()][TelcoAutomation::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://telcoautomation.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::telco_automation::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::telco_automation::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,24 @@ pub struct TelcoAutomation {
 }
 
 impl TelcoAutomation {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TelcoAutomation].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// let client = TelcoAutomation::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::telco_automation::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::telco_automation::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TelcoAutomation + 'static,
@@ -68,6 +95,11 @@ impl TelcoAutomation {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/texttospeech/v1/Cargo.toml
+++ b/src/generated/cloud/texttospeech/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/texttospeech/v1/src/builder.rs
+++ b/src/generated/cloud/texttospeech/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod text_to_speech {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TextToSpeech][super::super::client::TextToSpeech].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_texttospeech_v1::*;
+    /// # use builder::text_to_speech::ClientBuilder;
+    /// # use client::TextToSpeech;
+    /// let builder : ClientBuilder = TextToSpeech::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://texttospeech.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TextToSpeech;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TextToSpeech;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TextToSpeech] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -285,6 +313,34 @@ pub mod text_to_speech {
 pub mod text_to_speech_long_audio_synthesize {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [TextToSpeechLongAudioSynthesize][super::super::client::TextToSpeechLongAudioSynthesize].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_texttospeech_v1::*;
+    /// # use builder::text_to_speech_long_audio_synthesize::ClientBuilder;
+    /// # use client::TextToSpeechLongAudioSynthesize;
+    /// let builder : ClientBuilder = TextToSpeechLongAudioSynthesize::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://texttospeech.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TextToSpeechLongAudioSynthesize;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TextToSpeechLongAudioSynthesize;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::TextToSpeechLongAudioSynthesize] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/texttospeech/v1/src/client.rs
+++ b/src/generated/cloud/texttospeech/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Text-to-Speech API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_texttospeech_v1::client::TextToSpeech;
+/// let client = TextToSpeech::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service that implements Google Cloud Text-to-Speech API.
 ///
 /// # Configuration
 ///
-/// `TextToSpeech` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TextToSpeech` use the `with_*` methods in the type returned
+/// by [builder()][TextToSpeech::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://texttospeech.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::text_to_speech::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::text_to_speech::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct TextToSpeech {
 }
 
 impl TextToSpeech {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TextToSpeech].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_texttospeech_v1::client::TextToSpeech;
+    /// let client = TextToSpeech::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::text_to_speech::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::text_to_speech::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TextToSpeech + 'static,
@@ -64,6 +89,11 @@ impl TextToSpeech {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -124,14 +154,38 @@ impl TextToSpeech {
 
 /// Implements a client for the Cloud Text-to-Speech API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_texttospeech_v1::client::TextToSpeechLongAudioSynthesize;
+/// let client = TextToSpeechLongAudioSynthesize::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service that implements Google Cloud Text-to-Speech API.
 ///
 /// # Configuration
 ///
-/// `TextToSpeechLongAudioSynthesize` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TextToSpeechLongAudioSynthesize` use the `with_*` methods in the type returned
+/// by [builder()][TextToSpeechLongAudioSynthesize::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://texttospeech.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::text_to_speech_long_audio_synthesize::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::text_to_speech_long_audio_synthesize::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -145,21 +199,24 @@ pub struct TextToSpeechLongAudioSynthesize {
 }
 
 impl TextToSpeechLongAudioSynthesize {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TextToSpeechLongAudioSynthesize].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_texttospeech_v1::client::TextToSpeechLongAudioSynthesize;
+    /// let client = TextToSpeechLongAudioSynthesize::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::text_to_speech_long_audio_synthesize::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::text_to_speech_long_audio_synthesize::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TextToSpeechLongAudioSynthesize + 'static,
@@ -167,6 +224,11 @@ impl TextToSpeechLongAudioSynthesize {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
+++ b/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod timeseries_insights_controller {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TimeseriesInsightsController][super::super::client::TimeseriesInsightsController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_timeseriesinsights_v1::*;
+    /// # use builder::timeseries_insights_controller::ClientBuilder;
+    /// # use client::TimeseriesInsightsController;
+    /// let builder : ClientBuilder = TimeseriesInsightsController::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://timeseriesinsights.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TimeseriesInsightsController;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TimeseriesInsightsController;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TimeseriesInsightsController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/timeseriesinsights/v1/src/client.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/client.rs
@@ -21,13 +21,37 @@ use std::sync::Arc;
 
 /// Implements a client for the Timeseries Insights API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+/// let client = TimeseriesInsightsController::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 ///
 /// # Configuration
 ///
-/// `TimeseriesInsightsController` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TimeseriesInsightsController` use the `with_*` methods in the type returned
+/// by [builder()][TimeseriesInsightsController::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://timeseriesinsights.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::timeseries_insights_controller::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::timeseries_insights_controller::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -41,21 +65,24 @@ pub struct TimeseriesInsightsController {
 }
 
 impl TimeseriesInsightsController {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TimeseriesInsightsController].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+    /// let client = TimeseriesInsightsController::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::timeseries_insights_controller::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::timeseries_insights_controller::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TimeseriesInsightsController + 'static,
@@ -63,6 +90,11 @@ impl TimeseriesInsightsController {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/tpu/v2/Cargo.toml
+++ b/src/generated/cloud/tpu/v2/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/tpu/v2/src/builder.rs
+++ b/src/generated/cloud/tpu/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod tpu {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Tpu][super::super::client::Tpu].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_tpu_v2::*;
+    /// # use builder::tpu::ClientBuilder;
+    /// # use client::Tpu;
+    /// let builder : ClientBuilder = Tpu::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://tpu.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Tpu;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Tpu;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Tpu] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/tpu/v2/src/client.rs
+++ b/src/generated/cloud/tpu/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud TPU API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_tpu_v2::client::Tpu;
+/// let client = Tpu::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages TPU nodes and other resources
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Tpu` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Tpu` use the `with_*` methods in the type returned
+/// by [builder()][Tpu::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://tpu.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::tpu::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::tpu::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,22 @@ pub struct Tpu {
 }
 
 impl Tpu {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Tpu].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// let client = Tpu::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::tpu::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::tpu::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Tpu + 'static,
@@ -66,6 +91,11 @@ impl Tpu {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/translate/v3/src/builder.rs
+++ b/src/generated/cloud/translate/v3/src/builder.rs
@@ -18,6 +18,34 @@ pub mod translation_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TranslationService][super::super::client::TranslationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_translation_v3::*;
+    /// # use builder::translation_service::ClientBuilder;
+    /// # use client::TranslationService;
+    /// let builder : ClientBuilder = TranslationService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://translate.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TranslationService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TranslationService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TranslationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/translate/v3/src/client.rs
+++ b/src/generated/cloud/translate/v3/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Translation API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_translation_v3::client::TranslationService;
+/// let client = TranslationService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Provides natural language translation operations.
 ///
 /// # Configuration
 ///
-/// `TranslationService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TranslationService` use the `with_*` methods in the type returned
+/// by [builder()][TranslationService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://translate.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::translation_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::translation_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct TranslationService {
 }
 
 impl TranslationService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TranslationService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// let client = TranslationService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::translation_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::translation_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TranslationService + 'static,
@@ -64,6 +91,11 @@ impl TranslationService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/video/livestream/v1/Cargo.toml
+++ b/src/generated/cloud/video/livestream/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/video/livestream/v1/src/builder.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod livestream_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [LivestreamService][super::super::client::LivestreamService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_video_livestream_v1::*;
+    /// # use builder::livestream_service::ClientBuilder;
+    /// # use client::LivestreamService;
+    /// let builder : ClientBuilder = LivestreamService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://livestream.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::LivestreamService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = LivestreamService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::LivestreamService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/video/livestream/v1/src/client.rs
+++ b/src/generated/cloud/video/livestream/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Live Stream API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_video_livestream_v1::client::LivestreamService;
+/// let client = LivestreamService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Using Live Stream API, you can generate live streams in the various
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `LivestreamService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `LivestreamService` use the `with_*` methods in the type returned
+/// by [builder()][LivestreamService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://livestream.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::livestream_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::livestream_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,24 @@ pub struct LivestreamService {
 }
 
 impl LivestreamService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [LivestreamService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// let client = LivestreamService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::livestream_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::livestream_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::LivestreamService + 'static,
@@ -68,6 +95,11 @@ impl LivestreamService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/video/stitcher/v1/Cargo.toml
+++ b/src/generated/cloud/video/stitcher/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/video/stitcher/v1/src/builder.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod video_stitcher_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [VideoStitcherService][super::super::client::VideoStitcherService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_video_stitcher_v1::*;
+    /// # use builder::video_stitcher_service::ClientBuilder;
+    /// # use client::VideoStitcherService;
+    /// let builder : ClientBuilder = VideoStitcherService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://videostitcher.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VideoStitcherService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VideoStitcherService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::VideoStitcherService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/video/stitcher/v1/src/client.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Video Stitcher API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+/// let client = VideoStitcherService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Video-On-Demand content stitching API allows you to insert ads
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `VideoStitcherService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VideoStitcherService` use the `with_*` methods in the type returned
+/// by [builder()][VideoStitcherService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://videostitcher.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::video_stitcher_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::video_stitcher_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,24 @@ pub struct VideoStitcherService {
 }
 
 impl VideoStitcherService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VideoStitcherService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// let client = VideoStitcherService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::video_stitcher_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::video_stitcher_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VideoStitcherService + 'static,
@@ -68,6 +95,11 @@ impl VideoStitcherService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/video/transcoder/v1/Cargo.toml
+++ b/src/generated/cloud/video/transcoder/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/video/transcoder/v1/src/builder.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod transcoder_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TranscoderService][super::super::client::TranscoderService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_video_transcoder_v1::*;
+    /// # use builder::transcoder_service::ClientBuilder;
+    /// # use client::TranscoderService;
+    /// let builder : ClientBuilder = TranscoderService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://transcoder.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TranscoderService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TranscoderService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TranscoderService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/video/transcoder/v1/src/client.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Transcoder API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+/// let client = TranscoderService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Using the Transcoder API, you can queue asynchronous jobs for transcoding
@@ -32,8 +41,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `TranscoderService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TranscoderService` use the `with_*` methods in the type returned
+/// by [builder()][TranscoderService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://transcoder.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::transcoder_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::transcoder_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -47,21 +71,24 @@ pub struct TranscoderService {
 }
 
 impl TranscoderService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TranscoderService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+    /// let client = TranscoderService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::transcoder_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::transcoder_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TranscoderService + 'static,
@@ -69,6 +96,11 @@ impl TranscoderService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/videointelligence/v1/Cargo.toml
+++ b/src/generated/cloud/videointelligence/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/videointelligence/v1/src/builder.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod video_intelligence_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [VideoIntelligenceService][super::super::client::VideoIntelligenceService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_videointelligence_v1::*;
+    /// # use builder::video_intelligence_service::ClientBuilder;
+    /// # use client::VideoIntelligenceService;
+    /// let builder : ClientBuilder = VideoIntelligenceService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://videointelligence.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VideoIntelligenceService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VideoIntelligenceService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::VideoIntelligenceService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/videointelligence/v1/src/client.rs
+++ b/src/generated/cloud/videointelligence/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Video Intelligence API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_videointelligence_v1::client::VideoIntelligenceService;
+/// let client = VideoIntelligenceService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service that implements the Video Intelligence API.
 ///
 /// # Configuration
 ///
-/// `VideoIntelligenceService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VideoIntelligenceService` use the `with_*` methods in the type returned
+/// by [builder()][VideoIntelligenceService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://videointelligence.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::video_intelligence_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::video_intelligence_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct VideoIntelligenceService {
 }
 
 impl VideoIntelligenceService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VideoIntelligenceService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_videointelligence_v1::client::VideoIntelligenceService;
+    /// let client = VideoIntelligenceService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::video_intelligence_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::video_intelligence_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VideoIntelligenceService + 'static,
@@ -64,6 +91,11 @@ impl VideoIntelligenceService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/vision/v1/Cargo.toml
+++ b/src/generated/cloud/vision/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/vision/v1/src/builder.rs
+++ b/src/generated/cloud/vision/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod image_annotator {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ImageAnnotator][super::super::client::ImageAnnotator].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vision_v1::*;
+    /// # use builder::image_annotator::ClientBuilder;
+    /// # use client::ImageAnnotator;
+    /// let builder : ClientBuilder = ImageAnnotator::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://vision.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ImageAnnotator;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ImageAnnotator;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ImageAnnotator] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -455,6 +483,34 @@ pub mod image_annotator {
 pub mod product_search {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ProductSearch][super::super::client::ProductSearch].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vision_v1::*;
+    /// # use builder::product_search::ClientBuilder;
+    /// # use client::ProductSearch;
+    /// let builder : ClientBuilder = ProductSearch::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://vision.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ProductSearch;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ProductSearch;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ProductSearch] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/cloud/vision/v1/src/client.rs
+++ b/src/generated/cloud/vision/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Vision API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_vision_v1::client::ImageAnnotator;
+/// let client = ImageAnnotator::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service that performs Google Cloud Vision API detection tasks over client
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ImageAnnotator` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ImageAnnotator` use the `with_*` methods in the type returned
+/// by [builder()][ImageAnnotator::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://vision.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::image_annotator::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::image_annotator::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,22 @@ pub struct ImageAnnotator {
 }
 
 impl ImageAnnotator {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ImageAnnotator].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vision_v1::client::ImageAnnotator;
+    /// let client = ImageAnnotator::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::image_annotator::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::image_annotator::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ImageAnnotator + 'static,
@@ -66,6 +91,11 @@ impl ImageAnnotator {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -167,6 +197,15 @@ impl ImageAnnotator {
 
 /// Implements a client for the Cloud Vision API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_vision_v1::client::ProductSearch;
+/// let client = ProductSearch::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages Products and ProductSets of reference images for use in product
@@ -193,8 +232,23 @@ impl ImageAnnotator {
 ///
 /// # Configuration
 ///
-/// `ProductSearch` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ProductSearch` use the `with_*` methods in the type returned
+/// by [builder()][ProductSearch::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://vision.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::product_search::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::product_search::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -208,21 +262,22 @@ pub struct ProductSearch {
 }
 
 impl ProductSearch {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ProductSearch].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// let client = ProductSearch::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::product_search::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::product_search::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ProductSearch + 'static,
@@ -230,6 +285,11 @@ impl ProductSearch {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/vmmigration/v1/Cargo.toml
+++ b/src/generated/cloud/vmmigration/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/vmmigration/v1/src/builder.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod vm_migration {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [VmMigration][super::super::client::VmMigration].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vmmigration_v1::*;
+    /// # use builder::vm_migration::ClientBuilder;
+    /// # use client::VmMigration;
+    /// let builder : ClientBuilder = VmMigration::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://vmmigration.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VmMigration;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VmMigration;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::VmMigration] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/vmmigration/v1/src/client.rs
+++ b/src/generated/cloud/vmmigration/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the VM Migration API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_vmmigration_v1::client::VmMigration;
+/// let client = VmMigration::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// VM Migration Service
 ///
 /// # Configuration
 ///
-/// `VmMigration` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VmMigration` use the `with_*` methods in the type returned
+/// by [builder()][VmMigration::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://vmmigration.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::vm_migration::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::vm_migration::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct VmMigration {
 }
 
 impl VmMigration {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VmMigration].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// let client = VmMigration::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::vm_migration::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::vm_migration::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VmMigration + 'static,
@@ -64,6 +89,11 @@ impl VmMigration {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/vmwareengine/v1/Cargo.toml
+++ b/src/generated/cloud/vmwareengine/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/vmwareengine/v1/src/builder.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod vmware_engine {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [VmwareEngine][super::super::client::VmwareEngine].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vmwareengine_v1::*;
+    /// # use builder::vmware_engine::ClientBuilder;
+    /// # use client::VmwareEngine;
+    /// let builder : ClientBuilder = VmwareEngine::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://vmwareengine.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VmwareEngine;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VmwareEngine;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::VmwareEngine] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/vmwareengine/v1/src/client.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the VMware Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+/// let client = VmwareEngine::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// VMwareEngine manages VMware's private clusters in the Cloud.
 ///
 /// # Configuration
 ///
-/// `VmwareEngine` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VmwareEngine` use the `with_*` methods in the type returned
+/// by [builder()][VmwareEngine::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://vmwareengine.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::vmware_engine::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::vmware_engine::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct VmwareEngine {
 }
 
 impl VmwareEngine {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VmwareEngine].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// let client = VmwareEngine::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::vmware_engine::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::vmware_engine::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VmwareEngine + 'static,
@@ -64,6 +89,11 @@ impl VmwareEngine {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/vpcaccess/v1/Cargo.toml
+++ b/src/generated/cloud/vpcaccess/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/vpcaccess/v1/src/builder.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod vpc_access_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [VpcAccessService][super::super::client::VpcAccessService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vpcaccess_v1::*;
+    /// # use builder::vpc_access_service::ClientBuilder;
+    /// # use client::VpcAccessService;
+    /// let builder : ClientBuilder = VpcAccessService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://vpcaccess.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::VpcAccessService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = VpcAccessService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::VpcAccessService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/vpcaccess/v1/src/client.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Serverless VPC Access API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_vpcaccess_v1::client::VpcAccessService;
+/// let client = VpcAccessService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Serverless VPC Access API allows users to create and manage connectors for
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `VpcAccessService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `VpcAccessService` use the `with_*` methods in the type returned
+/// by [builder()][VpcAccessService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://vpcaccess.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::vpc_access_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::vpc_access_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,24 @@ pub struct VpcAccessService {
 }
 
 impl VpcAccessService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [VpcAccessService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_vpcaccess_v1::client::VpcAccessService;
+    /// let client = VpcAccessService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::vpc_access_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::vpc_access_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::VpcAccessService + 'static,
@@ -66,6 +93,11 @@ impl VpcAccessService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/webrisk/v1/src/builder.rs
+++ b/src/generated/cloud/webrisk/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod web_risk_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [WebRiskService][super::super::client::WebRiskService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_webrisk_v1::*;
+    /// # use builder::web_risk_service::ClientBuilder;
+    /// # use client::WebRiskService;
+    /// let builder : ClientBuilder = WebRiskService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://webrisk.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::WebRiskService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = WebRiskService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::WebRiskService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/webrisk/v1/src/client.rs
+++ b/src/generated/cloud/webrisk/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Web Risk API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_webrisk_v1::client::WebRiskService;
+/// let client = WebRiskService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Web Risk API defines an interface to detect malicious URLs on your
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `WebRiskService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `WebRiskService` use the `with_*` methods in the type returned
+/// by [builder()][WebRiskService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://webrisk.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::web_risk_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::web_risk_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,24 @@ pub struct WebRiskService {
 }
 
 impl WebRiskService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [WebRiskService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_webrisk_v1::client::WebRiskService;
+    /// let client = WebRiskService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::web_risk_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::web_risk_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::WebRiskService + 'static,
@@ -65,6 +92,11 @@ impl WebRiskService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/websecurityscanner/v1/Cargo.toml
+++ b/src/generated/cloud/websecurityscanner/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/websecurityscanner/v1/src/builder.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod web_security_scanner {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [WebSecurityScanner][super::super::client::WebSecurityScanner].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_websecurityscanner_v1::*;
+    /// # use builder::web_security_scanner::ClientBuilder;
+    /// # use client::WebSecurityScanner;
+    /// let builder : ClientBuilder = WebSecurityScanner::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://websecurityscanner.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::WebSecurityScanner;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = WebSecurityScanner;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::WebSecurityScanner] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/websecurityscanner/v1/src/client.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Web Security Scanner API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+/// let client = WebSecurityScanner::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Web Security Scanner Service identifies security vulnerabilities in web
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `WebSecurityScanner` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `WebSecurityScanner` use the `with_*` methods in the type returned
+/// by [builder()][WebSecurityScanner::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://websecurityscanner.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::web_security_scanner::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::web_security_scanner::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,24 @@ pub struct WebSecurityScanner {
 }
 
 impl WebSecurityScanner {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [WebSecurityScanner].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// let client = WebSecurityScanner::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::web_security_scanner::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::web_security_scanner::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::WebSecurityScanner + 'static,
@@ -66,6 +93,11 @@ impl WebSecurityScanner {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/workflows/executions/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/executions/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/cloud/workflows/executions/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod executions {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Executions][super::super::client::Executions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_workflows_executions_v1::*;
+    /// # use builder::executions::ClientBuilder;
+    /// # use client::Executions;
+    /// let builder : ClientBuilder = Executions::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://workflowexecutions.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Executions;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Executions;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Executions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/workflows/executions/v1/src/client.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Workflow Executions API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_workflows_executions_v1::client::Executions;
+/// let client = Executions::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Executions is used to start and manage running instances of
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Executions` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Executions` use the `with_*` methods in the type returned
+/// by [builder()][Executions::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://workflowexecutions.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::executions::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::executions::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct Executions {
 }
 
 impl Executions {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Executions].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_workflows_executions_v1::client::Executions;
+    /// let client = Executions::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::executions::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::executions::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Executions + 'static,
@@ -65,6 +90,11 @@ impl Executions {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/workflows/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod workflows {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Workflows][super::super::client::Workflows].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_workflows_v1::*;
+    /// # use builder::workflows::ClientBuilder;
+    /// # use client::Workflows;
+    /// let builder : ClientBuilder = Workflows::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://workflows.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Workflows;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Workflows;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Workflows] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/workflows/v1/src/client.rs
+++ b/src/generated/cloud/workflows/v1/src/client.rs
@@ -23,6 +23,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Workflows API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_workflows_v1::client::Workflows;
+/// let client = Workflows::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Workflows is used to deploy and execute workflow programs.
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Workflows` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Workflows` use the `with_*` methods in the type returned
+/// by [builder()][Workflows::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://workflows.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::workflows::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::workflows::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,22 @@ pub struct Workflows {
 }
 
 impl Workflows {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Workflows].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_workflows_v1::client::Workflows;
+    /// let client = Workflows::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::workflows::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::workflows::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Workflows + 'static,
@@ -68,6 +93,11 @@ impl Workflows {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/cloud/workstations/v1/Cargo.toml
+++ b/src/generated/cloud/workstations/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/cloud/workstations/v1/src/builder.rs
+++ b/src/generated/cloud/workstations/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod workstations {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Workstations][super::super::client::Workstations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_workstations_v1::*;
+    /// # use builder::workstations::ClientBuilder;
+    /// # use client::Workstations;
+    /// let builder : ClientBuilder = Workstations::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://workstations.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Workstations;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Workstations;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Workstations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/cloud/workstations/v1/src/client.rs
+++ b/src/generated/cloud/workstations/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Workstations API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_workstations_v1::client::Workstations;
+/// let client = Workstations::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for interacting with Cloud Workstations.
 ///
 /// # Configuration
 ///
-/// `Workstations` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Workstations` use the `with_*` methods in the type returned
+/// by [builder()][Workstations::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://workstations.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::workstations::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::workstations::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Workstations {
 }
 
 impl Workstations {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Workstations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// let client = Workstations::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::workstations::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::workstations::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Workstations + 'static,
@@ -64,6 +89,11 @@ impl Workstations {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/container/v1/Cargo.toml
+++ b/src/generated/container/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/container/v1/src/builder.rs
+++ b/src/generated/container/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cluster_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ClusterManager][super::super::client::ClusterManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_container_v1::*;
+    /// # use builder::cluster_manager::ClientBuilder;
+    /// # use client::ClusterManager;
+    /// let builder : ClientBuilder = ClusterManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://container.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ClusterManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ClusterManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ClusterManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/container/v1/src/client.rs
+++ b/src/generated/container/v1/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Kubernetes Engine API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_container_v1::client::ClusterManager;
+/// let client = ClusterManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Google Kubernetes Engine Cluster Manager v1
 ///
 /// # Configuration
 ///
-/// `ClusterManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ClusterManager` use the `with_*` methods in the type returned
+/// by [builder()][ClusterManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://container.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cluster_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cluster_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct ClusterManager {
 }
 
 impl ClusterManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ClusterManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// let client = ClusterManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cluster_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cluster_manager::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ClusterManager + 'static,
@@ -64,6 +89,11 @@ impl ClusterManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/datastore/admin/v1/Cargo.toml
+++ b/src/generated/datastore/admin/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/datastore/admin/v1/src/builder.rs
+++ b/src/generated/datastore/admin/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod datastore_admin {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DatastoreAdmin][super::super::client::DatastoreAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datastore_admin_v1::*;
+    /// # use builder::datastore_admin::ClientBuilder;
+    /// # use client::DatastoreAdmin;
+    /// let builder : ClientBuilder = DatastoreAdmin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://datastore.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DatastoreAdmin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DatastoreAdmin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DatastoreAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/datastore/admin/v1/src/client.rs
+++ b/src/generated/datastore/admin/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Datastore API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_datastore_admin_v1::client::DatastoreAdmin;
+/// let client = DatastoreAdmin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Google Cloud Datastore Admin API
@@ -73,8 +82,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `DatastoreAdmin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DatastoreAdmin` use the `with_*` methods in the type returned
+/// by [builder()][DatastoreAdmin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://datastore.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::datastore_admin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::datastore_admin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -88,21 +112,22 @@ pub struct DatastoreAdmin {
 }
 
 impl DatastoreAdmin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DatastoreAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_datastore_admin_v1::client::DatastoreAdmin;
+    /// let client = DatastoreAdmin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::datastore_admin::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::datastore_admin::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DatastoreAdmin + 'static,
@@ -110,6 +135,11 @@ impl DatastoreAdmin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/devtools/artifactregistry/v1/Cargo.toml
+++ b/src/generated/devtools/artifactregistry/v1/Cargo.toml
@@ -46,4 +46,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/devtools/artifactregistry/v1/src/builder.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod artifact_registry {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ArtifactRegistry][super::super::client::ArtifactRegistry].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_artifactregistry_v1::*;
+    /// # use builder::artifact_registry::ClientBuilder;
+    /// # use client::ArtifactRegistry;
+    /// let builder : ClientBuilder = ArtifactRegistry::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://artifactregistry.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ArtifactRegistry;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ArtifactRegistry;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ArtifactRegistry] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/devtools/artifactregistry/v1/src/client.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Artifact Registry API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+/// let client = ArtifactRegistry::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Artifact Registry API service.
@@ -39,8 +48,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ArtifactRegistry` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ArtifactRegistry` use the `with_*` methods in the type returned
+/// by [builder()][ArtifactRegistry::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://artifactregistry.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::artifact_registry::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::artifact_registry::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -54,21 +78,24 @@ pub struct ArtifactRegistry {
 }
 
 impl ArtifactRegistry {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ArtifactRegistry].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// let client = ArtifactRegistry::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::artifact_registry::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::artifact_registry::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ArtifactRegistry + 'static,
@@ -76,6 +103,11 @@ impl ArtifactRegistry {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/devtools/cloudbuild/v1/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/devtools/cloudbuild/v1/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod cloud_build {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [CloudBuild][super::super::client::CloudBuild].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_build_v1::*;
+    /// # use builder::cloud_build::ClientBuilder;
+    /// # use client::CloudBuild;
+    /// let builder : ClientBuilder = CloudBuild::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudbuild.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::CloudBuild;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = CloudBuild;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::CloudBuild] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/devtools/cloudbuild/v1/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Build API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_build_v1::client::CloudBuild;
+/// let client = CloudBuild::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Creates and manages builds on Google Cloud Platform.
@@ -34,8 +43,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `CloudBuild` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `CloudBuild` use the `with_*` methods in the type returned
+/// by [builder()][CloudBuild::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudbuild.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::cloud_build::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::cloud_build::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -49,21 +73,22 @@ pub struct CloudBuild {
 }
 
 impl CloudBuild {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [CloudBuild].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// let client = CloudBuild::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::cloud_build::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::cloud_build::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::CloudBuild + 'static,
@@ -71,6 +96,11 @@ impl CloudBuild {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/devtools/cloudbuild/v2/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod repository_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [RepositoryManager][super::super::client::RepositoryManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_build_v2::*;
+    /// # use builder::repository_manager::ClientBuilder;
+    /// # use client::RepositoryManager;
+    /// let builder : ClientBuilder = RepositoryManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudbuild.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::RepositoryManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = RepositoryManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::RepositoryManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/devtools/cloudbuild/v2/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Build API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_build_v2::client::RepositoryManager;
+/// let client = RepositoryManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages connections to source code repositories.
 ///
 /// # Configuration
 ///
-/// `RepositoryManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `RepositoryManager` use the `with_*` methods in the type returned
+/// by [builder()][RepositoryManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudbuild.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::repository_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::repository_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct RepositoryManager {
 }
 
 impl RepositoryManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [RepositoryManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// let client = RepositoryManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::repository_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::repository_manager::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::RepositoryManager + 'static,
@@ -64,6 +91,11 @@ impl RepositoryManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/devtools/cloudprofiler/v2/Cargo.toml
+++ b/src/generated/devtools/cloudprofiler/v2/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/devtools/cloudprofiler/v2/src/builder.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod profiler_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ProfilerService][super::super::client::ProfilerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_profiler_v2::*;
+    /// # use builder::profiler_service::ClientBuilder;
+    /// # use client::ProfilerService;
+    /// let builder : ClientBuilder = ProfilerService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudprofiler.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ProfilerService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ProfilerService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ProfilerService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -213,6 +241,34 @@ pub mod profiler_service {
 pub mod export_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ExportService][super::super::client::ExportService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_profiler_v2::*;
+    /// # use builder::export_service::ClientBuilder;
+    /// # use client::ExportService;
+    /// let builder : ClientBuilder = ExportService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudprofiler.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ExportService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ExportService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ExportService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/devtools/cloudprofiler/v2/src/client.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Profiler API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_profiler_v2::client::ProfilerService;
+/// let client = ProfilerService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manage the collection of continuous profiling data provided by profiling
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ProfilerService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ProfilerService` use the `with_*` methods in the type returned
+/// by [builder()][ProfilerService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudprofiler.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::profiler_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::profiler_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,24 @@ pub struct ProfilerService {
 }
 
 impl ProfilerService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ProfilerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_profiler_v2::client::ProfilerService;
+    /// let client = ProfilerService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::profiler_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::profiler_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ProfilerService + 'static,
@@ -68,6 +95,11 @@ impl ProfilerService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -155,6 +187,15 @@ impl ProfilerService {
 
 /// Implements a client for the Cloud Profiler API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_profiler_v2::client::ExportService;
+/// let client = ExportService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service allows existing Cloud Profiler customers to export their profile data
@@ -162,8 +203,23 @@ impl ProfilerService {
 ///
 /// # Configuration
 ///
-/// `ExportService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ExportService` use the `with_*` methods in the type returned
+/// by [builder()][ExportService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudprofiler.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::export_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::export_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -177,21 +233,22 @@ pub struct ExportService {
 }
 
 impl ExportService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ExportService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_profiler_v2::client::ExportService;
+    /// let client = ExportService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::export_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::export_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ExportService + 'static,
@@ -199,6 +256,11 @@ impl ExportService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/devtools/cloudtrace/v2/Cargo.toml
+++ b/src/generated/devtools/cloudtrace/v2/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/devtools/cloudtrace/v2/src/builder.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod trace_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [TraceService][super::super::client::TraceService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_trace_v2::*;
+    /// # use builder::trace_service::ClientBuilder;
+    /// # use client::TraceService;
+    /// let builder : ClientBuilder = TraceService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://cloudtrace.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::TraceService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = TraceService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::TraceService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/devtools/cloudtrace/v2/src/client.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Stackdriver Trace API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_trace_v2::client::TraceService;
+/// let client = TraceService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for collecting and viewing traces and spans within a trace.
@@ -33,8 +42,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `TraceService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `TraceService` use the `with_*` methods in the type returned
+/// by [builder()][TraceService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://cloudtrace.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::trace_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::trace_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -48,21 +72,22 @@ pub struct TraceService {
 }
 
 impl TraceService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [TraceService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_trace_v2::client::TraceService;
+    /// let client = TraceService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::trace_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::trace_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::TraceService + 'static,
@@ -70,6 +95,11 @@ impl TraceService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/devtools/containeranalysis/v1/Cargo.toml
+++ b/src/generated/devtools/containeranalysis/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/devtools/containeranalysis/v1/src/builder.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod container_analysis {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [ContainerAnalysis][super::super::client::ContainerAnalysis].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_containeranalysis_v1::*;
+    /// # use builder::container_analysis::ClientBuilder;
+    /// # use client::ContainerAnalysis;
+    /// let builder : ClientBuilder = ContainerAnalysis::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://containeranalysis.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ContainerAnalysis;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ContainerAnalysis;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::ContainerAnalysis] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/devtools/containeranalysis/v1/src/client.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Container Analysis API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
+/// let client = ContainerAnalysis::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Retrieves analysis results of Cloud components such as Docker container
@@ -39,8 +48,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `ContainerAnalysis` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ContainerAnalysis` use the `with_*` methods in the type returned
+/// by [builder()][ContainerAnalysis::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://containeranalysis.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::container_analysis::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::container_analysis::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -54,21 +78,24 @@ pub struct ContainerAnalysis {
 }
 
 impl ContainerAnalysis {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ContainerAnalysis].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
+    /// let client = ContainerAnalysis::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::container_analysis::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::container_analysis::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ContainerAnalysis + 'static,
@@ -76,6 +103,11 @@ impl ContainerAnalysis {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/firestore/admin/v1/Cargo.toml
+++ b/src/generated/firestore/admin/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/firestore/admin/v1/src/builder.rs
+++ b/src/generated/firestore/admin/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod firestore_admin {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [FirestoreAdmin][super::super::client::FirestoreAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_firestore_admin_v1::*;
+    /// # use builder::firestore_admin::ClientBuilder;
+    /// # use client::FirestoreAdmin;
+    /// let builder : ClientBuilder = FirestoreAdmin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://firestore.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::FirestoreAdmin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = FirestoreAdmin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::FirestoreAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/firestore/admin/v1/src/client.rs
+++ b/src/generated/firestore/admin/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Firestore API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+/// let client = FirestoreAdmin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Cloud Firestore Admin API.
@@ -54,8 +63,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `FirestoreAdmin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `FirestoreAdmin` use the `with_*` methods in the type returned
+/// by [builder()][FirestoreAdmin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://firestore.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::firestore_admin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::firestore_admin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -69,21 +93,22 @@ pub struct FirestoreAdmin {
 }
 
 impl FirestoreAdmin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [FirestoreAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// let client = FirestoreAdmin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::firestore_admin::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::firestore_admin::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::FirestoreAdmin + 'static,
@@ -91,6 +116,11 @@ impl FirestoreAdmin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/grafeas/v1/Cargo.toml
+++ b/src/generated/grafeas/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/grafeas/v1/src/builder.rs
+++ b/src/generated/grafeas/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod grafeas {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Grafeas][super::super::client::Grafeas].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_grafeas_v1::*;
+    /// # use builder::grafeas::ClientBuilder;
+    /// # use client::Grafeas;
+    /// let builder : ClientBuilder = Grafeas::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://containeranalysis.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Grafeas;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Grafeas;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Grafeas] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/grafeas/v1/src/client.rs
+++ b/src/generated/grafeas/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Container Analysis API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_grafeas_v1::client::Grafeas;
+/// let client = Grafeas::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// [Grafeas](https://grafeas.io) API.
@@ -40,8 +49,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Grafeas` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Grafeas` use the `with_*` methods in the type returned
+/// by [builder()][Grafeas::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://containeranalysis.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::grafeas::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::grafeas::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -55,21 +79,22 @@ pub struct Grafeas {
 }
 
 impl Grafeas {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Grafeas].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// let client = Grafeas::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::grafeas::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::grafeas::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Grafeas + 'static,
@@ -77,6 +102,11 @@ impl Grafeas {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/iam/admin/v1/Cargo.toml
+++ b/src/generated/iam/admin/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/iam/admin/v1/src/builder.rs
+++ b/src/generated/iam/admin/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod iam {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Iam][super::super::client::Iam].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_admin_v1::*;
+    /// # use builder::iam::ClientBuilder;
+    /// # use client::Iam;
+    /// let builder : ClientBuilder = Iam::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iam.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Iam;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Iam;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Iam] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/iam/admin/v1/src/client.rs
+++ b/src/generated/iam/admin/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Identity and Access Management (IAM) API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_iam_admin_v1::client::Iam;
+/// let client = Iam::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Creates and manages Identity and Access Management (IAM) resources.
@@ -55,8 +64,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Iam` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Iam` use the `with_*` methods in the type returned
+/// by [builder()][Iam::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iam.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::iam::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::iam::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -70,21 +94,22 @@ pub struct Iam {
 }
 
 impl Iam {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Iam].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// let client = Iam::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::iam::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::iam::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Iam + 'static,
@@ -92,6 +117,11 @@ impl Iam {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/iam/credentials/v1/Cargo.toml
+++ b/src/generated/iam/credentials/v1/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/iam/credentials/v1/src/builder.rs
+++ b/src/generated/iam/credentials/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod iam_credentials {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [IAMCredentials][super::super::client::IAMCredentials].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_credentials_v1::*;
+    /// # use builder::iam_credentials::ClientBuilder;
+    /// # use client::IAMCredentials;
+    /// let builder : ClientBuilder = IAMCredentials::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iamcredentials.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::IAMCredentials;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = IAMCredentials;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::IAMCredentials] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/iam/credentials/v1/src/client.rs
+++ b/src/generated/iam/credentials/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the IAM Service Account Credentials API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_iam_credentials_v1::client::IAMCredentials;
+/// let client = IAMCredentials::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// A service account is a special type of Google account that belongs to your
@@ -35,8 +44,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `IAMCredentials` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `IAMCredentials` use the `with_*` methods in the type returned
+/// by [builder()][IAMCredentials::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iamcredentials.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::iam_credentials::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::iam_credentials::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -50,21 +74,22 @@ pub struct IAMCredentials {
 }
 
 impl IAMCredentials {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [IAMCredentials].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_credentials_v1::client::IAMCredentials;
+    /// let client = IAMCredentials::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::iam_credentials::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::iam_credentials::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::IAMCredentials + 'static,
@@ -72,6 +97,11 @@ impl IAMCredentials {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/iam/v1/src/builder.rs
+++ b/src/generated/iam/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod iam_policy {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [IAMPolicy][super::super::client::IAMPolicy].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_v1::*;
+    /// # use builder::iam_policy::ClientBuilder;
+    /// # use client::IAMPolicy;
+    /// let builder : ClientBuilder = IAMPolicy::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iam-meta-api.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::IAMPolicy;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = IAMPolicy;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::IAMPolicy] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the IAM Meta API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_iam_v1::client::IAMPolicy;
+/// let client = IAMPolicy::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API Overview
@@ -51,8 +60,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `IAMPolicy` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `IAMPolicy` use the `with_*` methods in the type returned
+/// by [builder()][IAMPolicy::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iam-meta-api.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::iam_policy::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::iam_policy::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -66,21 +90,22 @@ pub struct IAMPolicy {
 }
 
 impl IAMPolicy {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [IAMPolicy].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_v1::client::IAMPolicy;
+    /// let client = IAMPolicy::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::iam_policy::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::iam_policy::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::IAMPolicy + 'static,
@@ -88,6 +113,11 @@ impl IAMPolicy {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/iam/v2/Cargo.toml
+++ b/src/generated/iam/v2/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/iam/v2/src/builder.rs
+++ b/src/generated/iam/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod policies {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Policies][super::super::client::Policies].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_v2::*;
+    /// # use builder::policies::ClientBuilder;
+    /// # use client::Policies;
+    /// let builder : ClientBuilder = Policies::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iam.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Policies;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Policies;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Policies] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/iam/v2/src/client.rs
+++ b/src/generated/iam/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Identity and Access Management (IAM) API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_iam_v2::client::Policies;
+/// let client = Policies::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// An interface for managing Identity and Access Management (IAM) policies.
 ///
 /// # Configuration
 ///
-/// `Policies` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Policies` use the `with_*` methods in the type returned
+/// by [builder()][Policies::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iam.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::policies::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::policies::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,22 @@ pub struct Policies {
 }
 
 impl Policies {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Policies].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_v2::client::Policies;
+    /// let client = Policies::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::policies::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::policies::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Policies + 'static,
@@ -64,6 +89,11 @@ impl Policies {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/iam/v3/Cargo.toml
+++ b/src/generated/iam/v3/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/iam/v3/src/builder.rs
+++ b/src/generated/iam/v3/src/builder.rs
@@ -18,6 +18,34 @@ pub mod policy_bindings {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [PolicyBindings][super::super::client::PolicyBindings].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_v3::*;
+    /// # use builder::policy_bindings::ClientBuilder;
+    /// # use client::PolicyBindings;
+    /// let builder : ClientBuilder = PolicyBindings::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iam.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PolicyBindings;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PolicyBindings;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::PolicyBindings] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -592,6 +620,34 @@ pub mod policy_bindings {
 pub mod principal_access_boundary_policies {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [PrincipalAccessBoundaryPolicies][super::super::client::PrincipalAccessBoundaryPolicies].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_v3::*;
+    /// # use builder::principal_access_boundary_policies::ClientBuilder;
+    /// # use client::PrincipalAccessBoundaryPolicies;
+    /// let builder : ClientBuilder = PrincipalAccessBoundaryPolicies::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://iam.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::PrincipalAccessBoundaryPolicies;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = PrincipalAccessBoundaryPolicies;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::PrincipalAccessBoundaryPolicies] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/iam/v3/src/client.rs
+++ b/src/generated/iam/v3/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Identity and Access Management (IAM) API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_iam_v3::client::PolicyBindings;
+/// let client = PolicyBindings::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// An interface for managing Identity and Access Management (IAM) policy
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `PolicyBindings` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PolicyBindings` use the `with_*` methods in the type returned
+/// by [builder()][PolicyBindings::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iam.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::policy_bindings::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::policy_bindings::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct PolicyBindings {
 }
 
 impl PolicyBindings {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PolicyBindings].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_v3::client::PolicyBindings;
+    /// let client = PolicyBindings::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::policy_bindings::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::policy_bindings::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PolicyBindings + 'static,
@@ -65,6 +90,11 @@ impl PolicyBindings {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -196,6 +226,15 @@ impl PolicyBindings {
 
 /// Implements a client for the Identity and Access Management (IAM) API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_iam_v3::client::PrincipalAccessBoundaryPolicies;
+/// let client = PrincipalAccessBoundaryPolicies::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages Identity and Access Management (IAM) principal access boundary
@@ -203,8 +242,23 @@ impl PolicyBindings {
 ///
 /// # Configuration
 ///
-/// `PrincipalAccessBoundaryPolicies` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `PrincipalAccessBoundaryPolicies` use the `with_*` methods in the type returned
+/// by [builder()][PrincipalAccessBoundaryPolicies::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://iam.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::principal_access_boundary_policies::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::principal_access_boundary_policies::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -218,21 +272,24 @@ pub struct PrincipalAccessBoundaryPolicies {
 }
 
 impl PrincipalAccessBoundaryPolicies {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [PrincipalAccessBoundaryPolicies].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_iam_v3::client::PrincipalAccessBoundaryPolicies;
+    /// let client = PrincipalAccessBoundaryPolicies::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::principal_access_boundary_policies::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::principal_access_boundary_policies::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::PrincipalAccessBoundaryPolicies + 'static,
@@ -240,6 +297,11 @@ impl PrincipalAccessBoundaryPolicies {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/identity/accesscontextmanager/type/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/type/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/identity/accesscontextmanager/v1/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/v1/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/identity/accesscontextmanager/v1/src/builder.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod access_context_manager {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AccessContextManager][super::super::client::AccessContextManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_identity_accesscontextmanager_v1::*;
+    /// # use builder::access_context_manager::ClientBuilder;
+    /// # use client::AccessContextManager;
+    /// let builder : ClientBuilder = AccessContextManager::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://accesscontextmanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AccessContextManager;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AccessContextManager;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AccessContextManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/identity/accesscontextmanager/v1/src/client.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Access Context Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+/// let client = AccessContextManager::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// API for setting [access levels]
@@ -37,8 +46,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AccessContextManager` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AccessContextManager` use the `with_*` methods in the type returned
+/// by [builder()][AccessContextManager::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://accesscontextmanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::access_context_manager::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::access_context_manager::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -52,21 +76,24 @@ pub struct AccessContextManager {
 }
 
 impl AccessContextManager {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AccessContextManager].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// let client = AccessContextManager::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::access_context_manager::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::access_context_manager::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AccessContextManager + 'static,
@@ -74,6 +101,11 @@ impl AccessContextManager {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/logging/type/Cargo.toml
+++ b/src/generated/logging/type/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/logging/v2/Cargo.toml
+++ b/src/generated/logging/v2/Cargo.toml
@@ -45,4 +45,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/logging/v2/src/builder.rs
+++ b/src/generated/logging/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod logging_service_v_2 {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [LoggingServiceV2][super::super::client::LoggingServiceV2].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_logging_v2::*;
+    /// # use builder::logging_service_v_2::ClientBuilder;
+    /// # use client::LoggingServiceV2;
+    /// let builder : ClientBuilder = LoggingServiceV2::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://logging.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::LoggingServiceV2;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = LoggingServiceV2;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::LoggingServiceV2] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -559,6 +587,34 @@ pub mod logging_service_v_2 {
 pub mod config_service_v_2 {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ConfigServiceV2][super::super::client::ConfigServiceV2].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_logging_v2::*;
+    /// # use builder::config_service_v_2::ClientBuilder;
+    /// # use client::ConfigServiceV2;
+    /// let builder : ClientBuilder = ConfigServiceV2::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://logging.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ConfigServiceV2;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ConfigServiceV2;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ConfigServiceV2] request builders.
     #[derive(Clone, Debug)]
@@ -2642,6 +2698,34 @@ pub mod config_service_v_2 {
 pub mod metrics_service_v_2 {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [MetricsServiceV2][super::super::client::MetricsServiceV2].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_logging_v2::*;
+    /// # use builder::metrics_service_v_2::ClientBuilder;
+    /// # use client::MetricsServiceV2;
+    /// let builder : ClientBuilder = MetricsServiceV2::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://logging.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::MetricsServiceV2;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = MetricsServiceV2;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::MetricsServiceV2] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/logging/v2/src/client.rs
+++ b/src/generated/logging/v2/src/client.rs
@@ -21,14 +21,38 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Logging API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_logging_v2::client::LoggingServiceV2;
+/// let client = LoggingServiceV2::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for ingesting and querying logs.
 ///
 /// # Configuration
 ///
-/// `LoggingServiceV2` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `LoggingServiceV2` use the `with_*` methods in the type returned
+/// by [builder()][LoggingServiceV2::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://logging.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::logging_service_v_2::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::logging_service_v_2::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -42,21 +66,24 @@ pub struct LoggingServiceV2 {
 }
 
 impl LoggingServiceV2 {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [LoggingServiceV2].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_logging_v2::client::LoggingServiceV2;
+    /// let client = LoggingServiceV2::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::logging_service_v_2::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::logging_service_v_2::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::LoggingServiceV2 + 'static,
@@ -64,6 +91,11 @@ impl LoggingServiceV2 {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -175,14 +207,38 @@ impl LoggingServiceV2 {
 
 /// Implements a client for the Cloud Logging API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_logging_v2::client::ConfigServiceV2;
+/// let client = ConfigServiceV2::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for configuring sinks used to route log entries.
 ///
 /// # Configuration
 ///
-/// `ConfigServiceV2` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ConfigServiceV2` use the `with_*` methods in the type returned
+/// by [builder()][ConfigServiceV2::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://logging.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::config_service_v_2::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::config_service_v_2::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -196,21 +252,24 @@ pub struct ConfigServiceV2 {
 }
 
 impl ConfigServiceV2 {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ConfigServiceV2].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// let client = ConfigServiceV2::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::config_service_v_2::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::config_service_v_2::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ConfigServiceV2 + 'static,
@@ -218,6 +277,11 @@ impl ConfigServiceV2 {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -701,14 +765,38 @@ impl ConfigServiceV2 {
 
 /// Implements a client for the Cloud Logging API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_logging_v2::client::MetricsServiceV2;
+/// let client = MetricsServiceV2::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Service for configuring logs-based metrics.
 ///
 /// # Configuration
 ///
-/// `MetricsServiceV2` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `MetricsServiceV2` use the `with_*` methods in the type returned
+/// by [builder()][MetricsServiceV2::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://logging.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::metrics_service_v_2::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::metrics_service_v_2::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -722,21 +810,24 @@ pub struct MetricsServiceV2 {
 }
 
 impl MetricsServiceV2 {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [MetricsServiceV2].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_logging_v2::client::MetricsServiceV2;
+    /// let client = MetricsServiceV2::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::metrics_service_v_2::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::metrics_service_v_2::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::MetricsServiceV2 + 'static,
@@ -744,6 +835,11 @@ impl MetricsServiceV2 {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/longrunning/src/builder.rs
+++ b/src/generated/longrunning/src/builder.rs
@@ -18,6 +18,34 @@ pub mod operations {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [Operations][super::super::client::Operations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_longrunning::*;
+    /// # use builder::operations::ClientBuilder;
+    /// # use client::Operations;
+    /// let builder : ClientBuilder = Operations::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://longrunning.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::Operations;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = Operations;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::Operations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/longrunning/src/client.rs
+++ b/src/generated/longrunning/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Long Running Operations API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_longrunning::client::Operations;
+/// let client = Operations::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages long-running operations with an API service.
@@ -37,8 +46,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `Operations` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `Operations` use the `with_*` methods in the type returned
+/// by [builder()][Operations::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://longrunning.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::operations::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::operations::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -52,21 +76,22 @@ pub struct Operations {
 }
 
 impl Operations {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [Operations].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_longrunning::client::Operations;
+    /// let client = Operations::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::operations::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::operations::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::Operations + 'static,
@@ -74,6 +99,11 @@ impl Operations {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/monitoring/dashboard/v1/Cargo.toml
+++ b/src/generated/monitoring/dashboard/v1/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/monitoring/dashboard/v1/src/builder.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod dashboards_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DashboardsService][super::super::client::DashboardsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_dashboard_v1::*;
+    /// # use builder::dashboards_service::ClientBuilder;
+    /// # use client::DashboardsService;
+    /// let builder : ClientBuilder = DashboardsService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DashboardsService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DashboardsService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DashboardsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/monitoring/dashboard/v1/src/client.rs
+++ b/src/generated/monitoring/dashboard/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_dashboard_v1::client::DashboardsService;
+/// let client = DashboardsService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages Stackdriver dashboards. A dashboard is an arrangement of data display
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `DashboardsService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DashboardsService` use the `with_*` methods in the type returned
+/// by [builder()][DashboardsService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::dashboards_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::dashboards_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,24 @@ pub struct DashboardsService {
 }
 
 impl DashboardsService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DashboardsService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_dashboard_v1::client::DashboardsService;
+    /// let client = DashboardsService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::dashboards_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::dashboards_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DashboardsService + 'static,
@@ -65,6 +92,11 @@ impl DashboardsService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/monitoring/metricsscope/v1/Cargo.toml
+++ b/src/generated/monitoring/metricsscope/v1/Cargo.toml
@@ -42,4 +42,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/monitoring/metricsscope/v1/src/builder.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod metrics_scopes {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [MetricsScopes][super::super::client::MetricsScopes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_metricsscope_v1::*;
+    /// # use builder::metrics_scopes::ClientBuilder;
+    /// # use client::MetricsScopes;
+    /// let builder : ClientBuilder = MetricsScopes::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::MetricsScopes;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = MetricsScopes;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::MetricsScopes] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/monitoring/metricsscope/v1/src/client.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_metricsscope_v1::client::MetricsScopes;
+/// let client = MetricsScopes::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages Cloud Monitoring Metrics Scopes, and the monitoring of Google Cloud
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `MetricsScopes` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `MetricsScopes` use the `with_*` methods in the type returned
+/// by [builder()][MetricsScopes::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::metrics_scopes::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::metrics_scopes::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,22 @@ pub struct MetricsScopes {
 }
 
 impl MetricsScopes {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [MetricsScopes].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_metricsscope_v1::client::MetricsScopes;
+    /// let client = MetricsScopes::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::metrics_scopes::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::metrics_scopes::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::MetricsScopes + 'static,
@@ -65,6 +90,11 @@ impl MetricsScopes {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/monitoring/v3/Cargo.toml
+++ b/src/generated/monitoring/v3/Cargo.toml
@@ -41,3 +41,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/monitoring/v3/src/builder.rs
+++ b/src/generated/monitoring/v3/src/builder.rs
@@ -18,6 +18,34 @@ pub mod alert_policy_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [AlertPolicyService][super::super::client::AlertPolicyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::*;
+    /// # use builder::alert_policy_service::ClientBuilder;
+    /// # use client::AlertPolicyService;
+    /// let builder : ClientBuilder = AlertPolicyService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::AlertPolicyService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = AlertPolicyService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::AlertPolicyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -325,6 +353,34 @@ pub mod alert_policy_service {
 pub mod group_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [GroupService][super::super::client::GroupService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::*;
+    /// # use builder::group_service::ClientBuilder;
+    /// # use client::GroupService;
+    /// let builder : ClientBuilder = GroupService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::GroupService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = GroupService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::GroupService] request builders.
     #[derive(Clone, Debug)]
@@ -714,6 +770,34 @@ pub mod group_service {
 pub mod metric_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [MetricService][super::super::client::MetricService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::*;
+    /// # use builder::metric_service::ClientBuilder;
+    /// # use client::MetricService;
+    /// let builder : ClientBuilder = MetricService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::MetricService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = MetricService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::MetricService] request builders.
     #[derive(Clone, Debug)]
@@ -1328,6 +1412,34 @@ pub mod metric_service {
 pub mod notification_channel_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [NotificationChannelService][super::super::client::NotificationChannelService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::*;
+    /// # use builder::notification_channel_service::ClientBuilder;
+    /// # use client::NotificationChannelService;
+    /// let builder : ClientBuilder = NotificationChannelService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::NotificationChannelService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = NotificationChannelService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::NotificationChannelService] request builders.
     #[derive(Clone, Debug)]
@@ -1969,6 +2081,34 @@ pub mod query_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [QueryService][super::super::client::QueryService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::*;
+    /// # use builder::query_service::ClientBuilder;
+    /// # use client::QueryService;
+    /// let builder : ClientBuilder = QueryService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::QueryService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = QueryService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::QueryService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2069,6 +2209,34 @@ pub mod query_service {
 pub mod service_monitoring_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [ServiceMonitoringService][super::super::client::ServiceMonitoringService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::*;
+    /// # use builder::service_monitoring_service::ClientBuilder;
+    /// # use client::ServiceMonitoringService;
+    /// let builder : ClientBuilder = ServiceMonitoringService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::ServiceMonitoringService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = ServiceMonitoringService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::ServiceMonitoringService] request builders.
     #[derive(Clone, Debug)]
@@ -2710,6 +2878,34 @@ pub mod snooze_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SnoozeService][super::super::client::SnoozeService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::*;
+    /// # use builder::snooze_service::ClientBuilder;
+    /// # use client::SnoozeService;
+    /// let builder : ClientBuilder = SnoozeService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SnoozeService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SnoozeService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SnoozeService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
@@ -2957,6 +3153,34 @@ pub mod snooze_service {
 pub mod uptime_check_service {
     use crate::Result;
     use std::sync::Arc;
+
+    /// A builder for [UptimeCheckService][super::super::client::UptimeCheckService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::*;
+    /// # use builder::uptime_check_service::ClientBuilder;
+    /// # use client::UptimeCheckService;
+    /// let builder : ClientBuilder = UptimeCheckService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://monitoring.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::UptimeCheckService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = UptimeCheckService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
 
     /// Common implementation for [super::super::client::UptimeCheckService] request builders.
     #[derive(Clone, Debug)]

--- a/src/generated/monitoring/v3/src/client.rs
+++ b/src/generated/monitoring/v3/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_v3::client::AlertPolicyService;
+/// let client = AlertPolicyService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The AlertPolicyService API is used to manage (list, create, delete,
@@ -35,8 +44,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `AlertPolicyService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `AlertPolicyService` use the `with_*` methods in the type returned
+/// by [builder()][AlertPolicyService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::alert_policy_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::alert_policy_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -50,21 +74,24 @@ pub struct AlertPolicyService {
 }
 
 impl AlertPolicyService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [AlertPolicyService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::client::AlertPolicyService;
+    /// let client = AlertPolicyService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::alert_policy_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::alert_policy_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::AlertPolicyService + 'static,
@@ -72,6 +99,11 @@ impl AlertPolicyService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -160,6 +192,15 @@ impl AlertPolicyService {
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_v3::client::GroupService;
+/// let client = GroupService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Group API lets you inspect and manage your
@@ -177,8 +218,23 @@ impl AlertPolicyService {
 ///
 /// # Configuration
 ///
-/// `GroupService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `GroupService` use the `with_*` methods in the type returned
+/// by [builder()][GroupService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::group_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::group_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -192,21 +248,22 @@ pub struct GroupService {
 }
 
 impl GroupService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [GroupService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::client::GroupService;
+    /// let client = GroupService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::group_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::group_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::GroupService + 'static,
@@ -214,6 +271,11 @@ impl GroupService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -292,6 +354,15 @@ impl GroupService {
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_v3::client::MetricService;
+/// let client = MetricService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Manages metric descriptors, monitored resource descriptors, and
@@ -299,8 +370,23 @@ impl GroupService {
 ///
 /// # Configuration
 ///
-/// `MetricService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `MetricService` use the `with_*` methods in the type returned
+/// by [builder()][MetricService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::metric_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::metric_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -314,21 +400,22 @@ pub struct MetricService {
 }
 
 impl MetricService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [MetricService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::client::MetricService;
+    /// let client = MetricService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::metric_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::metric_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::MetricService + 'static,
@@ -336,6 +423,11 @@ impl MetricService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -468,6 +560,15 @@ impl MetricService {
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+/// let client = NotificationChannelService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Notification Channel API provides access to configuration that
@@ -475,8 +576,23 @@ impl MetricService {
 ///
 /// # Configuration
 ///
-/// `NotificationChannelService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `NotificationChannelService` use the `with_*` methods in the type returned
+/// by [builder()][NotificationChannelService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::notification_channel_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::notification_channel_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -490,21 +606,24 @@ pub struct NotificationChannelService {
 }
 
 impl NotificationChannelService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [NotificationChannelService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// let client = NotificationChannelService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::notification_channel_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::notification_channel_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::NotificationChannelService + 'static,
@@ -512,6 +631,11 @@ impl NotificationChannelService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -698,6 +822,15 @@ impl NotificationChannelService {
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_v3::client::QueryService;
+/// let client = QueryService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The QueryService API is used to manage time series data in Cloud
@@ -706,8 +839,23 @@ impl NotificationChannelService {
 ///
 /// # Configuration
 ///
-/// `QueryService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `QueryService` use the `with_*` methods in the type returned
+/// by [builder()][QueryService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::query_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::query_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -721,21 +869,22 @@ pub struct QueryService {
 }
 
 impl QueryService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [QueryService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::client::QueryService;
+    /// let client = QueryService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::query_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::query_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::QueryService + 'static,
@@ -743,6 +892,11 @@ impl QueryService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -783,6 +937,15 @@ impl QueryService {
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+/// let client = ServiceMonitoringService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The Cloud Monitoring Service-Oriented Monitoring API has endpoints for
@@ -792,8 +955,23 @@ impl QueryService {
 ///
 /// # Configuration
 ///
-/// `ServiceMonitoringService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `ServiceMonitoringService` use the `with_*` methods in the type returned
+/// by [builder()][ServiceMonitoringService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::service_monitoring_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::service_monitoring_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -807,21 +985,24 @@ pub struct ServiceMonitoringService {
 }
 
 impl ServiceMonitoringService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [ServiceMonitoringService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// let client = ServiceMonitoringService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::service_monitoring_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::service_monitoring_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::ServiceMonitoringService + 'static,
@@ -829,6 +1010,11 @@ impl ServiceMonitoringService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -957,6 +1143,15 @@ impl ServiceMonitoringService {
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_v3::client::SnoozeService;
+/// let client = SnoozeService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The SnoozeService API is used to temporarily prevent an alert policy from
@@ -965,8 +1160,23 @@ impl ServiceMonitoringService {
 ///
 /// # Configuration
 ///
-/// `SnoozeService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SnoozeService` use the `with_*` methods in the type returned
+/// by [builder()][SnoozeService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::snooze_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::snooze_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -980,21 +1190,22 @@ pub struct SnoozeService {
 }
 
 impl SnoozeService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SnoozeService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::client::SnoozeService;
+    /// let client = SnoozeService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::snooze_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::snooze_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SnoozeService + 'static,
@@ -1002,6 +1213,11 @@ impl SnoozeService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(
@@ -1069,6 +1285,15 @@ impl SnoozeService {
 
 /// Implements a client for the Cloud Monitoring API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_monitoring_v3::client::UptimeCheckService;
+/// let client = UptimeCheckService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// The UptimeCheckService API is used to manage (list, create, delete, edit)
@@ -1082,8 +1307,23 @@ impl SnoozeService {
 ///
 /// # Configuration
 ///
-/// `UptimeCheckService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `UptimeCheckService` use the `with_*` methods in the type returned
+/// by [builder()][UptimeCheckService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://monitoring.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::uptime_check_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::uptime_check_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -1097,21 +1337,24 @@ pub struct UptimeCheckService {
 }
 
 impl UptimeCheckService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [UptimeCheckService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_monitoring_v3::client::UptimeCheckService;
+    /// let client = UptimeCheckService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::uptime_check_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::uptime_check_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::UptimeCheckService + 'static,
@@ -1119,6 +1362,11 @@ impl UptimeCheckService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/openapi-validation/src/builder.rs
+++ b/src/generated/openapi-validation/src/builder.rs
@@ -18,6 +18,34 @@ pub mod secret_manager_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [SecretManagerService][super::super::client::SecretManagerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use secretmanager_openapi_v1::*;
+    /// # use builder::secret_manager_service::ClientBuilder;
+    /// # use client::SecretManagerService;
+    /// let builder : ClientBuilder = SecretManagerService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://secretmanager.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::SecretManagerService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = SecretManagerService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Secret Manager API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use secretmanager_openapi_v1::client::SecretManagerService;
+/// let client = SecretManagerService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Stores sensitive data such as API keys, passwords, and certificates.
@@ -28,8 +37,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `SecretManagerService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `SecretManagerService` use the `with_*` methods in the type returned
+/// by [builder()][SecretManagerService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://secretmanager.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::secret_manager_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::secret_manager_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -43,21 +67,24 @@ pub struct SecretManagerService {
 }
 
 impl SecretManagerService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [SecretManagerService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// let client = SecretManagerService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::secret_manager_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::secret_manager_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::SecretManagerService + 'static,
@@ -65,6 +92,11 @@ impl SecretManagerService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/oslogin/common/Cargo.toml
+++ b/src/generated/oslogin/common/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/privacy/dlp/v2/Cargo.toml
+++ b/src/generated/privacy/dlp/v2/Cargo.toml
@@ -40,3 +40,6 @@ serde_json = { version = "1" }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/privacy/dlp/v2/src/builder.rs
+++ b/src/generated/privacy/dlp/v2/src/builder.rs
@@ -18,6 +18,34 @@ pub mod dlp_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DlpService][super::super::client::DlpService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_privacy_dlp_v2::*;
+    /// # use builder::dlp_service::ClientBuilder;
+    /// # use client::DlpService;
+    /// let builder : ClientBuilder = DlpService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://dlp.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DlpService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DlpService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DlpService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/privacy/dlp/v2/src/client.rs
+++ b/src/generated/privacy/dlp/v2/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Sensitive Data Protection (DLP).
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_privacy_dlp_v2::client::DlpService;
+/// let client = DlpService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Sensitive Data Protection provides access to a powerful sensitive data
@@ -31,8 +40,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `DlpService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DlpService` use the `with_*` methods in the type returned
+/// by [builder()][DlpService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://dlp.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::dlp_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::dlp_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -46,21 +70,22 @@ pub struct DlpService {
 }
 
 impl DlpService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DlpService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// let client = DlpService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::dlp_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::dlp_service::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DlpService + 'static,
@@ -68,6 +93,11 @@ impl DlpService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/rpc/context/Cargo.toml
+++ b/src/generated/rpc/context/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/rpc/types/Cargo.toml
+++ b/src/generated/rpc/types/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/spanner/admin/database/v1/src/builder.rs
+++ b/src/generated/spanner/admin/database/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod database_admin {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [DatabaseAdmin][super::super::client::DatabaseAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_spanner_admin_database_v1::*;
+    /// # use builder::database_admin::ClientBuilder;
+    /// # use client::DatabaseAdmin;
+    /// let builder : ClientBuilder = DatabaseAdmin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://spanner.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::DatabaseAdmin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = DatabaseAdmin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::DatabaseAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/spanner/admin/database/v1/src/client.rs
+++ b/src/generated/spanner/admin/database/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Spanner API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+/// let client = DatabaseAdmin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Spanner Database Admin API
@@ -34,8 +43,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `DatabaseAdmin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `DatabaseAdmin` use the `with_*` methods in the type returned
+/// by [builder()][DatabaseAdmin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://spanner.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::database_admin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::database_admin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -49,21 +73,22 @@ pub struct DatabaseAdmin {
 }
 
 impl DatabaseAdmin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [DatabaseAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// let client = DatabaseAdmin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::database_admin::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::database_admin::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::DatabaseAdmin + 'static,
@@ -71,6 +96,11 @@ impl DatabaseAdmin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -43,4 +43,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/spanner/admin/instance/v1/src/builder.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod instance_admin {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [InstanceAdmin][super::super::client::InstanceAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_spanner_admin_instance_v1::*;
+    /// # use builder::instance_admin::ClientBuilder;
+    /// # use client::InstanceAdmin;
+    /// let builder : ClientBuilder = InstanceAdmin::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://spanner.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::InstanceAdmin;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = InstanceAdmin;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::InstanceAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/spanner/admin/instance/v1/src/client.rs
+++ b/src/generated/spanner/admin/instance/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Cloud Spanner API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+/// let client = InstanceAdmin::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Cloud Spanner Instance Admin API
@@ -47,8 +56,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `InstanceAdmin` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `InstanceAdmin` use the `with_*` methods in the type returned
+/// by [builder()][InstanceAdmin::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://spanner.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::instance_admin::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::instance_admin::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -62,21 +86,22 @@ pub struct InstanceAdmin {
 }
 
 impl InstanceAdmin {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [InstanceAdmin].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// let client = InstanceAdmin::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::instance_admin::ClientBuilder {
+        gax::client_builder::internal::new_builder(super::builder::instance_admin::client::Factory)
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::InstanceAdmin + 'static,
@@ -84,6 +109,11 @@ impl InstanceAdmin {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/storagetransfer/v1/Cargo.toml
+++ b/src/generated/storagetransfer/v1/Cargo.toml
@@ -44,4 +44,5 @@ tracing    = { version = "0.1" }
 wkt        = { version = "0.3", path = "../../../../src/wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
+tokio-test.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/src/generated/storagetransfer/v1/src/builder.rs
+++ b/src/generated/storagetransfer/v1/src/builder.rs
@@ -18,6 +18,34 @@ pub mod storage_transfer_service {
     use crate::Result;
     use std::sync::Arc;
 
+    /// A builder for [StorageTransferService][super::super::client::StorageTransferService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_storagetransfer_v1::*;
+    /// # use builder::storage_transfer_service::ClientBuilder;
+    /// # use client::StorageTransferService;
+    /// let builder : ClientBuilder = StorageTransferService::builder();
+    /// let client = builder
+    ///     .with_endpoint("https://storagetransfer.googleapis.com")
+    ///     .build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub type ClientBuilder =
+        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+
+    pub(crate) mod client {
+        use super::super::super::client::StorageTransferService;
+        pub struct Factory;
+        impl gax::client_builder::internal::ClientFactory for Factory {
+            type Client = StorageTransferService;
+            type Credentials = gaxi::options::Credentials;
+            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
+                Self::Client::new(config).await
+            }
+        }
+    }
+
     /// Common implementation for [super::super::client::StorageTransferService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/generated/storagetransfer/v1/src/client.rs
+++ b/src/generated/storagetransfer/v1/src/client.rs
@@ -21,6 +21,15 @@ use std::sync::Arc;
 
 /// Implements a client for the Storage Transfer API.
 ///
+/// # Example
+/// ```
+/// # tokio_test::block_on(async {
+/// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+/// let client = StorageTransferService::builder().build().await?;
+/// // use `client` to make requests to the {Codec.APITitle}}.
+/// # gax::Result::<()>::Ok(()) });
+/// ```
+///
 /// # Service Description
 ///
 /// Storage Transfer Service and its protos.
@@ -29,8 +38,23 @@ use std::sync::Arc;
 ///
 /// # Configuration
 ///
-/// `StorageTransferService` has various configuration parameters, the defaults should
-/// work with most applications.
+/// To configure `StorageTransferService` use the `with_*` methods in the type returned
+/// by [builder()][StorageTransferService::builder]. The default configuration should
+/// work for most applications. Common configuration changes include
+///
+/// * [with_endpoint()]: by default this client uses the global default endpoint
+///   (`https://storagetransfer.googleapis.com`). Applications using regional
+///   endpoints or running in restricted networks (e.g. a network configured
+//    with [Private Google Access with VPC Service Controls]) may want to
+///   override this default.
+/// * [with_credentials()]: by default this client uses
+///   [Application Default Credentials]. Applications using custom
+///   authentication may need to override this default.
+///
+/// [with_endpoint()]: super::builder::storage_transfer_service::ClientBuilder::with_endpoint
+/// [with_credentials()]: super::builder::storage_transfer_service::ClientBuilder::credentials
+/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
+/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 ///
 /// # Pooling and Cloning
 ///
@@ -44,21 +68,24 @@ pub struct StorageTransferService {
 }
 
 impl StorageTransferService {
-    /// Creates a new client with the default configuration.
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(gax::options::ClientConfig::default()).await
-    }
-
-    /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
-        let inner = Self::build_inner(conf).await?;
-        Ok(Self { inner })
+    /// Returns a builder for [StorageTransferService].
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// let client = StorageTransferService::builder().build().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    /// ```
+    pub fn builder() -> super::builder::storage_transfer_service::ClientBuilder {
+        gax::client_builder::internal::new_builder(
+            super::builder::storage_transfer_service::client::Factory,
+        )
     }
 
     /// Creates a new client from the provided stub.
     ///
-    /// The most common case for calling this function is when mocking the
-    /// client.
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
         T: super::stub::StorageTransferService + 'static,
@@ -66,6 +93,11 @@ impl StorageTransferService {
         Self {
             inner: Arc::new(stub),
         }
+    }
+
+    pub(crate) async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
+        let inner = Self::build_inner(config).await?;
+        Ok(Self { inner })
     }
 
     async fn build_inner(

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -31,3 +31,6 @@ bytes      = { version = "1", features = ["serde"] }
 serde      = { version = "1", features = ["serde_derive"] }
 serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 wkt        = { version = "0.3", path = "../../../src/wkt", package = "google-cloud-wkt" }
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -15,19 +15,7 @@
 use crate::Result;
 use rand::{Rng, distr::Alphanumeric};
 
-async fn new_client(
-    config: Option<gax::options::ClientConfig>,
-) -> Result<smo::client::SecretManagerService> {
-    // We could simplify the code, but we want to test both ::new_with_config()
-    // and ::new().
-    if let Some(config) = config {
-        smo::client::SecretManagerService::new_with_config(config).await
-    } else {
-        smo::client::SecretManagerService::new().await
-    }
-}
-
-pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
+pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -48,7 +36,7 @@ pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
         .map(char::from)
         .collect();
 
-    let client = new_client(config).await?;
+    let client = builder.build().await?;
 
     println!("\nTesting create_secret()");
     let create = client

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -16,7 +16,7 @@ use crate::Result;
 use gax::error::Error;
 use rand::{Rng, distr::Alphanumeric};
 
-pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
+pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -41,8 +41,7 @@ pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
     // We must override the configuration to use a regional endpoint.
     let location_id = "us-central1".to_string();
     let endpoint = format!("https://secretmanager.{location_id}.rep.googleapis.com");
-    let config = config.unwrap_or_default().set_endpoint(endpoint);
-    let client = smo::client::SecretManagerService::new_with_config(config).await?;
+    let client = builder.with_endpoint(endpoint).build().await?;
 
     cleanup_stale_secrets(&client, &project_id, &location_id).await?;
 

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -16,19 +16,7 @@ use crate::Result;
 use gax::error::Error;
 use rand::{Rng, distr::Alphanumeric};
 
-async fn new_client(
-    config: Option<gax::options::ClientConfig>,
-) -> Result<sm::client::SecretManagerService> {
-    // We could simplify the code, but we want to test both ::new_with_config()
-    // and ::new().
-    if let Some(config) = config {
-        sm::client::SecretManagerService::new_with_config(config).await
-    } else {
-        sm::client::SecretManagerService::new().await
-    }
-}
-
-pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
+pub async fn run(builder: sm::builder::secret_manager_service::ClientBuilder) -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -50,7 +38,7 @@ pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
         .map(char::from)
         .collect();
 
-    let client = new_client(config).await?;
+    let client = builder.build().await?;
     cleanup_stale_secrets(&client, &project_id, &secret_id).await?;
 
     println!("\nTesting create_secret()");

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -40,8 +40,6 @@ pub async fn until_done(builder: wf::builder::workflows::ClientBuilder) -> Resul
     let location_id = crate::region_id();
     let workflows_runner = crate::workflows_runner()?;
 
-    // We could simplify the code, but we want to test both ::new_with_config()
-    // and ::new().
     let client = builder.build().await?;
     cleanup_stale_workflows(&client, &project_id, &location_id).await?;
 
@@ -110,8 +108,6 @@ pub async fn explicit_loop(builder: wf::builder::workflows::ClientBuilder) -> Re
     let location_id = crate::region_id();
     let workflows_runner = crate::workflows_runner()?;
 
-    // We could simplify the code, but we want to test both ::new_with_config()
-    // and ::new().
     let client = builder.build().await?;
     cleanup_stale_workflows(&client, &project_id, &location_id).await?;
 

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -21,7 +21,7 @@ use wf::Poller;
 
 pub const WORKFLOW_ID_LENGTH: usize = 64;
 
-pub async fn until_done(config: Option<gax::options::ClientConfig>) -> Result<()> {
+pub async fn until_done(builder: wf::builder::workflows::ClientBuilder) -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -42,11 +42,7 @@ pub async fn until_done(config: Option<gax::options::ClientConfig>) -> Result<()
 
     // We could simplify the code, but we want to test both ::new_with_config()
     // and ::new().
-    let client = if let Some(config) = config {
-        wf::client::Workflows::new_with_config(config).await?
-    } else {
-        wf::client::Workflows::new().await?
-    };
+    let client = builder.build().await?;
     cleanup_stale_workflows(&client, &project_id, &location_id).await?;
 
     let source_contents = r###"# Test only workflow
@@ -95,7 +91,7 @@ main:
     Ok(())
 }
 
-pub async fn explicit_loop(config: Option<gax::options::ClientConfig>) -> Result<()> {
+pub async fn explicit_loop(builder: wf::builder::workflows::ClientBuilder) -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -116,11 +112,7 @@ pub async fn explicit_loop(config: Option<gax::options::ClientConfig>) -> Result
 
     // We could simplify the code, but we want to test both ::new_with_config()
     // and ::new().
-    let client = if let Some(config) = config {
-        wf::client::Workflows::new_with_config(config).await?
-    } else {
-        wf::client::Workflows::new().await?
-    };
+    let client = builder.build().await?;
     cleanup_stale_workflows(&client, &project_id, &location_id).await?;
 
     let source_contents = r###"# Test only workflow
@@ -254,7 +246,7 @@ pub async fn manual(
     workflow_id: String,
     workflow: wf::model::Workflow,
 ) -> Result<()> {
-    let client = wf::client::Workflows::new().await?;
+    let client = wf::client::Workflows::builder().build().await?;
 
     println!("\n\nStart create_workflow() LRO and poll it to completion");
     let create = client

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -15,7 +15,6 @@
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod driver {
     use gax::error::*;
-    use gax::options::ClientConfig as Config;
     use test_case::test_case;
 
     fn report(e: Error) -> Error {
@@ -32,8 +31,8 @@ mod driver {
     }
 
     #[test_case(firestore::client::Firestore::builder(); "default")]
-    #[test_case(firestore::client::Firestore::builder().enable_tracing(); "with tracing enabled")]
-    #[test_case(firestore::client::Firestore::builder().set_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(firestore::client::Firestore::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(firestore::client::Firestore::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_firestore(
         builder: firestore::builder::firestore::ClientBuilder,
@@ -44,8 +43,8 @@ mod driver {
     }
 
     #[test_case(sm::client::SecretManagerService::builder(); "default")]
-    #[test_case(sm::client::SecretManagerService::builder().enable_tracing(); "with tracing enabled")]
-    #[test_case(sm::client::SecretManagerService::builder().set_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(sm::client::SecretManagerService::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(sm::client::SecretManagerService::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_secretmanager_protobuf(
         builder: sm::builder::secret_manager_service::ClientBuilder,
@@ -56,8 +55,8 @@ mod driver {
     }
 
     #[test_case(smo::client::SecretManagerService::builder(); "default")]
-    #[test_case(smo::client::SecretManagerService::builder()Config::new().enable_tracing(); "with tracing enabled")]
-    #[test_case(smo::client::SecretManagerService::builder()Config::new().set_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(smo::client::SecretManagerService::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(smo::client::SecretManagerService::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_secretmanager_openapi(
         builder: smo::builder::secret_manager_service::ClientBuilder,
@@ -68,8 +67,8 @@ mod driver {
     }
 
     #[test_case(smo::client::SecretManagerService::builder(); "default")]
-    #[test_case(smo::client::SecretManagerService::builder().enable_tracing(); "with tracing enabled")]
-    #[test_case(smo::client::SecretManagerService::builder().set_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(smo::client::SecretManagerService::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(smo::client::SecretManagerService::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_secretmanager_openapi_locational(
         builder: smo::builder::secret_manager_service::ClientBuilder,
@@ -80,8 +79,8 @@ mod driver {
     }
 
     #[test_case(wf::client::Workflows::builder(); "default")]
-    #[test_case(wf::client::Workflows::builder().enable_tracing(); "with tracing enabled")]
-    #[test_case(wf::client::Workflows::builder().set_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(wf::client::Workflows::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(wf::client::Workflows::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn workflows_until_done(
         builder: wf::builder::workflows::ClientBuilder,
@@ -92,8 +91,8 @@ mod driver {
     }
 
     #[test_case(wf::client::Workflows::builder(); "default")]
-    #[test_case(wf::client::Workflows::builder().enable_tracing(); "with tracing enabled")]
-    #[test_case(wf::client::Workflows::builder().set_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(wf::client::Workflows::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(wf::client::Workflows::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn workflows_explicit(
         builder: wf::builder::workflows::ClientBuilder,
@@ -104,8 +103,8 @@ mod driver {
     }
 
     #[test_case(wf::client::Workflows::builder(); "default")]
-    #[test_case(wf::client::Workflows::builder().enable_tracing(); "with tracing enabled")]
-    #[test_case(wf::client::Workflows::builder().set_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(wf::client::Workflows::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(wf::client::Workflows::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn workflows_manual(
         builder: wf::builder::workflows::ClientBuilder,

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -31,74 +31,86 @@ mod driver {
             .with_attempt_limit(5)
     }
 
-    #[test_case(None; "default")]
-    #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
-    #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
+    #[test_case(firestore::client::Firestore::builder(); "default")]
+    #[test_case(firestore::client::Firestore::builder().enable_tracing(); "with tracing enabled")]
+    #[test_case(firestore::client::Firestore::builder().set_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_firestore(config: Option<Config>) -> integration_tests::Result<()> {
-        integration_tests::firestore::basic(config)
+    async fn run_firestore(
+        builder: firestore::builder::firestore::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::firestore::basic(builder)
             .await
             .map_err(report)
     }
 
-    #[test_case(None; "default")]
-    #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
-    #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
+    #[test_case(sm::client::SecretManagerService::builder(); "default")]
+    #[test_case(sm::client::SecretManagerService::builder().enable_tracing(); "with tracing enabled")]
+    #[test_case(sm::client::SecretManagerService::builder().set_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_secretmanager_protobuf(config: Option<Config>) -> integration_tests::Result<()> {
-        integration_tests::secret_manager::protobuf::run(config)
+    async fn run_secretmanager_protobuf(
+        builder: sm::builder::secret_manager_service::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::secret_manager::protobuf::run(builder)
             .await
             .map_err(report)
     }
 
-    #[test_case(None; "default")]
-    #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
-    #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
+    #[test_case(smo::client::SecretManagerService::builder(); "default")]
+    #[test_case(smo::client::SecretManagerService::builder()Config::new().enable_tracing(); "with tracing enabled")]
+    #[test_case(smo::client::SecretManagerService::builder()Config::new().set_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_secretmanager_openapi(config: Option<Config>) -> integration_tests::Result<()> {
-        integration_tests::secret_manager::openapi::run(config)
+    async fn run_secretmanager_openapi(
+        builder: smo::builder::secret_manager_service::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::secret_manager::openapi::run(builder)
             .await
             .map_err(report)
     }
 
-    #[test_case(None; "default")]
-    #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
-    #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
+    #[test_case(smo::client::SecretManagerService::builder(); "default")]
+    #[test_case(smo::client::SecretManagerService::builder().enable_tracing(); "with tracing enabled")]
+    #[test_case(smo::client::SecretManagerService::builder().set_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_secretmanager_openapi_locational(
-        config: Option<Config>,
+        builder: smo::builder::secret_manager_service::ClientBuilder,
     ) -> integration_tests::Result<()> {
-        integration_tests::secret_manager::openapi_locational::run(config)
+        integration_tests::secret_manager::openapi_locational::run(builder)
             .await
             .map_err(report)
     }
 
-    #[test_case(None; "default")]
-    #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
-    #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
+    #[test_case(wf::client::Workflows::builder(); "default")]
+    #[test_case(wf::client::Workflows::builder().enable_tracing(); "with tracing enabled")]
+    #[test_case(wf::client::Workflows::builder().set_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_until_done(config: Option<Config>) -> integration_tests::Result<()> {
-        integration_tests::workflows::until_done(config)
+    async fn workflows_until_done(
+        builder: wf::builder::workflows::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::workflows::until_done(builder)
             .await
             .map_err(report)
     }
 
-    #[test_case(None; "default")]
-    #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
-    #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
+    #[test_case(wf::client::Workflows::builder(); "default")]
+    #[test_case(wf::client::Workflows::builder().enable_tracing(); "with tracing enabled")]
+    #[test_case(wf::client::Workflows::builder().set_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_explicit(config: Option<Config>) -> integration_tests::Result<()> {
-        integration_tests::workflows::explicit_loop(config)
+    async fn workflows_explicit(
+        builder: wf::builder::workflows::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::workflows::explicit_loop(builder)
             .await
             .map_err(report)
     }
 
-    #[test_case(None; "default")]
-    #[test_case(Some(Config::new().enable_tracing()); "with tracing enabled")]
-    #[test_case(Some(Config::new().set_retry_policy(retry_policy())); "with retry enabled")]
+    #[test_case(wf::client::Workflows::builder(); "default")]
+    #[test_case(wf::client::Workflows::builder().enable_tracing(); "with tracing enabled")]
+    #[test_case(wf::client::Workflows::builder().set_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_manual(config: Option<Config>) -> integration_tests::Result<()> {
-        integration_tests::workflows::until_done(config)
+    async fn workflows_manual(
+        builder: wf::builder::workflows::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::workflows::until_done(builder)
             .await
             .map_err(report)
     }


### PR DESCRIPTION
Change the generated clients to be initialized using a `ClientBuilder`.
Generate some basic examples of how to use this, and change all the
integration tests, user-guide samples, and other code to use the new
initialization.

Part of the work for #1548
