### PR TITLE
refactor(generator/dart): minor refactorings and code cleanups

### DIFF
--- a/generator/dart/examples/lib/language.dart
+++ b/generator/dart/examples/lib/language.dart
@@ -32,7 +32,7 @@ void main(List<String> args) async {
   final apiKey = args[0];
 
   final client = auth.clientViaApiKey(apiKey);
-  final service = LanguageService(httpClient: client);
+  final service = LanguageService(client: client);
   final document = Document(
     content: 'Hello, world!',
     type: Document$Type.plainText,

--- a/generator/dart/generated/google_cloud_language/README.md
+++ b/generator/dart/generated/google_cloud_language/README.md
@@ -21,4 +21,4 @@ annotations, to developers.
 
 The main types for this package are:
 
-- LanguageService
+- `LanguageService`

--- a/generator/dart/generated/google_cloud_language/lib/language.dart
+++ b/generator/dart/generated/google_cloud_language/lib/language.dart
@@ -34,8 +34,8 @@ class LanguageService {
 
   final ServiceClient _client;
 
-  LanguageService({required http.Client httpClient})
-      : _client = ServiceClient(httpClient: httpClient);
+  LanguageService({required http.Client client})
+      : _client = ServiceClient(client: client);
 
   /// Analyzes the sentiment of the provided text.
   Future<AnalyzeSentimentResponse> analyzeSentiment(

--- a/generator/dart/packages/google_cloud_gax/lib/common.dart
+++ b/generator/dart/packages/google_cloud_gax/lib/common.dart
@@ -50,12 +50,12 @@ abstract class Enum implements JsonEncodable {
 }
 
 class ServiceClient {
-  final http.Client httpClient;
+  final http.Client client;
 
-  ServiceClient({required this.httpClient});
+  ServiceClient({required this.client});
 
   Future<Map<String, dynamic>> get(Uri url) async {
-    final response = await httpClient.get(
+    final response = await client.get(
       url,
       headers: {
         'x-goog-api-client': _clientName,
@@ -65,7 +65,7 @@ class ServiceClient {
   }
 
   Future<Map<String, dynamic>> post(Uri url, {JsonEncodable? body}) async {
-    final response = await httpClient.post(
+    final response = await client.post(
       url,
       body: body == null ? null : jsonEncode(body.toJson()),
       headers: {
@@ -77,7 +77,7 @@ class ServiceClient {
   }
 
   Future<Map<String, dynamic>> patch(Uri url, {JsonEncodable? body}) async {
-    final response = await httpClient.patch(
+    final response = await client.patch(
       url,
       body: body == null ? null : jsonEncode(body.toJson()),
       headers: {
@@ -89,7 +89,7 @@ class ServiceClient {
   }
 
   Future<Map<String, dynamic>> delete(Uri url) async {
-    final response = await httpClient.delete(
+    final response = await client.delete(
       url,
       headers: {
         'x-goog-api-client': _clientName,
@@ -101,7 +101,7 @@ class ServiceClient {
   /// Closes the client and cleans up any resources associated with it.
   ///
   /// Once [close] is called, no other methods should be called.
-  void close() => httpClient.close();
+  void close() => client.close();
 
   Map<String, dynamic> _processResponse(http.Response response) {
     final statusOK = response.statusCode >= 200 && response.statusCode < 300;

--- a/generator/internal/dart/annotate.go
+++ b/generator/internal/dart/annotate.go
@@ -364,8 +364,8 @@ func (annotate *annotateModel) annotateMessage(m *api.Message, imports map[strin
 	for _, f := range m.Fields {
 		annotate.annotateField(f)
 	}
-	for _, f := range m.OneOfs {
-		annotate.annotateOneOf(f)
+	for _, o := range m.OneOfs {
+		annotate.annotateOneOf(o)
 	}
 	for _, e := range m.Enums {
 		annotate.annotateEnum(e)
@@ -464,10 +464,10 @@ func (annotate *annotateModel) annotateMethod(method *api.Method) {
 	method.Codec = annotation
 }
 
-func (annotate *annotateModel) annotateOneOf(field *api.OneOf) {
-	field.Codec = &oneOfAnnotation{
-		Name:     strcase.ToLowerCamel(field.Name),
-		DocLines: formatDocComments(field.Documentation, annotate.state),
+func (annotate *annotateModel) annotateOneOf(oneof *api.OneOf) {
+	oneof.Codec = &oneOfAnnotation{
+		Name:     strcase.ToLowerCamel(oneof.Name),
+		DocLines: formatDocComments(oneof.Documentation, annotate.state),
 	}
 }
 
@@ -476,7 +476,7 @@ func (annotate *annotateModel) annotateField(field *api.Field) {
 	state := annotate.state
 
 	field.Codec = &fieldAnnotation{
-		Name:     strcase.ToLowerCamel(field.Name),
+		Name:     fieldName(field),
 		Type:     annotate.fieldType(field),
 		DocLines: formatDocComments(field.Documentation, state),
 		Required: required,
@@ -487,7 +487,7 @@ func (annotate *annotateModel) annotateField(field *api.Field) {
 }
 
 func createFromJsonLine(field *api.Field, state *api.APIState, required bool) string {
-	name := strcase.ToLowerCamel(field.Name)
+	name := fieldName(field)
 	message := state.MessageByID[field.TypezID]
 	typeName := ""
 
@@ -548,7 +548,7 @@ func createFromJsonLine(field *api.Field, state *api.APIState, required bool) st
 }
 
 func createToJsonLine(field *api.Field, state *api.APIState, required bool) string {
-	name := strcase.ToLowerCamel(field.Name)
+	name := fieldName(field)
 	message := state.MessageByID[field.TypezID]
 
 	isList := field.Repeated

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -66,6 +66,10 @@ func qualifiedName(m *api.Message) string {
 	return strings.TrimPrefix(m.ID, ".")
 }
 
+func fieldName(field *api.Field) string {
+	return strcase.ToLowerCamel(field.Name)
+}
+
 func enumName(e *api.Enum) string {
 	if e.Parent != nil {
 		return messageName(e.Parent) + "$" + strcase.ToCamel(e.Name)

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -509,7 +509,6 @@ func TestFormatDocCommentsTrimTrailingEmptyLines(t *testing.T) {
 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
 
-
 `
 
 	want := []string{

--- a/generator/internal/dart/generate.go
+++ b/generator/internal/dart/generate.go
@@ -17,7 +17,6 @@ package dart
 import (
 	"embed"
 	"path/filepath"
-	"strconv"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
 	"github.com/googleapis/google-cloud-rust/generator/internal/config"
@@ -39,8 +38,7 @@ func Generate(model *api.API, outdir string, config *config.Config) error {
 	if err == nil {
 		// Check if we're configured to skip formatting.
 		skipFormat := config.Codec["skip-format"]
-		value, _ := strconv.ParseBool(skipFormat)
-		if skipFormat == "" || !value {
+		if skipFormat != "true" {
 			err = formatDirectory(outdir)
 		}
 	}

--- a/generator/internal/dart/templates/README.md.mustache
+++ b/generator/internal/dart/templates/README.md.mustache
@@ -36,6 +36,6 @@ We welcome feedback about the APIs, documentation, missing features, bugs, etc.
 The main types for this package are:
 
 {{#Services}}
-- {{Codec.Name}}
+- `{{Codec.Name}}`
 {{/Services}}
 {{/Codec.HasServices}}

--- a/generator/internal/dart/templates/lib/service.mustache
+++ b/generator/internal/dart/templates/lib/service.mustache
@@ -22,8 +22,8 @@ class {{Codec.Name}} {
 
   final ServiceClient _client;
 
-  {{Codec.Name}}({required http.Client httpClient})
-      : _client = ServiceClient(httpClient: httpClient);
+  {{Codec.Name}}({required http.Client client})
+      : _client = ServiceClient(client: client);
   {{#Codec.Methods}}
   {{> method}}
   {{/Codec.Methods}}

--- a/generator/testdata/dart/protobuf/golden/secretmanager/README.md
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/README.md
@@ -20,4 +20,4 @@ Provides convenience while improving security.
 
 The main types for this package are:
 
-- SecretManagerService
+- `SecretManagerService`

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -41,8 +41,8 @@ class SecretManagerService {
 
   final ServiceClient _client;
 
-  SecretManagerService({required http.Client httpClient})
-      : _client = ServiceClient(httpClient: httpClient);
+  SecretManagerService({required http.Client client})
+      : _client = ServiceClient(client: client);
 
   /// Lists `Secrets`.
   Future<ListSecretsResponse> listSecrets(ListSecretsRequest request) async {


### PR DESCRIPTION
Minor refactorings and code cleanups:
- rename the main (http client) parameter into the service constructors
- consolidate the logic to name fields into a `fieldName()` method
- updates to the generated README.md files
