### PR TITLE
fix(generator/dart): fix decoding for floats and doubles

### DIFF
--- a/generator/dart/generated/google_cloud_language/lib/language.dart
+++ b/generator/dart/generated/google_cloud_language/lib/language.dart
@@ -384,8 +384,8 @@ class Sentiment extends Message {
 
   factory Sentiment.fromJson(Map<String, dynamic> json) {
     return Sentiment(
-      magnitude: json['magnitude'],
-      score: json['score'],
+      magnitude: (json['magnitude'] as num?)?.toDouble(),
+      score: (json['score'] as num?)?.toDouble(),
     );
   }
 
@@ -443,7 +443,7 @@ class EntityMention extends Message {
       text: decode(json['text'], TextSpan.fromJson),
       type: decode(json['type'], EntityMention$Type.fromJson),
       sentiment: decode(json['sentiment'], Sentiment.fromJson),
-      probability: json['probability'],
+      probability: (json['probability'] as num?)?.toDouble(),
     );
   }
 
@@ -559,8 +559,8 @@ class ClassificationCategory extends Message {
   factory ClassificationCategory.fromJson(Map<String, dynamic> json) {
     return ClassificationCategory(
       name: json['name'],
-      confidence: json['confidence'],
-      severity: json['severity'],
+      confidence: (json['confidence'] as num?)?.toDouble(),
+      severity: (json['severity'] as num?)?.toDouble(),
     );
   }
 

--- a/generator/dart/tests/test/encoding_test.dart
+++ b/generator/dart/tests/test/encoding_test.dart
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 /// Tests to validate the generated JSON encoding code using types from
-/// package:google_cloud_rpc.
+/// package:google_cloud_language and package:google_cloud_rpc.
 library;
 
 import 'dart:convert';
 
+import 'package:google_cloud_language/language.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:test/test.dart';
@@ -141,6 +142,26 @@ void main() {
     expect(actual.code, expected.code);
     expect(actual.message, expected.message);
     expect(actual.details, isEmpty);
+  });
+
+  // doubles
+  test('Sentiment', () {
+    // ints
+    var expected = Sentiment(magnitude: 123, score: 0);
+    var actual = Sentiment.fromJson(encodeDecode(expected.toJson()));
+    expect(actual.magnitude, 123.0);
+    expect(actual.score, 0.0);
+
+    // doubles
+    expected = Sentiment(magnitude: 1.5, score: 0.5);
+    actual = Sentiment.fromJson(encodeDecode(expected.toJson()));
+    expect(actual.magnitude, 1.5);
+    expect(actual.score, 0.5);
+
+    // Make sure we handle ints in JSON as doubles.
+    actual = Sentiment.fromJson(jsonDecode('{"magnitude":123,"score":0}'));
+    expect(actual.magnitude, 123);
+    expect(actual.score, 0);
   });
 }
 

--- a/generator/internal/dart/annotate.go
+++ b/generator/internal/dart/annotate.go
@@ -495,6 +495,7 @@ func createFromJsonLine(field *api.Field, state *api.APIState, required bool) st
 	isMessage := field.Typez == api.MESSAGE_TYPE
 	isEnum := field.Typez == api.ENUM_TYPE
 	isBytes := field.Typez == api.BYTES_TYPE
+	isDouble := field.Typez == api.DOUBLE_TYPE || field.Typez == api.FLOAT_TYPE
 	isMap := message != nil && message.IsMap
 	isMessageMap := isMap && message.Fields[1].Typez == api.MESSAGE_TYPE
 
@@ -541,6 +542,9 @@ func createFromJsonLine(field *api.Field, state *api.APIState, required bool) st
 		}
 	} else if isBytes {
 		return "decodeBytes(" + data + ")" + bang
+	} else if isDouble {
+		// (json['name'] as num?)?.toDouble(),
+		return "(" + data + " as num" + opt + ")" + opt + ".toDouble()"
 	} else {
 		// json['name']
 		return data


### PR DESCRIPTION
- fix decoding for floats and doubles

This lets us correctly generate the gemini API (`google/ai/generativelanguage/v1`). A `1.0` would be represented in JSON as a `1`; when decoded by Dart's json decoder, that comes out as an `int`, which is not assignable to a double. Instead we expect a `num` (the parent class of int and double), and then ask it to convert itself to a double.
