### PR TITLE
ci: fix cargo doc for new library

### DIFF
--- a/generator/internal/sidekick/rust_generate.go
+++ b/generator/internal/sidekick/rust_generate.go
@@ -95,7 +95,7 @@ func rust_generate(rootConfig *config.Config, cmdLine *CommandLine) error {
 		return err
 	}
 	slog.Info("Running `cargo doc` on new client library")
-	if err := runExternalCommand("env", "RUSTDOCFLAGS=-D warnings", "cargo", "doc", "--package", packagez); err != nil {
+	if err := runExternalCommand("env", "RUSTDOCFLAGS=-D warnings", "cargo", "doc", "--package", packagez, "--no-deps"); err != nil {
 		return err
 	}
 	slog.Info("Running `cargo clippy` on new client library")


### PR DESCRIPTION
For some reason, `cargo doc` goes into modules that are `#[doc(hidden)]`.

This was making the `sidekick rust-generate` command fail because `crate::grpc::Client` does not exist in `gax-internal` when we only enable the HTTP feature:

https://github.com/googleapis/google-cloud-rust/blob/26c98334608cc879fe1457aa0688eb96324afaa2/src/gax-internal/src/options.rs#L17

Try for yourself with:

```sh
env RUSTDOCFLAGS="-D warnings" cargo doc -p google-cloud-tpu-v2
```

My fix is to not build docs for any dependencies in this command, which is sufficient, and a good change anyway. `cargo docs --no-deps` will still fail if we try to link types that don't exist in dependencies.