### PR TITLE
docs: user-guide section on retry policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6476,6 +6476,7 @@ dependencies = [
  "google-cloud-longrunning",
  "google-cloud-secretmanager-v1",
  "google-cloud-speech-v2",
+ "rand 0.9.0",
  "tokio",
 ]
 

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -45,3 +45,6 @@ google-cloud-secretmanager-v1 = { version = "0.2", path = "../../src/generated/c
 [features]
 run-integration-tests = []
 log-integration-tests = []
+
+[dev-dependencies]
+rand = "0.9"

--- a/guide/samples/src/lib.rs
+++ b/guide/samples/src/lib.rs
@@ -19,3 +19,4 @@ pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 pub mod lro;
 pub mod polling_policies;
+pub mod retry_policies;

--- a/guide/samples/src/retry_policies.rs
+++ b/guide/samples/src/retry_policies.rs
@@ -1,0 +1,105 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Examples showing how to configure retry policies.
+
+// ANCHOR: client-retry
+pub async fn client_retry(project_id: &str) -> crate::Result<()> {
+    use google_cloud_gax::retry_policy::Aip194Strict;
+    use google_cloud_secretmanager_v1 as secret_manager;
+
+    // ANCHOR: client-retry-client
+    let client = secret_manager::client::SecretManagerService::builder()
+        .with_retry_policy(Aip194Strict)
+        .build()
+        .await?;
+    // ANCHOR_END: client-retry-client
+
+    // ANCHOR: client-retry-request
+    let mut list = client
+        .list_secrets(format!("projects/{project_id}"))
+        .paginator()
+        .await
+        .items();
+    while let Some(secret) = list.next().await {
+        let secret = secret?;
+        println!("  secret={}", secret.name);
+    }
+    // ANCHOR_END: client-retry-request
+
+    Ok(())
+}
+// ANCHOR_END: client-retry
+
+// ANCHOR: client-retry-full
+pub async fn client_retry_full(project_id: &str) -> crate::Result<()> {
+    use google_cloud_gax::retry_policy::Aip194Strict;
+    use google_cloud_gax::retry_policy::RetryPolicyExt;
+    use google_cloud_secretmanager_v1 as secret_manager;
+    use std::time::Duration;
+
+    // ANCHOR: client-retry-full-client
+    let client = secret_manager::client::SecretManagerService::builder()
+        .with_retry_policy(
+            Aip194Strict
+                .with_attempt_limit(5)
+                .with_time_limit(Duration::from_secs(15)),
+        )
+        .build()
+        .await?;
+    // ANCHOR_END: client-retry-full-client
+
+    // ANCHOR: client-retry-full-request
+    let mut list = client
+        .list_secrets(format!("projects/{project_id}"))
+        .paginator()
+        .await
+        .items();
+    while let Some(secret) = list.next().await {
+        let secret = secret?;
+        println!("  secret={}", secret.name);
+    }
+    // ANCHOR_END: client-retry-full-request
+
+    Ok(())
+}
+// ANCHOR_END: client-retry-full
+
+// ANCHOR: request-retry
+use google_cloud_secretmanager_v1 as secret_manager;
+pub async fn request_retry(
+    client: &secret_manager::client::SecretManagerService,
+    project_id: &str,
+    secret_id: &str,
+) -> crate::Result<()> {
+    use google_cloud_gax::options::RequestOptionsBuilder;
+    use google_cloud_gax::retry_policy::AlwaysRetry;
+    use google_cloud_gax::retry_policy::RetryPolicyExt;
+    use std::time::Duration;
+
+    // ANCHOR: request-retry-request
+    client
+        .delete_secret(format!("projects/{project_id}/secrets/{secret_id}"))
+        .with_retry_policy(
+            AlwaysRetry
+                .with_attempt_limit(5)
+                .with_time_limit(Duration::from_secs(15)),
+        )
+        .send()
+        .await?;
+    // ANCHOR_END: request-retry-request
+
+    Ok(())
+}
+// ANCHOR_END: request-retry

--- a/guide/samples/tests/driver.rs
+++ b/guide/samples/tests/driver.rs
@@ -14,6 +14,10 @@
 
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod driver {
+    use rand::{Rng, distr::Alphanumeric};
+
+    const SECRET_ID_LENGTH: usize = 32;
+
     #[tokio::test(flavor = "multi_thread")]
     async fn lro_start() -> user_guide_samples::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
@@ -54,5 +58,59 @@ mod driver {
     async fn polling_policies_rpc_errors() -> user_guide_samples::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         user_guide_samples::polling_policies::rpc_errors(&project_id).await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn retry_policies_client() -> user_guide_samples::Result<()> {
+        let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
+        user_guide_samples::retry_policies::client_retry(&project_id).await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn retry_policies_client_full() -> user_guide_samples::Result<()> {
+        let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
+        user_guide_samples::retry_policies::client_retry_full(&project_id).await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn retry_policies_request() -> user_guide_samples::Result<()> {
+        use google_cloud_gax::options::RequestOptionsBuilder;
+        use google_cloud_gax::retry_policy::AlwaysRetry;
+        use google_cloud_gax::retry_policy::RetryPolicyExt;
+        use google_cloud_secretmanager_v1 as sm;
+        use std::time::Duration;
+
+        let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
+        let secret_id: String = rand::rng()
+            .sample_iter(&Alphanumeric)
+            .take(SECRET_ID_LENGTH)
+            .map(char::from)
+            .collect();
+
+        let client = sm::client::SecretManagerService::builder().build().await?;
+        // The sample will delete this secret. If that fails, the cleanup step
+        // for the integration tests will garbage collect it in a couple of
+        // days.
+        let _ = client
+            .create_secret(format!("projects/{project_id}"))
+            .with_retry_policy(
+                AlwaysRetry
+                    .with_attempt_limit(5)
+                    .with_time_limit(Duration::from_secs(15)),
+            )
+            .set_secret_id(&secret_id)
+            .set_secret(
+                sm::model::Secret::new()
+                    .set_replication(sm::model::Replication::new().set_replication(
+                        sm::model::replication::Replication::Automatic(
+                            sm::model::replication::Automatic::new().into(),
+                        ),
+                    ))
+                    .set_labels([("integration-test", "true")]),
+            )
+            .send()
+            .await?;
+
+        user_guide_samples::retry_policies::request_retry(&client, &project_id, &secret_id).await
     }
 }

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -20,5 +20,6 @@ limitations under the License.
 - [Setting up your development environment](setting_up_your_development_environment.md)
 - [Setting up Rust on Cloud Shell](setting_up_rust_on_cloud_shell.md)
 - [How to initialize a client](initialize_a_client.md)
+- [Configuring retry policies](configuring_retry_policies.md)
 - [Working with long-running operations](working_with_long_running_operations.md)
 - [Configuring polling policies](configuring_polling_policies.md)

--- a/guide/src/configuring_retry_policies.md
+++ b/guide/src/configuring_retry_policies.md
@@ -22,13 +22,13 @@ enable the retry loop. The application must set the retry policy to enable
 this feature.
 
 This guide will show you how to enable the retry loop. First we will show how
-to enable the a common retry policy for all requests in a cient, and then how
+to enable the a common retry policy for all requests in a client, and then how
 to override this default for a specific request.
 
 ## Prerequisites
 
 The guide uses the [Secret Manager] service, that makes the examples more
-concrete and thefore easier to follow. With that said, the same ideas work for
+concrete and therefore easier to follow. With that said, the same ideas work for
 any other service.
 
 You may want to follow the service [quickstart]. This guide will walk you

--- a/guide/src/configuring_retry_policies.md
+++ b/guide/src/configuring_retry_policies.md
@@ -1,0 +1,130 @@
+<!-- 
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Configuring Retry Policies
+
+The Google Cloud client libraries for Rust can automatically retry operations
+that fail due to transient errors. However, the clients do not automatically
+enable the retry loop. The application must set the retry policy to enable
+this feature.
+
+This guide will show you how to enable the retry loop. First we will show how
+to enable the a common retry policy for all requests in a cient, and then how
+to override this default for a specific request.
+
+## Prerequisites
+
+The guide uses the [Secret Manager] service, that makes the examples more
+concrete and thefore easier to follow. With that said, the same ideas work for
+any other service.
+
+You may want to follow the service [quickstart]. This guide will walk you
+through the steps necessary to enable the service, ensure you have logged in,
+and that your account has the necessary permissions.
+
+## Dependencies
+
+As it is usual with Rust, you must declare the dependency in your
+`Cargo.toml` file. We use:
+
+```toml
+{{#include ../samples/Cargo.toml:secretmanager}}
+```
+
+## Configuring the default retry policy
+
+In this example we will use the [`Aip194Strict`] policy, as the name implies
+this policy is based on the guidelines in [`AIP-194`]. The policy is fairly
+conservative, and will not retry any error that indicates the request *may* have
+reached the service, **unless** the request is idempotent. As such, the policy
+is safe to use as a default. The only downside may be additional requests to the
+service, consuming some quota and billing.
+
+To make this the default policy for the service, set the policy during the
+client initialization:
+
+```rust,ignore
+{{#include ../samples/src/retry_policies.rs:client-retry-client}}
+```
+
+The use the service as usual:
+
+```rust,ignore
+{{#include ../samples/src/retry_policies.rs:client-retry-request}}
+```
+
+See [below](#configuring-the-default-retry-policy-complete-code)
+for the complete code.
+
+## Configuring the default retry policy with limits
+
+The [`Aip194Strict`] policy does not limit the number of retry attempts or the
+time spent retrying requests. However, it can be decorated to set such limits,
+for example, you can limit *both* the number of attempts and the time spent in
+the retry loop using::
+
+```rust,ignore
+{{#include ../samples/src/retry_policies.rs:client-retry-full-client}}
+```
+
+Requests work as usual too:
+
+```rust,ignore
+{{#include ../samples/src/retry_policies.rs:client-retry-full-request}}
+```
+
+See [below](#configuring-the-default-retry-policy-with-limits-complete-code)
+for the complete code.
+
+## Override the retry policy for one request
+
+Sometimes applications need to override the retry policy for a specific request.
+For example, the application developer may known specific details of the service
+or application and determine it is safe to tolerate more errors.
+
+For example, deleting a secret is idempotent, it can only succeed once. But the
+client library assumes all delete operations are unsafe. The application can
+override the policy for one request:
+
+```rust,ignore
+{{#include ../samples/src/retry_policies.rs:request-retry-request}}
+```
+
+See [below](#configuring-the-default-retry-policy-with-limits-complete-code)
+for the complete code.
+
+## Configuring the default retry policy: complete code
+
+```rust,ignore
+{{#include ../samples/src/retry_policies.rs:client-retry}}
+```
+
+## Configuring the default retry policy with limits: complete code
+
+```rust,ignore
+{{#include ../samples/src/retry_policies.rs:client-retry-full}}
+```
+
+## Override the retry policy for one request: complete code
+
+```rust,ignore
+{{#include ../samples/src/retry_policies.rs:request-retry}}
+```
+
+[quickstart]: https://cloud.google.com/secret-manager/docs/quickstart
+[secret manager]: https://cloud.google.com/secret-manager
+[`aip-194`]: https://aip.dev/194
+[`aip194strict`]: https://docs.rs/google-cloud-gax/latest/google_cloud_gax/retry_policy/struct.Aip194Strict.html

--- a/guide/src/configuring_retry_policies.md
+++ b/guide/src/configuring_retry_policies.md
@@ -22,12 +22,12 @@ enable the retry loop. The application must set the retry policy to enable
 this feature.
 
 This guide will show you how to enable the retry loop. First we will show how
-to enable the a common retry policy for all requests in a client, and then how
-to override this default for a specific request.
+to enable a common retry policy for all requests in a client, and then how to
+override this default for a specific request.
 
 ## Prerequisites
 
-The guide uses the [Secret Manager] service, that makes the examples more
+The guide uses the [Secret Manager] service. That makes the examples more
 concrete and therefore easier to follow. With that said, the same ideas work for
 any other service.
 
@@ -60,7 +60,7 @@ client initialization:
 {{#include ../samples/src/retry_policies.rs:client-retry-client}}
 ```
 
-The use the service as usual:
+Then use the service as usual:
 
 ```rust,ignore
 {{#include ../samples/src/retry_policies.rs:client-retry-request}}
@@ -72,8 +72,8 @@ for the complete code.
 ## Configuring the default retry policy with limits
 
 The [`Aip194Strict`] policy does not limit the number of retry attempts or the
-time spent retrying requests. However, it can be decorated to set such limits,
-for example, you can limit *both* the number of attempts and the time spent in
+time spent retrying requests. However, it can be decorated to set such limits.
+For example, you can limit *both* the number of attempts and the time spent in
 the retry loop using::
 
 ```rust,ignore
@@ -92,12 +92,12 @@ for the complete code.
 ## Override the retry policy for one request
 
 Sometimes applications need to override the retry policy for a specific request.
-For example, the application developer may known specific details of the service
+For example, the application developer may know specific details of the service
 or application and determine it is safe to tolerate more errors.
 
-For example, deleting a secret is idempotent, it can only succeed once. But the
-client library assumes all delete operations are unsafe. The application can
-override the policy for one request:
+For example, deleting a secret is idempotent, because it can only succeed once.
+But the client library assumes all delete operations are unsafe. The application
+can override the policy for one request:
 
 ```rust,ignore
 {{#include ../samples/src/retry_policies.rs:request-retry-request}}


### PR DESCRIPTION
Add a section on how to configure retry policies for the client and
per-request.

Fixes #1652 and fixes #1653
