### PR TITLE
docs: link client call in builder

### DIFF
--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -71,7 +71,7 @@ pub mod {{Codec.ModuleName}} {
     }
 
     {{#Codec.Methods}}
-    /// The request builder for a {{Codec.ServiceNameToPascal}}::{{Codec.Name}} call.
+    /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.Name}}][super::super::client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}] calls.
     #[derive(Clone, Debug)]
     pub struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
 

--- a/generator/testdata/rust/openapi/golden/src/builder.rs
+++ b/generator/testdata/rust/openapi/golden/src/builder.rs
@@ -65,7 +65,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_locations call.
+    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations()] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<crate::model::ListLocationsRequest>);
 
@@ -137,7 +137,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_location call.
+    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location()] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<crate::model::GetLocationRequest>);
 
@@ -185,7 +185,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secrets call.
+    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets()] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecrets(RequestBuilder<crate::model::ListSecretsRequest>);
 
@@ -257,7 +257,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::create_secret call.
+    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecret(RequestBuilder<crate::model::CreateSecretRequest>);
 
@@ -311,7 +311,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secrets_by_project_and_location call.
+    /// The request builder for [SecretManagerService::list_secrets_by_project_and_location][super::super::client::SecretManagerService::list_secrets_by_project_and_location()] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretsByProjectAndLocation(RequestBuilder<crate::model::ListSecretsByProjectAndLocationRequest>);
 
@@ -389,7 +389,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::create_secret_by_project_and_location call.
+    /// The request builder for [SecretManagerService::create_secret_by_project_and_location][super::super::client::SecretManagerService::create_secret_by_project_and_location()] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecretByProjectAndLocation(RequestBuilder<crate::model::CreateSecretByProjectAndLocationRequest>);
 
@@ -449,7 +449,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::add_secret_version call.
+    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersion(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -509,7 +509,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::add_secret_version_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::add_secret_version_by_project_and_location_and_secret][super::super::client::SecretManagerService::add_secret_version_by_project_and_location_and_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersionByProjectAndLocationAndSecret(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -569,7 +569,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret call.
+    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecret(RequestBuilder<crate::model::GetSecretRequest>);
 
@@ -617,7 +617,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::delete_secret call.
+    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecret(RequestBuilder<crate::model::DeleteSecretRequest>);
 
@@ -671,7 +671,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::update_secret call.
+    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecret(RequestBuilder<crate::model::UpdateSecretRequest>);
 
@@ -731,7 +731,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::get_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_secret_by_project_and_location_and_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretByProjectAndLocationAndSecret(RequestBuilder<crate::model::GetSecretByProjectAndLocationAndSecretRequest>);
 
@@ -785,7 +785,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::delete_secret_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::delete_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::delete_secret_by_project_and_location_and_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecretByProjectAndLocationAndSecret(RequestBuilder<crate::model::DeleteSecretByProjectAndLocationAndSecretRequest>);
 
@@ -845,7 +845,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::update_secret_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::update_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::update_secret_by_project_and_location_and_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecretByProjectAndLocationAndSecret(RequestBuilder<crate::model::UpdateSecretByProjectAndLocationAndSecretRequest>);
 
@@ -911,7 +911,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secret_versions call.
+    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions()] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersions(RequestBuilder<crate::model::ListSecretVersionsRequest>);
 
@@ -989,7 +989,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secret_versions_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::list_secret_versions_by_project_and_location_and_secret][super::super::client::SecretManagerService::list_secret_versions_by_project_and_location_and_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersionsByProjectAndLocationAndSecret(RequestBuilder<crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest>);
 
@@ -1073,7 +1073,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret_version call.
+    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersion(RequestBuilder<crate::model::GetSecretVersionRequest>);
 
@@ -1127,7 +1127,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version()] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest>);
 
@@ -1187,7 +1187,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::access_secret_version call.
+    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersion(RequestBuilder<crate::model::AccessSecretVersionRequest>);
 
@@ -1241,7 +1241,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version()] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest>);
 
@@ -1301,7 +1301,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::disable_secret_version call.
+    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -1367,7 +1367,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version()] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -1433,7 +1433,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::enable_secret_version call.
+    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -1499,7 +1499,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version()] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -1565,7 +1565,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::destroy_secret_version call.
+    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -1631,7 +1631,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version()] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -1697,7 +1697,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::set_iam_policy call.
+    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy()] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -1763,7 +1763,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::set_iam_policy_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::set_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::set_iam_policy_by_project_and_location_and_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicyByProjectAndLocationAndSecret(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -1829,7 +1829,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_iam_policy call.
+    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy()] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<crate::model::GetIamPolicyRequest>);
 
@@ -1883,7 +1883,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_iam_policy_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::get_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_iam_policy_by_project_and_location_and_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicyByProjectAndLocationAndSecret(RequestBuilder<crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest>);
 
@@ -1943,7 +1943,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::test_iam_permissions call.
+    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions()] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 
@@ -2008,7 +2008,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::test_iam_permissions_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::test_iam_permissions_by_project_and_location_and_secret][super::super::client::SecretManagerService::test_iam_permissions_by_project_and_location_and_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissionsByProjectAndLocationAndSecret(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 

--- a/generator/testdata/rust/openapi/golden/src/builder.rs
+++ b/generator/testdata/rust/openapi/golden/src/builder.rs
@@ -65,7 +65,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations()] calls.
+    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<crate::model::ListLocationsRequest>);
 
@@ -137,7 +137,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location()] calls.
+    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<crate::model::GetLocationRequest>);
 
@@ -185,7 +185,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets()] calls.
+    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecrets(RequestBuilder<crate::model::ListSecretsRequest>);
 
@@ -257,7 +257,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret()] calls.
+    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecret(RequestBuilder<crate::model::CreateSecretRequest>);
 
@@ -311,7 +311,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secrets_by_project_and_location][super::super::client::SecretManagerService::list_secrets_by_project_and_location()] calls.
+    /// The request builder for [SecretManagerService::list_secrets_by_project_and_location][super::super::client::SecretManagerService::list_secrets_by_project_and_location] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretsByProjectAndLocation(RequestBuilder<crate::model::ListSecretsByProjectAndLocationRequest>);
 
@@ -389,7 +389,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::create_secret_by_project_and_location][super::super::client::SecretManagerService::create_secret_by_project_and_location()] calls.
+    /// The request builder for [SecretManagerService::create_secret_by_project_and_location][super::super::client::SecretManagerService::create_secret_by_project_and_location] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecretByProjectAndLocation(RequestBuilder<crate::model::CreateSecretByProjectAndLocationRequest>);
 
@@ -449,7 +449,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version()] calls.
+    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersion(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -509,7 +509,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::add_secret_version_by_project_and_location_and_secret][super::super::client::SecretManagerService::add_secret_version_by_project_and_location_and_secret()] calls.
+    /// The request builder for [SecretManagerService::add_secret_version_by_project_and_location_and_secret][super::super::client::SecretManagerService::add_secret_version_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersionByProjectAndLocationAndSecret(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -569,7 +569,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret()] calls.
+    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecret(RequestBuilder<crate::model::GetSecretRequest>);
 
@@ -617,7 +617,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret()] calls.
+    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecret(RequestBuilder<crate::model::DeleteSecretRequest>);
 
@@ -671,7 +671,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret()] calls.
+    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecret(RequestBuilder<crate::model::UpdateSecretRequest>);
 
@@ -731,7 +731,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_secret_by_project_and_location_and_secret()] calls.
+    /// The request builder for [SecretManagerService::get_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_secret_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretByProjectAndLocationAndSecret(RequestBuilder<crate::model::GetSecretByProjectAndLocationAndSecretRequest>);
 
@@ -785,7 +785,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::delete_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::delete_secret_by_project_and_location_and_secret()] calls.
+    /// The request builder for [SecretManagerService::delete_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::delete_secret_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecretByProjectAndLocationAndSecret(RequestBuilder<crate::model::DeleteSecretByProjectAndLocationAndSecretRequest>);
 
@@ -845,7 +845,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::update_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::update_secret_by_project_and_location_and_secret()] calls.
+    /// The request builder for [SecretManagerService::update_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::update_secret_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecretByProjectAndLocationAndSecret(RequestBuilder<crate::model::UpdateSecretByProjectAndLocationAndSecretRequest>);
 
@@ -911,7 +911,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions()] calls.
+    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersions(RequestBuilder<crate::model::ListSecretVersionsRequest>);
 
@@ -989,7 +989,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secret_versions_by_project_and_location_and_secret][super::super::client::SecretManagerService::list_secret_versions_by_project_and_location_and_secret()] calls.
+    /// The request builder for [SecretManagerService::list_secret_versions_by_project_and_location_and_secret][super::super::client::SecretManagerService::list_secret_versions_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersionsByProjectAndLocationAndSecret(RequestBuilder<crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest>);
 
@@ -1073,7 +1073,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version()] calls.
+    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersion(RequestBuilder<crate::model::GetSecretVersionRequest>);
 
@@ -1127,7 +1127,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version()] calls.
+    /// The request builder for [SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest>);
 
@@ -1187,7 +1187,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version()] calls.
+    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersion(RequestBuilder<crate::model::AccessSecretVersionRequest>);
 
@@ -1241,7 +1241,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version()] calls.
+    /// The request builder for [SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest>);
 
@@ -1301,7 +1301,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version()] calls.
+    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -1367,7 +1367,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version()] calls.
+    /// The request builder for [SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -1433,7 +1433,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version()] calls.
+    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -1499,7 +1499,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version()] calls.
+    /// The request builder for [SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -1565,7 +1565,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version()] calls.
+    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -1631,7 +1631,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version()] calls.
+    /// The request builder for [SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersionByProjectAndLocationAndSecretAndVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -1697,7 +1697,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy()] calls.
+    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -1763,7 +1763,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::set_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::set_iam_policy_by_project_and_location_and_secret()] calls.
+    /// The request builder for [SecretManagerService::set_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::set_iam_policy_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicyByProjectAndLocationAndSecret(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -1829,7 +1829,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy()] calls.
+    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<crate::model::GetIamPolicyRequest>);
 
@@ -1883,7 +1883,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_iam_policy_by_project_and_location_and_secret()] calls.
+    /// The request builder for [SecretManagerService::get_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_iam_policy_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicyByProjectAndLocationAndSecret(RequestBuilder<crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest>);
 
@@ -1943,7 +1943,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions()] calls.
+    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 
@@ -2008,7 +2008,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::test_iam_permissions_by_project_and_location_and_secret][super::super::client::SecretManagerService::test_iam_permissions_by_project_and_location_and_secret()] calls.
+    /// The request builder for [SecretManagerService::test_iam_permissions_by_project_and_location_and_secret][super::super::client::SecretManagerService::test_iam_permissions_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissionsByProjectAndLocationAndSecret(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/builder.rs
@@ -65,7 +65,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for a IAMPolicy::set_iam_policy call.
+    /// The request builder for [IAMPolicy::set_iam_policy][super::super::client::IAMPolicy::set_iam_policy()] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -119,7 +119,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for a IAMPolicy::get_iam_policy call.
+    /// The request builder for [IAMPolicy::get_iam_policy][super::super::client::IAMPolicy::get_iam_policy()] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<crate::model::GetIamPolicyRequest>);
 
@@ -167,7 +167,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for a IAMPolicy::test_iam_permissions call.
+    /// The request builder for [IAMPolicy::test_iam_permissions][super::super::client::IAMPolicy::test_iam_permissions()] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/builder.rs
@@ -65,7 +65,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for [IAMPolicy::set_iam_policy][super::super::client::IAMPolicy::set_iam_policy()] calls.
+    /// The request builder for [IAMPolicy::set_iam_policy][super::super::client::IAMPolicy::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -119,7 +119,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for [IAMPolicy::get_iam_policy][super::super::client::IAMPolicy::get_iam_policy()] calls.
+    /// The request builder for [IAMPolicy::get_iam_policy][super::super::client::IAMPolicy::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<crate::model::GetIamPolicyRequest>);
 
@@ -167,7 +167,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for [IAMPolicy::test_iam_permissions][super::super::client::IAMPolicy::test_iam_permissions()] calls.
+    /// The request builder for [IAMPolicy::test_iam_permissions][super::super::client::IAMPolicy::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 

--- a/generator/testdata/rust/protobuf/golden/location/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builder.rs
@@ -65,7 +65,7 @@ pub mod locations {
         }
     }
 
-    /// The request builder for [Locations::list_locations][super::super::client::Locations::list_locations()] calls.
+    /// The request builder for [Locations::list_locations][super::super::client::Locations::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<crate::model::ListLocationsRequest>);
 
@@ -137,7 +137,7 @@ pub mod locations {
         }
     }
 
-    /// The request builder for [Locations::get_location][super::super::client::Locations::get_location()] calls.
+    /// The request builder for [Locations::get_location][super::super::client::Locations::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<crate::model::GetLocationRequest>);
 

--- a/generator/testdata/rust/protobuf/golden/location/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builder.rs
@@ -65,7 +65,7 @@ pub mod locations {
         }
     }
 
-    /// The request builder for a Locations::list_locations call.
+    /// The request builder for [Locations::list_locations][super::super::client::Locations::list_locations()] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<crate::model::ListLocationsRequest>);
 
@@ -137,7 +137,7 @@ pub mod locations {
         }
     }
 
-    /// The request builder for a Locations::get_location call.
+    /// The request builder for [Locations::get_location][super::super::client::Locations::get_location()] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<crate::model::GetLocationRequest>);
 

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builder.rs
@@ -65,7 +65,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secrets call.
+    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets()] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecrets(RequestBuilder<crate::model::ListSecretsRequest>);
 
@@ -137,7 +137,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::create_secret call.
+    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecret(RequestBuilder<crate::model::CreateSecretRequest>);
 
@@ -191,7 +191,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::add_secret_version call.
+    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersion(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -239,7 +239,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret call.
+    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecret(RequestBuilder<crate::model::GetSecretRequest>);
 
@@ -281,7 +281,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::update_secret call.
+    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecret(RequestBuilder<crate::model::UpdateSecretRequest>);
 
@@ -329,7 +329,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::delete_secret call.
+    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret()] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecret(RequestBuilder<crate::model::DeleteSecretRequest>);
 
@@ -377,7 +377,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secret_versions call.
+    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions()] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersions(RequestBuilder<crate::model::ListSecretVersionsRequest>);
 
@@ -449,7 +449,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret_version call.
+    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersion(RequestBuilder<crate::model::GetSecretVersionRequest>);
 
@@ -491,7 +491,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::access_secret_version call.
+    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersion(RequestBuilder<crate::model::AccessSecretVersionRequest>);
 
@@ -533,7 +533,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::disable_secret_version call.
+    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -581,7 +581,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::enable_secret_version call.
+    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -629,7 +629,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::destroy_secret_version call.
+    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version()] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -677,7 +677,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::set_iam_policy call.
+    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy()] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam::model::SetIamPolicyRequest>);
 
@@ -731,7 +731,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_iam_policy call.
+    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy()] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam::model::GetIamPolicyRequest>);
 
@@ -779,7 +779,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::test_iam_permissions call.
+    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions()] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam::model::TestIamPermissionsRequest>);
 
@@ -832,7 +832,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_locations call.
+    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations()] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -904,7 +904,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_location call.
+    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location()] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builder.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builder.rs
@@ -65,7 +65,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets()] calls.
+    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecrets(RequestBuilder<crate::model::ListSecretsRequest>);
 
@@ -137,7 +137,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret()] calls.
+    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecret(RequestBuilder<crate::model::CreateSecretRequest>);
 
@@ -191,7 +191,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version()] calls.
+    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersion(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -239,7 +239,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret()] calls.
+    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecret(RequestBuilder<crate::model::GetSecretRequest>);
 
@@ -281,7 +281,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret()] calls.
+    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecret(RequestBuilder<crate::model::UpdateSecretRequest>);
 
@@ -329,7 +329,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret()] calls.
+    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecret(RequestBuilder<crate::model::DeleteSecretRequest>);
 
@@ -377,7 +377,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions()] calls.
+    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersions(RequestBuilder<crate::model::ListSecretVersionsRequest>);
 
@@ -449,7 +449,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version()] calls.
+    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersion(RequestBuilder<crate::model::GetSecretVersionRequest>);
 
@@ -491,7 +491,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version()] calls.
+    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersion(RequestBuilder<crate::model::AccessSecretVersionRequest>);
 
@@ -533,7 +533,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version()] calls.
+    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -581,7 +581,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version()] calls.
+    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -629,7 +629,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version()] calls.
+    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -677,7 +677,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy()] calls.
+    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam::model::SetIamPolicyRequest>);
 
@@ -731,7 +731,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy()] calls.
+    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam::model::GetIamPolicyRequest>);
 
@@ -779,7 +779,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions()] calls.
+    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam::model::TestIamPermissionsRequest>);
 
@@ -832,7 +832,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations()] calls.
+    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -904,7 +904,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location()] calls.
+    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/firestore/src/generated/gapic/builder.rs
+++ b/src/firestore/src/generated/gapic/builder.rs
@@ -67,7 +67,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::get_document call.
+    /// The request builder for [Firestore::get_document][super::super::client::Firestore::get_document] calls.
     #[derive(Clone, Debug)]
     pub struct GetDocument(RequestBuilder<crate::model::GetDocumentRequest>);
 
@@ -129,7 +129,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::list_documents call.
+    /// The request builder for [Firestore::list_documents][super::super::client::Firestore::list_documents] calls.
     #[derive(Clone, Debug)]
     pub struct ListDocuments(RequestBuilder<crate::model::ListDocumentsRequest>);
 
@@ -236,7 +236,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::update_document call.
+    /// The request builder for [Firestore::update_document][super::super::client::Firestore::update_document] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDocument(RequestBuilder<crate::model::UpdateDocumentRequest>);
 
@@ -308,7 +308,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::delete_document call.
+    /// The request builder for [Firestore::delete_document][super::super::client::Firestore::delete_document] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDocument(RequestBuilder<crate::model::DeleteDocumentRequest>);
 
@@ -359,7 +359,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::begin_transaction call.
+    /// The request builder for [Firestore::begin_transaction][super::super::client::Firestore::begin_transaction] calls.
     #[derive(Clone, Debug)]
     pub struct BeginTransaction(RequestBuilder<crate::model::BeginTransactionRequest>);
 
@@ -413,7 +413,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::commit call.
+    /// The request builder for [Firestore::commit][super::super::client::Firestore::commit] calls.
     #[derive(Clone, Debug)]
     pub struct Commit(RequestBuilder<crate::model::CommitRequest>);
 
@@ -470,7 +470,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::rollback call.
+    /// The request builder for [Firestore::rollback][super::super::client::Firestore::rollback] calls.
     #[derive(Clone, Debug)]
     pub struct Rollback(RequestBuilder<crate::model::RollbackRequest>);
 
@@ -518,7 +518,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::partition_query call.
+    /// The request builder for [Firestore::partition_query][super::super::client::Firestore::partition_query] calls.
     #[derive(Clone, Debug)]
     pub struct PartitionQuery(RequestBuilder<crate::model::PartitionQueryRequest>);
 
@@ -613,7 +613,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::list_collection_ids call.
+    /// The request builder for [Firestore::list_collection_ids][super::super::client::Firestore::list_collection_ids] calls.
     #[derive(Clone, Debug)]
     pub struct ListCollectionIds(RequestBuilder<crate::model::ListCollectionIdsRequest>);
 
@@ -681,7 +681,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::batch_write call.
+    /// The request builder for [Firestore::batch_write][super::super::client::Firestore::batch_write] calls.
     #[derive(Clone, Debug)]
     pub struct BatchWrite(RequestBuilder<crate::model::BatchWriteRequest>);
 
@@ -745,7 +745,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for a Firestore::create_document call.
+    /// The request builder for [Firestore::create_document][super::super::client::Firestore::create_document] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDocument(RequestBuilder<crate::model::CreateDocumentRequest>);
 

--- a/src/generated/api/apikeys/v2/src/builder.rs
+++ b/src/generated/api/apikeys/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::create_key call.
+    /// The request builder for [ApiKeys::create_key][super::super::client::ApiKeys::create_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateKey(RequestBuilder<crate::model::CreateKeyRequest>);
 
@@ -156,7 +156,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::list_keys call.
+    /// The request builder for [ApiKeys::list_keys][super::super::client::ApiKeys::list_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListKeys(RequestBuilder<crate::model::ListKeysRequest>);
 
@@ -230,7 +230,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::get_key call.
+    /// The request builder for [ApiKeys::get_key][super::super::client::ApiKeys::get_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetKey(RequestBuilder<crate::model::GetKeyRequest>);
 
@@ -270,7 +270,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::get_key_string call.
+    /// The request builder for [ApiKeys::get_key_string][super::super::client::ApiKeys::get_key_string] calls.
     #[derive(Clone, Debug)]
     pub struct GetKeyString(RequestBuilder<crate::model::GetKeyStringRequest>);
 
@@ -312,7 +312,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::update_key call.
+    /// The request builder for [ApiKeys::update_key][super::super::client::ApiKeys::update_key] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateKey(RequestBuilder<crate::model::UpdateKeyRequest>);
 
@@ -398,7 +398,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::delete_key call.
+    /// The request builder for [ApiKeys::delete_key][super::super::client::ApiKeys::delete_key] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteKey(RequestBuilder<crate::model::DeleteKeyRequest>);
 
@@ -481,7 +481,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::undelete_key call.
+    /// The request builder for [ApiKeys::undelete_key][super::super::client::ApiKeys::undelete_key] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteKey(RequestBuilder<crate::model::UndeleteKeyRequest>);
 
@@ -558,7 +558,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::lookup_key call.
+    /// The request builder for [ApiKeys::lookup_key][super::super::client::ApiKeys::lookup_key] calls.
     #[derive(Clone, Debug)]
     pub struct LookupKey(RequestBuilder<crate::model::LookupKeyRequest>);
 
@@ -600,7 +600,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for a ApiKeys::get_operation call.
+    /// The request builder for [ApiKeys::get_operation][super::super::client::ApiKeys::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/api/servicecontrol/v1/src/builder.rs
+++ b/src/generated/api/servicecontrol/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod quota_controller {
         }
     }
 
-    /// The request builder for a QuotaController::allocate_quota call.
+    /// The request builder for [QuotaController::allocate_quota][super::super::client::QuotaController::allocate_quota] calls.
     #[derive(Clone, Debug)]
     pub struct AllocateQuota(RequestBuilder<crate::model::AllocateQuotaRequest>);
 
@@ -180,7 +180,7 @@ pub mod service_controller {
         }
     }
 
-    /// The request builder for a ServiceController::check call.
+    /// The request builder for [ServiceController::check][super::super::client::ServiceController::check] calls.
     #[derive(Clone, Debug)]
     pub struct Check(RequestBuilder<crate::model::CheckRequest>);
 
@@ -235,7 +235,7 @@ pub mod service_controller {
         }
     }
 
-    /// The request builder for a ServiceController::report call.
+    /// The request builder for [ServiceController::report][super::super::client::ServiceController::report] calls.
     #[derive(Clone, Debug)]
     pub struct Report(RequestBuilder<crate::model::ReportRequest>);
 

--- a/src/generated/api/servicecontrol/v2/src/builder.rs
+++ b/src/generated/api/servicecontrol/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod service_controller {
         }
     }
 
-    /// The request builder for a ServiceController::check call.
+    /// The request builder for [ServiceController::check][super::super::client::ServiceController::check] calls.
     #[derive(Clone, Debug)]
     pub struct Check(RequestBuilder<crate::model::CheckRequest>);
 
@@ -141,7 +141,7 @@ pub mod service_controller {
         }
     }
 
-    /// The request builder for a ServiceController::report call.
+    /// The request builder for [ServiceController::report][super::super::client::ServiceController::report] calls.
     #[derive(Clone, Debug)]
     pub struct Report(RequestBuilder<crate::model::ReportRequest>);
 

--- a/src/generated/api/servicemanagement/v1/src/builder.rs
+++ b/src/generated/api/servicemanagement/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::list_services call.
+    /// The request builder for [ServiceManager::list_services][super::super::client::ServiceManager::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -142,7 +142,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::get_service call.
+    /// The request builder for [ServiceManager::get_service][super::super::client::ServiceManager::get_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -184,7 +184,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::create_service call.
+    /// The request builder for [ServiceManager::create_service][super::super::client::ServiceManager::create_service] calls.
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -268,7 +268,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::delete_service call.
+    /// The request builder for [ServiceManager::delete_service][super::super::client::ServiceManager::delete_service] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -345,7 +345,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::undelete_service call.
+    /// The request builder for [ServiceManager::undelete_service][super::super::client::ServiceManager::undelete_service] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteService(RequestBuilder<crate::model::UndeleteServiceRequest>);
 
@@ -428,7 +428,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::list_service_configs call.
+    /// The request builder for [ServiceManager::list_service_configs][super::super::client::ServiceManager::list_service_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceConfigs(RequestBuilder<crate::model::ListServiceConfigsRequest>);
 
@@ -500,7 +500,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::get_service_config call.
+    /// The request builder for [ServiceManager::get_service_config][super::super::client::ServiceManager::get_service_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceConfig(RequestBuilder<crate::model::GetServiceConfigRequest>);
 
@@ -560,7 +560,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::create_service_config call.
+    /// The request builder for [ServiceManager::create_service_config][super::super::client::ServiceManager::create_service_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceConfig(RequestBuilder<crate::model::CreateServiceConfigRequest>);
 
@@ -614,7 +614,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::submit_config_source call.
+    /// The request builder for [ServiceManager::submit_config_source][super::super::client::ServiceManager::submit_config_source] calls.
     #[derive(Clone, Debug)]
     pub struct SubmitConfigSource(RequestBuilder<crate::model::SubmitConfigSourceRequest>);
 
@@ -715,7 +715,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::list_service_rollouts call.
+    /// The request builder for [ServiceManager::list_service_rollouts][super::super::client::ServiceManager::list_service_rollouts] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceRollouts(RequestBuilder<crate::model::ListServiceRolloutsRequest>);
 
@@ -793,7 +793,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::get_service_rollout call.
+    /// The request builder for [ServiceManager::get_service_rollout][super::super::client::ServiceManager::get_service_rollout] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceRollout(RequestBuilder<crate::model::GetServiceRolloutRequest>);
 
@@ -844,7 +844,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::create_service_rollout call.
+    /// The request builder for [ServiceManager::create_service_rollout][super::super::client::ServiceManager::create_service_rollout] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceRollout(RequestBuilder<crate::model::CreateServiceRolloutRequest>);
 
@@ -935,7 +935,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::generate_config_report call.
+    /// The request builder for [ServiceManager::generate_config_report][super::super::client::ServiceManager::generate_config_report] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateConfigReport(RequestBuilder<crate::model::GenerateConfigReportRequest>);
 
@@ -986,7 +986,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::set_iam_policy call.
+    /// The request builder for [ServiceManager::set_iam_policy][super::super::client::ServiceManager::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1046,7 +1046,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::get_iam_policy call.
+    /// The request builder for [ServiceManager::get_iam_policy][super::super::client::ServiceManager::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1097,7 +1097,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::test_iam_permissions call.
+    /// The request builder for [ServiceManager::test_iam_permissions][super::super::client::ServiceManager::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1153,7 +1153,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::list_operations call.
+    /// The request builder for [ServiceManager::list_operations][super::super::client::ServiceManager::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1231,7 +1231,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for a ServiceManager::get_operation call.
+    /// The request builder for [ServiceManager::get_operation][super::super::client::ServiceManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/api/serviceusage/v1/src/builder.rs
+++ b/src/generated/api/serviceusage/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for a ServiceUsage::enable_service call.
+    /// The request builder for [ServiceUsage::enable_service][super::super::client::ServiceUsage::enable_service] calls.
     #[derive(Clone, Debug)]
     pub struct EnableService(RequestBuilder<crate::model::EnableServiceRequest>);
 
@@ -150,7 +150,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for a ServiceUsage::disable_service call.
+    /// The request builder for [ServiceUsage::disable_service][super::super::client::ServiceUsage::disable_service] calls.
     #[derive(Clone, Debug)]
     pub struct DisableService(RequestBuilder<crate::model::DisableServiceRequest>);
 
@@ -250,7 +250,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for a ServiceUsage::get_service call.
+    /// The request builder for [ServiceUsage::get_service][super::super::client::ServiceUsage::get_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -292,7 +292,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for a ServiceUsage::list_services call.
+    /// The request builder for [ServiceUsage::list_services][super::super::client::ServiceUsage::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -367,7 +367,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for a ServiceUsage::batch_enable_services call.
+    /// The request builder for [ServiceUsage::batch_enable_services][super::super::client::ServiceUsage::batch_enable_services] calls.
     #[derive(Clone, Debug)]
     pub struct BatchEnableServices(RequestBuilder<crate::model::BatchEnableServicesRequest>);
 
@@ -464,7 +464,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for a ServiceUsage::batch_get_services call.
+    /// The request builder for [ServiceUsage::batch_get_services][super::super::client::ServiceUsage::batch_get_services] calls.
     #[derive(Clone, Debug)]
     pub struct BatchGetServices(RequestBuilder<crate::model::BatchGetServicesRequest>);
 
@@ -520,7 +520,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for a ServiceUsage::list_operations call.
+    /// The request builder for [ServiceUsage::list_operations][super::super::client::ServiceUsage::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -598,7 +598,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for a ServiceUsage::get_operation call.
+    /// The request builder for [ServiceUsage::get_operation][super::super::client::ServiceUsage::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/appengine/v1/src/builder.rs
+++ b/src/generated/appengine/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for a Applications::get_application call.
+    /// The request builder for [Applications::get_application][super::super::client::Applications::get_application] calls.
     #[derive(Clone, Debug)]
     pub struct GetApplication(RequestBuilder<crate::model::GetApplicationRequest>);
 
@@ -109,7 +109,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for a Applications::create_application call.
+    /// The request builder for [Applications::create_application][super::super::client::Applications::create_application] calls.
     #[derive(Clone, Debug)]
     pub struct CreateApplication(RequestBuilder<crate::model::CreateApplicationRequest>);
 
@@ -196,7 +196,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for a Applications::update_application call.
+    /// The request builder for [Applications::update_application][super::super::client::Applications::update_application] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateApplication(RequestBuilder<crate::model::UpdateApplicationRequest>);
 
@@ -298,7 +298,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for a Applications::repair_application call.
+    /// The request builder for [Applications::repair_application][super::super::client::Applications::repair_application] calls.
     #[derive(Clone, Debug)]
     pub struct RepairApplication(RequestBuilder<crate::model::RepairApplicationRequest>);
 
@@ -382,7 +382,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for a Applications::list_operations call.
+    /// The request builder for [Applications::list_operations][super::super::client::Applications::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -460,7 +460,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for a Applications::get_operation call.
+    /// The request builder for [Applications::get_operation][super::super::client::Applications::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -559,7 +559,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::list_services call.
+    /// The request builder for [Services::list_services][super::super::client::Services::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -628,7 +628,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::get_service call.
+    /// The request builder for [Services::get_service][super::super::client::Services::get_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -670,7 +670,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::update_service call.
+    /// The request builder for [Services::update_service][super::super::client::Services::update_service] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -774,7 +774,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::delete_service call.
+    /// The request builder for [Services::delete_service][super::super::client::Services::delete_service] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -851,7 +851,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::list_operations call.
+    /// The request builder for [Services::list_operations][super::super::client::Services::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -929,7 +929,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::get_operation call.
+    /// The request builder for [Services::get_operation][super::super::client::Services::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1028,7 +1028,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::list_versions call.
+    /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -1103,7 +1103,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::get_version call.
+    /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -1151,7 +1151,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::create_version call.
+    /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVersion(RequestBuilder<crate::model::CreateVersionRequest>);
 
@@ -1241,7 +1241,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::update_version call.
+    /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -1339,7 +1339,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::delete_version call.
+    /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -1416,7 +1416,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::list_operations call.
+    /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1494,7 +1494,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::get_operation call.
+    /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1593,7 +1593,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for a Instances::list_instances call.
+    /// The request builder for [Instances::list_instances][super::super::client::Instances::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -1662,7 +1662,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for a Instances::get_instance call.
+    /// The request builder for [Instances::get_instance][super::super::client::Instances::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -1704,7 +1704,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for a Instances::delete_instance call.
+    /// The request builder for [Instances::delete_instance][super::super::client::Instances::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -1781,7 +1781,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for a Instances::debug_instance call.
+    /// The request builder for [Instances::debug_instance][super::super::client::Instances::debug_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DebugInstance(RequestBuilder<crate::model::DebugInstanceRequest>);
 
@@ -1867,7 +1867,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for a Instances::list_operations call.
+    /// The request builder for [Instances::list_operations][super::super::client::Instances::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1945,7 +1945,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for a Instances::get_operation call.
+    /// The request builder for [Instances::get_operation][super::super::client::Instances::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2044,7 +2044,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for a Firewall::list_ingress_rules call.
+    /// The request builder for [Firewall::list_ingress_rules][super::super::client::Firewall::list_ingress_rules] calls.
     #[derive(Clone, Debug)]
     pub struct ListIngressRules(RequestBuilder<crate::model::ListIngressRulesRequest>);
 
@@ -2122,7 +2122,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for a Firewall::batch_update_ingress_rules call.
+    /// The request builder for [Firewall::batch_update_ingress_rules][super::super::client::Firewall::batch_update_ingress_rules] calls.
     #[derive(Clone, Debug)]
     pub struct BatchUpdateIngressRules(
         RequestBuilder<crate::model::BatchUpdateIngressRulesRequest>,
@@ -2180,7 +2180,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for a Firewall::create_ingress_rule call.
+    /// The request builder for [Firewall::create_ingress_rule][super::super::client::Firewall::create_ingress_rule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIngressRule(RequestBuilder<crate::model::CreateIngressRuleRequest>);
 
@@ -2234,7 +2234,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for a Firewall::get_ingress_rule call.
+    /// The request builder for [Firewall::get_ingress_rule][super::super::client::Firewall::get_ingress_rule] calls.
     #[derive(Clone, Debug)]
     pub struct GetIngressRule(RequestBuilder<crate::model::GetIngressRuleRequest>);
 
@@ -2276,7 +2276,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for a Firewall::update_ingress_rule call.
+    /// The request builder for [Firewall::update_ingress_rule][super::super::client::Firewall::update_ingress_rule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateIngressRule(RequestBuilder<crate::model::UpdateIngressRuleRequest>);
 
@@ -2339,7 +2339,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for a Firewall::delete_ingress_rule call.
+    /// The request builder for [Firewall::delete_ingress_rule][super::super::client::Firewall::delete_ingress_rule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIngressRule(RequestBuilder<crate::model::DeleteIngressRuleRequest>);
 
@@ -2384,7 +2384,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for a Firewall::list_operations call.
+    /// The request builder for [Firewall::list_operations][super::super::client::Firewall::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2462,7 +2462,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for a Firewall::get_operation call.
+    /// The request builder for [Firewall::get_operation][super::super::client::Firewall::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2561,7 +2561,7 @@ pub mod authorized_domains {
         }
     }
 
-    /// The request builder for a AuthorizedDomains::list_authorized_domains call.
+    /// The request builder for [AuthorizedDomains::list_authorized_domains][super::super::client::AuthorizedDomains::list_authorized_domains] calls.
     #[derive(Clone, Debug)]
     pub struct ListAuthorizedDomains(RequestBuilder<crate::model::ListAuthorizedDomainsRequest>);
 
@@ -2633,7 +2633,7 @@ pub mod authorized_domains {
         }
     }
 
-    /// The request builder for a AuthorizedDomains::list_operations call.
+    /// The request builder for [AuthorizedDomains::list_operations][super::super::client::AuthorizedDomains::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2711,7 +2711,7 @@ pub mod authorized_domains {
         }
     }
 
-    /// The request builder for a AuthorizedDomains::get_operation call.
+    /// The request builder for [AuthorizedDomains::get_operation][super::super::client::AuthorizedDomains::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2812,7 +2812,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for a AuthorizedCertificates::list_authorized_certificates call.
+    /// The request builder for [AuthorizedCertificates::list_authorized_certificates][super::super::client::AuthorizedCertificates::list_authorized_certificates] calls.
     #[derive(Clone, Debug)]
     pub struct ListAuthorizedCertificates(
         RequestBuilder<crate::model::ListAuthorizedCertificatesRequest>,
@@ -2896,7 +2896,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for a AuthorizedCertificates::get_authorized_certificate call.
+    /// The request builder for [AuthorizedCertificates::get_authorized_certificate][super::super::client::AuthorizedCertificates::get_authorized_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct GetAuthorizedCertificate(
         RequestBuilder<crate::model::GetAuthorizedCertificateRequest>,
@@ -2951,7 +2951,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for a AuthorizedCertificates::create_authorized_certificate call.
+    /// The request builder for [AuthorizedCertificates::create_authorized_certificate][super::super::client::AuthorizedCertificates::create_authorized_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAuthorizedCertificate(
         RequestBuilder<crate::model::CreateAuthorizedCertificateRequest>,
@@ -3011,7 +3011,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for a AuthorizedCertificates::update_authorized_certificate call.
+    /// The request builder for [AuthorizedCertificates::update_authorized_certificate][super::super::client::AuthorizedCertificates::update_authorized_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAuthorizedCertificate(
         RequestBuilder<crate::model::UpdateAuthorizedCertificateRequest>,
@@ -3080,7 +3080,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for a AuthorizedCertificates::delete_authorized_certificate call.
+    /// The request builder for [AuthorizedCertificates::delete_authorized_certificate][super::super::client::AuthorizedCertificates::delete_authorized_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAuthorizedCertificate(
         RequestBuilder<crate::model::DeleteAuthorizedCertificateRequest>,
@@ -3129,7 +3129,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for a AuthorizedCertificates::list_operations call.
+    /// The request builder for [AuthorizedCertificates::list_operations][super::super::client::AuthorizedCertificates::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3209,7 +3209,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for a AuthorizedCertificates::get_operation call.
+    /// The request builder for [AuthorizedCertificates::get_operation][super::super::client::AuthorizedCertificates::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3310,7 +3310,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for a DomainMappings::list_domain_mappings call.
+    /// The request builder for [DomainMappings::list_domain_mappings][super::super::client::DomainMappings::list_domain_mappings] calls.
     #[derive(Clone, Debug)]
     pub struct ListDomainMappings(RequestBuilder<crate::model::ListDomainMappingsRequest>);
 
@@ -3382,7 +3382,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for a DomainMappings::get_domain_mapping call.
+    /// The request builder for [DomainMappings::get_domain_mapping][super::super::client::DomainMappings::get_domain_mapping] calls.
     #[derive(Clone, Debug)]
     pub struct GetDomainMapping(RequestBuilder<crate::model::GetDomainMappingRequest>);
 
@@ -3427,7 +3427,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for a DomainMappings::create_domain_mapping call.
+    /// The request builder for [DomainMappings::create_domain_mapping][super::super::client::DomainMappings::create_domain_mapping] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDomainMapping(RequestBuilder<crate::model::CreateDomainMappingRequest>);
 
@@ -3529,7 +3529,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for a DomainMappings::update_domain_mapping call.
+    /// The request builder for [DomainMappings::update_domain_mapping][super::super::client::DomainMappings::update_domain_mapping] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDomainMapping(RequestBuilder<crate::model::UpdateDomainMappingRequest>);
 
@@ -3631,7 +3631,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for a DomainMappings::delete_domain_mapping call.
+    /// The request builder for [DomainMappings::delete_domain_mapping][super::super::client::DomainMappings::delete_domain_mapping] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDomainMapping(RequestBuilder<crate::model::DeleteDomainMappingRequest>);
 
@@ -3711,7 +3711,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for a DomainMappings::list_operations call.
+    /// The request builder for [DomainMappings::list_operations][super::super::client::DomainMappings::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3789,7 +3789,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for a DomainMappings::get_operation call.
+    /// The request builder for [DomainMappings::get_operation][super::super::client::DomainMappings::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/bigtable/admin/v2/src/builder.rs
+++ b/src/generated/bigtable/admin/v2/src/builder.rs
@@ -69,7 +69,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::create_instance call.
+    /// The request builder for [BigtableInstanceAdmin::create_instance][super::super::client::BigtableInstanceAdmin::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -178,7 +178,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::get_instance call.
+    /// The request builder for [BigtableInstanceAdmin::get_instance][super::super::client::BigtableInstanceAdmin::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -222,7 +222,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::list_instances call.
+    /// The request builder for [BigtableInstanceAdmin::list_instances][super::super::client::BigtableInstanceAdmin::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -272,7 +272,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::update_instance call.
+    /// The request builder for [BigtableInstanceAdmin::update_instance][super::super::client::BigtableInstanceAdmin::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::Instance>);
 
@@ -366,7 +366,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::partial_update_instance call.
+    /// The request builder for [BigtableInstanceAdmin::partial_update_instance][super::super::client::BigtableInstanceAdmin::partial_update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct PartialUpdateInstance(RequestBuilder<crate::model::PartialUpdateInstanceRequest>);
 
@@ -464,7 +464,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::delete_instance call.
+    /// The request builder for [BigtableInstanceAdmin::delete_instance][super::super::client::BigtableInstanceAdmin::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -508,7 +508,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::create_cluster call.
+    /// The request builder for [BigtableInstanceAdmin::create_cluster][super::super::client::BigtableInstanceAdmin::create_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -605,7 +605,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::get_cluster call.
+    /// The request builder for [BigtableInstanceAdmin::get_cluster][super::super::client::BigtableInstanceAdmin::get_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -649,7 +649,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::list_clusters call.
+    /// The request builder for [BigtableInstanceAdmin::list_clusters][super::super::client::BigtableInstanceAdmin::list_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -699,7 +699,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::update_cluster call.
+    /// The request builder for [BigtableInstanceAdmin::update_cluster][super::super::client::BigtableInstanceAdmin::update_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::Cluster>);
 
@@ -834,7 +834,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::partial_update_cluster call.
+    /// The request builder for [BigtableInstanceAdmin::partial_update_cluster][super::super::client::BigtableInstanceAdmin::partial_update_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct PartialUpdateCluster(RequestBuilder<crate::model::PartialUpdateClusterRequest>);
 
@@ -932,7 +932,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::delete_cluster call.
+    /// The request builder for [BigtableInstanceAdmin::delete_cluster][super::super::client::BigtableInstanceAdmin::delete_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -976,7 +976,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::create_app_profile call.
+    /// The request builder for [BigtableInstanceAdmin::create_app_profile][super::super::client::BigtableInstanceAdmin::create_app_profile] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAppProfile(RequestBuilder<crate::model::CreateAppProfileRequest>);
 
@@ -1044,7 +1044,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::get_app_profile call.
+    /// The request builder for [BigtableInstanceAdmin::get_app_profile][super::super::client::BigtableInstanceAdmin::get_app_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetAppProfile(RequestBuilder<crate::model::GetAppProfileRequest>);
 
@@ -1088,7 +1088,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::list_app_profiles call.
+    /// The request builder for [BigtableInstanceAdmin::list_app_profiles][super::super::client::BigtableInstanceAdmin::list_app_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListAppProfiles(RequestBuilder<crate::model::ListAppProfilesRequest>);
 
@@ -1159,7 +1159,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::update_app_profile call.
+    /// The request builder for [BigtableInstanceAdmin::update_app_profile][super::super::client::BigtableInstanceAdmin::update_app_profile] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAppProfile(RequestBuilder<crate::model::UpdateAppProfileRequest>);
 
@@ -1263,7 +1263,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::delete_app_profile call.
+    /// The request builder for [BigtableInstanceAdmin::delete_app_profile][super::super::client::BigtableInstanceAdmin::delete_app_profile] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAppProfile(RequestBuilder<crate::model::DeleteAppProfileRequest>);
 
@@ -1316,7 +1316,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::get_iam_policy call.
+    /// The request builder for [BigtableInstanceAdmin::get_iam_policy][super::super::client::BigtableInstanceAdmin::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1369,7 +1369,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::set_iam_policy call.
+    /// The request builder for [BigtableInstanceAdmin::set_iam_policy][super::super::client::BigtableInstanceAdmin::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1431,7 +1431,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::test_iam_permissions call.
+    /// The request builder for [BigtableInstanceAdmin::test_iam_permissions][super::super::client::BigtableInstanceAdmin::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1489,7 +1489,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::list_hot_tablets call.
+    /// The request builder for [BigtableInstanceAdmin::list_hot_tablets][super::super::client::BigtableInstanceAdmin::list_hot_tablets] calls.
     #[derive(Clone, Debug)]
     pub struct ListHotTablets(RequestBuilder<crate::model::ListHotTabletsRequest>);
 
@@ -1575,7 +1575,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::create_logical_view call.
+    /// The request builder for [BigtableInstanceAdmin::create_logical_view][super::super::client::BigtableInstanceAdmin::create_logical_view] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLogicalView(RequestBuilder<crate::model::CreateLogicalViewRequest>);
 
@@ -1676,7 +1676,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::get_logical_view call.
+    /// The request builder for [BigtableInstanceAdmin::get_logical_view][super::super::client::BigtableInstanceAdmin::get_logical_view] calls.
     #[derive(Clone, Debug)]
     pub struct GetLogicalView(RequestBuilder<crate::model::GetLogicalViewRequest>);
 
@@ -1720,7 +1720,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::list_logical_views call.
+    /// The request builder for [BigtableInstanceAdmin::list_logical_views][super::super::client::BigtableInstanceAdmin::list_logical_views] calls.
     #[derive(Clone, Debug)]
     pub struct ListLogicalViews(RequestBuilder<crate::model::ListLogicalViewsRequest>);
 
@@ -1794,7 +1794,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::update_logical_view call.
+    /// The request builder for [BigtableInstanceAdmin::update_logical_view][super::super::client::BigtableInstanceAdmin::update_logical_view] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateLogicalView(RequestBuilder<crate::model::UpdateLogicalViewRequest>);
 
@@ -1892,7 +1892,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::delete_logical_view call.
+    /// The request builder for [BigtableInstanceAdmin::delete_logical_view][super::super::client::BigtableInstanceAdmin::delete_logical_view] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLogicalView(RequestBuilder<crate::model::DeleteLogicalViewRequest>);
 
@@ -1945,7 +1945,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::create_materialized_view call.
+    /// The request builder for [BigtableInstanceAdmin::create_materialized_view][super::super::client::BigtableInstanceAdmin::create_materialized_view] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMaterializedView(RequestBuilder<crate::model::CreateMaterializedViewRequest>);
 
@@ -2050,7 +2050,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::get_materialized_view call.
+    /// The request builder for [BigtableInstanceAdmin::get_materialized_view][super::super::client::BigtableInstanceAdmin::get_materialized_view] calls.
     #[derive(Clone, Debug)]
     pub struct GetMaterializedView(RequestBuilder<crate::model::GetMaterializedViewRequest>);
 
@@ -2097,7 +2097,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::list_materialized_views call.
+    /// The request builder for [BigtableInstanceAdmin::list_materialized_views][super::super::client::BigtableInstanceAdmin::list_materialized_views] calls.
     #[derive(Clone, Debug)]
     pub struct ListMaterializedViews(RequestBuilder<crate::model::ListMaterializedViewsRequest>);
 
@@ -2171,7 +2171,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::update_materialized_view call.
+    /// The request builder for [BigtableInstanceAdmin::update_materialized_view][super::super::client::BigtableInstanceAdmin::update_materialized_view] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMaterializedView(RequestBuilder<crate::model::UpdateMaterializedViewRequest>);
 
@@ -2273,7 +2273,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::delete_materialized_view call.
+    /// The request builder for [BigtableInstanceAdmin::delete_materialized_view][super::super::client::BigtableInstanceAdmin::delete_materialized_view] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMaterializedView(RequestBuilder<crate::model::DeleteMaterializedViewRequest>);
 
@@ -2326,7 +2326,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::list_operations call.
+    /// The request builder for [BigtableInstanceAdmin::list_operations][super::super::client::BigtableInstanceAdmin::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2406,7 +2406,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::get_operation call.
+    /// The request builder for [BigtableInstanceAdmin::get_operation][super::super::client::BigtableInstanceAdmin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2453,7 +2453,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::delete_operation call.
+    /// The request builder for [BigtableInstanceAdmin::delete_operation][super::super::client::BigtableInstanceAdmin::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2500,7 +2500,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for a BigtableInstanceAdmin::cancel_operation call.
+    /// The request builder for [BigtableInstanceAdmin::cancel_operation][super::super::client::BigtableInstanceAdmin::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2601,7 +2601,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::create_table call.
+    /// The request builder for [BigtableTableAdmin::create_table][super::super::client::BigtableTableAdmin::create_table] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTable(RequestBuilder<crate::model::CreateTableRequest>);
 
@@ -2669,7 +2669,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::create_table_from_snapshot call.
+    /// The request builder for [BigtableTableAdmin::create_table_from_snapshot][super::super::client::BigtableTableAdmin::create_table_from_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTableFromSnapshot(
         RequestBuilder<crate::model::CreateTableFromSnapshotRequest>,
@@ -2767,7 +2767,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::list_tables call.
+    /// The request builder for [BigtableTableAdmin::list_tables][super::super::client::BigtableTableAdmin::list_tables] calls.
     #[derive(Clone, Debug)]
     pub struct ListTables(RequestBuilder<crate::model::ListTablesRequest>);
 
@@ -2842,7 +2842,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::get_table call.
+    /// The request builder for [BigtableTableAdmin::get_table][super::super::client::BigtableTableAdmin::get_table] calls.
     #[derive(Clone, Debug)]
     pub struct GetTable(RequestBuilder<crate::model::GetTableRequest>);
 
@@ -2890,7 +2890,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::update_table call.
+    /// The request builder for [BigtableTableAdmin::update_table][super::super::client::BigtableTableAdmin::update_table] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTable(RequestBuilder<crate::model::UpdateTableRequest>);
 
@@ -2987,7 +2987,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::delete_table call.
+    /// The request builder for [BigtableTableAdmin::delete_table][super::super::client::BigtableTableAdmin::delete_table] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTable(RequestBuilder<crate::model::DeleteTableRequest>);
 
@@ -3029,7 +3029,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::undelete_table call.
+    /// The request builder for [BigtableTableAdmin::undelete_table][super::super::client::BigtableTableAdmin::undelete_table] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteTable(RequestBuilder<crate::model::UndeleteTableRequest>);
 
@@ -3109,7 +3109,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::create_authorized_view call.
+    /// The request builder for [BigtableTableAdmin::create_authorized_view][super::super::client::BigtableTableAdmin::create_authorized_view] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAuthorizedView(RequestBuilder<crate::model::CreateAuthorizedViewRequest>);
 
@@ -3210,7 +3210,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::list_authorized_views call.
+    /// The request builder for [BigtableTableAdmin::list_authorized_views][super::super::client::BigtableTableAdmin::list_authorized_views] calls.
     #[derive(Clone, Debug)]
     pub struct ListAuthorizedViews(RequestBuilder<crate::model::ListAuthorizedViewsRequest>);
 
@@ -3291,7 +3291,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::get_authorized_view call.
+    /// The request builder for [BigtableTableAdmin::get_authorized_view][super::super::client::BigtableTableAdmin::get_authorized_view] calls.
     #[derive(Clone, Debug)]
     pub struct GetAuthorizedView(RequestBuilder<crate::model::GetAuthorizedViewRequest>);
 
@@ -3345,7 +3345,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::update_authorized_view call.
+    /// The request builder for [BigtableTableAdmin::update_authorized_view][super::super::client::BigtableTableAdmin::update_authorized_view] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAuthorizedView(RequestBuilder<crate::model::UpdateAuthorizedViewRequest>);
 
@@ -3449,7 +3449,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::delete_authorized_view call.
+    /// The request builder for [BigtableTableAdmin::delete_authorized_view][super::super::client::BigtableTableAdmin::delete_authorized_view] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAuthorizedView(RequestBuilder<crate::model::DeleteAuthorizedViewRequest>);
 
@@ -3500,7 +3500,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::modify_column_families call.
+    /// The request builder for [BigtableTableAdmin::modify_column_families][super::super::client::BigtableTableAdmin::modify_column_families] calls.
     #[derive(Clone, Debug)]
     pub struct ModifyColumnFamilies(RequestBuilder<crate::model::ModifyColumnFamiliesRequest>);
 
@@ -3562,7 +3562,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::drop_row_range call.
+    /// The request builder for [BigtableTableAdmin::drop_row_range][super::super::client::BigtableTableAdmin::drop_row_range] calls.
     #[derive(Clone, Debug)]
     pub struct DropRowRange(RequestBuilder<crate::model::DropRowRangeRequest>);
 
@@ -3613,7 +3613,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::generate_consistency_token call.
+    /// The request builder for [BigtableTableAdmin::generate_consistency_token][super::super::client::BigtableTableAdmin::generate_consistency_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateConsistencyToken(
         RequestBuilder<crate::model::GenerateConsistencyTokenRequest>,
@@ -3660,7 +3660,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::check_consistency call.
+    /// The request builder for [BigtableTableAdmin::check_consistency][super::super::client::BigtableTableAdmin::check_consistency] calls.
     #[derive(Clone, Debug)]
     pub struct CheckConsistency(RequestBuilder<crate::model::CheckConsistencyRequest>);
 
@@ -3720,7 +3720,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::snapshot_table call.
+    /// The request builder for [BigtableTableAdmin::snapshot_table][super::super::client::BigtableTableAdmin::snapshot_table] calls.
     #[derive(Clone, Debug)]
     pub struct SnapshotTable(RequestBuilder<crate::model::SnapshotTableRequest>);
 
@@ -3824,7 +3824,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::get_snapshot call.
+    /// The request builder for [BigtableTableAdmin::get_snapshot][super::super::client::BigtableTableAdmin::get_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct GetSnapshot(RequestBuilder<crate::model::GetSnapshotRequest>);
 
@@ -3866,7 +3866,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::list_snapshots call.
+    /// The request builder for [BigtableTableAdmin::list_snapshots][super::super::client::BigtableTableAdmin::list_snapshots] calls.
     #[derive(Clone, Debug)]
     pub struct ListSnapshots(RequestBuilder<crate::model::ListSnapshotsRequest>);
 
@@ -3935,7 +3935,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::delete_snapshot call.
+    /// The request builder for [BigtableTableAdmin::delete_snapshot][super::super::client::BigtableTableAdmin::delete_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSnapshot(RequestBuilder<crate::model::DeleteSnapshotRequest>);
 
@@ -3977,7 +3977,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::create_backup call.
+    /// The request builder for [BigtableTableAdmin::create_backup][super::super::client::BigtableTableAdmin::create_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -4072,7 +4072,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::get_backup call.
+    /// The request builder for [BigtableTableAdmin::get_backup][super::super::client::BigtableTableAdmin::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -4114,7 +4114,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::update_backup call.
+    /// The request builder for [BigtableTableAdmin::update_backup][super::super::client::BigtableTableAdmin::update_backup] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -4168,7 +4168,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::delete_backup call.
+    /// The request builder for [BigtableTableAdmin::delete_backup][super::super::client::BigtableTableAdmin::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -4210,7 +4210,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::list_backups call.
+    /// The request builder for [BigtableTableAdmin::list_backups][super::super::client::BigtableTableAdmin::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -4291,7 +4291,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::restore_table call.
+    /// The request builder for [BigtableTableAdmin::restore_table][super::super::client::BigtableTableAdmin::restore_table] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreTable(RequestBuilder<crate::model::RestoreTableRequest>);
 
@@ -4386,7 +4386,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::copy_backup call.
+    /// The request builder for [BigtableTableAdmin::copy_backup][super::super::client::BigtableTableAdmin::copy_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CopyBackup(RequestBuilder<crate::model::CopyBackupRequest>);
 
@@ -4486,7 +4486,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::get_iam_policy call.
+    /// The request builder for [BigtableTableAdmin::get_iam_policy][super::super::client::BigtableTableAdmin::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4537,7 +4537,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::set_iam_policy call.
+    /// The request builder for [BigtableTableAdmin::set_iam_policy][super::super::client::BigtableTableAdmin::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4597,7 +4597,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::test_iam_permissions call.
+    /// The request builder for [BigtableTableAdmin::test_iam_permissions][super::super::client::BigtableTableAdmin::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4653,7 +4653,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::list_operations call.
+    /// The request builder for [BigtableTableAdmin::list_operations][super::super::client::BigtableTableAdmin::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4731,7 +4731,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::get_operation call.
+    /// The request builder for [BigtableTableAdmin::get_operation][super::super::client::BigtableTableAdmin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4776,7 +4776,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::delete_operation call.
+    /// The request builder for [BigtableTableAdmin::delete_operation][super::super::client::BigtableTableAdmin::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4821,7 +4821,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for a BigtableTableAdmin::cancel_operation call.
+    /// The request builder for [BigtableTableAdmin::cancel_operation][super::super::client::BigtableTableAdmin::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/accessapproval/v1/src/builder.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::list_approval_requests call.
+    /// The request builder for [AccessApproval::list_approval_requests][super::super::client::AccessApproval::list_approval_requests] calls.
     #[derive(Clone, Debug)]
     pub struct ListApprovalRequests(RequestBuilder<crate::model::ListApprovalRequestsMessage>);
 
@@ -145,7 +145,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::get_approval_request call.
+    /// The request builder for [AccessApproval::get_approval_request][super::super::client::AccessApproval::get_approval_request] calls.
     #[derive(Clone, Debug)]
     pub struct GetApprovalRequest(RequestBuilder<crate::model::GetApprovalRequestMessage>);
 
@@ -190,7 +190,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::approve_approval_request call.
+    /// The request builder for [AccessApproval::approve_approval_request][super::super::client::AccessApproval::approve_approval_request] calls.
     #[derive(Clone, Debug)]
     pub struct ApproveApprovalRequest(RequestBuilder<crate::model::ApproveApprovalRequestMessage>);
 
@@ -244,7 +244,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::dismiss_approval_request call.
+    /// The request builder for [AccessApproval::dismiss_approval_request][super::super::client::AccessApproval::dismiss_approval_request] calls.
     #[derive(Clone, Debug)]
     pub struct DismissApprovalRequest(RequestBuilder<crate::model::DismissApprovalRequestMessage>);
 
@@ -289,7 +289,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::invalidate_approval_request call.
+    /// The request builder for [AccessApproval::invalidate_approval_request][super::super::client::AccessApproval::invalidate_approval_request] calls.
     #[derive(Clone, Debug)]
     pub struct InvalidateApprovalRequest(
         RequestBuilder<crate::model::InvalidateApprovalRequestMessage>,
@@ -336,7 +336,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::get_access_approval_settings call.
+    /// The request builder for [AccessApproval::get_access_approval_settings][super::super::client::AccessApproval::get_access_approval_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetAccessApprovalSettings(
         RequestBuilder<crate::model::GetAccessApprovalSettingsMessage>,
@@ -383,7 +383,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::update_access_approval_settings call.
+    /// The request builder for [AccessApproval::update_access_approval_settings][super::super::client::AccessApproval::update_access_approval_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAccessApprovalSettings(
         RequestBuilder<crate::model::UpdateAccessApprovalSettingsMessage>,
@@ -442,7 +442,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::delete_access_approval_settings call.
+    /// The request builder for [AccessApproval::delete_access_approval_settings][super::super::client::AccessApproval::delete_access_approval_settings] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAccessApprovalSettings(
         RequestBuilder<crate::model::DeleteAccessApprovalSettingsMessage>,
@@ -489,7 +489,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for a AccessApproval::get_access_approval_service_account call.
+    /// The request builder for [AccessApproval::get_access_approval_service_account][super::super::client::AccessApproval::get_access_approval_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct GetAccessApprovalServiceAccount(
         RequestBuilder<crate::model::GetAccessApprovalServiceAccountMessage>,

--- a/src/generated/cloud/advisorynotifications/v1/src/builder.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// The request builder for a AdvisoryNotificationsService::list_notifications call.
+    /// The request builder for [AdvisoryNotificationsService::list_notifications][super::super::client::AdvisoryNotificationsService::list_notifications] calls.
     #[derive(Clone, Debug)]
     pub struct ListNotifications(RequestBuilder<crate::model::ListNotificationsRequest>);
 
@@ -155,7 +155,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// The request builder for a AdvisoryNotificationsService::get_notification call.
+    /// The request builder for [AdvisoryNotificationsService::get_notification][super::super::client::AdvisoryNotificationsService::get_notification] calls.
     #[derive(Clone, Debug)]
     pub struct GetNotification(RequestBuilder<crate::model::GetNotificationRequest>);
 
@@ -205,7 +205,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// The request builder for a AdvisoryNotificationsService::get_settings call.
+    /// The request builder for [AdvisoryNotificationsService::get_settings][super::super::client::AdvisoryNotificationsService::get_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetSettings(RequestBuilder<crate::model::GetSettingsRequest>);
 
@@ -249,7 +249,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// The request builder for a AdvisoryNotificationsService::update_settings call.
+    /// The request builder for [AdvisoryNotificationsService::update_settings][super::super::client::AdvisoryNotificationsService::update_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSettings(RequestBuilder<crate::model::UpdateSettingsRequest>);
 

--- a/src/generated/cloud/aiplatform/v1/src/builder.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::create_dataset call.
+    /// The request builder for [DatasetService::create_dataset][super::super::client::DatasetService::create_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDataset(RequestBuilder<crate::model::CreateDatasetRequest>);
 
@@ -157,7 +157,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::get_dataset call.
+    /// The request builder for [DatasetService::get_dataset][super::super::client::DatasetService::get_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataset(RequestBuilder<crate::model::GetDatasetRequest>);
 
@@ -205,7 +205,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::update_dataset call.
+    /// The request builder for [DatasetService::update_dataset][super::super::client::DatasetService::update_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDataset(RequestBuilder<crate::model::UpdateDatasetRequest>);
 
@@ -259,7 +259,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::list_datasets call.
+    /// The request builder for [DatasetService::list_datasets][super::super::client::DatasetService::list_datasets] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatasets(RequestBuilder<crate::model::ListDatasetsRequest>);
 
@@ -346,7 +346,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::delete_dataset call.
+    /// The request builder for [DatasetService::delete_dataset][super::super::client::DatasetService::delete_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataset(RequestBuilder<crate::model::DeleteDatasetRequest>);
 
@@ -423,7 +423,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::import_data call.
+    /// The request builder for [DatasetService::import_data][super::super::client::DatasetService::import_data] calls.
     #[derive(Clone, Debug)]
     pub struct ImportData(RequestBuilder<crate::model::ImportDataRequest>);
 
@@ -517,7 +517,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::export_data call.
+    /// The request builder for [DatasetService::export_data][super::super::client::DatasetService::export_data] calls.
     #[derive(Clone, Debug)]
     pub struct ExportData(RequestBuilder<crate::model::ExportDataRequest>);
 
@@ -609,7 +609,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::create_dataset_version call.
+    /// The request builder for [DatasetService::create_dataset_version][super::super::client::DatasetService::create_dataset_version] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDatasetVersion(RequestBuilder<crate::model::CreateDatasetVersionRequest>);
 
@@ -706,7 +706,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::update_dataset_version call.
+    /// The request builder for [DatasetService::update_dataset_version][super::super::client::DatasetService::update_dataset_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDatasetVersion(RequestBuilder<crate::model::UpdateDatasetVersionRequest>);
 
@@ -763,7 +763,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::delete_dataset_version call.
+    /// The request builder for [DatasetService::delete_dataset_version][super::super::client::DatasetService::delete_dataset_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDatasetVersion(RequestBuilder<crate::model::DeleteDatasetVersionRequest>);
 
@@ -843,7 +843,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::get_dataset_version call.
+    /// The request builder for [DatasetService::get_dataset_version][super::super::client::DatasetService::get_dataset_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetDatasetVersion(RequestBuilder<crate::model::GetDatasetVersionRequest>);
 
@@ -894,7 +894,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::list_dataset_versions call.
+    /// The request builder for [DatasetService::list_dataset_versions][super::super::client::DatasetService::list_dataset_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatasetVersions(RequestBuilder<crate::model::ListDatasetVersionsRequest>);
 
@@ -984,7 +984,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::restore_dataset_version call.
+    /// The request builder for [DatasetService::restore_dataset_version][super::super::client::DatasetService::restore_dataset_version] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreDatasetVersion(RequestBuilder<crate::model::RestoreDatasetVersionRequest>);
 
@@ -1072,7 +1072,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::list_data_items call.
+    /// The request builder for [DatasetService::list_data_items][super::super::client::DatasetService::list_data_items] calls.
     #[derive(Clone, Debug)]
     pub struct ListDataItems(RequestBuilder<crate::model::ListDataItemsRequest>);
 
@@ -1159,7 +1159,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::search_data_items call.
+    /// The request builder for [DatasetService::search_data_items][super::super::client::DatasetService::search_data_items] calls.
     #[derive(Clone, Debug)]
     pub struct SearchDataItems(RequestBuilder<crate::model::SearchDataItemsRequest>);
 
@@ -1293,7 +1293,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::list_saved_queries call.
+    /// The request builder for [DatasetService::list_saved_queries][super::super::client::DatasetService::list_saved_queries] calls.
     #[derive(Clone, Debug)]
     pub struct ListSavedQueries(RequestBuilder<crate::model::ListSavedQueriesRequest>);
 
@@ -1383,7 +1383,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::delete_saved_query call.
+    /// The request builder for [DatasetService::delete_saved_query][super::super::client::DatasetService::delete_saved_query] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSavedQuery(RequestBuilder<crate::model::DeleteSavedQueryRequest>);
 
@@ -1463,7 +1463,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::get_annotation_spec call.
+    /// The request builder for [DatasetService::get_annotation_spec][super::super::client::DatasetService::get_annotation_spec] calls.
     #[derive(Clone, Debug)]
     pub struct GetAnnotationSpec(RequestBuilder<crate::model::GetAnnotationSpecRequest>);
 
@@ -1514,7 +1514,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::list_annotations call.
+    /// The request builder for [DatasetService::list_annotations][super::super::client::DatasetService::list_annotations] calls.
     #[derive(Clone, Debug)]
     pub struct ListAnnotations(RequestBuilder<crate::model::ListAnnotationsRequest>);
 
@@ -1601,7 +1601,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::list_locations call.
+    /// The request builder for [DatasetService::list_locations][super::super::client::DatasetService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1679,7 +1679,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::get_location call.
+    /// The request builder for [DatasetService::get_location][super::super::client::DatasetService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1721,7 +1721,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::set_iam_policy call.
+    /// The request builder for [DatasetService::set_iam_policy][super::super::client::DatasetService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1781,7 +1781,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::get_iam_policy call.
+    /// The request builder for [DatasetService::get_iam_policy][super::super::client::DatasetService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1832,7 +1832,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::test_iam_permissions call.
+    /// The request builder for [DatasetService::test_iam_permissions][super::super::client::DatasetService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1888,7 +1888,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::list_operations call.
+    /// The request builder for [DatasetService::list_operations][super::super::client::DatasetService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1966,7 +1966,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::get_operation call.
+    /// The request builder for [DatasetService::get_operation][super::super::client::DatasetService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2011,7 +2011,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::delete_operation call.
+    /// The request builder for [DatasetService::delete_operation][super::super::client::DatasetService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2056,7 +2056,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::cancel_operation call.
+    /// The request builder for [DatasetService::cancel_operation][super::super::client::DatasetService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2101,7 +2101,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::wait_operation call.
+    /// The request builder for [DatasetService::wait_operation][super::super::client::DatasetService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -2208,7 +2208,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::create_deployment_resource_pool call.
+    /// The request builder for [DeploymentResourcePoolService::create_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::create_deployment_resource_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDeploymentResourcePool(
         RequestBuilder<crate::model::CreateDeploymentResourcePoolRequest>,
@@ -2320,7 +2320,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::get_deployment_resource_pool call.
+    /// The request builder for [DeploymentResourcePoolService::get_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::get_deployment_resource_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeploymentResourcePool(
         RequestBuilder<crate::model::GetDeploymentResourcePoolRequest>,
@@ -2369,7 +2369,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::list_deployment_resource_pools call.
+    /// The request builder for [DeploymentResourcePoolService::list_deployment_resource_pools][super::super::client::DeploymentResourcePoolService::list_deployment_resource_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeploymentResourcePools(
         RequestBuilder<crate::model::ListDeploymentResourcePoolsRequest>,
@@ -2447,7 +2447,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::update_deployment_resource_pool call.
+    /// The request builder for [DeploymentResourcePoolService::update_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::update_deployment_resource_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDeploymentResourcePool(
         RequestBuilder<crate::model::UpdateDeploymentResourcePoolRequest>,
@@ -2553,7 +2553,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::delete_deployment_resource_pool call.
+    /// The request builder for [DeploymentResourcePoolService::delete_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::delete_deployment_resource_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDeploymentResourcePool(
         RequestBuilder<crate::model::DeleteDeploymentResourcePoolRequest>,
@@ -2637,7 +2637,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::query_deployed_models call.
+    /// The request builder for [DeploymentResourcePoolService::query_deployed_models][super::super::client::DeploymentResourcePoolService::query_deployed_models] calls.
     #[derive(Clone, Debug)]
     pub struct QueryDeployedModels(RequestBuilder<crate::model::QueryDeployedModelsRequest>);
 
@@ -2711,7 +2711,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::list_locations call.
+    /// The request builder for [DeploymentResourcePoolService::list_locations][super::super::client::DeploymentResourcePoolService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2791,7 +2791,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::get_location call.
+    /// The request builder for [DeploymentResourcePoolService::get_location][super::super::client::DeploymentResourcePoolService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2835,7 +2835,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::set_iam_policy call.
+    /// The request builder for [DeploymentResourcePoolService::set_iam_policy][super::super::client::DeploymentResourcePoolService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2897,7 +2897,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::get_iam_policy call.
+    /// The request builder for [DeploymentResourcePoolService::get_iam_policy][super::super::client::DeploymentResourcePoolService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2950,7 +2950,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::test_iam_permissions call.
+    /// The request builder for [DeploymentResourcePoolService::test_iam_permissions][super::super::client::DeploymentResourcePoolService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3008,7 +3008,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::list_operations call.
+    /// The request builder for [DeploymentResourcePoolService::list_operations][super::super::client::DeploymentResourcePoolService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3088,7 +3088,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::get_operation call.
+    /// The request builder for [DeploymentResourcePoolService::get_operation][super::super::client::DeploymentResourcePoolService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3135,7 +3135,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::delete_operation call.
+    /// The request builder for [DeploymentResourcePoolService::delete_operation][super::super::client::DeploymentResourcePoolService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3182,7 +3182,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::cancel_operation call.
+    /// The request builder for [DeploymentResourcePoolService::cancel_operation][super::super::client::DeploymentResourcePoolService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3229,7 +3229,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for a DeploymentResourcePoolService::wait_operation call.
+    /// The request builder for [DeploymentResourcePoolService::wait_operation][super::super::client::DeploymentResourcePoolService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -3336,7 +3336,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::create_endpoint call.
+    /// The request builder for [EndpointService::create_endpoint][super::super::client::EndpointService::create_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEndpoint(RequestBuilder<crate::model::CreateEndpointRequest>);
 
@@ -3434,7 +3434,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::get_endpoint call.
+    /// The request builder for [EndpointService::get_endpoint][super::super::client::EndpointService::get_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct GetEndpoint(RequestBuilder<crate::model::GetEndpointRequest>);
 
@@ -3476,7 +3476,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::list_endpoints call.
+    /// The request builder for [EndpointService::list_endpoints][super::super::client::EndpointService::list_endpoints] calls.
     #[derive(Clone, Debug)]
     pub struct ListEndpoints(RequestBuilder<crate::model::ListEndpointsRequest>);
 
@@ -3563,7 +3563,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::update_endpoint call.
+    /// The request builder for [EndpointService::update_endpoint][super::super::client::EndpointService::update_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEndpoint(RequestBuilder<crate::model::UpdateEndpointRequest>);
 
@@ -3617,7 +3617,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::update_endpoint_long_running call.
+    /// The request builder for [EndpointService::update_endpoint_long_running][super::super::client::EndpointService::update_endpoint_long_running] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEndpointLongRunning(
         RequestBuilder<crate::model::UpdateEndpointLongRunningRequest>,
@@ -3708,7 +3708,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::delete_endpoint call.
+    /// The request builder for [EndpointService::delete_endpoint][super::super::client::EndpointService::delete_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEndpoint(RequestBuilder<crate::model::DeleteEndpointRequest>);
 
@@ -3785,7 +3785,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::deploy_model call.
+    /// The request builder for [EndpointService::deploy_model][super::super::client::EndpointService::deploy_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeployModel(RequestBuilder<crate::model::DeployModelRequest>);
 
@@ -3891,7 +3891,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::undeploy_model call.
+    /// The request builder for [EndpointService::undeploy_model][super::super::client::EndpointService::undeploy_model] calls.
     #[derive(Clone, Debug)]
     pub struct UndeployModel(RequestBuilder<crate::model::UndeployModelRequest>);
 
@@ -3994,7 +3994,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::mutate_deployed_model call.
+    /// The request builder for [EndpointService::mutate_deployed_model][super::super::client::EndpointService::mutate_deployed_model] calls.
     #[derive(Clone, Debug)]
     pub struct MutateDeployedModel(RequestBuilder<crate::model::MutateDeployedModelRequest>);
 
@@ -4100,7 +4100,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::list_locations call.
+    /// The request builder for [EndpointService::list_locations][super::super::client::EndpointService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4178,7 +4178,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::get_location call.
+    /// The request builder for [EndpointService::get_location][super::super::client::EndpointService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4220,7 +4220,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::set_iam_policy call.
+    /// The request builder for [EndpointService::set_iam_policy][super::super::client::EndpointService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4280,7 +4280,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::get_iam_policy call.
+    /// The request builder for [EndpointService::get_iam_policy][super::super::client::EndpointService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4331,7 +4331,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::test_iam_permissions call.
+    /// The request builder for [EndpointService::test_iam_permissions][super::super::client::EndpointService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4387,7 +4387,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::list_operations call.
+    /// The request builder for [EndpointService::list_operations][super::super::client::EndpointService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4465,7 +4465,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::get_operation call.
+    /// The request builder for [EndpointService::get_operation][super::super::client::EndpointService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4510,7 +4510,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::delete_operation call.
+    /// The request builder for [EndpointService::delete_operation][super::super::client::EndpointService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4555,7 +4555,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::cancel_operation call.
+    /// The request builder for [EndpointService::cancel_operation][super::super::client::EndpointService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4600,7 +4600,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for a EndpointService::wait_operation call.
+    /// The request builder for [EndpointService::wait_operation][super::super::client::EndpointService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -4705,7 +4705,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::evaluate_instances call.
+    /// The request builder for [EvaluationService::evaluate_instances][super::super::client::EvaluationService::evaluate_instances] calls.
     #[derive(Clone, Debug)]
     pub struct EvaluateInstances(RequestBuilder<crate::model::EvaluateInstancesRequest>);
 
@@ -4761,7 +4761,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::list_locations call.
+    /// The request builder for [EvaluationService::list_locations][super::super::client::EvaluationService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4839,7 +4839,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::get_location call.
+    /// The request builder for [EvaluationService::get_location][super::super::client::EvaluationService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4881,7 +4881,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::set_iam_policy call.
+    /// The request builder for [EvaluationService::set_iam_policy][super::super::client::EvaluationService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4941,7 +4941,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::get_iam_policy call.
+    /// The request builder for [EvaluationService::get_iam_policy][super::super::client::EvaluationService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4992,7 +4992,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::test_iam_permissions call.
+    /// The request builder for [EvaluationService::test_iam_permissions][super::super::client::EvaluationService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5048,7 +5048,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::list_operations call.
+    /// The request builder for [EvaluationService::list_operations][super::super::client::EvaluationService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5126,7 +5126,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::get_operation call.
+    /// The request builder for [EvaluationService::get_operation][super::super::client::EvaluationService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5171,7 +5171,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::delete_operation call.
+    /// The request builder for [EvaluationService::delete_operation][super::super::client::EvaluationService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5216,7 +5216,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::cancel_operation call.
+    /// The request builder for [EvaluationService::cancel_operation][super::super::client::EvaluationService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5261,7 +5261,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for a EvaluationService::wait_operation call.
+    /// The request builder for [EvaluationService::wait_operation][super::super::client::EvaluationService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -5368,7 +5368,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::create_feature_online_store call.
+    /// The request builder for [FeatureOnlineStoreAdminService::create_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::create_feature_online_store] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeatureOnlineStore(
         RequestBuilder<crate::model::CreateFeatureOnlineStoreRequest>,
@@ -5477,7 +5477,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::get_feature_online_store call.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::get_feature_online_store] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeatureOnlineStore(RequestBuilder<crate::model::GetFeatureOnlineStoreRequest>);
 
@@ -5524,7 +5524,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::list_feature_online_stores call.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_online_stores][super::super::client::FeatureOnlineStoreAdminService::list_feature_online_stores] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeatureOnlineStores(
         RequestBuilder<crate::model::ListFeatureOnlineStoresRequest>,
@@ -5614,7 +5614,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::update_feature_online_store call.
+    /// The request builder for [FeatureOnlineStoreAdminService::update_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::update_feature_online_store] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeatureOnlineStore(
         RequestBuilder<crate::model::UpdateFeatureOnlineStoreRequest>,
@@ -5720,7 +5720,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::delete_feature_online_store call.
+    /// The request builder for [FeatureOnlineStoreAdminService::delete_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::delete_feature_online_store] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeatureOnlineStore(
         RequestBuilder<crate::model::DeleteFeatureOnlineStoreRequest>,
@@ -5810,7 +5810,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::create_feature_view call.
+    /// The request builder for [FeatureOnlineStoreAdminService::create_feature_view][super::super::client::FeatureOnlineStoreAdminService::create_feature_view] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeatureView(RequestBuilder<crate::model::CreateFeatureViewRequest>);
 
@@ -5919,7 +5919,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::get_feature_view call.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_view][super::super::client::FeatureOnlineStoreAdminService::get_feature_view] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeatureView(RequestBuilder<crate::model::GetFeatureViewRequest>);
 
@@ -5963,7 +5963,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::list_feature_views call.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_views][super::super::client::FeatureOnlineStoreAdminService::list_feature_views] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeatureViews(RequestBuilder<crate::model::ListFeatureViewsRequest>);
 
@@ -6049,7 +6049,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::update_feature_view call.
+    /// The request builder for [FeatureOnlineStoreAdminService::update_feature_view][super::super::client::FeatureOnlineStoreAdminService::update_feature_view] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeatureView(RequestBuilder<crate::model::UpdateFeatureViewRequest>);
 
@@ -6149,7 +6149,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::delete_feature_view call.
+    /// The request builder for [FeatureOnlineStoreAdminService::delete_feature_view][super::super::client::FeatureOnlineStoreAdminService::delete_feature_view] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeatureView(RequestBuilder<crate::model::DeleteFeatureViewRequest>);
 
@@ -6231,7 +6231,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::sync_feature_view call.
+    /// The request builder for [FeatureOnlineStoreAdminService::sync_feature_view][super::super::client::FeatureOnlineStoreAdminService::sync_feature_view] calls.
     #[derive(Clone, Debug)]
     pub struct SyncFeatureView(RequestBuilder<crate::model::SyncFeatureViewRequest>);
 
@@ -6275,7 +6275,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::get_feature_view_sync call.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_view_sync][super::super::client::FeatureOnlineStoreAdminService::get_feature_view_sync] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeatureViewSync(RequestBuilder<crate::model::GetFeatureViewSyncRequest>);
 
@@ -6322,7 +6322,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::list_feature_view_syncs call.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_view_syncs][super::super::client::FeatureOnlineStoreAdminService::list_feature_view_syncs] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeatureViewSyncs(RequestBuilder<crate::model::ListFeatureViewSyncsRequest>);
 
@@ -6408,7 +6408,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::list_locations call.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_locations][super::super::client::FeatureOnlineStoreAdminService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6488,7 +6488,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::get_location call.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_location][super::super::client::FeatureOnlineStoreAdminService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6532,7 +6532,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::set_iam_policy call.
+    /// The request builder for [FeatureOnlineStoreAdminService::set_iam_policy][super::super::client::FeatureOnlineStoreAdminService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -6594,7 +6594,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::get_iam_policy call.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_iam_policy][super::super::client::FeatureOnlineStoreAdminService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -6647,7 +6647,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::test_iam_permissions call.
+    /// The request builder for [FeatureOnlineStoreAdminService::test_iam_permissions][super::super::client::FeatureOnlineStoreAdminService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -6705,7 +6705,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::list_operations call.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_operations][super::super::client::FeatureOnlineStoreAdminService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6785,7 +6785,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::get_operation call.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_operation][super::super::client::FeatureOnlineStoreAdminService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6832,7 +6832,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::delete_operation call.
+    /// The request builder for [FeatureOnlineStoreAdminService::delete_operation][super::super::client::FeatureOnlineStoreAdminService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -6879,7 +6879,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::cancel_operation call.
+    /// The request builder for [FeatureOnlineStoreAdminService::cancel_operation][super::super::client::FeatureOnlineStoreAdminService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6926,7 +6926,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreAdminService::wait_operation call.
+    /// The request builder for [FeatureOnlineStoreAdminService::wait_operation][super::super::client::FeatureOnlineStoreAdminService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -7035,7 +7035,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::fetch_feature_values call.
+    /// The request builder for [FeatureOnlineStoreService::fetch_feature_values][super::super::client::FeatureOnlineStoreService::fetch_feature_values] calls.
     #[derive(Clone, Debug)]
     pub struct FetchFeatureValues(RequestBuilder<crate::model::FetchFeatureValuesRequest>);
 
@@ -7100,7 +7100,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::search_nearest_entities call.
+    /// The request builder for [FeatureOnlineStoreService::search_nearest_entities][super::super::client::FeatureOnlineStoreService::search_nearest_entities] calls.
     #[derive(Clone, Debug)]
     pub struct SearchNearestEntities(RequestBuilder<crate::model::SearchNearestEntitiesRequest>);
 
@@ -7162,7 +7162,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::list_locations call.
+    /// The request builder for [FeatureOnlineStoreService::list_locations][super::super::client::FeatureOnlineStoreService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -7242,7 +7242,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::get_location call.
+    /// The request builder for [FeatureOnlineStoreService::get_location][super::super::client::FeatureOnlineStoreService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -7286,7 +7286,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::set_iam_policy call.
+    /// The request builder for [FeatureOnlineStoreService::set_iam_policy][super::super::client::FeatureOnlineStoreService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -7348,7 +7348,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::get_iam_policy call.
+    /// The request builder for [FeatureOnlineStoreService::get_iam_policy][super::super::client::FeatureOnlineStoreService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -7401,7 +7401,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::test_iam_permissions call.
+    /// The request builder for [FeatureOnlineStoreService::test_iam_permissions][super::super::client::FeatureOnlineStoreService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -7459,7 +7459,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::list_operations call.
+    /// The request builder for [FeatureOnlineStoreService::list_operations][super::super::client::FeatureOnlineStoreService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7539,7 +7539,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::get_operation call.
+    /// The request builder for [FeatureOnlineStoreService::get_operation][super::super::client::FeatureOnlineStoreService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7586,7 +7586,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::delete_operation call.
+    /// The request builder for [FeatureOnlineStoreService::delete_operation][super::super::client::FeatureOnlineStoreService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -7633,7 +7633,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::cancel_operation call.
+    /// The request builder for [FeatureOnlineStoreService::cancel_operation][super::super::client::FeatureOnlineStoreService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7680,7 +7680,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for a FeatureOnlineStoreService::wait_operation call.
+    /// The request builder for [FeatureOnlineStoreService::wait_operation][super::super::client::FeatureOnlineStoreService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -7789,7 +7789,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::create_feature_group call.
+    /// The request builder for [FeatureRegistryService::create_feature_group][super::super::client::FeatureRegistryService::create_feature_group] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeatureGroup(RequestBuilder<crate::model::CreateFeatureGroupRequest>);
 
@@ -7894,7 +7894,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::get_feature_group call.
+    /// The request builder for [FeatureRegistryService::get_feature_group][super::super::client::FeatureRegistryService::get_feature_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeatureGroup(RequestBuilder<crate::model::GetFeatureGroupRequest>);
 
@@ -7938,7 +7938,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::list_feature_groups call.
+    /// The request builder for [FeatureRegistryService::list_feature_groups][super::super::client::FeatureRegistryService::list_feature_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeatureGroups(RequestBuilder<crate::model::ListFeatureGroupsRequest>);
 
@@ -8024,7 +8024,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::update_feature_group call.
+    /// The request builder for [FeatureRegistryService::update_feature_group][super::super::client::FeatureRegistryService::update_feature_group] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeatureGroup(RequestBuilder<crate::model::UpdateFeatureGroupRequest>);
 
@@ -8126,7 +8126,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::delete_feature_group call.
+    /// The request builder for [FeatureRegistryService::delete_feature_group][super::super::client::FeatureRegistryService::delete_feature_group] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeatureGroup(RequestBuilder<crate::model::DeleteFeatureGroupRequest>);
 
@@ -8214,7 +8214,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::create_feature call.
+    /// The request builder for [FeatureRegistryService::create_feature][super::super::client::FeatureRegistryService::create_feature] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeature(RequestBuilder<crate::model::CreateFeatureRequest>);
 
@@ -8312,7 +8312,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::batch_create_features call.
+    /// The request builder for [FeatureRegistryService::batch_create_features][super::super::client::FeatureRegistryService::batch_create_features] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateFeatures(RequestBuilder<crate::model::BatchCreateFeaturesRequest>);
 
@@ -8413,7 +8413,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::get_feature call.
+    /// The request builder for [FeatureRegistryService::get_feature][super::super::client::FeatureRegistryService::get_feature] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeature(RequestBuilder<crate::model::GetFeatureRequest>);
 
@@ -8457,7 +8457,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::list_features call.
+    /// The request builder for [FeatureRegistryService::list_features][super::super::client::FeatureRegistryService::list_features] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeatures(RequestBuilder<crate::model::ListFeaturesRequest>);
 
@@ -8552,7 +8552,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::update_feature call.
+    /// The request builder for [FeatureRegistryService::update_feature][super::super::client::FeatureRegistryService::update_feature] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeature(RequestBuilder<crate::model::UpdateFeatureRequest>);
 
@@ -8647,7 +8647,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::delete_feature call.
+    /// The request builder for [FeatureRegistryService::delete_feature][super::super::client::FeatureRegistryService::delete_feature] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeature(RequestBuilder<crate::model::DeleteFeatureRequest>);
 
@@ -8726,7 +8726,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::list_locations call.
+    /// The request builder for [FeatureRegistryService::list_locations][super::super::client::FeatureRegistryService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -8806,7 +8806,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::get_location call.
+    /// The request builder for [FeatureRegistryService::get_location][super::super::client::FeatureRegistryService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -8850,7 +8850,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::set_iam_policy call.
+    /// The request builder for [FeatureRegistryService::set_iam_policy][super::super::client::FeatureRegistryService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -8912,7 +8912,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::get_iam_policy call.
+    /// The request builder for [FeatureRegistryService::get_iam_policy][super::super::client::FeatureRegistryService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -8965,7 +8965,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::test_iam_permissions call.
+    /// The request builder for [FeatureRegistryService::test_iam_permissions][super::super::client::FeatureRegistryService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -9023,7 +9023,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::list_operations call.
+    /// The request builder for [FeatureRegistryService::list_operations][super::super::client::FeatureRegistryService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9103,7 +9103,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::get_operation call.
+    /// The request builder for [FeatureRegistryService::get_operation][super::super::client::FeatureRegistryService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9150,7 +9150,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::delete_operation call.
+    /// The request builder for [FeatureRegistryService::delete_operation][super::super::client::FeatureRegistryService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -9197,7 +9197,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::cancel_operation call.
+    /// The request builder for [FeatureRegistryService::cancel_operation][super::super::client::FeatureRegistryService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9244,7 +9244,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for a FeatureRegistryService::wait_operation call.
+    /// The request builder for [FeatureRegistryService::wait_operation][super::super::client::FeatureRegistryService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -9353,7 +9353,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::read_feature_values call.
+    /// The request builder for [FeaturestoreOnlineServingService::read_feature_values][super::super::client::FeaturestoreOnlineServingService::read_feature_values] calls.
     #[derive(Clone, Debug)]
     pub struct ReadFeatureValues(RequestBuilder<crate::model::ReadFeatureValuesRequest>);
 
@@ -9415,7 +9415,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::write_feature_values call.
+    /// The request builder for [FeaturestoreOnlineServingService::write_feature_values][super::super::client::FeaturestoreOnlineServingService::write_feature_values] calls.
     #[derive(Clone, Debug)]
     pub struct WriteFeatureValues(RequestBuilder<crate::model::WriteFeatureValuesRequest>);
 
@@ -9473,7 +9473,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::list_locations call.
+    /// The request builder for [FeaturestoreOnlineServingService::list_locations][super::super::client::FeaturestoreOnlineServingService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -9553,7 +9553,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::get_location call.
+    /// The request builder for [FeaturestoreOnlineServingService::get_location][super::super::client::FeaturestoreOnlineServingService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -9597,7 +9597,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::set_iam_policy call.
+    /// The request builder for [FeaturestoreOnlineServingService::set_iam_policy][super::super::client::FeaturestoreOnlineServingService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -9659,7 +9659,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::get_iam_policy call.
+    /// The request builder for [FeaturestoreOnlineServingService::get_iam_policy][super::super::client::FeaturestoreOnlineServingService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -9712,7 +9712,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::test_iam_permissions call.
+    /// The request builder for [FeaturestoreOnlineServingService::test_iam_permissions][super::super::client::FeaturestoreOnlineServingService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -9770,7 +9770,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::list_operations call.
+    /// The request builder for [FeaturestoreOnlineServingService::list_operations][super::super::client::FeaturestoreOnlineServingService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9850,7 +9850,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::get_operation call.
+    /// The request builder for [FeaturestoreOnlineServingService::get_operation][super::super::client::FeaturestoreOnlineServingService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9897,7 +9897,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::delete_operation call.
+    /// The request builder for [FeaturestoreOnlineServingService::delete_operation][super::super::client::FeaturestoreOnlineServingService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -9944,7 +9944,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::cancel_operation call.
+    /// The request builder for [FeaturestoreOnlineServingService::cancel_operation][super::super::client::FeaturestoreOnlineServingService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9991,7 +9991,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for a FeaturestoreOnlineServingService::wait_operation call.
+    /// The request builder for [FeaturestoreOnlineServingService::wait_operation][super::super::client::FeaturestoreOnlineServingService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -10098,7 +10098,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::create_featurestore call.
+    /// The request builder for [FeaturestoreService::create_featurestore][super::super::client::FeaturestoreService::create_featurestore] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeaturestore(RequestBuilder<crate::model::CreateFeaturestoreRequest>);
 
@@ -10201,7 +10201,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::get_featurestore call.
+    /// The request builder for [FeaturestoreService::get_featurestore][super::super::client::FeaturestoreService::get_featurestore] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeaturestore(RequestBuilder<crate::model::GetFeaturestoreRequest>);
 
@@ -10243,7 +10243,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::list_featurestores call.
+    /// The request builder for [FeaturestoreService::list_featurestores][super::super::client::FeaturestoreService::list_featurestores] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeaturestores(RequestBuilder<crate::model::ListFeaturestoresRequest>);
 
@@ -10333,7 +10333,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::update_featurestore call.
+    /// The request builder for [FeaturestoreService::update_featurestore][super::super::client::FeaturestoreService::update_featurestore] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeaturestore(RequestBuilder<crate::model::UpdateFeaturestoreRequest>);
 
@@ -10433,7 +10433,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::delete_featurestore call.
+    /// The request builder for [FeaturestoreService::delete_featurestore][super::super::client::FeaturestoreService::delete_featurestore] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeaturestore(RequestBuilder<crate::model::DeleteFeaturestoreRequest>);
 
@@ -10519,7 +10519,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::create_entity_type call.
+    /// The request builder for [FeaturestoreService::create_entity_type][super::super::client::FeaturestoreService::create_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEntityType(RequestBuilder<crate::model::CreateEntityTypeRequest>);
 
@@ -10620,7 +10620,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::get_entity_type call.
+    /// The request builder for [FeaturestoreService::get_entity_type][super::super::client::FeaturestoreService::get_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetEntityType(RequestBuilder<crate::model::GetEntityTypeRequest>);
 
@@ -10662,7 +10662,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::list_entity_types call.
+    /// The request builder for [FeaturestoreService::list_entity_types][super::super::client::FeaturestoreService::list_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListEntityTypes(RequestBuilder<crate::model::ListEntityTypesRequest>);
 
@@ -10749,7 +10749,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::update_entity_type call.
+    /// The request builder for [FeaturestoreService::update_entity_type][super::super::client::FeaturestoreService::update_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEntityType(RequestBuilder<crate::model::UpdateEntityTypeRequest>);
 
@@ -10806,7 +10806,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::delete_entity_type call.
+    /// The request builder for [FeaturestoreService::delete_entity_type][super::super::client::FeaturestoreService::delete_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEntityType(RequestBuilder<crate::model::DeleteEntityTypeRequest>);
 
@@ -10892,7 +10892,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::create_feature call.
+    /// The request builder for [FeaturestoreService::create_feature][super::super::client::FeaturestoreService::create_feature] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeature(RequestBuilder<crate::model::CreateFeatureRequest>);
 
@@ -10988,7 +10988,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::batch_create_features call.
+    /// The request builder for [FeaturestoreService::batch_create_features][super::super::client::FeaturestoreService::batch_create_features] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateFeatures(RequestBuilder<crate::model::BatchCreateFeaturesRequest>);
 
@@ -11087,7 +11087,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::get_feature call.
+    /// The request builder for [FeaturestoreService::get_feature][super::super::client::FeaturestoreService::get_feature] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeature(RequestBuilder<crate::model::GetFeatureRequest>);
 
@@ -11129,7 +11129,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::list_features call.
+    /// The request builder for [FeaturestoreService::list_features][super::super::client::FeaturestoreService::list_features] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeatures(RequestBuilder<crate::model::ListFeaturesRequest>);
 
@@ -11222,7 +11222,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::update_feature call.
+    /// The request builder for [FeaturestoreService::update_feature][super::super::client::FeaturestoreService::update_feature] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeature(RequestBuilder<crate::model::UpdateFeatureRequest>);
 
@@ -11276,7 +11276,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::delete_feature call.
+    /// The request builder for [FeaturestoreService::delete_feature][super::super::client::FeaturestoreService::delete_feature] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeature(RequestBuilder<crate::model::DeleteFeatureRequest>);
 
@@ -11353,7 +11353,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::import_feature_values call.
+    /// The request builder for [FeaturestoreService::import_feature_values][super::super::client::FeaturestoreService::import_feature_values] calls.
     #[derive(Clone, Debug)]
     pub struct ImportFeatureValues(RequestBuilder<crate::model::ImportFeatureValuesRequest>);
 
@@ -11496,7 +11496,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::batch_read_feature_values call.
+    /// The request builder for [FeaturestoreService::batch_read_feature_values][super::super::client::FeaturestoreService::batch_read_feature_values] calls.
     #[derive(Clone, Debug)]
     pub struct BatchReadFeatureValues(RequestBuilder<crate::model::BatchReadFeatureValuesRequest>);
 
@@ -11639,7 +11639,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::export_feature_values call.
+    /// The request builder for [FeaturestoreService::export_feature_values][super::super::client::FeaturestoreService::export_feature_values] calls.
     #[derive(Clone, Debug)]
     pub struct ExportFeatureValues(RequestBuilder<crate::model::ExportFeatureValuesRequest>);
 
@@ -11767,7 +11767,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::delete_feature_values call.
+    /// The request builder for [FeaturestoreService::delete_feature_values][super::super::client::FeaturestoreService::delete_feature_values] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeatureValues(RequestBuilder<crate::model::DeleteFeatureValuesRequest>);
 
@@ -11866,7 +11866,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::search_features call.
+    /// The request builder for [FeaturestoreService::search_features][super::super::client::FeaturestoreService::search_features] calls.
     #[derive(Clone, Debug)]
     pub struct SearchFeatures(RequestBuilder<crate::model::SearchFeaturesRequest>);
 
@@ -11941,7 +11941,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::list_locations call.
+    /// The request builder for [FeaturestoreService::list_locations][super::super::client::FeaturestoreService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12019,7 +12019,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::get_location call.
+    /// The request builder for [FeaturestoreService::get_location][super::super::client::FeaturestoreService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12061,7 +12061,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::set_iam_policy call.
+    /// The request builder for [FeaturestoreService::set_iam_policy][super::super::client::FeaturestoreService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -12121,7 +12121,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::get_iam_policy call.
+    /// The request builder for [FeaturestoreService::get_iam_policy][super::super::client::FeaturestoreService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -12172,7 +12172,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::test_iam_permissions call.
+    /// The request builder for [FeaturestoreService::test_iam_permissions][super::super::client::FeaturestoreService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -12228,7 +12228,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::list_operations call.
+    /// The request builder for [FeaturestoreService::list_operations][super::super::client::FeaturestoreService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -12306,7 +12306,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::get_operation call.
+    /// The request builder for [FeaturestoreService::get_operation][super::super::client::FeaturestoreService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -12351,7 +12351,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::delete_operation call.
+    /// The request builder for [FeaturestoreService::delete_operation][super::super::client::FeaturestoreService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -12396,7 +12396,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::cancel_operation call.
+    /// The request builder for [FeaturestoreService::cancel_operation][super::super::client::FeaturestoreService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -12441,7 +12441,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for a FeaturestoreService::wait_operation call.
+    /// The request builder for [FeaturestoreService::wait_operation][super::super::client::FeaturestoreService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -12546,7 +12546,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::create_cached_content call.
+    /// The request builder for [GenAiCacheService::create_cached_content][super::super::client::GenAiCacheService::create_cached_content] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCachedContent(RequestBuilder<crate::model::CreateCachedContentRequest>);
 
@@ -12600,7 +12600,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::get_cached_content call.
+    /// The request builder for [GenAiCacheService::get_cached_content][super::super::client::GenAiCacheService::get_cached_content] calls.
     #[derive(Clone, Debug)]
     pub struct GetCachedContent(RequestBuilder<crate::model::GetCachedContentRequest>);
 
@@ -12645,7 +12645,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::update_cached_content call.
+    /// The request builder for [GenAiCacheService::update_cached_content][super::super::client::GenAiCacheService::update_cached_content] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCachedContent(RequestBuilder<crate::model::UpdateCachedContentRequest>);
 
@@ -12702,7 +12702,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::delete_cached_content call.
+    /// The request builder for [GenAiCacheService::delete_cached_content][super::super::client::GenAiCacheService::delete_cached_content] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCachedContent(RequestBuilder<crate::model::DeleteCachedContentRequest>);
 
@@ -12747,7 +12747,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::list_cached_contents call.
+    /// The request builder for [GenAiCacheService::list_cached_contents][super::super::client::GenAiCacheService::list_cached_contents] calls.
     #[derive(Clone, Debug)]
     pub struct ListCachedContents(RequestBuilder<crate::model::ListCachedContentsRequest>);
 
@@ -12819,7 +12819,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::list_locations call.
+    /// The request builder for [GenAiCacheService::list_locations][super::super::client::GenAiCacheService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12897,7 +12897,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::get_location call.
+    /// The request builder for [GenAiCacheService::get_location][super::super::client::GenAiCacheService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12939,7 +12939,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::set_iam_policy call.
+    /// The request builder for [GenAiCacheService::set_iam_policy][super::super::client::GenAiCacheService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -12999,7 +12999,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::get_iam_policy call.
+    /// The request builder for [GenAiCacheService::get_iam_policy][super::super::client::GenAiCacheService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -13050,7 +13050,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::test_iam_permissions call.
+    /// The request builder for [GenAiCacheService::test_iam_permissions][super::super::client::GenAiCacheService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -13106,7 +13106,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::list_operations call.
+    /// The request builder for [GenAiCacheService::list_operations][super::super::client::GenAiCacheService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -13184,7 +13184,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::get_operation call.
+    /// The request builder for [GenAiCacheService::get_operation][super::super::client::GenAiCacheService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -13229,7 +13229,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::delete_operation call.
+    /// The request builder for [GenAiCacheService::delete_operation][super::super::client::GenAiCacheService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -13274,7 +13274,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::cancel_operation call.
+    /// The request builder for [GenAiCacheService::cancel_operation][super::super::client::GenAiCacheService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -13319,7 +13319,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for a GenAiCacheService::wait_operation call.
+    /// The request builder for [GenAiCacheService::wait_operation][super::super::client::GenAiCacheService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -13424,7 +13424,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::create_tuning_job call.
+    /// The request builder for [GenAiTuningService::create_tuning_job][super::super::client::GenAiTuningService::create_tuning_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTuningJob(RequestBuilder<crate::model::CreateTuningJobRequest>);
 
@@ -13475,7 +13475,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::get_tuning_job call.
+    /// The request builder for [GenAiTuningService::get_tuning_job][super::super::client::GenAiTuningService::get_tuning_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetTuningJob(RequestBuilder<crate::model::GetTuningJobRequest>);
 
@@ -13517,7 +13517,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::list_tuning_jobs call.
+    /// The request builder for [GenAiTuningService::list_tuning_jobs][super::super::client::GenAiTuningService::list_tuning_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListTuningJobs(RequestBuilder<crate::model::ListTuningJobsRequest>);
 
@@ -13592,7 +13592,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::cancel_tuning_job call.
+    /// The request builder for [GenAiTuningService::cancel_tuning_job][super::super::client::GenAiTuningService::cancel_tuning_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelTuningJob(RequestBuilder<crate::model::CancelTuningJobRequest>);
 
@@ -13634,7 +13634,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::rebase_tuned_model call.
+    /// The request builder for [GenAiTuningService::rebase_tuned_model][super::super::client::GenAiTuningService::rebase_tuned_model] calls.
     #[derive(Clone, Debug)]
     pub struct RebaseTunedModel(RequestBuilder<crate::model::RebaseTunedModelRequest>);
 
@@ -13755,7 +13755,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::list_locations call.
+    /// The request builder for [GenAiTuningService::list_locations][super::super::client::GenAiTuningService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -13833,7 +13833,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::get_location call.
+    /// The request builder for [GenAiTuningService::get_location][super::super::client::GenAiTuningService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -13875,7 +13875,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::set_iam_policy call.
+    /// The request builder for [GenAiTuningService::set_iam_policy][super::super::client::GenAiTuningService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -13935,7 +13935,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::get_iam_policy call.
+    /// The request builder for [GenAiTuningService::get_iam_policy][super::super::client::GenAiTuningService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -13986,7 +13986,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::test_iam_permissions call.
+    /// The request builder for [GenAiTuningService::test_iam_permissions][super::super::client::GenAiTuningService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -14042,7 +14042,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::list_operations call.
+    /// The request builder for [GenAiTuningService::list_operations][super::super::client::GenAiTuningService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -14120,7 +14120,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::get_operation call.
+    /// The request builder for [GenAiTuningService::get_operation][super::super::client::GenAiTuningService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -14165,7 +14165,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::delete_operation call.
+    /// The request builder for [GenAiTuningService::delete_operation][super::super::client::GenAiTuningService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -14210,7 +14210,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::cancel_operation call.
+    /// The request builder for [GenAiTuningService::cancel_operation][super::super::client::GenAiTuningService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -14255,7 +14255,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for a GenAiTuningService::wait_operation call.
+    /// The request builder for [GenAiTuningService::wait_operation][super::super::client::GenAiTuningService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -14362,7 +14362,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::create_index_endpoint call.
+    /// The request builder for [IndexEndpointService::create_index_endpoint][super::super::client::IndexEndpointService::create_index_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIndexEndpoint(RequestBuilder<crate::model::CreateIndexEndpointRequest>);
 
@@ -14461,7 +14461,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::get_index_endpoint call.
+    /// The request builder for [IndexEndpointService::get_index_endpoint][super::super::client::IndexEndpointService::get_index_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct GetIndexEndpoint(RequestBuilder<crate::model::GetIndexEndpointRequest>);
 
@@ -14508,7 +14508,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::list_index_endpoints call.
+    /// The request builder for [IndexEndpointService::list_index_endpoints][super::super::client::IndexEndpointService::list_index_endpoints] calls.
     #[derive(Clone, Debug)]
     pub struct ListIndexEndpoints(RequestBuilder<crate::model::ListIndexEndpointsRequest>);
 
@@ -14594,7 +14594,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::update_index_endpoint call.
+    /// The request builder for [IndexEndpointService::update_index_endpoint][super::super::client::IndexEndpointService::update_index_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateIndexEndpoint(RequestBuilder<crate::model::UpdateIndexEndpointRequest>);
 
@@ -14653,7 +14653,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::delete_index_endpoint call.
+    /// The request builder for [IndexEndpointService::delete_index_endpoint][super::super::client::IndexEndpointService::delete_index_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIndexEndpoint(RequestBuilder<crate::model::DeleteIndexEndpointRequest>);
 
@@ -14735,7 +14735,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::deploy_index call.
+    /// The request builder for [IndexEndpointService::deploy_index][super::super::client::IndexEndpointService::deploy_index] calls.
     #[derive(Clone, Debug)]
     pub struct DeployIndex(RequestBuilder<crate::model::DeployIndexRequest>);
 
@@ -14831,7 +14831,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::undeploy_index call.
+    /// The request builder for [IndexEndpointService::undeploy_index][super::super::client::IndexEndpointService::undeploy_index] calls.
     #[derive(Clone, Debug)]
     pub struct UndeployIndex(RequestBuilder<crate::model::UndeployIndexRequest>);
 
@@ -14924,7 +14924,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::mutate_deployed_index call.
+    /// The request builder for [IndexEndpointService::mutate_deployed_index][super::super::client::IndexEndpointService::mutate_deployed_index] calls.
     #[derive(Clone, Debug)]
     pub struct MutateDeployedIndex(RequestBuilder<crate::model::MutateDeployedIndexRequest>);
 
@@ -15023,7 +15023,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::list_locations call.
+    /// The request builder for [IndexEndpointService::list_locations][super::super::client::IndexEndpointService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -15103,7 +15103,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::get_location call.
+    /// The request builder for [IndexEndpointService::get_location][super::super::client::IndexEndpointService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -15147,7 +15147,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::set_iam_policy call.
+    /// The request builder for [IndexEndpointService::set_iam_policy][super::super::client::IndexEndpointService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -15209,7 +15209,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::get_iam_policy call.
+    /// The request builder for [IndexEndpointService::get_iam_policy][super::super::client::IndexEndpointService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -15262,7 +15262,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::test_iam_permissions call.
+    /// The request builder for [IndexEndpointService::test_iam_permissions][super::super::client::IndexEndpointService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -15320,7 +15320,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::list_operations call.
+    /// The request builder for [IndexEndpointService::list_operations][super::super::client::IndexEndpointService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -15400,7 +15400,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::get_operation call.
+    /// The request builder for [IndexEndpointService::get_operation][super::super::client::IndexEndpointService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -15447,7 +15447,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::delete_operation call.
+    /// The request builder for [IndexEndpointService::delete_operation][super::super::client::IndexEndpointService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -15494,7 +15494,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::cancel_operation call.
+    /// The request builder for [IndexEndpointService::cancel_operation][super::super::client::IndexEndpointService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -15541,7 +15541,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for a IndexEndpointService::wait_operation call.
+    /// The request builder for [IndexEndpointService::wait_operation][super::super::client::IndexEndpointService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -15648,7 +15648,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::create_index call.
+    /// The request builder for [IndexService::create_index][super::super::client::IndexService::create_index] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIndex(RequestBuilder<crate::model::CreateIndexRequest>);
 
@@ -15738,7 +15738,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::get_index call.
+    /// The request builder for [IndexService::get_index][super::super::client::IndexService::get_index] calls.
     #[derive(Clone, Debug)]
     pub struct GetIndex(RequestBuilder<crate::model::GetIndexRequest>);
 
@@ -15780,7 +15780,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::list_indexes call.
+    /// The request builder for [IndexService::list_indexes][super::super::client::IndexService::list_indexes] calls.
     #[derive(Clone, Debug)]
     pub struct ListIndexes(RequestBuilder<crate::model::ListIndexesRequest>);
 
@@ -15861,7 +15861,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::update_index call.
+    /// The request builder for [IndexService::update_index][super::super::client::IndexService::update_index] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateIndex(RequestBuilder<crate::model::UpdateIndexRequest>);
 
@@ -15954,7 +15954,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::delete_index call.
+    /// The request builder for [IndexService::delete_index][super::super::client::IndexService::delete_index] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIndex(RequestBuilder<crate::model::DeleteIndexRequest>);
 
@@ -16031,7 +16031,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::upsert_datapoints call.
+    /// The request builder for [IndexService::upsert_datapoints][super::super::client::IndexService::upsert_datapoints] calls.
     #[derive(Clone, Debug)]
     pub struct UpsertDatapoints(RequestBuilder<crate::model::UpsertDatapointsRequest>);
 
@@ -16096,7 +16096,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::remove_datapoints call.
+    /// The request builder for [IndexService::remove_datapoints][super::super::client::IndexService::remove_datapoints] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveDatapoints(RequestBuilder<crate::model::RemoveDatapointsRequest>);
 
@@ -16152,7 +16152,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::list_locations call.
+    /// The request builder for [IndexService::list_locations][super::super::client::IndexService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -16230,7 +16230,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::get_location call.
+    /// The request builder for [IndexService::get_location][super::super::client::IndexService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -16272,7 +16272,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::set_iam_policy call.
+    /// The request builder for [IndexService::set_iam_policy][super::super::client::IndexService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -16332,7 +16332,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::get_iam_policy call.
+    /// The request builder for [IndexService::get_iam_policy][super::super::client::IndexService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -16383,7 +16383,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::test_iam_permissions call.
+    /// The request builder for [IndexService::test_iam_permissions][super::super::client::IndexService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -16439,7 +16439,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::list_operations call.
+    /// The request builder for [IndexService::list_operations][super::super::client::IndexService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -16517,7 +16517,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::get_operation call.
+    /// The request builder for [IndexService::get_operation][super::super::client::IndexService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -16562,7 +16562,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::delete_operation call.
+    /// The request builder for [IndexService::delete_operation][super::super::client::IndexService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -16607,7 +16607,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::cancel_operation call.
+    /// The request builder for [IndexService::cancel_operation][super::super::client::IndexService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -16652,7 +16652,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for a IndexService::wait_operation call.
+    /// The request builder for [IndexService::wait_operation][super::super::client::IndexService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -16757,7 +16757,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::create_custom_job call.
+    /// The request builder for [JobService::create_custom_job][super::super::client::JobService::create_custom_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCustomJob(RequestBuilder<crate::model::CreateCustomJobRequest>);
 
@@ -16808,7 +16808,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_custom_job call.
+    /// The request builder for [JobService::get_custom_job][super::super::client::JobService::get_custom_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetCustomJob(RequestBuilder<crate::model::GetCustomJobRequest>);
 
@@ -16850,7 +16850,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_custom_jobs call.
+    /// The request builder for [JobService::list_custom_jobs][super::super::client::JobService::list_custom_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListCustomJobs(RequestBuilder<crate::model::ListCustomJobsRequest>);
 
@@ -16931,7 +16931,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::delete_custom_job call.
+    /// The request builder for [JobService::delete_custom_job][super::super::client::JobService::delete_custom_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCustomJob(RequestBuilder<crate::model::DeleteCustomJobRequest>);
 
@@ -17008,7 +17008,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::cancel_custom_job call.
+    /// The request builder for [JobService::cancel_custom_job][super::super::client::JobService::cancel_custom_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelCustomJob(RequestBuilder<crate::model::CancelCustomJobRequest>);
 
@@ -17050,7 +17050,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::create_data_labeling_job call.
+    /// The request builder for [JobService::create_data_labeling_job][super::super::client::JobService::create_data_labeling_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDataLabelingJob(RequestBuilder<crate::model::CreateDataLabelingJobRequest>);
 
@@ -17106,7 +17106,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_data_labeling_job call.
+    /// The request builder for [JobService::get_data_labeling_job][super::super::client::JobService::get_data_labeling_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataLabelingJob(RequestBuilder<crate::model::GetDataLabelingJobRequest>);
 
@@ -17151,7 +17151,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_data_labeling_jobs call.
+    /// The request builder for [JobService::list_data_labeling_jobs][super::super::client::JobService::list_data_labeling_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListDataLabelingJobs(RequestBuilder<crate::model::ListDataLabelingJobsRequest>);
 
@@ -17241,7 +17241,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::delete_data_labeling_job call.
+    /// The request builder for [JobService::delete_data_labeling_job][super::super::client::JobService::delete_data_labeling_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataLabelingJob(RequestBuilder<crate::model::DeleteDataLabelingJobRequest>);
 
@@ -17321,7 +17321,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::cancel_data_labeling_job call.
+    /// The request builder for [JobService::cancel_data_labeling_job][super::super::client::JobService::cancel_data_labeling_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelDataLabelingJob(RequestBuilder<crate::model::CancelDataLabelingJobRequest>);
 
@@ -17366,7 +17366,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::create_hyperparameter_tuning_job call.
+    /// The request builder for [JobService::create_hyperparameter_tuning_job][super::super::client::JobService::create_hyperparameter_tuning_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateHyperparameterTuningJob(
         RequestBuilder<crate::model::CreateHyperparameterTuningJobRequest>,
@@ -17424,7 +17424,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_hyperparameter_tuning_job call.
+    /// The request builder for [JobService::get_hyperparameter_tuning_job][super::super::client::JobService::get_hyperparameter_tuning_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetHyperparameterTuningJob(
         RequestBuilder<crate::model::GetHyperparameterTuningJobRequest>,
@@ -17471,7 +17471,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_hyperparameter_tuning_jobs call.
+    /// The request builder for [JobService::list_hyperparameter_tuning_jobs][super::super::client::JobService::list_hyperparameter_tuning_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListHyperparameterTuningJobs(
         RequestBuilder<crate::model::ListHyperparameterTuningJobsRequest>,
@@ -17559,7 +17559,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::delete_hyperparameter_tuning_job call.
+    /// The request builder for [JobService::delete_hyperparameter_tuning_job][super::super::client::JobService::delete_hyperparameter_tuning_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteHyperparameterTuningJob(
         RequestBuilder<crate::model::DeleteHyperparameterTuningJobRequest>,
@@ -17641,7 +17641,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::cancel_hyperparameter_tuning_job call.
+    /// The request builder for [JobService::cancel_hyperparameter_tuning_job][super::super::client::JobService::cancel_hyperparameter_tuning_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelHyperparameterTuningJob(
         RequestBuilder<crate::model::CancelHyperparameterTuningJobRequest>,
@@ -17688,7 +17688,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::create_nas_job call.
+    /// The request builder for [JobService::create_nas_job][super::super::client::JobService::create_nas_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNasJob(RequestBuilder<crate::model::CreateNasJobRequest>);
 
@@ -17739,7 +17739,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_nas_job call.
+    /// The request builder for [JobService::get_nas_job][super::super::client::JobService::get_nas_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetNasJob(RequestBuilder<crate::model::GetNasJobRequest>);
 
@@ -17781,7 +17781,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_nas_jobs call.
+    /// The request builder for [JobService::list_nas_jobs][super::super::client::JobService::list_nas_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListNasJobs(RequestBuilder<crate::model::ListNasJobsRequest>);
 
@@ -17862,7 +17862,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::delete_nas_job call.
+    /// The request builder for [JobService::delete_nas_job][super::super::client::JobService::delete_nas_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNasJob(RequestBuilder<crate::model::DeleteNasJobRequest>);
 
@@ -17939,7 +17939,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::cancel_nas_job call.
+    /// The request builder for [JobService::cancel_nas_job][super::super::client::JobService::cancel_nas_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelNasJob(RequestBuilder<crate::model::CancelNasJobRequest>);
 
@@ -17981,7 +17981,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_nas_trial_detail call.
+    /// The request builder for [JobService::get_nas_trial_detail][super::super::client::JobService::get_nas_trial_detail] calls.
     #[derive(Clone, Debug)]
     pub struct GetNasTrialDetail(RequestBuilder<crate::model::GetNasTrialDetailRequest>);
 
@@ -18026,7 +18026,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_nas_trial_details call.
+    /// The request builder for [JobService::list_nas_trial_details][super::super::client::JobService::list_nas_trial_details] calls.
     #[derive(Clone, Debug)]
     pub struct ListNasTrialDetails(RequestBuilder<crate::model::ListNasTrialDetailsRequest>);
 
@@ -18098,7 +18098,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::create_batch_prediction_job call.
+    /// The request builder for [JobService::create_batch_prediction_job][super::super::client::JobService::create_batch_prediction_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBatchPredictionJob(
         RequestBuilder<crate::model::CreateBatchPredictionJobRequest>,
@@ -18156,7 +18156,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_batch_prediction_job call.
+    /// The request builder for [JobService::get_batch_prediction_job][super::super::client::JobService::get_batch_prediction_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetBatchPredictionJob(RequestBuilder<crate::model::GetBatchPredictionJobRequest>);
 
@@ -18201,7 +18201,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_batch_prediction_jobs call.
+    /// The request builder for [JobService::list_batch_prediction_jobs][super::super::client::JobService::list_batch_prediction_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListBatchPredictionJobs(
         RequestBuilder<crate::model::ListBatchPredictionJobsRequest>,
@@ -18289,7 +18289,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::delete_batch_prediction_job call.
+    /// The request builder for [JobService::delete_batch_prediction_job][super::super::client::JobService::delete_batch_prediction_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBatchPredictionJob(
         RequestBuilder<crate::model::DeleteBatchPredictionJobRequest>,
@@ -18371,7 +18371,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::cancel_batch_prediction_job call.
+    /// The request builder for [JobService::cancel_batch_prediction_job][super::super::client::JobService::cancel_batch_prediction_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelBatchPredictionJob(
         RequestBuilder<crate::model::CancelBatchPredictionJobRequest>,
@@ -18418,7 +18418,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::create_model_deployment_monitoring_job call.
+    /// The request builder for [JobService::create_model_deployment_monitoring_job][super::super::client::JobService::create_model_deployment_monitoring_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::CreateModelDeploymentMonitoringJobRequest>,
@@ -18476,7 +18476,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::search_model_deployment_monitoring_stats_anomalies call.
+    /// The request builder for [JobService::search_model_deployment_monitoring_stats_anomalies][super::super::client::JobService::search_model_deployment_monitoring_stats_anomalies] calls.
     #[derive(Clone, Debug)]
     pub struct SearchModelDeploymentMonitoringStatsAnomalies(
         RequestBuilder<crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest>,
@@ -18597,7 +18597,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_model_deployment_monitoring_job call.
+    /// The request builder for [JobService::get_model_deployment_monitoring_job][super::super::client::JobService::get_model_deployment_monitoring_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::GetModelDeploymentMonitoringJobRequest>,
@@ -18644,7 +18644,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_model_deployment_monitoring_jobs call.
+    /// The request builder for [JobService::list_model_deployment_monitoring_jobs][super::super::client::JobService::list_model_deployment_monitoring_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListModelDeploymentMonitoringJobs(
         RequestBuilder<crate::model::ListModelDeploymentMonitoringJobsRequest>,
@@ -18732,7 +18732,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::update_model_deployment_monitoring_job call.
+    /// The request builder for [JobService::update_model_deployment_monitoring_job][super::super::client::JobService::update_model_deployment_monitoring_job] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::UpdateModelDeploymentMonitoringJobRequest>,
@@ -18836,7 +18836,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::delete_model_deployment_monitoring_job call.
+    /// The request builder for [JobService::delete_model_deployment_monitoring_job][super::super::client::JobService::delete_model_deployment_monitoring_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::DeleteModelDeploymentMonitoringJobRequest>,
@@ -18918,7 +18918,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::pause_model_deployment_monitoring_job call.
+    /// The request builder for [JobService::pause_model_deployment_monitoring_job][super::super::client::JobService::pause_model_deployment_monitoring_job] calls.
     #[derive(Clone, Debug)]
     pub struct PauseModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::PauseModelDeploymentMonitoringJobRequest>,
@@ -18965,7 +18965,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::resume_model_deployment_monitoring_job call.
+    /// The request builder for [JobService::resume_model_deployment_monitoring_job][super::super::client::JobService::resume_model_deployment_monitoring_job] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::ResumeModelDeploymentMonitoringJobRequest>,
@@ -19012,7 +19012,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_locations call.
+    /// The request builder for [JobService::list_locations][super::super::client::JobService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -19090,7 +19090,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_location call.
+    /// The request builder for [JobService::get_location][super::super::client::JobService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -19132,7 +19132,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::set_iam_policy call.
+    /// The request builder for [JobService::set_iam_policy][super::super::client::JobService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -19192,7 +19192,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_iam_policy call.
+    /// The request builder for [JobService::get_iam_policy][super::super::client::JobService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -19243,7 +19243,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::test_iam_permissions call.
+    /// The request builder for [JobService::test_iam_permissions][super::super::client::JobService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -19299,7 +19299,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_operations call.
+    /// The request builder for [JobService::list_operations][super::super::client::JobService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -19377,7 +19377,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_operation call.
+    /// The request builder for [JobService::get_operation][super::super::client::JobService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -19422,7 +19422,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::delete_operation call.
+    /// The request builder for [JobService::delete_operation][super::super::client::JobService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -19467,7 +19467,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::cancel_operation call.
+    /// The request builder for [JobService::cancel_operation][super::super::client::JobService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -19512,7 +19512,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::wait_operation call.
+    /// The request builder for [JobService::wait_operation][super::super::client::JobService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -19617,7 +19617,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::count_tokens call.
+    /// The request builder for [LlmUtilityService::count_tokens][super::super::client::LlmUtilityService::count_tokens] calls.
     #[derive(Clone, Debug)]
     pub struct CountTokens(RequestBuilder<crate::model::CountTokensRequest>);
 
@@ -19718,7 +19718,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::compute_tokens call.
+    /// The request builder for [LlmUtilityService::compute_tokens][super::super::client::LlmUtilityService::compute_tokens] calls.
     #[derive(Clone, Debug)]
     pub struct ComputeTokens(RequestBuilder<crate::model::ComputeTokensRequest>);
 
@@ -19788,7 +19788,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::list_locations call.
+    /// The request builder for [LlmUtilityService::list_locations][super::super::client::LlmUtilityService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -19866,7 +19866,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::get_location call.
+    /// The request builder for [LlmUtilityService::get_location][super::super::client::LlmUtilityService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -19908,7 +19908,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::set_iam_policy call.
+    /// The request builder for [LlmUtilityService::set_iam_policy][super::super::client::LlmUtilityService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -19968,7 +19968,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::get_iam_policy call.
+    /// The request builder for [LlmUtilityService::get_iam_policy][super::super::client::LlmUtilityService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -20019,7 +20019,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::test_iam_permissions call.
+    /// The request builder for [LlmUtilityService::test_iam_permissions][super::super::client::LlmUtilityService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -20075,7 +20075,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::list_operations call.
+    /// The request builder for [LlmUtilityService::list_operations][super::super::client::LlmUtilityService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -20153,7 +20153,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::get_operation call.
+    /// The request builder for [LlmUtilityService::get_operation][super::super::client::LlmUtilityService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -20198,7 +20198,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::delete_operation call.
+    /// The request builder for [LlmUtilityService::delete_operation][super::super::client::LlmUtilityService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -20243,7 +20243,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::cancel_operation call.
+    /// The request builder for [LlmUtilityService::cancel_operation][super::super::client::LlmUtilityService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -20288,7 +20288,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for a LlmUtilityService::wait_operation call.
+    /// The request builder for [LlmUtilityService::wait_operation][super::super::client::LlmUtilityService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -20393,7 +20393,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::find_neighbors call.
+    /// The request builder for [MatchService::find_neighbors][super::super::client::MatchService::find_neighbors] calls.
     #[derive(Clone, Debug)]
     pub struct FindNeighbors(RequestBuilder<crate::model::FindNeighborsRequest>);
 
@@ -20458,7 +20458,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::read_index_datapoints call.
+    /// The request builder for [MatchService::read_index_datapoints][super::super::client::MatchService::read_index_datapoints] calls.
     #[derive(Clone, Debug)]
     pub struct ReadIndexDatapoints(RequestBuilder<crate::model::ReadIndexDatapointsRequest>);
 
@@ -20520,7 +20520,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::list_locations call.
+    /// The request builder for [MatchService::list_locations][super::super::client::MatchService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -20598,7 +20598,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::get_location call.
+    /// The request builder for [MatchService::get_location][super::super::client::MatchService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -20640,7 +20640,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::set_iam_policy call.
+    /// The request builder for [MatchService::set_iam_policy][super::super::client::MatchService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -20700,7 +20700,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::get_iam_policy call.
+    /// The request builder for [MatchService::get_iam_policy][super::super::client::MatchService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -20751,7 +20751,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::test_iam_permissions call.
+    /// The request builder for [MatchService::test_iam_permissions][super::super::client::MatchService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -20807,7 +20807,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::list_operations call.
+    /// The request builder for [MatchService::list_operations][super::super::client::MatchService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -20885,7 +20885,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::get_operation call.
+    /// The request builder for [MatchService::get_operation][super::super::client::MatchService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -20930,7 +20930,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::delete_operation call.
+    /// The request builder for [MatchService::delete_operation][super::super::client::MatchService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -20975,7 +20975,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::cancel_operation call.
+    /// The request builder for [MatchService::cancel_operation][super::super::client::MatchService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -21020,7 +21020,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for a MatchService::wait_operation call.
+    /// The request builder for [MatchService::wait_operation][super::super::client::MatchService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -21125,7 +21125,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::create_metadata_store call.
+    /// The request builder for [MetadataService::create_metadata_store][super::super::client::MetadataService::create_metadata_store] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMetadataStore(RequestBuilder<crate::model::CreateMetadataStoreRequest>);
 
@@ -21228,7 +21228,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::get_metadata_store call.
+    /// The request builder for [MetadataService::get_metadata_store][super::super::client::MetadataService::get_metadata_store] calls.
     #[derive(Clone, Debug)]
     pub struct GetMetadataStore(RequestBuilder<crate::model::GetMetadataStoreRequest>);
 
@@ -21273,7 +21273,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::list_metadata_stores call.
+    /// The request builder for [MetadataService::list_metadata_stores][super::super::client::MetadataService::list_metadata_stores] calls.
     #[derive(Clone, Debug)]
     pub struct ListMetadataStores(RequestBuilder<crate::model::ListMetadataStoresRequest>);
 
@@ -21345,7 +21345,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::delete_metadata_store call.
+    /// The request builder for [MetadataService::delete_metadata_store][super::super::client::MetadataService::delete_metadata_store] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMetadataStore(RequestBuilder<crate::model::DeleteMetadataStoreRequest>);
 
@@ -21435,7 +21435,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::create_artifact call.
+    /// The request builder for [MetadataService::create_artifact][super::super::client::MetadataService::create_artifact] calls.
     #[derive(Clone, Debug)]
     pub struct CreateArtifact(RequestBuilder<crate::model::CreateArtifactRequest>);
 
@@ -21492,7 +21492,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::get_artifact call.
+    /// The request builder for [MetadataService::get_artifact][super::super::client::MetadataService::get_artifact] calls.
     #[derive(Clone, Debug)]
     pub struct GetArtifact(RequestBuilder<crate::model::GetArtifactRequest>);
 
@@ -21534,7 +21534,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::list_artifacts call.
+    /// The request builder for [MetadataService::list_artifacts][super::super::client::MetadataService::list_artifacts] calls.
     #[derive(Clone, Debug)]
     pub struct ListArtifacts(RequestBuilder<crate::model::ListArtifactsRequest>);
 
@@ -21615,7 +21615,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::update_artifact call.
+    /// The request builder for [MetadataService::update_artifact][super::super::client::MetadataService::update_artifact] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateArtifact(RequestBuilder<crate::model::UpdateArtifactRequest>);
 
@@ -21675,7 +21675,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::delete_artifact call.
+    /// The request builder for [MetadataService::delete_artifact][super::super::client::MetadataService::delete_artifact] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteArtifact(RequestBuilder<crate::model::DeleteArtifactRequest>);
 
@@ -21758,7 +21758,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::purge_artifacts call.
+    /// The request builder for [MetadataService::purge_artifacts][super::super::client::MetadataService::purge_artifacts] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeArtifacts(RequestBuilder<crate::model::PurgeArtifactsRequest>);
 
@@ -21853,7 +21853,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::create_context call.
+    /// The request builder for [MetadataService::create_context][super::super::client::MetadataService::create_context] calls.
     #[derive(Clone, Debug)]
     pub struct CreateContext(RequestBuilder<crate::model::CreateContextRequest>);
 
@@ -21910,7 +21910,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::get_context call.
+    /// The request builder for [MetadataService::get_context][super::super::client::MetadataService::get_context] calls.
     #[derive(Clone, Debug)]
     pub struct GetContext(RequestBuilder<crate::model::GetContextRequest>);
 
@@ -21952,7 +21952,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::list_contexts call.
+    /// The request builder for [MetadataService::list_contexts][super::super::client::MetadataService::list_contexts] calls.
     #[derive(Clone, Debug)]
     pub struct ListContexts(RequestBuilder<crate::model::ListContextsRequest>);
 
@@ -22033,7 +22033,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::update_context call.
+    /// The request builder for [MetadataService::update_context][super::super::client::MetadataService::update_context] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateContext(RequestBuilder<crate::model::UpdateContextRequest>);
 
@@ -22093,7 +22093,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::delete_context call.
+    /// The request builder for [MetadataService::delete_context][super::super::client::MetadataService::delete_context] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteContext(RequestBuilder<crate::model::DeleteContextRequest>);
 
@@ -22182,7 +22182,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::purge_contexts call.
+    /// The request builder for [MetadataService::purge_contexts][super::super::client::MetadataService::purge_contexts] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeContexts(RequestBuilder<crate::model::PurgeContextsRequest>);
 
@@ -22277,7 +22277,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::add_context_artifacts_and_executions call.
+    /// The request builder for [MetadataService::add_context_artifacts_and_executions][super::super::client::MetadataService::add_context_artifacts_and_executions] calls.
     #[derive(Clone, Debug)]
     pub struct AddContextArtifactsAndExecutions(
         RequestBuilder<crate::model::AddContextArtifactsAndExecutionsRequest>,
@@ -22346,7 +22346,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::add_context_children call.
+    /// The request builder for [MetadataService::add_context_children][super::super::client::MetadataService::add_context_children] calls.
     #[derive(Clone, Debug)]
     pub struct AddContextChildren(RequestBuilder<crate::model::AddContextChildrenRequest>);
 
@@ -22402,7 +22402,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::remove_context_children call.
+    /// The request builder for [MetadataService::remove_context_children][super::super::client::MetadataService::remove_context_children] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveContextChildren(RequestBuilder<crate::model::RemoveContextChildrenRequest>);
 
@@ -22458,7 +22458,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::query_context_lineage_subgraph call.
+    /// The request builder for [MetadataService::query_context_lineage_subgraph][super::super::client::MetadataService::query_context_lineage_subgraph] calls.
     #[derive(Clone, Debug)]
     pub struct QueryContextLineageSubgraph(
         RequestBuilder<crate::model::QueryContextLineageSubgraphRequest>,
@@ -22505,7 +22505,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::create_execution call.
+    /// The request builder for [MetadataService::create_execution][super::super::client::MetadataService::create_execution] calls.
     #[derive(Clone, Debug)]
     pub struct CreateExecution(RequestBuilder<crate::model::CreateExecutionRequest>);
 
@@ -22562,7 +22562,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::get_execution call.
+    /// The request builder for [MetadataService::get_execution][super::super::client::MetadataService::get_execution] calls.
     #[derive(Clone, Debug)]
     pub struct GetExecution(RequestBuilder<crate::model::GetExecutionRequest>);
 
@@ -22604,7 +22604,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::list_executions call.
+    /// The request builder for [MetadataService::list_executions][super::super::client::MetadataService::list_executions] calls.
     #[derive(Clone, Debug)]
     pub struct ListExecutions(RequestBuilder<crate::model::ListExecutionsRequest>);
 
@@ -22685,7 +22685,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::update_execution call.
+    /// The request builder for [MetadataService::update_execution][super::super::client::MetadataService::update_execution] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateExecution(RequestBuilder<crate::model::UpdateExecutionRequest>);
 
@@ -22745,7 +22745,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::delete_execution call.
+    /// The request builder for [MetadataService::delete_execution][super::super::client::MetadataService::delete_execution] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteExecution(RequestBuilder<crate::model::DeleteExecutionRequest>);
 
@@ -22828,7 +22828,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::purge_executions call.
+    /// The request builder for [MetadataService::purge_executions][super::super::client::MetadataService::purge_executions] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeExecutions(RequestBuilder<crate::model::PurgeExecutionsRequest>);
 
@@ -22923,7 +22923,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::add_execution_events call.
+    /// The request builder for [MetadataService::add_execution_events][super::super::client::MetadataService::add_execution_events] calls.
     #[derive(Clone, Debug)]
     pub struct AddExecutionEvents(RequestBuilder<crate::model::AddExecutionEventsRequest>);
 
@@ -22979,7 +22979,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::query_execution_inputs_and_outputs call.
+    /// The request builder for [MetadataService::query_execution_inputs_and_outputs][super::super::client::MetadataService::query_execution_inputs_and_outputs] calls.
     #[derive(Clone, Debug)]
     pub struct QueryExecutionInputsAndOutputs(
         RequestBuilder<crate::model::QueryExecutionInputsAndOutputsRequest>,
@@ -23026,7 +23026,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::create_metadata_schema call.
+    /// The request builder for [MetadataService::create_metadata_schema][super::super::client::MetadataService::create_metadata_schema] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMetadataSchema(RequestBuilder<crate::model::CreateMetadataSchemaRequest>);
 
@@ -23086,7 +23086,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::get_metadata_schema call.
+    /// The request builder for [MetadataService::get_metadata_schema][super::super::client::MetadataService::get_metadata_schema] calls.
     #[derive(Clone, Debug)]
     pub struct GetMetadataSchema(RequestBuilder<crate::model::GetMetadataSchemaRequest>);
 
@@ -23131,7 +23131,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::list_metadata_schemas call.
+    /// The request builder for [MetadataService::list_metadata_schemas][super::super::client::MetadataService::list_metadata_schemas] calls.
     #[derive(Clone, Debug)]
     pub struct ListMetadataSchemas(RequestBuilder<crate::model::ListMetadataSchemasRequest>);
 
@@ -23209,7 +23209,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::query_artifact_lineage_subgraph call.
+    /// The request builder for [MetadataService::query_artifact_lineage_subgraph][super::super::client::MetadataService::query_artifact_lineage_subgraph] calls.
     #[derive(Clone, Debug)]
     pub struct QueryArtifactLineageSubgraph(
         RequestBuilder<crate::model::QueryArtifactLineageSubgraphRequest>,
@@ -23268,7 +23268,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::list_locations call.
+    /// The request builder for [MetadataService::list_locations][super::super::client::MetadataService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -23346,7 +23346,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::get_location call.
+    /// The request builder for [MetadataService::get_location][super::super::client::MetadataService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -23388,7 +23388,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::set_iam_policy call.
+    /// The request builder for [MetadataService::set_iam_policy][super::super::client::MetadataService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -23448,7 +23448,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::get_iam_policy call.
+    /// The request builder for [MetadataService::get_iam_policy][super::super::client::MetadataService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -23499,7 +23499,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::test_iam_permissions call.
+    /// The request builder for [MetadataService::test_iam_permissions][super::super::client::MetadataService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -23555,7 +23555,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::list_operations call.
+    /// The request builder for [MetadataService::list_operations][super::super::client::MetadataService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -23633,7 +23633,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::get_operation call.
+    /// The request builder for [MetadataService::get_operation][super::super::client::MetadataService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -23678,7 +23678,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::delete_operation call.
+    /// The request builder for [MetadataService::delete_operation][super::super::client::MetadataService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -23723,7 +23723,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::cancel_operation call.
+    /// The request builder for [MetadataService::cancel_operation][super::super::client::MetadataService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -23768,7 +23768,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for a MetadataService::wait_operation call.
+    /// The request builder for [MetadataService::wait_operation][super::super::client::MetadataService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -23873,7 +23873,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::search_migratable_resources call.
+    /// The request builder for [MigrationService::search_migratable_resources][super::super::client::MigrationService::search_migratable_resources] calls.
     #[derive(Clone, Debug)]
     pub struct SearchMigratableResources(
         RequestBuilder<crate::model::SearchMigratableResourcesRequest>,
@@ -23955,7 +23955,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::batch_migrate_resources call.
+    /// The request builder for [MigrationService::batch_migrate_resources][super::super::client::MigrationService::batch_migrate_resources] calls.
     #[derive(Clone, Debug)]
     pub struct BatchMigrateResources(RequestBuilder<crate::model::BatchMigrateResourcesRequest>);
 
@@ -24054,7 +24054,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::list_locations call.
+    /// The request builder for [MigrationService::list_locations][super::super::client::MigrationService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -24132,7 +24132,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::get_location call.
+    /// The request builder for [MigrationService::get_location][super::super::client::MigrationService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -24174,7 +24174,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::set_iam_policy call.
+    /// The request builder for [MigrationService::set_iam_policy][super::super::client::MigrationService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -24234,7 +24234,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::get_iam_policy call.
+    /// The request builder for [MigrationService::get_iam_policy][super::super::client::MigrationService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -24285,7 +24285,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::test_iam_permissions call.
+    /// The request builder for [MigrationService::test_iam_permissions][super::super::client::MigrationService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -24341,7 +24341,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::list_operations call.
+    /// The request builder for [MigrationService::list_operations][super::super::client::MigrationService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -24419,7 +24419,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::get_operation call.
+    /// The request builder for [MigrationService::get_operation][super::super::client::MigrationService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -24464,7 +24464,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::delete_operation call.
+    /// The request builder for [MigrationService::delete_operation][super::super::client::MigrationService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -24509,7 +24509,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::cancel_operation call.
+    /// The request builder for [MigrationService::cancel_operation][super::super::client::MigrationService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -24554,7 +24554,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::wait_operation call.
+    /// The request builder for [MigrationService::wait_operation][super::super::client::MigrationService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -24659,7 +24659,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::get_publisher_model call.
+    /// The request builder for [ModelGardenService::get_publisher_model][super::super::client::ModelGardenService::get_publisher_model] calls.
     #[derive(Clone, Debug)]
     pub struct GetPublisherModel(RequestBuilder<crate::model::GetPublisherModelRequest>);
 
@@ -24728,7 +24728,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::list_locations call.
+    /// The request builder for [ModelGardenService::list_locations][super::super::client::ModelGardenService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -24806,7 +24806,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::get_location call.
+    /// The request builder for [ModelGardenService::get_location][super::super::client::ModelGardenService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -24848,7 +24848,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::set_iam_policy call.
+    /// The request builder for [ModelGardenService::set_iam_policy][super::super::client::ModelGardenService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -24908,7 +24908,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::get_iam_policy call.
+    /// The request builder for [ModelGardenService::get_iam_policy][super::super::client::ModelGardenService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -24959,7 +24959,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::test_iam_permissions call.
+    /// The request builder for [ModelGardenService::test_iam_permissions][super::super::client::ModelGardenService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -25015,7 +25015,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::list_operations call.
+    /// The request builder for [ModelGardenService::list_operations][super::super::client::ModelGardenService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -25093,7 +25093,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::get_operation call.
+    /// The request builder for [ModelGardenService::get_operation][super::super::client::ModelGardenService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -25138,7 +25138,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::delete_operation call.
+    /// The request builder for [ModelGardenService::delete_operation][super::super::client::ModelGardenService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -25183,7 +25183,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::cancel_operation call.
+    /// The request builder for [ModelGardenService::cancel_operation][super::super::client::ModelGardenService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -25228,7 +25228,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for a ModelGardenService::wait_operation call.
+    /// The request builder for [ModelGardenService::wait_operation][super::super::client::ModelGardenService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -25333,7 +25333,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::upload_model call.
+    /// The request builder for [ModelService::upload_model][super::super::client::ModelService::upload_model] calls.
     #[derive(Clone, Debug)]
     pub struct UploadModel(RequestBuilder<crate::model::UploadModelRequest>);
 
@@ -25445,7 +25445,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_model call.
+    /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -25487,7 +25487,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_models call.
+    /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -25574,7 +25574,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_model_versions call.
+    /// The request builder for [ModelService::list_model_versions][super::super::client::ModelService::list_model_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListModelVersions(RequestBuilder<crate::model::ListModelVersionsRequest>);
 
@@ -25664,7 +25664,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_model_version_checkpoints call.
+    /// The request builder for [ModelService::list_model_version_checkpoints][super::super::client::ModelService::list_model_version_checkpoints] calls.
     #[derive(Clone, Debug)]
     pub struct ListModelVersionCheckpoints(
         RequestBuilder<crate::model::ListModelVersionCheckpointsRequest>,
@@ -25740,7 +25740,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::update_model call.
+    /// The request builder for [ModelService::update_model][super::super::client::ModelService::update_model] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateModel(RequestBuilder<crate::model::UpdateModelRequest>);
 
@@ -25794,7 +25794,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::update_explanation_dataset call.
+    /// The request builder for [ModelService::update_explanation_dataset][super::super::client::ModelService::update_explanation_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateExplanationDataset(
         RequestBuilder<crate::model::UpdateExplanationDatasetRequest>,
@@ -25893,7 +25893,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::delete_model call.
+    /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -25970,7 +25970,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::delete_model_version call.
+    /// The request builder for [ModelService::delete_model_version][super::super::client::ModelService::delete_model_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteModelVersion(RequestBuilder<crate::model::DeleteModelVersionRequest>);
 
@@ -26050,7 +26050,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::merge_version_aliases call.
+    /// The request builder for [ModelService::merge_version_aliases][super::super::client::ModelService::merge_version_aliases] calls.
     #[derive(Clone, Debug)]
     pub struct MergeVersionAliases(RequestBuilder<crate::model::MergeVersionAliasesRequest>);
 
@@ -26106,7 +26106,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::export_model call.
+    /// The request builder for [ModelService::export_model][super::super::client::ModelService::export_model] calls.
     #[derive(Clone, Debug)]
     pub struct ExportModel(RequestBuilder<crate::model::ExportModelRequest>);
 
@@ -26202,7 +26202,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::copy_model call.
+    /// The request builder for [ModelService::copy_model][super::super::client::ModelService::copy_model] calls.
     #[derive(Clone, Debug)]
     pub struct CopyModel(RequestBuilder<crate::model::CopyModelRequest>);
 
@@ -26311,7 +26311,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::import_model_evaluation call.
+    /// The request builder for [ModelService::import_model_evaluation][super::super::client::ModelService::import_model_evaluation] calls.
     #[derive(Clone, Debug)]
     pub struct ImportModelEvaluation(RequestBuilder<crate::model::ImportModelEvaluationRequest>);
 
@@ -26365,7 +26365,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::batch_import_model_evaluation_slices call.
+    /// The request builder for [ModelService::batch_import_model_evaluation_slices][super::super::client::ModelService::batch_import_model_evaluation_slices] calls.
     #[derive(Clone, Debug)]
     pub struct BatchImportModelEvaluationSlices(
         RequestBuilder<crate::model::BatchImportModelEvaluationSlicesRequest>,
@@ -26423,7 +26423,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::batch_import_evaluated_annotations call.
+    /// The request builder for [ModelService::batch_import_evaluated_annotations][super::super::client::ModelService::batch_import_evaluated_annotations] calls.
     #[derive(Clone, Debug)]
     pub struct BatchImportEvaluatedAnnotations(
         RequestBuilder<crate::model::BatchImportEvaluatedAnnotationsRequest>,
@@ -26481,7 +26481,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_model_evaluation call.
+    /// The request builder for [ModelService::get_model_evaluation][super::super::client::ModelService::get_model_evaluation] calls.
     #[derive(Clone, Debug)]
     pub struct GetModelEvaluation(RequestBuilder<crate::model::GetModelEvaluationRequest>);
 
@@ -26526,7 +26526,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_model_evaluations call.
+    /// The request builder for [ModelService::list_model_evaluations][super::super::client::ModelService::list_model_evaluations] calls.
     #[derive(Clone, Debug)]
     pub struct ListModelEvaluations(RequestBuilder<crate::model::ListModelEvaluationsRequest>);
 
@@ -26610,7 +26610,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_model_evaluation_slice call.
+    /// The request builder for [ModelService::get_model_evaluation_slice][super::super::client::ModelService::get_model_evaluation_slice] calls.
     #[derive(Clone, Debug)]
     pub struct GetModelEvaluationSlice(
         RequestBuilder<crate::model::GetModelEvaluationSliceRequest>,
@@ -26657,7 +26657,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_model_evaluation_slices call.
+    /// The request builder for [ModelService::list_model_evaluation_slices][super::super::client::ModelService::list_model_evaluation_slices] calls.
     #[derive(Clone, Debug)]
     pub struct ListModelEvaluationSlices(
         RequestBuilder<crate::model::ListModelEvaluationSlicesRequest>,
@@ -26745,7 +26745,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_locations call.
+    /// The request builder for [ModelService::list_locations][super::super::client::ModelService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -26823,7 +26823,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_location call.
+    /// The request builder for [ModelService::get_location][super::super::client::ModelService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -26865,7 +26865,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::set_iam_policy call.
+    /// The request builder for [ModelService::set_iam_policy][super::super::client::ModelService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -26925,7 +26925,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_iam_policy call.
+    /// The request builder for [ModelService::get_iam_policy][super::super::client::ModelService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -26976,7 +26976,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::test_iam_permissions call.
+    /// The request builder for [ModelService::test_iam_permissions][super::super::client::ModelService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -27032,7 +27032,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_operations call.
+    /// The request builder for [ModelService::list_operations][super::super::client::ModelService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -27110,7 +27110,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_operation call.
+    /// The request builder for [ModelService::get_operation][super::super::client::ModelService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -27155,7 +27155,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::delete_operation call.
+    /// The request builder for [ModelService::delete_operation][super::super::client::ModelService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -27200,7 +27200,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::cancel_operation call.
+    /// The request builder for [ModelService::cancel_operation][super::super::client::ModelService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -27245,7 +27245,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::wait_operation call.
+    /// The request builder for [ModelService::wait_operation][super::super::client::ModelService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -27350,7 +27350,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::create_notebook_runtime_template call.
+    /// The request builder for [NotebookService::create_notebook_runtime_template][super::super::client::NotebookService::create_notebook_runtime_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNotebookRuntimeTemplate(
         RequestBuilder<crate::model::CreateNotebookRuntimeTemplateRequest>,
@@ -27460,7 +27460,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_notebook_runtime_template call.
+    /// The request builder for [NotebookService::get_notebook_runtime_template][super::super::client::NotebookService::get_notebook_runtime_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetNotebookRuntimeTemplate(
         RequestBuilder<crate::model::GetNotebookRuntimeTemplateRequest>,
@@ -27507,7 +27507,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::list_notebook_runtime_templates call.
+    /// The request builder for [NotebookService::list_notebook_runtime_templates][super::super::client::NotebookService::list_notebook_runtime_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListNotebookRuntimeTemplates(
         RequestBuilder<crate::model::ListNotebookRuntimeTemplatesRequest>,
@@ -27601,7 +27601,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::delete_notebook_runtime_template call.
+    /// The request builder for [NotebookService::delete_notebook_runtime_template][super::super::client::NotebookService::delete_notebook_runtime_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNotebookRuntimeTemplate(
         RequestBuilder<crate::model::DeleteNotebookRuntimeTemplateRequest>,
@@ -27683,7 +27683,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::update_notebook_runtime_template call.
+    /// The request builder for [NotebookService::update_notebook_runtime_template][super::super::client::NotebookService::update_notebook_runtime_template] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNotebookRuntimeTemplate(
         RequestBuilder<crate::model::UpdateNotebookRuntimeTemplateRequest>,
@@ -27744,7 +27744,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::assign_notebook_runtime call.
+    /// The request builder for [NotebookService::assign_notebook_runtime][super::super::client::NotebookService::assign_notebook_runtime] calls.
     #[derive(Clone, Debug)]
     pub struct AssignNotebookRuntime(RequestBuilder<crate::model::AssignNotebookRuntimeRequest>);
 
@@ -27853,7 +27853,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_notebook_runtime call.
+    /// The request builder for [NotebookService::get_notebook_runtime][super::super::client::NotebookService::get_notebook_runtime] calls.
     #[derive(Clone, Debug)]
     pub struct GetNotebookRuntime(RequestBuilder<crate::model::GetNotebookRuntimeRequest>);
 
@@ -27898,7 +27898,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::list_notebook_runtimes call.
+    /// The request builder for [NotebookService::list_notebook_runtimes][super::super::client::NotebookService::list_notebook_runtimes] calls.
     #[derive(Clone, Debug)]
     pub struct ListNotebookRuntimes(RequestBuilder<crate::model::ListNotebookRuntimesRequest>);
 
@@ -27988,7 +27988,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::delete_notebook_runtime call.
+    /// The request builder for [NotebookService::delete_notebook_runtime][super::super::client::NotebookService::delete_notebook_runtime] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNotebookRuntime(RequestBuilder<crate::model::DeleteNotebookRuntimeRequest>);
 
@@ -28068,7 +28068,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::upgrade_notebook_runtime call.
+    /// The request builder for [NotebookService::upgrade_notebook_runtime][super::super::client::NotebookService::upgrade_notebook_runtime] calls.
     #[derive(Clone, Debug)]
     pub struct UpgradeNotebookRuntime(RequestBuilder<crate::model::UpgradeNotebookRuntimeRequest>);
 
@@ -28156,7 +28156,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::start_notebook_runtime call.
+    /// The request builder for [NotebookService::start_notebook_runtime][super::super::client::NotebookService::start_notebook_runtime] calls.
     #[derive(Clone, Debug)]
     pub struct StartNotebookRuntime(RequestBuilder<crate::model::StartNotebookRuntimeRequest>);
 
@@ -28244,7 +28244,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::stop_notebook_runtime call.
+    /// The request builder for [NotebookService::stop_notebook_runtime][super::super::client::NotebookService::stop_notebook_runtime] calls.
     #[derive(Clone, Debug)]
     pub struct StopNotebookRuntime(RequestBuilder<crate::model::StopNotebookRuntimeRequest>);
 
@@ -28332,7 +28332,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::create_notebook_execution_job call.
+    /// The request builder for [NotebookService::create_notebook_execution_job][super::super::client::NotebookService::create_notebook_execution_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNotebookExecutionJob(
         RequestBuilder<crate::model::CreateNotebookExecutionJobRequest>,
@@ -28439,7 +28439,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_notebook_execution_job call.
+    /// The request builder for [NotebookService::get_notebook_execution_job][super::super::client::NotebookService::get_notebook_execution_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetNotebookExecutionJob(
         RequestBuilder<crate::model::GetNotebookExecutionJobRequest>,
@@ -28492,7 +28492,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::list_notebook_execution_jobs call.
+    /// The request builder for [NotebookService::list_notebook_execution_jobs][super::super::client::NotebookService::list_notebook_execution_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListNotebookExecutionJobs(
         RequestBuilder<crate::model::ListNotebookExecutionJobsRequest>,
@@ -28586,7 +28586,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::delete_notebook_execution_job call.
+    /// The request builder for [NotebookService::delete_notebook_execution_job][super::super::client::NotebookService::delete_notebook_execution_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNotebookExecutionJob(
         RequestBuilder<crate::model::DeleteNotebookExecutionJobRequest>,
@@ -28668,7 +28668,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::list_locations call.
+    /// The request builder for [NotebookService::list_locations][super::super::client::NotebookService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -28746,7 +28746,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_location call.
+    /// The request builder for [NotebookService::get_location][super::super::client::NotebookService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -28788,7 +28788,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::set_iam_policy call.
+    /// The request builder for [NotebookService::set_iam_policy][super::super::client::NotebookService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -28848,7 +28848,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_iam_policy call.
+    /// The request builder for [NotebookService::get_iam_policy][super::super::client::NotebookService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -28899,7 +28899,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::test_iam_permissions call.
+    /// The request builder for [NotebookService::test_iam_permissions][super::super::client::NotebookService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -28955,7 +28955,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::list_operations call.
+    /// The request builder for [NotebookService::list_operations][super::super::client::NotebookService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -29033,7 +29033,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_operation call.
+    /// The request builder for [NotebookService::get_operation][super::super::client::NotebookService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -29078,7 +29078,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::delete_operation call.
+    /// The request builder for [NotebookService::delete_operation][super::super::client::NotebookService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -29123,7 +29123,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::cancel_operation call.
+    /// The request builder for [NotebookService::cancel_operation][super::super::client::NotebookService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -29168,7 +29168,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::wait_operation call.
+    /// The request builder for [NotebookService::wait_operation][super::super::client::NotebookService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -29275,7 +29275,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::create_persistent_resource call.
+    /// The request builder for [PersistentResourceService::create_persistent_resource][super::super::client::PersistentResourceService::create_persistent_resource] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePersistentResource(
         RequestBuilder<crate::model::CreatePersistentResourceRequest>,
@@ -29384,7 +29384,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::get_persistent_resource call.
+    /// The request builder for [PersistentResourceService::get_persistent_resource][super::super::client::PersistentResourceService::get_persistent_resource] calls.
     #[derive(Clone, Debug)]
     pub struct GetPersistentResource(RequestBuilder<crate::model::GetPersistentResourceRequest>);
 
@@ -29431,7 +29431,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::list_persistent_resources call.
+    /// The request builder for [PersistentResourceService::list_persistent_resources][super::super::client::PersistentResourceService::list_persistent_resources] calls.
     #[derive(Clone, Debug)]
     pub struct ListPersistentResources(
         RequestBuilder<crate::model::ListPersistentResourcesRequest>,
@@ -29509,7 +29509,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::delete_persistent_resource call.
+    /// The request builder for [PersistentResourceService::delete_persistent_resource][super::super::client::PersistentResourceService::delete_persistent_resource] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePersistentResource(
         RequestBuilder<crate::model::DeletePersistentResourceRequest>,
@@ -29593,7 +29593,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::update_persistent_resource call.
+    /// The request builder for [PersistentResourceService::update_persistent_resource][super::super::client::PersistentResourceService::update_persistent_resource] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePersistentResource(
         RequestBuilder<crate::model::UpdatePersistentResourceRequest>,
@@ -29699,7 +29699,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::reboot_persistent_resource call.
+    /// The request builder for [PersistentResourceService::reboot_persistent_resource][super::super::client::PersistentResourceService::reboot_persistent_resource] calls.
     #[derive(Clone, Debug)]
     pub struct RebootPersistentResource(
         RequestBuilder<crate::model::RebootPersistentResourceRequest>,
@@ -29791,7 +29791,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::list_locations call.
+    /// The request builder for [PersistentResourceService::list_locations][super::super::client::PersistentResourceService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -29871,7 +29871,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::get_location call.
+    /// The request builder for [PersistentResourceService::get_location][super::super::client::PersistentResourceService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -29915,7 +29915,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::set_iam_policy call.
+    /// The request builder for [PersistentResourceService::set_iam_policy][super::super::client::PersistentResourceService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -29977,7 +29977,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::get_iam_policy call.
+    /// The request builder for [PersistentResourceService::get_iam_policy][super::super::client::PersistentResourceService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -30030,7 +30030,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::test_iam_permissions call.
+    /// The request builder for [PersistentResourceService::test_iam_permissions][super::super::client::PersistentResourceService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -30088,7 +30088,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::list_operations call.
+    /// The request builder for [PersistentResourceService::list_operations][super::super::client::PersistentResourceService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -30168,7 +30168,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::get_operation call.
+    /// The request builder for [PersistentResourceService::get_operation][super::super::client::PersistentResourceService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -30215,7 +30215,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::delete_operation call.
+    /// The request builder for [PersistentResourceService::delete_operation][super::super::client::PersistentResourceService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -30262,7 +30262,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::cancel_operation call.
+    /// The request builder for [PersistentResourceService::cancel_operation][super::super::client::PersistentResourceService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -30309,7 +30309,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for a PersistentResourceService::wait_operation call.
+    /// The request builder for [PersistentResourceService::wait_operation][super::super::client::PersistentResourceService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -30416,7 +30416,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::create_training_pipeline call.
+    /// The request builder for [PipelineService::create_training_pipeline][super::super::client::PipelineService::create_training_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTrainingPipeline(RequestBuilder<crate::model::CreateTrainingPipelineRequest>);
 
@@ -30472,7 +30472,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::get_training_pipeline call.
+    /// The request builder for [PipelineService::get_training_pipeline][super::super::client::PipelineService::get_training_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct GetTrainingPipeline(RequestBuilder<crate::model::GetTrainingPipelineRequest>);
 
@@ -30517,7 +30517,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::list_training_pipelines call.
+    /// The request builder for [PipelineService::list_training_pipelines][super::super::client::PipelineService::list_training_pipelines] calls.
     #[derive(Clone, Debug)]
     pub struct ListTrainingPipelines(RequestBuilder<crate::model::ListTrainingPipelinesRequest>);
 
@@ -30601,7 +30601,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::delete_training_pipeline call.
+    /// The request builder for [PipelineService::delete_training_pipeline][super::super::client::PipelineService::delete_training_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTrainingPipeline(RequestBuilder<crate::model::DeleteTrainingPipelineRequest>);
 
@@ -30681,7 +30681,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::cancel_training_pipeline call.
+    /// The request builder for [PipelineService::cancel_training_pipeline][super::super::client::PipelineService::cancel_training_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct CancelTrainingPipeline(RequestBuilder<crate::model::CancelTrainingPipelineRequest>);
 
@@ -30726,7 +30726,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::create_pipeline_job call.
+    /// The request builder for [PipelineService::create_pipeline_job][super::super::client::PipelineService::create_pipeline_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePipelineJob(RequestBuilder<crate::model::CreatePipelineJobRequest>);
 
@@ -30786,7 +30786,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::get_pipeline_job call.
+    /// The request builder for [PipelineService::get_pipeline_job][super::super::client::PipelineService::get_pipeline_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetPipelineJob(RequestBuilder<crate::model::GetPipelineJobRequest>);
 
@@ -30828,7 +30828,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::list_pipeline_jobs call.
+    /// The request builder for [PipelineService::list_pipeline_jobs][super::super::client::PipelineService::list_pipeline_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListPipelineJobs(RequestBuilder<crate::model::ListPipelineJobsRequest>);
 
@@ -30918,7 +30918,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::delete_pipeline_job call.
+    /// The request builder for [PipelineService::delete_pipeline_job][super::super::client::PipelineService::delete_pipeline_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePipelineJob(RequestBuilder<crate::model::DeletePipelineJobRequest>);
 
@@ -30998,7 +30998,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::batch_delete_pipeline_jobs call.
+    /// The request builder for [PipelineService::batch_delete_pipeline_jobs][super::super::client::PipelineService::batch_delete_pipeline_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeletePipelineJobs(
         RequestBuilder<crate::model::BatchDeletePipelineJobsRequest>,
@@ -31099,7 +31099,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::cancel_pipeline_job call.
+    /// The request builder for [PipelineService::cancel_pipeline_job][super::super::client::PipelineService::cancel_pipeline_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelPipelineJob(RequestBuilder<crate::model::CancelPipelineJobRequest>);
 
@@ -31144,7 +31144,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::batch_cancel_pipeline_jobs call.
+    /// The request builder for [PipelineService::batch_cancel_pipeline_jobs][super::super::client::PipelineService::batch_cancel_pipeline_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCancelPipelineJobs(
         RequestBuilder<crate::model::BatchCancelPipelineJobsRequest>,
@@ -31245,7 +31245,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::list_locations call.
+    /// The request builder for [PipelineService::list_locations][super::super::client::PipelineService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -31323,7 +31323,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::get_location call.
+    /// The request builder for [PipelineService::get_location][super::super::client::PipelineService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -31365,7 +31365,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::set_iam_policy call.
+    /// The request builder for [PipelineService::set_iam_policy][super::super::client::PipelineService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -31425,7 +31425,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::get_iam_policy call.
+    /// The request builder for [PipelineService::get_iam_policy][super::super::client::PipelineService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -31476,7 +31476,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::test_iam_permissions call.
+    /// The request builder for [PipelineService::test_iam_permissions][super::super::client::PipelineService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -31532,7 +31532,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::list_operations call.
+    /// The request builder for [PipelineService::list_operations][super::super::client::PipelineService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -31610,7 +31610,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::get_operation call.
+    /// The request builder for [PipelineService::get_operation][super::super::client::PipelineService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -31655,7 +31655,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::delete_operation call.
+    /// The request builder for [PipelineService::delete_operation][super::super::client::PipelineService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -31700,7 +31700,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::cancel_operation call.
+    /// The request builder for [PipelineService::cancel_operation][super::super::client::PipelineService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -31745,7 +31745,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for a PipelineService::wait_operation call.
+    /// The request builder for [PipelineService::wait_operation][super::super::client::PipelineService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -31850,7 +31850,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::predict call.
+    /// The request builder for [PredictionService::predict][super::super::client::PredictionService::predict] calls.
     #[derive(Clone, Debug)]
     pub struct Predict(RequestBuilder<crate::model::PredictRequest>);
 
@@ -31907,7 +31907,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::raw_predict call.
+    /// The request builder for [PredictionService::raw_predict][super::super::client::PredictionService::raw_predict] calls.
     #[derive(Clone, Debug)]
     pub struct RawPredict(RequestBuilder<crate::model::RawPredictRequest>);
 
@@ -31958,7 +31958,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::direct_predict call.
+    /// The request builder for [PredictionService::direct_predict][super::super::client::PredictionService::direct_predict] calls.
     #[derive(Clone, Debug)]
     pub struct DirectPredict(RequestBuilder<crate::model::DirectPredictRequest>);
 
@@ -32020,7 +32020,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::direct_raw_predict call.
+    /// The request builder for [PredictionService::direct_raw_predict][super::super::client::PredictionService::direct_raw_predict] calls.
     #[derive(Clone, Debug)]
     pub struct DirectRawPredict(RequestBuilder<crate::model::DirectRawPredictRequest>);
 
@@ -32077,7 +32077,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::explain call.
+    /// The request builder for [PredictionService::explain][super::super::client::PredictionService::explain] calls.
     #[derive(Clone, Debug)]
     pub struct Explain(RequestBuilder<crate::model::ExplainRequest>);
 
@@ -32151,7 +32151,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::generate_content call.
+    /// The request builder for [PredictionService::generate_content][super::super::client::PredictionService::generate_content] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateContent(RequestBuilder<crate::model::GenerateContentRequest>);
 
@@ -32272,7 +32272,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::list_locations call.
+    /// The request builder for [PredictionService::list_locations][super::super::client::PredictionService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -32350,7 +32350,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::get_location call.
+    /// The request builder for [PredictionService::get_location][super::super::client::PredictionService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -32392,7 +32392,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::set_iam_policy call.
+    /// The request builder for [PredictionService::set_iam_policy][super::super::client::PredictionService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -32452,7 +32452,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::get_iam_policy call.
+    /// The request builder for [PredictionService::get_iam_policy][super::super::client::PredictionService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -32503,7 +32503,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::test_iam_permissions call.
+    /// The request builder for [PredictionService::test_iam_permissions][super::super::client::PredictionService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -32559,7 +32559,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::list_operations call.
+    /// The request builder for [PredictionService::list_operations][super::super::client::PredictionService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -32637,7 +32637,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::get_operation call.
+    /// The request builder for [PredictionService::get_operation][super::super::client::PredictionService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -32682,7 +32682,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::delete_operation call.
+    /// The request builder for [PredictionService::delete_operation][super::super::client::PredictionService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -32727,7 +32727,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::cancel_operation call.
+    /// The request builder for [PredictionService::cancel_operation][super::super::client::PredictionService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -32772,7 +32772,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::wait_operation call.
+    /// The request builder for [PredictionService::wait_operation][super::super::client::PredictionService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -32879,7 +32879,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::query_reasoning_engine call.
+    /// The request builder for [ReasoningEngineExecutionService::query_reasoning_engine][super::super::client::ReasoningEngineExecutionService::query_reasoning_engine] calls.
     #[derive(Clone, Debug)]
     pub struct QueryReasoningEngine(RequestBuilder<crate::model::QueryReasoningEngineRequest>);
 
@@ -32938,7 +32938,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::list_locations call.
+    /// The request builder for [ReasoningEngineExecutionService::list_locations][super::super::client::ReasoningEngineExecutionService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -33018,7 +33018,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::get_location call.
+    /// The request builder for [ReasoningEngineExecutionService::get_location][super::super::client::ReasoningEngineExecutionService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -33062,7 +33062,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::set_iam_policy call.
+    /// The request builder for [ReasoningEngineExecutionService::set_iam_policy][super::super::client::ReasoningEngineExecutionService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -33124,7 +33124,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::get_iam_policy call.
+    /// The request builder for [ReasoningEngineExecutionService::get_iam_policy][super::super::client::ReasoningEngineExecutionService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -33177,7 +33177,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::test_iam_permissions call.
+    /// The request builder for [ReasoningEngineExecutionService::test_iam_permissions][super::super::client::ReasoningEngineExecutionService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -33235,7 +33235,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::list_operations call.
+    /// The request builder for [ReasoningEngineExecutionService::list_operations][super::super::client::ReasoningEngineExecutionService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -33315,7 +33315,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::get_operation call.
+    /// The request builder for [ReasoningEngineExecutionService::get_operation][super::super::client::ReasoningEngineExecutionService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -33362,7 +33362,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::delete_operation call.
+    /// The request builder for [ReasoningEngineExecutionService::delete_operation][super::super::client::ReasoningEngineExecutionService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -33409,7 +33409,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::cancel_operation call.
+    /// The request builder for [ReasoningEngineExecutionService::cancel_operation][super::super::client::ReasoningEngineExecutionService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -33456,7 +33456,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineExecutionService::wait_operation call.
+    /// The request builder for [ReasoningEngineExecutionService::wait_operation][super::super::client::ReasoningEngineExecutionService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -33565,7 +33565,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::create_reasoning_engine call.
+    /// The request builder for [ReasoningEngineService::create_reasoning_engine][super::super::client::ReasoningEngineService::create_reasoning_engine] calls.
     #[derive(Clone, Debug)]
     pub struct CreateReasoningEngine(RequestBuilder<crate::model::CreateReasoningEngineRequest>);
 
@@ -33664,7 +33664,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::get_reasoning_engine call.
+    /// The request builder for [ReasoningEngineService::get_reasoning_engine][super::super::client::ReasoningEngineService::get_reasoning_engine] calls.
     #[derive(Clone, Debug)]
     pub struct GetReasoningEngine(RequestBuilder<crate::model::GetReasoningEngineRequest>);
 
@@ -33711,7 +33711,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::list_reasoning_engines call.
+    /// The request builder for [ReasoningEngineService::list_reasoning_engines][super::super::client::ReasoningEngineService::list_reasoning_engines] calls.
     #[derive(Clone, Debug)]
     pub struct ListReasoningEngines(RequestBuilder<crate::model::ListReasoningEnginesRequest>);
 
@@ -33791,7 +33791,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::update_reasoning_engine call.
+    /// The request builder for [ReasoningEngineService::update_reasoning_engine][super::super::client::ReasoningEngineService::update_reasoning_engine] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateReasoningEngine(RequestBuilder<crate::model::UpdateReasoningEngineRequest>);
 
@@ -33893,7 +33893,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::delete_reasoning_engine call.
+    /// The request builder for [ReasoningEngineService::delete_reasoning_engine][super::super::client::ReasoningEngineService::delete_reasoning_engine] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteReasoningEngine(RequestBuilder<crate::model::DeleteReasoningEngineRequest>);
 
@@ -33981,7 +33981,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::list_locations call.
+    /// The request builder for [ReasoningEngineService::list_locations][super::super::client::ReasoningEngineService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -34061,7 +34061,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::get_location call.
+    /// The request builder for [ReasoningEngineService::get_location][super::super::client::ReasoningEngineService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -34105,7 +34105,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::set_iam_policy call.
+    /// The request builder for [ReasoningEngineService::set_iam_policy][super::super::client::ReasoningEngineService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -34167,7 +34167,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::get_iam_policy call.
+    /// The request builder for [ReasoningEngineService::get_iam_policy][super::super::client::ReasoningEngineService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -34220,7 +34220,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::test_iam_permissions call.
+    /// The request builder for [ReasoningEngineService::test_iam_permissions][super::super::client::ReasoningEngineService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -34278,7 +34278,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::list_operations call.
+    /// The request builder for [ReasoningEngineService::list_operations][super::super::client::ReasoningEngineService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -34358,7 +34358,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::get_operation call.
+    /// The request builder for [ReasoningEngineService::get_operation][super::super::client::ReasoningEngineService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -34405,7 +34405,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::delete_operation call.
+    /// The request builder for [ReasoningEngineService::delete_operation][super::super::client::ReasoningEngineService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -34452,7 +34452,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::cancel_operation call.
+    /// The request builder for [ReasoningEngineService::cancel_operation][super::super::client::ReasoningEngineService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -34499,7 +34499,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for a ReasoningEngineService::wait_operation call.
+    /// The request builder for [ReasoningEngineService::wait_operation][super::super::client::ReasoningEngineService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -34606,7 +34606,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::create_schedule call.
+    /// The request builder for [ScheduleService::create_schedule][super::super::client::ScheduleService::create_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSchedule(RequestBuilder<crate::model::CreateScheduleRequest>);
 
@@ -34657,7 +34657,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::delete_schedule call.
+    /// The request builder for [ScheduleService::delete_schedule][super::super::client::ScheduleService::delete_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSchedule(RequestBuilder<crate::model::DeleteScheduleRequest>);
 
@@ -34734,7 +34734,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::get_schedule call.
+    /// The request builder for [ScheduleService::get_schedule][super::super::client::ScheduleService::get_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct GetSchedule(RequestBuilder<crate::model::GetScheduleRequest>);
 
@@ -34776,7 +34776,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::list_schedules call.
+    /// The request builder for [ScheduleService::list_schedules][super::super::client::ScheduleService::list_schedules] calls.
     #[derive(Clone, Debug)]
     pub struct ListSchedules(RequestBuilder<crate::model::ListSchedulesRequest>);
 
@@ -34857,7 +34857,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::pause_schedule call.
+    /// The request builder for [ScheduleService::pause_schedule][super::super::client::ScheduleService::pause_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct PauseSchedule(RequestBuilder<crate::model::PauseScheduleRequest>);
 
@@ -34899,7 +34899,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::resume_schedule call.
+    /// The request builder for [ScheduleService::resume_schedule][super::super::client::ScheduleService::resume_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeSchedule(RequestBuilder<crate::model::ResumeScheduleRequest>);
 
@@ -34947,7 +34947,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::update_schedule call.
+    /// The request builder for [ScheduleService::update_schedule][super::super::client::ScheduleService::update_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSchedule(RequestBuilder<crate::model::UpdateScheduleRequest>);
 
@@ -35001,7 +35001,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::list_locations call.
+    /// The request builder for [ScheduleService::list_locations][super::super::client::ScheduleService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -35079,7 +35079,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::get_location call.
+    /// The request builder for [ScheduleService::get_location][super::super::client::ScheduleService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -35121,7 +35121,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::set_iam_policy call.
+    /// The request builder for [ScheduleService::set_iam_policy][super::super::client::ScheduleService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -35181,7 +35181,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::get_iam_policy call.
+    /// The request builder for [ScheduleService::get_iam_policy][super::super::client::ScheduleService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -35232,7 +35232,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::test_iam_permissions call.
+    /// The request builder for [ScheduleService::test_iam_permissions][super::super::client::ScheduleService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -35288,7 +35288,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::list_operations call.
+    /// The request builder for [ScheduleService::list_operations][super::super::client::ScheduleService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -35366,7 +35366,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::get_operation call.
+    /// The request builder for [ScheduleService::get_operation][super::super::client::ScheduleService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -35411,7 +35411,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::delete_operation call.
+    /// The request builder for [ScheduleService::delete_operation][super::super::client::ScheduleService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -35456,7 +35456,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::cancel_operation call.
+    /// The request builder for [ScheduleService::cancel_operation][super::super::client::ScheduleService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -35501,7 +35501,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for a ScheduleService::wait_operation call.
+    /// The request builder for [ScheduleService::wait_operation][super::super::client::ScheduleService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -35608,7 +35608,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::create_specialist_pool call.
+    /// The request builder for [SpecialistPoolService::create_specialist_pool][super::super::client::SpecialistPoolService::create_specialist_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSpecialistPool(RequestBuilder<crate::model::CreateSpecialistPoolRequest>);
 
@@ -35707,7 +35707,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::get_specialist_pool call.
+    /// The request builder for [SpecialistPoolService::get_specialist_pool][super::super::client::SpecialistPoolService::get_specialist_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetSpecialistPool(RequestBuilder<crate::model::GetSpecialistPoolRequest>);
 
@@ -35754,7 +35754,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::list_specialist_pools call.
+    /// The request builder for [SpecialistPoolService::list_specialist_pools][super::super::client::SpecialistPoolService::list_specialist_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListSpecialistPools(RequestBuilder<crate::model::ListSpecialistPoolsRequest>);
 
@@ -35834,7 +35834,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::delete_specialist_pool call.
+    /// The request builder for [SpecialistPoolService::delete_specialist_pool][super::super::client::SpecialistPoolService::delete_specialist_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSpecialistPool(RequestBuilder<crate::model::DeleteSpecialistPoolRequest>);
 
@@ -35922,7 +35922,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::update_specialist_pool call.
+    /// The request builder for [SpecialistPoolService::update_specialist_pool][super::super::client::SpecialistPoolService::update_specialist_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSpecialistPool(RequestBuilder<crate::model::UpdateSpecialistPoolRequest>);
 
@@ -36024,7 +36024,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::list_locations call.
+    /// The request builder for [SpecialistPoolService::list_locations][super::super::client::SpecialistPoolService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -36104,7 +36104,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::get_location call.
+    /// The request builder for [SpecialistPoolService::get_location][super::super::client::SpecialistPoolService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -36148,7 +36148,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::set_iam_policy call.
+    /// The request builder for [SpecialistPoolService::set_iam_policy][super::super::client::SpecialistPoolService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -36210,7 +36210,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::get_iam_policy call.
+    /// The request builder for [SpecialistPoolService::get_iam_policy][super::super::client::SpecialistPoolService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -36263,7 +36263,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::test_iam_permissions call.
+    /// The request builder for [SpecialistPoolService::test_iam_permissions][super::super::client::SpecialistPoolService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -36321,7 +36321,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::list_operations call.
+    /// The request builder for [SpecialistPoolService::list_operations][super::super::client::SpecialistPoolService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -36401,7 +36401,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::get_operation call.
+    /// The request builder for [SpecialistPoolService::get_operation][super::super::client::SpecialistPoolService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -36448,7 +36448,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::delete_operation call.
+    /// The request builder for [SpecialistPoolService::delete_operation][super::super::client::SpecialistPoolService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -36495,7 +36495,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::cancel_operation call.
+    /// The request builder for [SpecialistPoolService::cancel_operation][super::super::client::SpecialistPoolService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -36542,7 +36542,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for a SpecialistPoolService::wait_operation call.
+    /// The request builder for [SpecialistPoolService::wait_operation][super::super::client::SpecialistPoolService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -36649,7 +36649,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::create_tensorboard call.
+    /// The request builder for [TensorboardService::create_tensorboard][super::super::client::TensorboardService::create_tensorboard] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTensorboard(RequestBuilder<crate::model::CreateTensorboardRequest>);
 
@@ -36744,7 +36744,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::get_tensorboard call.
+    /// The request builder for [TensorboardService::get_tensorboard][super::super::client::TensorboardService::get_tensorboard] calls.
     #[derive(Clone, Debug)]
     pub struct GetTensorboard(RequestBuilder<crate::model::GetTensorboardRequest>);
 
@@ -36786,7 +36786,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::update_tensorboard call.
+    /// The request builder for [TensorboardService::update_tensorboard][super::super::client::TensorboardService::update_tensorboard] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTensorboard(RequestBuilder<crate::model::UpdateTensorboardRequest>);
 
@@ -36884,7 +36884,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::list_tensorboards call.
+    /// The request builder for [TensorboardService::list_tensorboards][super::super::client::TensorboardService::list_tensorboards] calls.
     #[derive(Clone, Debug)]
     pub struct ListTensorboards(RequestBuilder<crate::model::ListTensorboardsRequest>);
 
@@ -36974,7 +36974,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::delete_tensorboard call.
+    /// The request builder for [TensorboardService::delete_tensorboard][super::super::client::TensorboardService::delete_tensorboard] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTensorboard(RequestBuilder<crate::model::DeleteTensorboardRequest>);
 
@@ -37054,7 +37054,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::read_tensorboard_usage call.
+    /// The request builder for [TensorboardService::read_tensorboard_usage][super::super::client::TensorboardService::read_tensorboard_usage] calls.
     #[derive(Clone, Debug)]
     pub struct ReadTensorboardUsage(RequestBuilder<crate::model::ReadTensorboardUsageRequest>);
 
@@ -37099,7 +37099,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::read_tensorboard_size call.
+    /// The request builder for [TensorboardService::read_tensorboard_size][super::super::client::TensorboardService::read_tensorboard_size] calls.
     #[derive(Clone, Debug)]
     pub struct ReadTensorboardSize(RequestBuilder<crate::model::ReadTensorboardSizeRequest>);
 
@@ -37144,7 +37144,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::create_tensorboard_experiment call.
+    /// The request builder for [TensorboardService::create_tensorboard_experiment][super::super::client::TensorboardService::create_tensorboard_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTensorboardExperiment(
         RequestBuilder<crate::model::CreateTensorboardExperimentRequest>,
@@ -37208,7 +37208,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::get_tensorboard_experiment call.
+    /// The request builder for [TensorboardService::get_tensorboard_experiment][super::super::client::TensorboardService::get_tensorboard_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct GetTensorboardExperiment(
         RequestBuilder<crate::model::GetTensorboardExperimentRequest>,
@@ -37255,7 +37255,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::update_tensorboard_experiment call.
+    /// The request builder for [TensorboardService::update_tensorboard_experiment][super::super::client::TensorboardService::update_tensorboard_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTensorboardExperiment(
         RequestBuilder<crate::model::UpdateTensorboardExperimentRequest>,
@@ -37316,7 +37316,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::list_tensorboard_experiments call.
+    /// The request builder for [TensorboardService::list_tensorboard_experiments][super::super::client::TensorboardService::list_tensorboard_experiments] calls.
     #[derive(Clone, Debug)]
     pub struct ListTensorboardExperiments(
         RequestBuilder<crate::model::ListTensorboardExperimentsRequest>,
@@ -37410,7 +37410,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::delete_tensorboard_experiment call.
+    /// The request builder for [TensorboardService::delete_tensorboard_experiment][super::super::client::TensorboardService::delete_tensorboard_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTensorboardExperiment(
         RequestBuilder<crate::model::DeleteTensorboardExperimentRequest>,
@@ -37492,7 +37492,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::create_tensorboard_run call.
+    /// The request builder for [TensorboardService::create_tensorboard_run][super::super::client::TensorboardService::create_tensorboard_run] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTensorboardRun(RequestBuilder<crate::model::CreateTensorboardRunRequest>);
 
@@ -37552,7 +37552,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::batch_create_tensorboard_runs call.
+    /// The request builder for [TensorboardService::batch_create_tensorboard_runs][super::super::client::TensorboardService::batch_create_tensorboard_runs] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateTensorboardRuns(
         RequestBuilder<crate::model::BatchCreateTensorboardRunsRequest>,
@@ -37610,7 +37610,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::get_tensorboard_run call.
+    /// The request builder for [TensorboardService::get_tensorboard_run][super::super::client::TensorboardService::get_tensorboard_run] calls.
     #[derive(Clone, Debug)]
     pub struct GetTensorboardRun(RequestBuilder<crate::model::GetTensorboardRunRequest>);
 
@@ -37655,7 +37655,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::update_tensorboard_run call.
+    /// The request builder for [TensorboardService::update_tensorboard_run][super::super::client::TensorboardService::update_tensorboard_run] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTensorboardRun(RequestBuilder<crate::model::UpdateTensorboardRunRequest>);
 
@@ -37712,7 +37712,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::list_tensorboard_runs call.
+    /// The request builder for [TensorboardService::list_tensorboard_runs][super::super::client::TensorboardService::list_tensorboard_runs] calls.
     #[derive(Clone, Debug)]
     pub struct ListTensorboardRuns(RequestBuilder<crate::model::ListTensorboardRunsRequest>);
 
@@ -37802,7 +37802,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::delete_tensorboard_run call.
+    /// The request builder for [TensorboardService::delete_tensorboard_run][super::super::client::TensorboardService::delete_tensorboard_run] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTensorboardRun(RequestBuilder<crate::model::DeleteTensorboardRunRequest>);
 
@@ -37882,7 +37882,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::batch_create_tensorboard_time_series call.
+    /// The request builder for [TensorboardService::batch_create_tensorboard_time_series][super::super::client::TensorboardService::batch_create_tensorboard_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateTensorboardTimeSeries(
         RequestBuilder<crate::model::BatchCreateTensorboardTimeSeriesRequest>,
@@ -37940,7 +37940,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::create_tensorboard_time_series call.
+    /// The request builder for [TensorboardService::create_tensorboard_time_series][super::super::client::TensorboardService::create_tensorboard_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTensorboardTimeSeries(
         RequestBuilder<crate::model::CreateTensorboardTimeSeriesRequest>,
@@ -38007,7 +38007,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::get_tensorboard_time_series call.
+    /// The request builder for [TensorboardService::get_tensorboard_time_series][super::super::client::TensorboardService::get_tensorboard_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct GetTensorboardTimeSeries(
         RequestBuilder<crate::model::GetTensorboardTimeSeriesRequest>,
@@ -38054,7 +38054,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::update_tensorboard_time_series call.
+    /// The request builder for [TensorboardService::update_tensorboard_time_series][super::super::client::TensorboardService::update_tensorboard_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTensorboardTimeSeries(
         RequestBuilder<crate::model::UpdateTensorboardTimeSeriesRequest>,
@@ -38115,7 +38115,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::list_tensorboard_time_series call.
+    /// The request builder for [TensorboardService::list_tensorboard_time_series][super::super::client::TensorboardService::list_tensorboard_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct ListTensorboardTimeSeries(
         RequestBuilder<crate::model::ListTensorboardTimeSeriesRequest>,
@@ -38209,7 +38209,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::delete_tensorboard_time_series call.
+    /// The request builder for [TensorboardService::delete_tensorboard_time_series][super::super::client::TensorboardService::delete_tensorboard_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTensorboardTimeSeries(
         RequestBuilder<crate::model::DeleteTensorboardTimeSeriesRequest>,
@@ -38291,7 +38291,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::batch_read_tensorboard_time_series_data call.
+    /// The request builder for [TensorboardService::batch_read_tensorboard_time_series_data][super::super::client::TensorboardService::batch_read_tensorboard_time_series_data] calls.
     #[derive(Clone, Debug)]
     pub struct BatchReadTensorboardTimeSeriesData(
         RequestBuilder<crate::model::BatchReadTensorboardTimeSeriesDataRequest>,
@@ -38351,7 +38351,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::read_tensorboard_time_series_data call.
+    /// The request builder for [TensorboardService::read_tensorboard_time_series_data][super::super::client::TensorboardService::read_tensorboard_time_series_data] calls.
     #[derive(Clone, Debug)]
     pub struct ReadTensorboardTimeSeriesData(
         RequestBuilder<crate::model::ReadTensorboardTimeSeriesDataRequest>,
@@ -38410,7 +38410,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::write_tensorboard_experiment_data call.
+    /// The request builder for [TensorboardService::write_tensorboard_experiment_data][super::super::client::TensorboardService::write_tensorboard_experiment_data] calls.
     #[derive(Clone, Debug)]
     pub struct WriteTensorboardExperimentData(
         RequestBuilder<crate::model::WriteTensorboardExperimentDataRequest>,
@@ -38468,7 +38468,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::write_tensorboard_run_data call.
+    /// The request builder for [TensorboardService::write_tensorboard_run_data][super::super::client::TensorboardService::write_tensorboard_run_data] calls.
     #[derive(Clone, Debug)]
     pub struct WriteTensorboardRunData(
         RequestBuilder<crate::model::WriteTensorboardRunDataRequest>,
@@ -38526,7 +38526,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::export_tensorboard_time_series_data call.
+    /// The request builder for [TensorboardService::export_tensorboard_time_series_data][super::super::client::TensorboardService::export_tensorboard_time_series_data] calls.
     #[derive(Clone, Debug)]
     pub struct ExportTensorboardTimeSeriesData(
         RequestBuilder<crate::model::ExportTensorboardTimeSeriesDataRequest>,
@@ -38614,7 +38614,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::list_locations call.
+    /// The request builder for [TensorboardService::list_locations][super::super::client::TensorboardService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -38692,7 +38692,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::get_location call.
+    /// The request builder for [TensorboardService::get_location][super::super::client::TensorboardService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -38734,7 +38734,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::set_iam_policy call.
+    /// The request builder for [TensorboardService::set_iam_policy][super::super::client::TensorboardService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -38794,7 +38794,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::get_iam_policy call.
+    /// The request builder for [TensorboardService::get_iam_policy][super::super::client::TensorboardService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -38845,7 +38845,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::test_iam_permissions call.
+    /// The request builder for [TensorboardService::test_iam_permissions][super::super::client::TensorboardService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -38901,7 +38901,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::list_operations call.
+    /// The request builder for [TensorboardService::list_operations][super::super::client::TensorboardService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -38979,7 +38979,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::get_operation call.
+    /// The request builder for [TensorboardService::get_operation][super::super::client::TensorboardService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -39024,7 +39024,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::delete_operation call.
+    /// The request builder for [TensorboardService::delete_operation][super::super::client::TensorboardService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -39069,7 +39069,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::cancel_operation call.
+    /// The request builder for [TensorboardService::cancel_operation][super::super::client::TensorboardService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -39114,7 +39114,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for a TensorboardService::wait_operation call.
+    /// The request builder for [TensorboardService::wait_operation][super::super::client::TensorboardService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -39221,7 +39221,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::create_rag_corpus call.
+    /// The request builder for [VertexRagDataService::create_rag_corpus][super::super::client::VertexRagDataService::create_rag_corpus] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRagCorpus(RequestBuilder<crate::model::CreateRagCorpusRequest>);
 
@@ -39315,7 +39315,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::update_rag_corpus call.
+    /// The request builder for [VertexRagDataService::update_rag_corpus][super::super::client::VertexRagDataService::update_rag_corpus] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRagCorpus(RequestBuilder<crate::model::UpdateRagCorpusRequest>);
 
@@ -39403,7 +39403,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::get_rag_corpus call.
+    /// The request builder for [VertexRagDataService::get_rag_corpus][super::super::client::VertexRagDataService::get_rag_corpus] calls.
     #[derive(Clone, Debug)]
     pub struct GetRagCorpus(RequestBuilder<crate::model::GetRagCorpusRequest>);
 
@@ -39447,7 +39447,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::list_rag_corpora call.
+    /// The request builder for [VertexRagDataService::list_rag_corpora][super::super::client::VertexRagDataService::list_rag_corpora] calls.
     #[derive(Clone, Debug)]
     pub struct ListRagCorpora(RequestBuilder<crate::model::ListRagCorporaRequest>);
 
@@ -39518,7 +39518,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::delete_rag_corpus call.
+    /// The request builder for [VertexRagDataService::delete_rag_corpus][super::super::client::VertexRagDataService::delete_rag_corpus] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRagCorpus(RequestBuilder<crate::model::DeleteRagCorpusRequest>);
 
@@ -39603,7 +39603,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::upload_rag_file call.
+    /// The request builder for [VertexRagDataService::upload_rag_file][super::super::client::VertexRagDataService::upload_rag_file] calls.
     #[derive(Clone, Debug)]
     pub struct UploadRagFile(RequestBuilder<crate::model::UploadRagFileRequest>);
 
@@ -39667,7 +39667,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::import_rag_files call.
+    /// The request builder for [VertexRagDataService::import_rag_files][super::super::client::VertexRagDataService::import_rag_files] calls.
     #[derive(Clone, Debug)]
     pub struct ImportRagFiles(RequestBuilder<crate::model::ImportRagFilesRequest>);
 
@@ -39765,7 +39765,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::get_rag_file call.
+    /// The request builder for [VertexRagDataService::get_rag_file][super::super::client::VertexRagDataService::get_rag_file] calls.
     #[derive(Clone, Debug)]
     pub struct GetRagFile(RequestBuilder<crate::model::GetRagFileRequest>);
 
@@ -39809,7 +39809,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::list_rag_files call.
+    /// The request builder for [VertexRagDataService::list_rag_files][super::super::client::VertexRagDataService::list_rag_files] calls.
     #[derive(Clone, Debug)]
     pub struct ListRagFiles(RequestBuilder<crate::model::ListRagFilesRequest>);
 
@@ -39880,7 +39880,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::delete_rag_file call.
+    /// The request builder for [VertexRagDataService::delete_rag_file][super::super::client::VertexRagDataService::delete_rag_file] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRagFile(RequestBuilder<crate::model::DeleteRagFileRequest>);
 
@@ -39959,7 +39959,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::list_locations call.
+    /// The request builder for [VertexRagDataService::list_locations][super::super::client::VertexRagDataService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -40039,7 +40039,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::get_location call.
+    /// The request builder for [VertexRagDataService::get_location][super::super::client::VertexRagDataService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -40083,7 +40083,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::set_iam_policy call.
+    /// The request builder for [VertexRagDataService::set_iam_policy][super::super::client::VertexRagDataService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -40145,7 +40145,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::get_iam_policy call.
+    /// The request builder for [VertexRagDataService::get_iam_policy][super::super::client::VertexRagDataService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -40198,7 +40198,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::test_iam_permissions call.
+    /// The request builder for [VertexRagDataService::test_iam_permissions][super::super::client::VertexRagDataService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -40256,7 +40256,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::list_operations call.
+    /// The request builder for [VertexRagDataService::list_operations][super::super::client::VertexRagDataService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -40336,7 +40336,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::get_operation call.
+    /// The request builder for [VertexRagDataService::get_operation][super::super::client::VertexRagDataService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -40383,7 +40383,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::delete_operation call.
+    /// The request builder for [VertexRagDataService::delete_operation][super::super::client::VertexRagDataService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -40430,7 +40430,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::cancel_operation call.
+    /// The request builder for [VertexRagDataService::cancel_operation][super::super::client::VertexRagDataService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -40477,7 +40477,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for a VertexRagDataService::wait_operation call.
+    /// The request builder for [VertexRagDataService::wait_operation][super::super::client::VertexRagDataService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -40584,7 +40584,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::retrieve_contexts call.
+    /// The request builder for [VertexRagService::retrieve_contexts][super::super::client::VertexRagService::retrieve_contexts] calls.
     #[derive(Clone, Debug)]
     pub struct RetrieveContexts(RequestBuilder<crate::model::RetrieveContextsRequest>);
 
@@ -40649,7 +40649,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::augment_prompt call.
+    /// The request builder for [VertexRagService::augment_prompt][super::super::client::VertexRagService::augment_prompt] calls.
     #[derive(Clone, Debug)]
     pub struct AugmentPrompt(RequestBuilder<crate::model::AugmentPromptRequest>);
 
@@ -40724,7 +40724,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::corroborate_content call.
+    /// The request builder for [VertexRagService::corroborate_content][super::super::client::VertexRagService::corroborate_content] calls.
     #[derive(Clone, Debug)]
     pub struct CorroborateContent(RequestBuilder<crate::model::CorroborateContentRequest>);
 
@@ -40800,7 +40800,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::list_locations call.
+    /// The request builder for [VertexRagService::list_locations][super::super::client::VertexRagService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -40878,7 +40878,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::get_location call.
+    /// The request builder for [VertexRagService::get_location][super::super::client::VertexRagService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -40920,7 +40920,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::set_iam_policy call.
+    /// The request builder for [VertexRagService::set_iam_policy][super::super::client::VertexRagService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -40980,7 +40980,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::get_iam_policy call.
+    /// The request builder for [VertexRagService::get_iam_policy][super::super::client::VertexRagService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -41031,7 +41031,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::test_iam_permissions call.
+    /// The request builder for [VertexRagService::test_iam_permissions][super::super::client::VertexRagService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -41087,7 +41087,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::list_operations call.
+    /// The request builder for [VertexRagService::list_operations][super::super::client::VertexRagService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -41165,7 +41165,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::get_operation call.
+    /// The request builder for [VertexRagService::get_operation][super::super::client::VertexRagService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -41210,7 +41210,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::delete_operation call.
+    /// The request builder for [VertexRagService::delete_operation][super::super::client::VertexRagService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -41255,7 +41255,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::cancel_operation call.
+    /// The request builder for [VertexRagService::cancel_operation][super::super::client::VertexRagService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -41300,7 +41300,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for a VertexRagService::wait_operation call.
+    /// The request builder for [VertexRagService::wait_operation][super::super::client::VertexRagService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -41405,7 +41405,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::create_study call.
+    /// The request builder for [VizierService::create_study][super::super::client::VizierService::create_study] calls.
     #[derive(Clone, Debug)]
     pub struct CreateStudy(RequestBuilder<crate::model::CreateStudyRequest>);
 
@@ -41456,7 +41456,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::get_study call.
+    /// The request builder for [VizierService::get_study][super::super::client::VizierService::get_study] calls.
     #[derive(Clone, Debug)]
     pub struct GetStudy(RequestBuilder<crate::model::GetStudyRequest>);
 
@@ -41498,7 +41498,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::list_studies call.
+    /// The request builder for [VizierService::list_studies][super::super::client::VizierService::list_studies] calls.
     #[derive(Clone, Debug)]
     pub struct ListStudies(RequestBuilder<crate::model::ListStudiesRequest>);
 
@@ -41567,7 +41567,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::delete_study call.
+    /// The request builder for [VizierService::delete_study][super::super::client::VizierService::delete_study] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteStudy(RequestBuilder<crate::model::DeleteStudyRequest>);
 
@@ -41609,7 +41609,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::lookup_study call.
+    /// The request builder for [VizierService::lookup_study][super::super::client::VizierService::lookup_study] calls.
     #[derive(Clone, Debug)]
     pub struct LookupStudy(RequestBuilder<crate::model::LookupStudyRequest>);
 
@@ -41657,7 +41657,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::suggest_trials call.
+    /// The request builder for [VizierService::suggest_trials][super::super::client::VizierService::suggest_trials] calls.
     #[derive(Clone, Debug)]
     pub struct SuggestTrials(RequestBuilder<crate::model::SuggestTrialsRequest>);
 
@@ -41763,7 +41763,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::create_trial call.
+    /// The request builder for [VizierService::create_trial][super::super::client::VizierService::create_trial] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTrial(RequestBuilder<crate::model::CreateTrialRequest>);
 
@@ -41814,7 +41814,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::get_trial call.
+    /// The request builder for [VizierService::get_trial][super::super::client::VizierService::get_trial] calls.
     #[derive(Clone, Debug)]
     pub struct GetTrial(RequestBuilder<crate::model::GetTrialRequest>);
 
@@ -41856,7 +41856,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::list_trials call.
+    /// The request builder for [VizierService::list_trials][super::super::client::VizierService::list_trials] calls.
     #[derive(Clone, Debug)]
     pub struct ListTrials(RequestBuilder<crate::model::ListTrialsRequest>);
 
@@ -41925,7 +41925,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::add_trial_measurement call.
+    /// The request builder for [VizierService::add_trial_measurement][super::super::client::VizierService::add_trial_measurement] calls.
     #[derive(Clone, Debug)]
     pub struct AddTrialMeasurement(RequestBuilder<crate::model::AddTrialMeasurementRequest>);
 
@@ -41979,7 +41979,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::complete_trial call.
+    /// The request builder for [VizierService::complete_trial][super::super::client::VizierService::complete_trial] calls.
     #[derive(Clone, Debug)]
     pub struct CompleteTrial(RequestBuilder<crate::model::CompleteTrialRequest>);
 
@@ -42042,7 +42042,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::delete_trial call.
+    /// The request builder for [VizierService::delete_trial][super::super::client::VizierService::delete_trial] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTrial(RequestBuilder<crate::model::DeleteTrialRequest>);
 
@@ -42084,7 +42084,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::check_trial_early_stopping_state call.
+    /// The request builder for [VizierService::check_trial_early_stopping_state][super::super::client::VizierService::check_trial_early_stopping_state] calls.
     #[derive(Clone, Debug)]
     pub struct CheckTrialEarlyStoppingState(
         RequestBuilder<crate::model::CheckTrialEarlyStoppingStateRequest>,
@@ -42174,7 +42174,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::stop_trial call.
+    /// The request builder for [VizierService::stop_trial][super::super::client::VizierService::stop_trial] calls.
     #[derive(Clone, Debug)]
     pub struct StopTrial(RequestBuilder<crate::model::StopTrialRequest>);
 
@@ -42216,7 +42216,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::list_optimal_trials call.
+    /// The request builder for [VizierService::list_optimal_trials][super::super::client::VizierService::list_optimal_trials] calls.
     #[derive(Clone, Debug)]
     pub struct ListOptimalTrials(RequestBuilder<crate::model::ListOptimalTrialsRequest>);
 
@@ -42261,7 +42261,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::list_locations call.
+    /// The request builder for [VizierService::list_locations][super::super::client::VizierService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -42339,7 +42339,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::get_location call.
+    /// The request builder for [VizierService::get_location][super::super::client::VizierService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -42381,7 +42381,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::set_iam_policy call.
+    /// The request builder for [VizierService::set_iam_policy][super::super::client::VizierService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -42441,7 +42441,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::get_iam_policy call.
+    /// The request builder for [VizierService::get_iam_policy][super::super::client::VizierService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -42492,7 +42492,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::test_iam_permissions call.
+    /// The request builder for [VizierService::test_iam_permissions][super::super::client::VizierService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -42548,7 +42548,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::list_operations call.
+    /// The request builder for [VizierService::list_operations][super::super::client::VizierService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -42626,7 +42626,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::get_operation call.
+    /// The request builder for [VizierService::get_operation][super::super::client::VizierService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -42671,7 +42671,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::delete_operation call.
+    /// The request builder for [VizierService::delete_operation][super::super::client::VizierService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -42716,7 +42716,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::cancel_operation call.
+    /// The request builder for [VizierService::cancel_operation][super::super::client::VizierService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -42761,7 +42761,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for a VizierService::wait_operation call.
+    /// The request builder for [VizierService::wait_operation][super::super::client::VizierService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 

--- a/src/generated/cloud/alloydb/v1/src/builder.rs
+++ b/src/generated/cloud/alloydb/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::list_clusters call.
+    /// The request builder for [AlloyDBAdmin::list_clusters][super::super::client::AlloyDBAdmin::list_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -148,7 +148,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::get_cluster call.
+    /// The request builder for [AlloyDBAdmin::get_cluster][super::super::client::AlloyDBAdmin::get_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -196,7 +196,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::create_cluster call.
+    /// The request builder for [AlloyDBAdmin::create_cluster][super::super::client::AlloyDBAdmin::create_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -302,7 +302,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::update_cluster call.
+    /// The request builder for [AlloyDBAdmin::update_cluster][super::super::client::AlloyDBAdmin::update_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -411,7 +411,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::delete_cluster call.
+    /// The request builder for [AlloyDBAdmin::delete_cluster][super::super::client::AlloyDBAdmin::delete_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -512,7 +512,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::promote_cluster call.
+    /// The request builder for [AlloyDBAdmin::promote_cluster][super::super::client::AlloyDBAdmin::promote_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct PromoteCluster(RequestBuilder<crate::model::PromoteClusterRequest>);
 
@@ -609,7 +609,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::switchover_cluster call.
+    /// The request builder for [AlloyDBAdmin::switchover_cluster][super::super::client::AlloyDBAdmin::switchover_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct SwitchoverCluster(RequestBuilder<crate::model::SwitchoverClusterRequest>);
 
@@ -703,7 +703,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::restore_cluster call.
+    /// The request builder for [AlloyDBAdmin::restore_cluster][super::super::client::AlloyDBAdmin::restore_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreCluster(RequestBuilder<crate::model::RestoreClusterRequest>);
 
@@ -818,7 +818,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::create_secondary_cluster call.
+    /// The request builder for [AlloyDBAdmin::create_secondary_cluster][super::super::client::AlloyDBAdmin::create_secondary_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecondaryCluster(RequestBuilder<crate::model::CreateSecondaryClusterRequest>);
 
@@ -927,7 +927,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::list_instances call.
+    /// The request builder for [AlloyDBAdmin::list_instances][super::super::client::AlloyDBAdmin::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -1008,7 +1008,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::get_instance call.
+    /// The request builder for [AlloyDBAdmin::get_instance][super::super::client::AlloyDBAdmin::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -1056,7 +1056,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::create_instance call.
+    /// The request builder for [AlloyDBAdmin::create_instance][super::super::client::AlloyDBAdmin::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -1163,7 +1163,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::create_secondary_instance call.
+    /// The request builder for [AlloyDBAdmin::create_secondary_instance][super::super::client::AlloyDBAdmin::create_secondary_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecondaryInstance(
         RequestBuilder<crate::model::CreateSecondaryInstanceRequest>,
@@ -1275,7 +1275,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::batch_create_instances call.
+    /// The request builder for [AlloyDBAdmin::batch_create_instances][super::super::client::AlloyDBAdmin::batch_create_instances] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateInstances(RequestBuilder<crate::model::BatchCreateInstancesRequest>);
 
@@ -1376,7 +1376,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::update_instance call.
+    /// The request builder for [AlloyDBAdmin::update_instance][super::super::client::AlloyDBAdmin::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -1486,7 +1486,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::delete_instance call.
+    /// The request builder for [AlloyDBAdmin::delete_instance][super::super::client::AlloyDBAdmin::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -1581,7 +1581,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::failover_instance call.
+    /// The request builder for [AlloyDBAdmin::failover_instance][super::super::client::AlloyDBAdmin::failover_instance] calls.
     #[derive(Clone, Debug)]
     pub struct FailoverInstance(RequestBuilder<crate::model::FailoverInstanceRequest>);
 
@@ -1676,7 +1676,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::inject_fault call.
+    /// The request builder for [AlloyDBAdmin::inject_fault][super::super::client::AlloyDBAdmin::inject_fault] calls.
     #[derive(Clone, Debug)]
     pub struct InjectFault(RequestBuilder<crate::model::InjectFaultRequest>);
 
@@ -1777,7 +1777,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::restart_instance call.
+    /// The request builder for [AlloyDBAdmin::restart_instance][super::super::client::AlloyDBAdmin::restart_instance] calls.
     #[derive(Clone, Debug)]
     pub struct RestartInstance(RequestBuilder<crate::model::RestartInstanceRequest>);
 
@@ -1880,7 +1880,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::execute_sql call.
+    /// The request builder for [AlloyDBAdmin::execute_sql][super::super::client::AlloyDBAdmin::execute_sql] calls.
     #[derive(Clone, Debug)]
     pub struct ExecuteSql(RequestBuilder<crate::model::ExecuteSqlRequest>);
 
@@ -1951,7 +1951,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::list_backups call.
+    /// The request builder for [AlloyDBAdmin::list_backups][super::super::client::AlloyDBAdmin::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -2032,7 +2032,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::get_backup call.
+    /// The request builder for [AlloyDBAdmin::get_backup][super::super::client::AlloyDBAdmin::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -2074,7 +2074,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::create_backup call.
+    /// The request builder for [AlloyDBAdmin::create_backup][super::super::client::AlloyDBAdmin::create_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -2180,7 +2180,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::update_backup call.
+    /// The request builder for [AlloyDBAdmin::update_backup][super::super::client::AlloyDBAdmin::update_backup] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -2289,7 +2289,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::delete_backup call.
+    /// The request builder for [AlloyDBAdmin::delete_backup][super::super::client::AlloyDBAdmin::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -2384,7 +2384,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::list_supported_database_flags call.
+    /// The request builder for [AlloyDBAdmin::list_supported_database_flags][super::super::client::AlloyDBAdmin::list_supported_database_flags] calls.
     #[derive(Clone, Debug)]
     pub struct ListSupportedDatabaseFlags(
         RequestBuilder<crate::model::ListSupportedDatabaseFlagsRequest>,
@@ -2460,7 +2460,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::generate_client_certificate call.
+    /// The request builder for [AlloyDBAdmin::generate_client_certificate][super::super::client::AlloyDBAdmin::generate_client_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateClientCertificate(
         RequestBuilder<crate::model::GenerateClientCertificateRequest>,
@@ -2534,7 +2534,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::get_connection_info call.
+    /// The request builder for [AlloyDBAdmin::get_connection_info][super::super::client::AlloyDBAdmin::get_connection_info] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnectionInfo(RequestBuilder<crate::model::GetConnectionInfoRequest>);
 
@@ -2585,7 +2585,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::list_users call.
+    /// The request builder for [AlloyDBAdmin::list_users][super::super::client::AlloyDBAdmin::list_users] calls.
     #[derive(Clone, Debug)]
     pub struct ListUsers(RequestBuilder<crate::model::ListUsersRequest>);
 
@@ -2665,7 +2665,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::get_user call.
+    /// The request builder for [AlloyDBAdmin::get_user][super::super::client::AlloyDBAdmin::get_user] calls.
     #[derive(Clone, Debug)]
     pub struct GetUser(RequestBuilder<crate::model::GetUserRequest>);
 
@@ -2707,7 +2707,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::create_user call.
+    /// The request builder for [AlloyDBAdmin::create_user][super::super::client::AlloyDBAdmin::create_user] calls.
     #[derive(Clone, Debug)]
     pub struct CreateUser(RequestBuilder<crate::model::CreateUserRequest>);
 
@@ -2773,7 +2773,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::update_user call.
+    /// The request builder for [AlloyDBAdmin::update_user][super::super::client::AlloyDBAdmin::update_user] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateUser(RequestBuilder<crate::model::UpdateUserRequest>);
 
@@ -2842,7 +2842,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::delete_user call.
+    /// The request builder for [AlloyDBAdmin::delete_user][super::super::client::AlloyDBAdmin::delete_user] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteUser(RequestBuilder<crate::model::DeleteUserRequest>);
 
@@ -2896,7 +2896,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::list_databases call.
+    /// The request builder for [AlloyDBAdmin::list_databases][super::super::client::AlloyDBAdmin::list_databases] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatabases(RequestBuilder<crate::model::ListDatabasesRequest>);
 
@@ -2971,7 +2971,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::list_locations call.
+    /// The request builder for [AlloyDBAdmin::list_locations][super::super::client::AlloyDBAdmin::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3049,7 +3049,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::get_location call.
+    /// The request builder for [AlloyDBAdmin::get_location][super::super::client::AlloyDBAdmin::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3091,7 +3091,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::list_operations call.
+    /// The request builder for [AlloyDBAdmin::list_operations][super::super::client::AlloyDBAdmin::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3169,7 +3169,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::get_operation call.
+    /// The request builder for [AlloyDBAdmin::get_operation][super::super::client::AlloyDBAdmin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3214,7 +3214,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::delete_operation call.
+    /// The request builder for [AlloyDBAdmin::delete_operation][super::super::client::AlloyDBAdmin::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3259,7 +3259,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for a AlloyDBAdmin::cancel_operation call.
+    /// The request builder for [AlloyDBAdmin::cancel_operation][super::super::client::AlloyDBAdmin::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/apigateway/v1/src/builder.rs
+++ b/src/generated/cloud/apigateway/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::list_gateways call.
+    /// The request builder for [ApiGatewayService::list_gateways][super::super::client::ApiGatewayService::list_gateways] calls.
     #[derive(Clone, Debug)]
     pub struct ListGateways(RequestBuilder<crate::model::ListGatewaysRequest>);
 
@@ -148,7 +148,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::get_gateway call.
+    /// The request builder for [ApiGatewayService::get_gateway][super::super::client::ApiGatewayService::get_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct GetGateway(RequestBuilder<crate::model::GetGatewayRequest>);
 
@@ -190,7 +190,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::create_gateway call.
+    /// The request builder for [ApiGatewayService::create_gateway][super::super::client::ApiGatewayService::create_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGateway(RequestBuilder<crate::model::CreateGatewayRequest>);
 
@@ -284,7 +284,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::update_gateway call.
+    /// The request builder for [ApiGatewayService::update_gateway][super::super::client::ApiGatewayService::update_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGateway(RequestBuilder<crate::model::UpdateGatewayRequest>);
 
@@ -375,7 +375,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::delete_gateway call.
+    /// The request builder for [ApiGatewayService::delete_gateway][super::super::client::ApiGatewayService::delete_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGateway(RequestBuilder<crate::model::DeleteGatewayRequest>);
 
@@ -452,7 +452,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::list_apis call.
+    /// The request builder for [ApiGatewayService::list_apis][super::super::client::ApiGatewayService::list_apis] calls.
     #[derive(Clone, Debug)]
     pub struct ListApis(RequestBuilder<crate::model::ListApisRequest>);
 
@@ -532,7 +532,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::get_api call.
+    /// The request builder for [ApiGatewayService::get_api][super::super::client::ApiGatewayService::get_api] calls.
     #[derive(Clone, Debug)]
     pub struct GetApi(RequestBuilder<crate::model::GetApiRequest>);
 
@@ -572,7 +572,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::create_api call.
+    /// The request builder for [ApiGatewayService::create_api][super::super::client::ApiGatewayService::create_api] calls.
     #[derive(Clone, Debug)]
     pub struct CreateApi(RequestBuilder<crate::model::CreateApiRequest>);
 
@@ -663,7 +663,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::update_api call.
+    /// The request builder for [ApiGatewayService::update_api][super::super::client::ApiGatewayService::update_api] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateApi(RequestBuilder<crate::model::UpdateApiRequest>);
 
@@ -751,7 +751,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::delete_api call.
+    /// The request builder for [ApiGatewayService::delete_api][super::super::client::ApiGatewayService::delete_api] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteApi(RequestBuilder<crate::model::DeleteApiRequest>);
 
@@ -828,7 +828,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::list_api_configs call.
+    /// The request builder for [ApiGatewayService::list_api_configs][super::super::client::ApiGatewayService::list_api_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListApiConfigs(RequestBuilder<crate::model::ListApiConfigsRequest>);
 
@@ -909,7 +909,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::get_api_config call.
+    /// The request builder for [ApiGatewayService::get_api_config][super::super::client::ApiGatewayService::get_api_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetApiConfig(RequestBuilder<crate::model::GetApiConfigRequest>);
 
@@ -960,7 +960,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::create_api_config call.
+    /// The request builder for [ApiGatewayService::create_api_config][super::super::client::ApiGatewayService::create_api_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateApiConfig(RequestBuilder<crate::model::CreateApiConfigRequest>);
 
@@ -1055,7 +1055,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::update_api_config call.
+    /// The request builder for [ApiGatewayService::update_api_config][super::super::client::ApiGatewayService::update_api_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateApiConfig(RequestBuilder<crate::model::UpdateApiConfigRequest>);
 
@@ -1147,7 +1147,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::delete_api_config call.
+    /// The request builder for [ApiGatewayService::delete_api_config][super::super::client::ApiGatewayService::delete_api_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteApiConfig(RequestBuilder<crate::model::DeleteApiConfigRequest>);
 
@@ -1224,7 +1224,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::list_operations call.
+    /// The request builder for [ApiGatewayService::list_operations][super::super::client::ApiGatewayService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1302,7 +1302,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::get_operation call.
+    /// The request builder for [ApiGatewayService::get_operation][super::super::client::ApiGatewayService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1347,7 +1347,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::delete_operation call.
+    /// The request builder for [ApiGatewayService::delete_operation][super::super::client::ApiGatewayService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1392,7 +1392,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for a ApiGatewayService::cancel_operation call.
+    /// The request builder for [ApiGatewayService::cancel_operation][super::super::client::ApiGatewayService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/apigeeconnect/v1/src/builder.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::list_connections call.
+    /// The request builder for [ConnectionService::list_connections][super::super::client::ConnectionService::list_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 

--- a/src/generated/cloud/apihub/v1/src/builder.rs
+++ b/src/generated/cloud/apihub/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::create_api call.
+    /// The request builder for [ApiHub::create_api][super::super::client::ApiHub::create_api] calls.
     #[derive(Clone, Debug)]
     pub struct CreateApi(RequestBuilder<crate::model::CreateApiRequest>);
 
@@ -121,7 +121,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_api call.
+    /// The request builder for [ApiHub::get_api][super::super::client::ApiHub::get_api] calls.
     #[derive(Clone, Debug)]
     pub struct GetApi(RequestBuilder<crate::model::GetApiRequest>);
 
@@ -161,7 +161,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_apis call.
+    /// The request builder for [ApiHub::list_apis][super::super::client::ApiHub::list_apis] calls.
     #[derive(Clone, Debug)]
     pub struct ListApis(RequestBuilder<crate::model::ListApisRequest>);
 
@@ -235,7 +235,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::update_api call.
+    /// The request builder for [ApiHub::update_api][super::super::client::ApiHub::update_api] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateApi(RequestBuilder<crate::model::UpdateApiRequest>);
 
@@ -286,7 +286,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::delete_api call.
+    /// The request builder for [ApiHub::delete_api][super::super::client::ApiHub::delete_api] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteApi(RequestBuilder<crate::model::DeleteApiRequest>);
 
@@ -334,7 +334,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::create_version call.
+    /// The request builder for [ApiHub::create_version][super::super::client::ApiHub::create_version] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVersion(RequestBuilder<crate::model::CreateVersionRequest>);
 
@@ -391,7 +391,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_version call.
+    /// The request builder for [ApiHub::get_version][super::super::client::ApiHub::get_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -433,7 +433,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_versions call.
+    /// The request builder for [ApiHub::list_versions][super::super::client::ApiHub::list_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -508,7 +508,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::update_version call.
+    /// The request builder for [ApiHub::update_version][super::super::client::ApiHub::update_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -562,7 +562,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::delete_version call.
+    /// The request builder for [ApiHub::delete_version][super::super::client::ApiHub::delete_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -610,7 +610,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::create_spec call.
+    /// The request builder for [ApiHub::create_spec][super::super::client::ApiHub::create_spec] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSpec(RequestBuilder<crate::model::CreateSpecRequest>);
 
@@ -664,7 +664,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_spec call.
+    /// The request builder for [ApiHub::get_spec][super::super::client::ApiHub::get_spec] calls.
     #[derive(Clone, Debug)]
     pub struct GetSpec(RequestBuilder<crate::model::GetSpecRequest>);
 
@@ -706,7 +706,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_spec_contents call.
+    /// The request builder for [ApiHub::get_spec_contents][super::super::client::ApiHub::get_spec_contents] calls.
     #[derive(Clone, Debug)]
     pub struct GetSpecContents(RequestBuilder<crate::model::GetSpecContentsRequest>);
 
@@ -748,7 +748,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_specs call.
+    /// The request builder for [ApiHub::list_specs][super::super::client::ApiHub::list_specs] calls.
     #[derive(Clone, Debug)]
     pub struct ListSpecs(RequestBuilder<crate::model::ListSpecsRequest>);
 
@@ -822,7 +822,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::update_spec call.
+    /// The request builder for [ApiHub::update_spec][super::super::client::ApiHub::update_spec] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSpec(RequestBuilder<crate::model::UpdateSpecRequest>);
 
@@ -873,7 +873,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::delete_spec call.
+    /// The request builder for [ApiHub::delete_spec][super::super::client::ApiHub::delete_spec] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSpec(RequestBuilder<crate::model::DeleteSpecRequest>);
 
@@ -915,7 +915,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_api_operation call.
+    /// The request builder for [ApiHub::get_api_operation][super::super::client::ApiHub::get_api_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetApiOperation(RequestBuilder<crate::model::GetApiOperationRequest>);
 
@@ -957,7 +957,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_api_operations call.
+    /// The request builder for [ApiHub::list_api_operations][super::super::client::ApiHub::list_api_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListApiOperations(RequestBuilder<crate::model::ListApiOperationsRequest>);
 
@@ -1035,7 +1035,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_definition call.
+    /// The request builder for [ApiHub::get_definition][super::super::client::ApiHub::get_definition] calls.
     #[derive(Clone, Debug)]
     pub struct GetDefinition(RequestBuilder<crate::model::GetDefinitionRequest>);
 
@@ -1077,7 +1077,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::create_deployment call.
+    /// The request builder for [ApiHub::create_deployment][super::super::client::ApiHub::create_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDeployment(RequestBuilder<crate::model::CreateDeploymentRequest>);
 
@@ -1137,7 +1137,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_deployment call.
+    /// The request builder for [ApiHub::get_deployment][super::super::client::ApiHub::get_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -1179,7 +1179,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_deployments call.
+    /// The request builder for [ApiHub::list_deployments][super::super::client::ApiHub::list_deployments] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -1254,7 +1254,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::update_deployment call.
+    /// The request builder for [ApiHub::update_deployment][super::super::client::ApiHub::update_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDeployment(RequestBuilder<crate::model::UpdateDeploymentRequest>);
 
@@ -1311,7 +1311,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::delete_deployment call.
+    /// The request builder for [ApiHub::delete_deployment][super::super::client::ApiHub::delete_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDeployment(RequestBuilder<crate::model::DeleteDeploymentRequest>);
 
@@ -1356,7 +1356,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::create_attribute call.
+    /// The request builder for [ApiHub::create_attribute][super::super::client::ApiHub::create_attribute] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAttribute(RequestBuilder<crate::model::CreateAttributeRequest>);
 
@@ -1413,7 +1413,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_attribute call.
+    /// The request builder for [ApiHub::get_attribute][super::super::client::ApiHub::get_attribute] calls.
     #[derive(Clone, Debug)]
     pub struct GetAttribute(RequestBuilder<crate::model::GetAttributeRequest>);
 
@@ -1455,7 +1455,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::update_attribute call.
+    /// The request builder for [ApiHub::update_attribute][super::super::client::ApiHub::update_attribute] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAttribute(RequestBuilder<crate::model::UpdateAttributeRequest>);
 
@@ -1509,7 +1509,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::delete_attribute call.
+    /// The request builder for [ApiHub::delete_attribute][super::super::client::ApiHub::delete_attribute] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAttribute(RequestBuilder<crate::model::DeleteAttributeRequest>);
 
@@ -1551,7 +1551,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_attributes call.
+    /// The request builder for [ApiHub::list_attributes][super::super::client::ApiHub::list_attributes] calls.
     #[derive(Clone, Debug)]
     pub struct ListAttributes(RequestBuilder<crate::model::ListAttributesRequest>);
 
@@ -1626,7 +1626,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::search_resources call.
+    /// The request builder for [ApiHub::search_resources][super::super::client::ApiHub::search_resources] calls.
     #[derive(Clone, Debug)]
     pub struct SearchResources(RequestBuilder<crate::model::SearchResourcesRequest>);
 
@@ -1707,7 +1707,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::create_external_api call.
+    /// The request builder for [ApiHub::create_external_api][super::super::client::ApiHub::create_external_api] calls.
     #[derive(Clone, Debug)]
     pub struct CreateExternalApi(RequestBuilder<crate::model::CreateExternalApiRequest>);
 
@@ -1767,7 +1767,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_external_api call.
+    /// The request builder for [ApiHub::get_external_api][super::super::client::ApiHub::get_external_api] calls.
     #[derive(Clone, Debug)]
     pub struct GetExternalApi(RequestBuilder<crate::model::GetExternalApiRequest>);
 
@@ -1809,7 +1809,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::update_external_api call.
+    /// The request builder for [ApiHub::update_external_api][super::super::client::ApiHub::update_external_api] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateExternalApi(RequestBuilder<crate::model::UpdateExternalApiRequest>);
 
@@ -1866,7 +1866,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::delete_external_api call.
+    /// The request builder for [ApiHub::delete_external_api][super::super::client::ApiHub::delete_external_api] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteExternalApi(RequestBuilder<crate::model::DeleteExternalApiRequest>);
 
@@ -1911,7 +1911,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_external_apis call.
+    /// The request builder for [ApiHub::list_external_apis][super::super::client::ApiHub::list_external_apis] calls.
     #[derive(Clone, Debug)]
     pub struct ListExternalApis(RequestBuilder<crate::model::ListExternalApisRequest>);
 
@@ -1983,7 +1983,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_locations call.
+    /// The request builder for [ApiHub::list_locations][super::super::client::ApiHub::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2061,7 +2061,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_location call.
+    /// The request builder for [ApiHub::get_location][super::super::client::ApiHub::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2103,7 +2103,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::list_operations call.
+    /// The request builder for [ApiHub::list_operations][super::super::client::ApiHub::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2181,7 +2181,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::get_operation call.
+    /// The request builder for [ApiHub::get_operation][super::super::client::ApiHub::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2226,7 +2226,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::delete_operation call.
+    /// The request builder for [ApiHub::delete_operation][super::super::client::ApiHub::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2271,7 +2271,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for a ApiHub::cancel_operation call.
+    /// The request builder for [ApiHub::cancel_operation][super::super::client::ApiHub::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2370,7 +2370,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::create_dependency call.
+    /// The request builder for [ApiHubDependencies::create_dependency][super::super::client::ApiHubDependencies::create_dependency] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDependency(RequestBuilder<crate::model::CreateDependencyRequest>);
 
@@ -2430,7 +2430,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::get_dependency call.
+    /// The request builder for [ApiHubDependencies::get_dependency][super::super::client::ApiHubDependencies::get_dependency] calls.
     #[derive(Clone, Debug)]
     pub struct GetDependency(RequestBuilder<crate::model::GetDependencyRequest>);
 
@@ -2472,7 +2472,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::update_dependency call.
+    /// The request builder for [ApiHubDependencies::update_dependency][super::super::client::ApiHubDependencies::update_dependency] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDependency(RequestBuilder<crate::model::UpdateDependencyRequest>);
 
@@ -2529,7 +2529,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::delete_dependency call.
+    /// The request builder for [ApiHubDependencies::delete_dependency][super::super::client::ApiHubDependencies::delete_dependency] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDependency(RequestBuilder<crate::model::DeleteDependencyRequest>);
 
@@ -2574,7 +2574,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::list_dependencies call.
+    /// The request builder for [ApiHubDependencies::list_dependencies][super::super::client::ApiHubDependencies::list_dependencies] calls.
     #[derive(Clone, Debug)]
     pub struct ListDependencies(RequestBuilder<crate::model::ListDependenciesRequest>);
 
@@ -2652,7 +2652,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::list_locations call.
+    /// The request builder for [ApiHubDependencies::list_locations][super::super::client::ApiHubDependencies::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2730,7 +2730,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::get_location call.
+    /// The request builder for [ApiHubDependencies::get_location][super::super::client::ApiHubDependencies::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2772,7 +2772,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::list_operations call.
+    /// The request builder for [ApiHubDependencies::list_operations][super::super::client::ApiHubDependencies::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2850,7 +2850,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::get_operation call.
+    /// The request builder for [ApiHubDependencies::get_operation][super::super::client::ApiHubDependencies::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2895,7 +2895,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::delete_operation call.
+    /// The request builder for [ApiHubDependencies::delete_operation][super::super::client::ApiHubDependencies::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2940,7 +2940,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for a ApiHubDependencies::cancel_operation call.
+    /// The request builder for [ApiHubDependencies::cancel_operation][super::super::client::ApiHubDependencies::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3041,7 +3041,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::create_host_project_registration call.
+    /// The request builder for [HostProjectRegistrationService::create_host_project_registration][super::super::client::HostProjectRegistrationService::create_host_project_registration] calls.
     #[derive(Clone, Debug)]
     pub struct CreateHostProjectRegistration(
         RequestBuilder<crate::model::CreateHostProjectRegistrationRequest>,
@@ -3110,7 +3110,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::get_host_project_registration call.
+    /// The request builder for [HostProjectRegistrationService::get_host_project_registration][super::super::client::HostProjectRegistrationService::get_host_project_registration] calls.
     #[derive(Clone, Debug)]
     pub struct GetHostProjectRegistration(
         RequestBuilder<crate::model::GetHostProjectRegistrationRequest>,
@@ -3159,7 +3159,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::list_host_project_registrations call.
+    /// The request builder for [HostProjectRegistrationService::list_host_project_registrations][super::super::client::HostProjectRegistrationService::list_host_project_registrations] calls.
     #[derive(Clone, Debug)]
     pub struct ListHostProjectRegistrations(
         RequestBuilder<crate::model::ListHostProjectRegistrationsRequest>,
@@ -3249,7 +3249,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::list_locations call.
+    /// The request builder for [HostProjectRegistrationService::list_locations][super::super::client::HostProjectRegistrationService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3329,7 +3329,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::get_location call.
+    /// The request builder for [HostProjectRegistrationService::get_location][super::super::client::HostProjectRegistrationService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3373,7 +3373,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::list_operations call.
+    /// The request builder for [HostProjectRegistrationService::list_operations][super::super::client::HostProjectRegistrationService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3453,7 +3453,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::get_operation call.
+    /// The request builder for [HostProjectRegistrationService::get_operation][super::super::client::HostProjectRegistrationService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3500,7 +3500,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::delete_operation call.
+    /// The request builder for [HostProjectRegistrationService::delete_operation][super::super::client::HostProjectRegistrationService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3547,7 +3547,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for a HostProjectRegistrationService::cancel_operation call.
+    /// The request builder for [HostProjectRegistrationService::cancel_operation][super::super::client::HostProjectRegistrationService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3648,7 +3648,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::get_style_guide call.
+    /// The request builder for [LintingService::get_style_guide][super::super::client::LintingService::get_style_guide] calls.
     #[derive(Clone, Debug)]
     pub struct GetStyleGuide(RequestBuilder<crate::model::GetStyleGuideRequest>);
 
@@ -3690,7 +3690,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::update_style_guide call.
+    /// The request builder for [LintingService::update_style_guide][super::super::client::LintingService::update_style_guide] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateStyleGuide(RequestBuilder<crate::model::UpdateStyleGuideRequest>);
 
@@ -3747,7 +3747,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::get_style_guide_contents call.
+    /// The request builder for [LintingService::get_style_guide_contents][super::super::client::LintingService::get_style_guide_contents] calls.
     #[derive(Clone, Debug)]
     pub struct GetStyleGuideContents(RequestBuilder<crate::model::GetStyleGuideContentsRequest>);
 
@@ -3792,7 +3792,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::lint_spec call.
+    /// The request builder for [LintingService::lint_spec][super::super::client::LintingService::lint_spec] calls.
     #[derive(Clone, Debug)]
     pub struct LintSpec(RequestBuilder<crate::model::LintSpecRequest>);
 
@@ -3834,7 +3834,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::list_locations call.
+    /// The request builder for [LintingService::list_locations][super::super::client::LintingService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3912,7 +3912,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::get_location call.
+    /// The request builder for [LintingService::get_location][super::super::client::LintingService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3954,7 +3954,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::list_operations call.
+    /// The request builder for [LintingService::list_operations][super::super::client::LintingService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4032,7 +4032,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::get_operation call.
+    /// The request builder for [LintingService::get_operation][super::super::client::LintingService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4077,7 +4077,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::delete_operation call.
+    /// The request builder for [LintingService::delete_operation][super::super::client::LintingService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4122,7 +4122,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for a LintingService::cancel_operation call.
+    /// The request builder for [LintingService::cancel_operation][super::super::client::LintingService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4221,7 +4221,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::get_plugin call.
+    /// The request builder for [ApiHubPlugin::get_plugin][super::super::client::ApiHubPlugin::get_plugin] calls.
     #[derive(Clone, Debug)]
     pub struct GetPlugin(RequestBuilder<crate::model::GetPluginRequest>);
 
@@ -4263,7 +4263,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::enable_plugin call.
+    /// The request builder for [ApiHubPlugin::enable_plugin][super::super::client::ApiHubPlugin::enable_plugin] calls.
     #[derive(Clone, Debug)]
     pub struct EnablePlugin(RequestBuilder<crate::model::EnablePluginRequest>);
 
@@ -4305,7 +4305,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::disable_plugin call.
+    /// The request builder for [ApiHubPlugin::disable_plugin][super::super::client::ApiHubPlugin::disable_plugin] calls.
     #[derive(Clone, Debug)]
     pub struct DisablePlugin(RequestBuilder<crate::model::DisablePluginRequest>);
 
@@ -4347,7 +4347,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::list_locations call.
+    /// The request builder for [ApiHubPlugin::list_locations][super::super::client::ApiHubPlugin::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4425,7 +4425,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::get_location call.
+    /// The request builder for [ApiHubPlugin::get_location][super::super::client::ApiHubPlugin::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4467,7 +4467,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::list_operations call.
+    /// The request builder for [ApiHubPlugin::list_operations][super::super::client::ApiHubPlugin::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4545,7 +4545,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::get_operation call.
+    /// The request builder for [ApiHubPlugin::get_operation][super::super::client::ApiHubPlugin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4590,7 +4590,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::delete_operation call.
+    /// The request builder for [ApiHubPlugin::delete_operation][super::super::client::ApiHubPlugin::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4635,7 +4635,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for a ApiHubPlugin::cancel_operation call.
+    /// The request builder for [ApiHubPlugin::cancel_operation][super::super::client::ApiHubPlugin::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4734,7 +4734,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::create_api_hub_instance call.
+    /// The request builder for [Provisioning::create_api_hub_instance][super::super::client::Provisioning::create_api_hub_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateApiHubInstance(RequestBuilder<crate::model::CreateApiHubInstanceRequest>);
 
@@ -4833,7 +4833,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::get_api_hub_instance call.
+    /// The request builder for [Provisioning::get_api_hub_instance][super::super::client::Provisioning::get_api_hub_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetApiHubInstance(RequestBuilder<crate::model::GetApiHubInstanceRequest>);
 
@@ -4878,7 +4878,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::lookup_api_hub_instance call.
+    /// The request builder for [Provisioning::lookup_api_hub_instance][super::super::client::Provisioning::lookup_api_hub_instance] calls.
     #[derive(Clone, Debug)]
     pub struct LookupApiHubInstance(RequestBuilder<crate::model::LookupApiHubInstanceRequest>);
 
@@ -4923,7 +4923,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::list_locations call.
+    /// The request builder for [Provisioning::list_locations][super::super::client::Provisioning::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5001,7 +5001,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::get_location call.
+    /// The request builder for [Provisioning::get_location][super::super::client::Provisioning::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5043,7 +5043,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::list_operations call.
+    /// The request builder for [Provisioning::list_operations][super::super::client::Provisioning::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5121,7 +5121,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::get_operation call.
+    /// The request builder for [Provisioning::get_operation][super::super::client::Provisioning::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5166,7 +5166,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::delete_operation call.
+    /// The request builder for [Provisioning::delete_operation][super::super::client::Provisioning::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5211,7 +5211,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for a Provisioning::cancel_operation call.
+    /// The request builder for [Provisioning::cancel_operation][super::super::client::Provisioning::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5312,7 +5312,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::create_runtime_project_attachment call.
+    /// The request builder for [RuntimeProjectAttachmentService::create_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::create_runtime_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRuntimeProjectAttachment(
         RequestBuilder<crate::model::CreateRuntimeProjectAttachmentRequest>,
@@ -5381,7 +5381,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::get_runtime_project_attachment call.
+    /// The request builder for [RuntimeProjectAttachmentService::get_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::get_runtime_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct GetRuntimeProjectAttachment(
         RequestBuilder<crate::model::GetRuntimeProjectAttachmentRequest>,
@@ -5430,7 +5430,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::list_runtime_project_attachments call.
+    /// The request builder for [RuntimeProjectAttachmentService::list_runtime_project_attachments][super::super::client::RuntimeProjectAttachmentService::list_runtime_project_attachments] calls.
     #[derive(Clone, Debug)]
     pub struct ListRuntimeProjectAttachments(
         RequestBuilder<crate::model::ListRuntimeProjectAttachmentsRequest>,
@@ -5520,7 +5520,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::delete_runtime_project_attachment call.
+    /// The request builder for [RuntimeProjectAttachmentService::delete_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::delete_runtime_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRuntimeProjectAttachment(
         RequestBuilder<crate::model::DeleteRuntimeProjectAttachmentRequest>,
@@ -5569,7 +5569,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::lookup_runtime_project_attachment call.
+    /// The request builder for [RuntimeProjectAttachmentService::lookup_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::lookup_runtime_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct LookupRuntimeProjectAttachment(
         RequestBuilder<crate::model::LookupRuntimeProjectAttachmentRequest>,
@@ -5618,7 +5618,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::list_locations call.
+    /// The request builder for [RuntimeProjectAttachmentService::list_locations][super::super::client::RuntimeProjectAttachmentService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5698,7 +5698,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::get_location call.
+    /// The request builder for [RuntimeProjectAttachmentService::get_location][super::super::client::RuntimeProjectAttachmentService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5742,7 +5742,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::list_operations call.
+    /// The request builder for [RuntimeProjectAttachmentService::list_operations][super::super::client::RuntimeProjectAttachmentService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5822,7 +5822,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::get_operation call.
+    /// The request builder for [RuntimeProjectAttachmentService::get_operation][super::super::client::RuntimeProjectAttachmentService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5869,7 +5869,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::delete_operation call.
+    /// The request builder for [RuntimeProjectAttachmentService::delete_operation][super::super::client::RuntimeProjectAttachmentService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5916,7 +5916,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for a RuntimeProjectAttachmentService::cancel_operation call.
+    /// The request builder for [RuntimeProjectAttachmentService::cancel_operation][super::super::client::RuntimeProjectAttachmentService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/apphub/v1/src/builder.rs
+++ b/src/generated/cloud/apphub/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::lookup_service_project_attachment call.
+    /// The request builder for [AppHub::lookup_service_project_attachment][super::super::client::AppHub::lookup_service_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct LookupServiceProjectAttachment(
         RequestBuilder<crate::model::LookupServiceProjectAttachmentRequest>,
@@ -114,7 +114,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::list_service_project_attachments call.
+    /// The request builder for [AppHub::list_service_project_attachments][super::super::client::AppHub::list_service_project_attachments] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceProjectAttachments(
         RequestBuilder<crate::model::ListServiceProjectAttachmentsRequest>,
@@ -202,7 +202,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::create_service_project_attachment call.
+    /// The request builder for [AppHub::create_service_project_attachment][super::super::client::AppHub::create_service_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceProjectAttachment(
         RequestBuilder<crate::model::CreateServiceProjectAttachmentRequest>,
@@ -316,7 +316,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_service_project_attachment call.
+    /// The request builder for [AppHub::get_service_project_attachment][super::super::client::AppHub::get_service_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceProjectAttachment(
         RequestBuilder<crate::model::GetServiceProjectAttachmentRequest>,
@@ -363,7 +363,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::delete_service_project_attachment call.
+    /// The request builder for [AppHub::delete_service_project_attachment][super::super::client::AppHub::delete_service_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceProjectAttachment(
         RequestBuilder<crate::model::DeleteServiceProjectAttachmentRequest>,
@@ -451,7 +451,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::detach_service_project_attachment call.
+    /// The request builder for [AppHub::detach_service_project_attachment][super::super::client::AppHub::detach_service_project_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct DetachServiceProjectAttachment(
         RequestBuilder<crate::model::DetachServiceProjectAttachmentRequest>,
@@ -498,7 +498,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::list_discovered_services call.
+    /// The request builder for [AppHub::list_discovered_services][super::super::client::AppHub::list_discovered_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListDiscoveredServices(RequestBuilder<crate::model::ListDiscoveredServicesRequest>);
 
@@ -584,7 +584,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_discovered_service call.
+    /// The request builder for [AppHub::get_discovered_service][super::super::client::AppHub::get_discovered_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetDiscoveredService(RequestBuilder<crate::model::GetDiscoveredServiceRequest>);
 
@@ -629,7 +629,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::lookup_discovered_service call.
+    /// The request builder for [AppHub::lookup_discovered_service][super::super::client::AppHub::lookup_discovered_service] calls.
     #[derive(Clone, Debug)]
     pub struct LookupDiscoveredService(
         RequestBuilder<crate::model::LookupDiscoveredServiceRequest>,
@@ -682,7 +682,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::list_services call.
+    /// The request builder for [AppHub::list_services][super::super::client::AppHub::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -763,7 +763,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::create_service call.
+    /// The request builder for [AppHub::create_service][super::super::client::AppHub::create_service] calls.
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -863,7 +863,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_service call.
+    /// The request builder for [AppHub::get_service][super::super::client::AppHub::get_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -905,7 +905,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::update_service call.
+    /// The request builder for [AppHub::update_service][super::super::client::AppHub::update_service] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -1002,7 +1002,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::delete_service call.
+    /// The request builder for [AppHub::delete_service][super::super::client::AppHub::delete_service] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -1085,7 +1085,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::list_discovered_workloads call.
+    /// The request builder for [AppHub::list_discovered_workloads][super::super::client::AppHub::list_discovered_workloads] calls.
     #[derive(Clone, Debug)]
     pub struct ListDiscoveredWorkloads(
         RequestBuilder<crate::model::ListDiscoveredWorkloadsRequest>,
@@ -1173,7 +1173,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_discovered_workload call.
+    /// The request builder for [AppHub::get_discovered_workload][super::super::client::AppHub::get_discovered_workload] calls.
     #[derive(Clone, Debug)]
     pub struct GetDiscoveredWorkload(RequestBuilder<crate::model::GetDiscoveredWorkloadRequest>);
 
@@ -1218,7 +1218,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::lookup_discovered_workload call.
+    /// The request builder for [AppHub::lookup_discovered_workload][super::super::client::AppHub::lookup_discovered_workload] calls.
     #[derive(Clone, Debug)]
     pub struct LookupDiscoveredWorkload(
         RequestBuilder<crate::model::LookupDiscoveredWorkloadRequest>,
@@ -1271,7 +1271,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::list_workloads call.
+    /// The request builder for [AppHub::list_workloads][super::super::client::AppHub::list_workloads] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkloads(RequestBuilder<crate::model::ListWorkloadsRequest>);
 
@@ -1352,7 +1352,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::create_workload call.
+    /// The request builder for [AppHub::create_workload][super::super::client::AppHub::create_workload] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWorkload(RequestBuilder<crate::model::CreateWorkloadRequest>);
 
@@ -1453,7 +1453,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_workload call.
+    /// The request builder for [AppHub::get_workload][super::super::client::AppHub::get_workload] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkload(RequestBuilder<crate::model::GetWorkloadRequest>);
 
@@ -1495,7 +1495,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::update_workload call.
+    /// The request builder for [AppHub::update_workload][super::super::client::AppHub::update_workload] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWorkload(RequestBuilder<crate::model::UpdateWorkloadRequest>);
 
@@ -1593,7 +1593,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::delete_workload call.
+    /// The request builder for [AppHub::delete_workload][super::super::client::AppHub::delete_workload] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWorkload(RequestBuilder<crate::model::DeleteWorkloadRequest>);
 
@@ -1676,7 +1676,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::list_applications call.
+    /// The request builder for [AppHub::list_applications][super::super::client::AppHub::list_applications] calls.
     #[derive(Clone, Debug)]
     pub struct ListApplications(RequestBuilder<crate::model::ListApplicationsRequest>);
 
@@ -1760,7 +1760,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::create_application call.
+    /// The request builder for [AppHub::create_application][super::super::client::AppHub::create_application] calls.
     #[derive(Clone, Debug)]
     pub struct CreateApplication(RequestBuilder<crate::model::CreateApplicationRequest>);
 
@@ -1864,7 +1864,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_application call.
+    /// The request builder for [AppHub::get_application][super::super::client::AppHub::get_application] calls.
     #[derive(Clone, Debug)]
     pub struct GetApplication(RequestBuilder<crate::model::GetApplicationRequest>);
 
@@ -1906,7 +1906,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::update_application call.
+    /// The request builder for [AppHub::update_application][super::super::client::AppHub::update_application] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateApplication(RequestBuilder<crate::model::UpdateApplicationRequest>);
 
@@ -2007,7 +2007,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::delete_application call.
+    /// The request builder for [AppHub::delete_application][super::super::client::AppHub::delete_application] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteApplication(RequestBuilder<crate::model::DeleteApplicationRequest>);
 
@@ -2093,7 +2093,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::list_locations call.
+    /// The request builder for [AppHub::list_locations][super::super::client::AppHub::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2171,7 +2171,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_location call.
+    /// The request builder for [AppHub::get_location][super::super::client::AppHub::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2213,7 +2213,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::set_iam_policy call.
+    /// The request builder for [AppHub::set_iam_policy][super::super::client::AppHub::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2273,7 +2273,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_iam_policy call.
+    /// The request builder for [AppHub::get_iam_policy][super::super::client::AppHub::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2324,7 +2324,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::test_iam_permissions call.
+    /// The request builder for [AppHub::test_iam_permissions][super::super::client::AppHub::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2380,7 +2380,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::list_operations call.
+    /// The request builder for [AppHub::list_operations][super::super::client::AppHub::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2458,7 +2458,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::get_operation call.
+    /// The request builder for [AppHub::get_operation][super::super::client::AppHub::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2503,7 +2503,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::delete_operation call.
+    /// The request builder for [AppHub::delete_operation][super::super::client::AppHub::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2548,7 +2548,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for a AppHub::cancel_operation call.
+    /// The request builder for [AppHub::cancel_operation][super::super::client::AppHub::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/asset/v1/src/builder.rs
+++ b/src/generated/cloud/asset/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::export_assets call.
+    /// The request builder for [AssetService::export_assets][super::super::client::AssetService::export_assets] calls.
     #[derive(Clone, Debug)]
     pub struct ExportAssets(RequestBuilder<crate::model::ExportAssetsRequest>);
 
@@ -193,7 +193,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::list_assets call.
+    /// The request builder for [AssetService::list_assets][super::super::client::AssetService::list_assets] calls.
     #[derive(Clone, Debug)]
     pub struct ListAssets(RequestBuilder<crate::model::ListAssetsRequest>);
 
@@ -296,7 +296,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::batch_get_assets_history call.
+    /// The request builder for [AssetService::batch_get_assets_history][super::super::client::AssetService::batch_get_assets_history] calls.
     #[derive(Clone, Debug)]
     pub struct BatchGetAssetsHistory(RequestBuilder<crate::model::BatchGetAssetsHistoryRequest>);
 
@@ -378,7 +378,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::create_feed call.
+    /// The request builder for [AssetService::create_feed][super::super::client::AssetService::create_feed] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeed(RequestBuilder<crate::model::CreateFeedRequest>);
 
@@ -432,7 +432,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::get_feed call.
+    /// The request builder for [AssetService::get_feed][super::super::client::AssetService::get_feed] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeed(RequestBuilder<crate::model::GetFeedRequest>);
 
@@ -474,7 +474,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::list_feeds call.
+    /// The request builder for [AssetService::list_feeds][super::super::client::AssetService::list_feeds] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeeds(RequestBuilder<crate::model::ListFeedsRequest>);
 
@@ -516,7 +516,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::update_feed call.
+    /// The request builder for [AssetService::update_feed][super::super::client::AssetService::update_feed] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeed(RequestBuilder<crate::model::UpdateFeedRequest>);
 
@@ -567,7 +567,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::delete_feed call.
+    /// The request builder for [AssetService::delete_feed][super::super::client::AssetService::delete_feed] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeed(RequestBuilder<crate::model::DeleteFeedRequest>);
 
@@ -609,7 +609,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::search_all_resources call.
+    /// The request builder for [AssetService::search_all_resources][super::super::client::AssetService::search_all_resources] calls.
     #[derive(Clone, Debug)]
     pub struct SearchAllResources(RequestBuilder<crate::model::SearchAllResourcesRequest>);
 
@@ -710,7 +710,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::search_all_iam_policies call.
+    /// The request builder for [AssetService::search_all_iam_policies][super::super::client::AssetService::search_all_iam_policies] calls.
     #[derive(Clone, Debug)]
     pub struct SearchAllIamPolicies(RequestBuilder<crate::model::SearchAllIamPoliciesRequest>);
 
@@ -805,7 +805,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::analyze_iam_policy call.
+    /// The request builder for [AssetService::analyze_iam_policy][super::super::client::AssetService::analyze_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeIamPolicy(RequestBuilder<crate::model::AnalyzeIamPolicyRequest>);
 
@@ -870,7 +870,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::analyze_iam_policy_longrunning call.
+    /// The request builder for [AssetService::analyze_iam_policy_longrunning][super::super::client::AssetService::analyze_iam_policy_longrunning] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeIamPolicyLongrunning(
         RequestBuilder<crate::model::AnalyzeIamPolicyLongrunningRequest>,
@@ -982,7 +982,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::analyze_move call.
+    /// The request builder for [AssetService::analyze_move][super::super::client::AssetService::analyze_move] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeMove(RequestBuilder<crate::model::AnalyzeMoveRequest>);
 
@@ -1039,7 +1039,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::query_assets call.
+    /// The request builder for [AssetService::query_assets][super::super::client::AssetService::query_assets] calls.
     #[derive(Clone, Debug)]
     pub struct QueryAssets(RequestBuilder<crate::model::QueryAssetsRequest>);
 
@@ -1128,7 +1128,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::create_saved_query call.
+    /// The request builder for [AssetService::create_saved_query][super::super::client::AssetService::create_saved_query] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSavedQuery(RequestBuilder<crate::model::CreateSavedQueryRequest>);
 
@@ -1188,7 +1188,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::get_saved_query call.
+    /// The request builder for [AssetService::get_saved_query][super::super::client::AssetService::get_saved_query] calls.
     #[derive(Clone, Debug)]
     pub struct GetSavedQuery(RequestBuilder<crate::model::GetSavedQueryRequest>);
 
@@ -1230,7 +1230,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::list_saved_queries call.
+    /// The request builder for [AssetService::list_saved_queries][super::super::client::AssetService::list_saved_queries] calls.
     #[derive(Clone, Debug)]
     pub struct ListSavedQueries(RequestBuilder<crate::model::ListSavedQueriesRequest>);
 
@@ -1308,7 +1308,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::update_saved_query call.
+    /// The request builder for [AssetService::update_saved_query][super::super::client::AssetService::update_saved_query] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSavedQuery(RequestBuilder<crate::model::UpdateSavedQueryRequest>);
 
@@ -1365,7 +1365,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::delete_saved_query call.
+    /// The request builder for [AssetService::delete_saved_query][super::super::client::AssetService::delete_saved_query] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSavedQuery(RequestBuilder<crate::model::DeleteSavedQueryRequest>);
 
@@ -1410,7 +1410,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::batch_get_effective_iam_policies call.
+    /// The request builder for [AssetService::batch_get_effective_iam_policies][super::super::client::AssetService::batch_get_effective_iam_policies] calls.
     #[derive(Clone, Debug)]
     pub struct BatchGetEffectiveIamPolicies(
         RequestBuilder<crate::model::BatchGetEffectiveIamPoliciesRequest>,
@@ -1468,7 +1468,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::analyze_org_policies call.
+    /// The request builder for [AssetService::analyze_org_policies][super::super::client::AssetService::analyze_org_policies] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeOrgPolicies(RequestBuilder<crate::model::AnalyzeOrgPoliciesRequest>);
 
@@ -1552,7 +1552,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::analyze_org_policy_governed_containers call.
+    /// The request builder for [AssetService::analyze_org_policy_governed_containers][super::super::client::AssetService::analyze_org_policy_governed_containers] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeOrgPolicyGovernedContainers(
         RequestBuilder<crate::model::AnalyzeOrgPolicyGovernedContainersRequest>,
@@ -1642,7 +1642,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::analyze_org_policy_governed_assets call.
+    /// The request builder for [AssetService::analyze_org_policy_governed_assets][super::super::client::AssetService::analyze_org_policy_governed_assets] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeOrgPolicyGovernedAssets(
         RequestBuilder<crate::model::AnalyzeOrgPolicyGovernedAssetsRequest>,
@@ -1730,7 +1730,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for a AssetService::get_operation call.
+    /// The request builder for [AssetService::get_operation][super::super::client::AssetService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/assuredworkloads/v1/src/builder.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for a AssuredWorkloadsService::create_workload call.
+    /// The request builder for [AssuredWorkloadsService::create_workload][super::super::client::AssuredWorkloadsService::create_workload] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWorkload(RequestBuilder<crate::model::CreateWorkloadRequest>);
 
@@ -169,7 +169,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for a AssuredWorkloadsService::update_workload call.
+    /// The request builder for [AssuredWorkloadsService::update_workload][super::super::client::AssuredWorkloadsService::update_workload] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWorkload(RequestBuilder<crate::model::UpdateWorkloadRequest>);
 
@@ -225,7 +225,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for a AssuredWorkloadsService::restrict_allowed_resources call.
+    /// The request builder for [AssuredWorkloadsService::restrict_allowed_resources][super::super::client::AssuredWorkloadsService::restrict_allowed_resources] calls.
     #[derive(Clone, Debug)]
     pub struct RestrictAllowedResources(
         RequestBuilder<crate::model::RestrictAllowedResourcesRequest>,
@@ -285,7 +285,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for a AssuredWorkloadsService::delete_workload call.
+    /// The request builder for [AssuredWorkloadsService::delete_workload][super::super::client::AssuredWorkloadsService::delete_workload] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWorkload(RequestBuilder<crate::model::DeleteWorkloadRequest>);
 
@@ -335,7 +335,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for a AssuredWorkloadsService::get_workload call.
+    /// The request builder for [AssuredWorkloadsService::get_workload][super::super::client::AssuredWorkloadsService::get_workload] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkload(RequestBuilder<crate::model::GetWorkloadRequest>);
 
@@ -379,7 +379,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for a AssuredWorkloadsService::list_workloads call.
+    /// The request builder for [AssuredWorkloadsService::list_workloads][super::super::client::AssuredWorkloadsService::list_workloads] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkloads(RequestBuilder<crate::model::ListWorkloadsRequest>);
 
@@ -456,7 +456,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for a AssuredWorkloadsService::list_operations call.
+    /// The request builder for [AssuredWorkloadsService::list_operations][super::super::client::AssuredWorkloadsService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -536,7 +536,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for a AssuredWorkloadsService::get_operation call.
+    /// The request builder for [AssuredWorkloadsService::get_operation][super::super::client::AssuredWorkloadsService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/backupdr/v1/src/builder.rs
+++ b/src/generated/cloud/backupdr/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::list_management_servers call.
+    /// The request builder for [BackupDR::list_management_servers][super::super::client::BackupDR::list_management_servers] calls.
     #[derive(Clone, Debug)]
     pub struct ListManagementServers(RequestBuilder<crate::model::ListManagementServersRequest>);
 
@@ -157,7 +157,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_management_server call.
+    /// The request builder for [BackupDR::get_management_server][super::super::client::BackupDR::get_management_server] calls.
     #[derive(Clone, Debug)]
     pub struct GetManagementServer(RequestBuilder<crate::model::GetManagementServerRequest>);
 
@@ -202,7 +202,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::create_management_server call.
+    /// The request builder for [BackupDR::create_management_server][super::super::client::BackupDR::create_management_server] calls.
     #[derive(Clone, Debug)]
     pub struct CreateManagementServer(RequestBuilder<crate::model::CreateManagementServerRequest>);
 
@@ -309,7 +309,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::delete_management_server call.
+    /// The request builder for [BackupDR::delete_management_server][super::super::client::BackupDR::delete_management_server] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteManagementServer(RequestBuilder<crate::model::DeleteManagementServerRequest>);
 
@@ -395,7 +395,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::create_backup_vault call.
+    /// The request builder for [BackupDR::create_backup_vault][super::super::client::BackupDR::create_backup_vault] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackupVault(RequestBuilder<crate::model::CreateBackupVaultRequest>);
 
@@ -505,7 +505,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::list_backup_vaults call.
+    /// The request builder for [BackupDR::list_backup_vaults][super::super::client::BackupDR::list_backup_vaults] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupVaults(RequestBuilder<crate::model::ListBackupVaultsRequest>);
 
@@ -595,7 +595,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::fetch_usable_backup_vaults call.
+    /// The request builder for [BackupDR::fetch_usable_backup_vaults][super::super::client::BackupDR::fetch_usable_backup_vaults] calls.
     #[derive(Clone, Debug)]
     pub struct FetchUsableBackupVaults(
         RequestBuilder<crate::model::FetchUsableBackupVaultsRequest>,
@@ -683,7 +683,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_backup_vault call.
+    /// The request builder for [BackupDR::get_backup_vault][super::super::client::BackupDR::get_backup_vault] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupVault(RequestBuilder<crate::model::GetBackupVaultRequest>);
 
@@ -731,7 +731,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::update_backup_vault call.
+    /// The request builder for [BackupDR::update_backup_vault][super::super::client::BackupDR::update_backup_vault] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackupVault(RequestBuilder<crate::model::UpdateBackupVaultRequest>);
 
@@ -844,7 +844,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::delete_backup_vault call.
+    /// The request builder for [BackupDR::delete_backup_vault][super::super::client::BackupDR::delete_backup_vault] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackupVault(RequestBuilder<crate::model::DeleteBackupVaultRequest>);
 
@@ -960,7 +960,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::list_data_sources call.
+    /// The request builder for [BackupDR::list_data_sources][super::super::client::BackupDR::list_data_sources] calls.
     #[derive(Clone, Debug)]
     pub struct ListDataSources(RequestBuilder<crate::model::ListDataSourcesRequest>);
 
@@ -1041,7 +1041,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_data_source call.
+    /// The request builder for [BackupDR::get_data_source][super::super::client::BackupDR::get_data_source] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataSource(RequestBuilder<crate::model::GetDataSourceRequest>);
 
@@ -1083,7 +1083,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::update_data_source call.
+    /// The request builder for [BackupDR::update_data_source][super::super::client::BackupDR::update_data_source] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDataSource(RequestBuilder<crate::model::UpdateDataSourceRequest>);
 
@@ -1190,7 +1190,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::list_backups call.
+    /// The request builder for [BackupDR::list_backups][super::super::client::BackupDR::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1277,7 +1277,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_backup call.
+    /// The request builder for [BackupDR::get_backup][super::super::client::BackupDR::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1325,7 +1325,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::update_backup call.
+    /// The request builder for [BackupDR::update_backup][super::super::client::BackupDR::update_backup] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -1422,7 +1422,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::delete_backup call.
+    /// The request builder for [BackupDR::delete_backup][super::super::client::BackupDR::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1507,7 +1507,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::restore_backup call.
+    /// The request builder for [BackupDR::restore_backup][super::super::client::BackupDR::restore_backup] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreBackup(RequestBuilder<crate::model::RestoreBackupRequest>);
 
@@ -1618,7 +1618,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::create_backup_plan call.
+    /// The request builder for [BackupDR::create_backup_plan][super::super::client::BackupDR::create_backup_plan] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackupPlan(RequestBuilder<crate::model::CreateBackupPlanRequest>);
 
@@ -1722,7 +1722,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_backup_plan call.
+    /// The request builder for [BackupDR::get_backup_plan][super::super::client::BackupDR::get_backup_plan] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupPlan(RequestBuilder<crate::model::GetBackupPlanRequest>);
 
@@ -1764,7 +1764,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::list_backup_plans call.
+    /// The request builder for [BackupDR::list_backup_plans][super::super::client::BackupDR::list_backup_plans] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupPlans(RequestBuilder<crate::model::ListBackupPlansRequest>);
 
@@ -1845,7 +1845,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::delete_backup_plan call.
+    /// The request builder for [BackupDR::delete_backup_plan][super::super::client::BackupDR::delete_backup_plan] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackupPlan(RequestBuilder<crate::model::DeleteBackupPlanRequest>);
 
@@ -1931,7 +1931,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::create_backup_plan_association call.
+    /// The request builder for [BackupDR::create_backup_plan_association][super::super::client::BackupDR::create_backup_plan_association] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackupPlanAssociation(
         RequestBuilder<crate::model::CreateBackupPlanAssociationRequest>,
@@ -2045,7 +2045,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_backup_plan_association call.
+    /// The request builder for [BackupDR::get_backup_plan_association][super::super::client::BackupDR::get_backup_plan_association] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupPlanAssociation(
         RequestBuilder<crate::model::GetBackupPlanAssociationRequest>,
@@ -2092,7 +2092,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::list_backup_plan_associations call.
+    /// The request builder for [BackupDR::list_backup_plan_associations][super::super::client::BackupDR::list_backup_plan_associations] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupPlanAssociations(
         RequestBuilder<crate::model::ListBackupPlanAssociationsRequest>,
@@ -2174,7 +2174,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::delete_backup_plan_association call.
+    /// The request builder for [BackupDR::delete_backup_plan_association][super::super::client::BackupDR::delete_backup_plan_association] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackupPlanAssociation(
         RequestBuilder<crate::model::DeleteBackupPlanAssociationRequest>,
@@ -2262,7 +2262,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::trigger_backup call.
+    /// The request builder for [BackupDR::trigger_backup][super::super::client::BackupDR::trigger_backup] calls.
     #[derive(Clone, Debug)]
     pub struct TriggerBackup(RequestBuilder<crate::model::TriggerBackupRequest>);
 
@@ -2357,7 +2357,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::initialize_service call.
+    /// The request builder for [BackupDR::initialize_service][super::super::client::BackupDR::initialize_service] calls.
     #[derive(Clone, Debug)]
     pub struct InitializeService(RequestBuilder<crate::model::InitializeServiceRequest>);
 
@@ -2455,7 +2455,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::list_locations call.
+    /// The request builder for [BackupDR::list_locations][super::super::client::BackupDR::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2533,7 +2533,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_location call.
+    /// The request builder for [BackupDR::get_location][super::super::client::BackupDR::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2575,7 +2575,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::set_iam_policy call.
+    /// The request builder for [BackupDR::set_iam_policy][super::super::client::BackupDR::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2635,7 +2635,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_iam_policy call.
+    /// The request builder for [BackupDR::get_iam_policy][super::super::client::BackupDR::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2686,7 +2686,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::test_iam_permissions call.
+    /// The request builder for [BackupDR::test_iam_permissions][super::super::client::BackupDR::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2742,7 +2742,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::list_operations call.
+    /// The request builder for [BackupDR::list_operations][super::super::client::BackupDR::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2820,7 +2820,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::get_operation call.
+    /// The request builder for [BackupDR::get_operation][super::super::client::BackupDR::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2865,7 +2865,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::delete_operation call.
+    /// The request builder for [BackupDR::delete_operation][super::super::client::BackupDR::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2910,7 +2910,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for a BackupDR::cancel_operation call.
+    /// The request builder for [BackupDR::cancel_operation][super::super::client::BackupDR::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/baremetalsolution/v2/src/builder.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_instances call.
+    /// The request builder for [BareMetalSolution::list_instances][super::super::client::BareMetalSolution::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -142,7 +142,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_instance call.
+    /// The request builder for [BareMetalSolution::get_instance][super::super::client::BareMetalSolution::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -184,7 +184,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::update_instance call.
+    /// The request builder for [BareMetalSolution::update_instance][super::super::client::BareMetalSolution::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -276,7 +276,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::rename_instance call.
+    /// The request builder for [BareMetalSolution::rename_instance][super::super::client::BareMetalSolution::rename_instance] calls.
     #[derive(Clone, Debug)]
     pub struct RenameInstance(RequestBuilder<crate::model::RenameInstanceRequest>);
 
@@ -324,7 +324,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::reset_instance call.
+    /// The request builder for [BareMetalSolution::reset_instance][super::super::client::BareMetalSolution::reset_instance] calls.
     #[derive(Clone, Debug)]
     pub struct ResetInstance(RequestBuilder<crate::model::ResetInstanceRequest>);
 
@@ -407,7 +407,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::start_instance call.
+    /// The request builder for [BareMetalSolution::start_instance][super::super::client::BareMetalSolution::start_instance] calls.
     #[derive(Clone, Debug)]
     pub struct StartInstance(RequestBuilder<crate::model::StartInstanceRequest>);
 
@@ -490,7 +490,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::stop_instance call.
+    /// The request builder for [BareMetalSolution::stop_instance][super::super::client::BareMetalSolution::stop_instance] calls.
     #[derive(Clone, Debug)]
     pub struct StopInstance(RequestBuilder<crate::model::StopInstanceRequest>);
 
@@ -571,7 +571,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::enable_interactive_serial_console call.
+    /// The request builder for [BareMetalSolution::enable_interactive_serial_console][super::super::client::BareMetalSolution::enable_interactive_serial_console] calls.
     #[derive(Clone, Debug)]
     pub struct EnableInteractiveSerialConsole(
         RequestBuilder<crate::model::EnableInteractiveSerialConsoleRequest>,
@@ -661,7 +661,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::disable_interactive_serial_console call.
+    /// The request builder for [BareMetalSolution::disable_interactive_serial_console][super::super::client::BareMetalSolution::disable_interactive_serial_console] calls.
     #[derive(Clone, Debug)]
     pub struct DisableInteractiveSerialConsole(
         RequestBuilder<crate::model::DisableInteractiveSerialConsoleRequest>,
@@ -751,7 +751,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::detach_lun call.
+    /// The request builder for [BareMetalSolution::detach_lun][super::super::client::BareMetalSolution::detach_lun] calls.
     #[derive(Clone, Debug)]
     pub struct DetachLun(RequestBuilder<crate::model::DetachLunRequest>);
 
@@ -843,7 +843,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_ssh_keys call.
+    /// The request builder for [BareMetalSolution::list_ssh_keys][super::super::client::BareMetalSolution::list_ssh_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListSSHKeys(RequestBuilder<crate::model::ListSSHKeysRequest>);
 
@@ -912,7 +912,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::create_ssh_key call.
+    /// The request builder for [BareMetalSolution::create_ssh_key][super::super::client::BareMetalSolution::create_ssh_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSSHKey(RequestBuilder<crate::model::CreateSSHKeyRequest>);
 
@@ -969,7 +969,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::delete_ssh_key call.
+    /// The request builder for [BareMetalSolution::delete_ssh_key][super::super::client::BareMetalSolution::delete_ssh_key] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSSHKey(RequestBuilder<crate::model::DeleteSSHKeyRequest>);
 
@@ -1011,7 +1011,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_volumes call.
+    /// The request builder for [BareMetalSolution::list_volumes][super::super::client::BareMetalSolution::list_volumes] calls.
     #[derive(Clone, Debug)]
     pub struct ListVolumes(RequestBuilder<crate::model::ListVolumesRequest>);
 
@@ -1086,7 +1086,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_volume call.
+    /// The request builder for [BareMetalSolution::get_volume][super::super::client::BareMetalSolution::get_volume] calls.
     #[derive(Clone, Debug)]
     pub struct GetVolume(RequestBuilder<crate::model::GetVolumeRequest>);
 
@@ -1128,7 +1128,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::update_volume call.
+    /// The request builder for [BareMetalSolution::update_volume][super::super::client::BareMetalSolution::update_volume] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVolume(RequestBuilder<crate::model::UpdateVolumeRequest>);
 
@@ -1219,7 +1219,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::rename_volume call.
+    /// The request builder for [BareMetalSolution::rename_volume][super::super::client::BareMetalSolution::rename_volume] calls.
     #[derive(Clone, Debug)]
     pub struct RenameVolume(RequestBuilder<crate::model::RenameVolumeRequest>);
 
@@ -1267,7 +1267,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::evict_volume call.
+    /// The request builder for [BareMetalSolution::evict_volume][super::super::client::BareMetalSolution::evict_volume] calls.
     #[derive(Clone, Debug)]
     pub struct EvictVolume(RequestBuilder<crate::model::EvictVolumeRequest>);
 
@@ -1344,7 +1344,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::resize_volume call.
+    /// The request builder for [BareMetalSolution::resize_volume][super::super::client::BareMetalSolution::resize_volume] calls.
     #[derive(Clone, Debug)]
     pub struct ResizeVolume(RequestBuilder<crate::model::ResizeVolumeRequest>);
 
@@ -1429,7 +1429,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_networks call.
+    /// The request builder for [BareMetalSolution::list_networks][super::super::client::BareMetalSolution::list_networks] calls.
     #[derive(Clone, Debug)]
     pub struct ListNetworks(RequestBuilder<crate::model::ListNetworksRequest>);
 
@@ -1504,7 +1504,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_network_usage call.
+    /// The request builder for [BareMetalSolution::list_network_usage][super::super::client::BareMetalSolution::list_network_usage] calls.
     #[derive(Clone, Debug)]
     pub struct ListNetworkUsage(RequestBuilder<crate::model::ListNetworkUsageRequest>);
 
@@ -1549,7 +1549,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_network call.
+    /// The request builder for [BareMetalSolution::get_network][super::super::client::BareMetalSolution::get_network] calls.
     #[derive(Clone, Debug)]
     pub struct GetNetwork(RequestBuilder<crate::model::GetNetworkRequest>);
 
@@ -1591,7 +1591,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::update_network call.
+    /// The request builder for [BareMetalSolution::update_network][super::super::client::BareMetalSolution::update_network] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNetwork(RequestBuilder<crate::model::UpdateNetworkRequest>);
 
@@ -1682,7 +1682,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::create_volume_snapshot call.
+    /// The request builder for [BareMetalSolution::create_volume_snapshot][super::super::client::BareMetalSolution::create_volume_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVolumeSnapshot(RequestBuilder<crate::model::CreateVolumeSnapshotRequest>);
 
@@ -1736,7 +1736,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::restore_volume_snapshot call.
+    /// The request builder for [BareMetalSolution::restore_volume_snapshot][super::super::client::BareMetalSolution::restore_volume_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreVolumeSnapshot(RequestBuilder<crate::model::RestoreVolumeSnapshotRequest>);
 
@@ -1820,7 +1820,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::delete_volume_snapshot call.
+    /// The request builder for [BareMetalSolution::delete_volume_snapshot][super::super::client::BareMetalSolution::delete_volume_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVolumeSnapshot(RequestBuilder<crate::model::DeleteVolumeSnapshotRequest>);
 
@@ -1865,7 +1865,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_volume_snapshot call.
+    /// The request builder for [BareMetalSolution::get_volume_snapshot][super::super::client::BareMetalSolution::get_volume_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct GetVolumeSnapshot(RequestBuilder<crate::model::GetVolumeSnapshotRequest>);
 
@@ -1910,7 +1910,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_volume_snapshots call.
+    /// The request builder for [BareMetalSolution::list_volume_snapshots][super::super::client::BareMetalSolution::list_volume_snapshots] calls.
     #[derive(Clone, Debug)]
     pub struct ListVolumeSnapshots(RequestBuilder<crate::model::ListVolumeSnapshotsRequest>);
 
@@ -1982,7 +1982,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_lun call.
+    /// The request builder for [BareMetalSolution::get_lun][super::super::client::BareMetalSolution::get_lun] calls.
     #[derive(Clone, Debug)]
     pub struct GetLun(RequestBuilder<crate::model::GetLunRequest>);
 
@@ -2022,7 +2022,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_luns call.
+    /// The request builder for [BareMetalSolution::list_luns][super::super::client::BareMetalSolution::list_luns] calls.
     #[derive(Clone, Debug)]
     pub struct ListLuns(RequestBuilder<crate::model::ListLunsRequest>);
 
@@ -2090,7 +2090,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::evict_lun call.
+    /// The request builder for [BareMetalSolution::evict_lun][super::super::client::BareMetalSolution::evict_lun] calls.
     #[derive(Clone, Debug)]
     pub struct EvictLun(RequestBuilder<crate::model::EvictLunRequest>);
 
@@ -2167,7 +2167,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_nfs_share call.
+    /// The request builder for [BareMetalSolution::get_nfs_share][super::super::client::BareMetalSolution::get_nfs_share] calls.
     #[derive(Clone, Debug)]
     pub struct GetNfsShare(RequestBuilder<crate::model::GetNfsShareRequest>);
 
@@ -2209,7 +2209,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_nfs_shares call.
+    /// The request builder for [BareMetalSolution::list_nfs_shares][super::super::client::BareMetalSolution::list_nfs_shares] calls.
     #[derive(Clone, Debug)]
     pub struct ListNfsShares(RequestBuilder<crate::model::ListNfsSharesRequest>);
 
@@ -2284,7 +2284,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::update_nfs_share call.
+    /// The request builder for [BareMetalSolution::update_nfs_share][super::super::client::BareMetalSolution::update_nfs_share] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNfsShare(RequestBuilder<crate::model::UpdateNfsShareRequest>);
 
@@ -2376,7 +2376,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::create_nfs_share call.
+    /// The request builder for [BareMetalSolution::create_nfs_share][super::super::client::BareMetalSolution::create_nfs_share] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNfsShare(RequestBuilder<crate::model::CreateNfsShareRequest>);
 
@@ -2465,7 +2465,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::rename_nfs_share call.
+    /// The request builder for [BareMetalSolution::rename_nfs_share][super::super::client::BareMetalSolution::rename_nfs_share] calls.
     #[derive(Clone, Debug)]
     pub struct RenameNfsShare(RequestBuilder<crate::model::RenameNfsShareRequest>);
 
@@ -2513,7 +2513,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::delete_nfs_share call.
+    /// The request builder for [BareMetalSolution::delete_nfs_share][super::super::client::BareMetalSolution::delete_nfs_share] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNfsShare(RequestBuilder<crate::model::DeleteNfsShareRequest>);
 
@@ -2590,7 +2590,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_provisioning_quotas call.
+    /// The request builder for [BareMetalSolution::list_provisioning_quotas][super::super::client::BareMetalSolution::list_provisioning_quotas] calls.
     #[derive(Clone, Debug)]
     pub struct ListProvisioningQuotas(RequestBuilder<crate::model::ListProvisioningQuotasRequest>);
 
@@ -2664,7 +2664,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::submit_provisioning_config call.
+    /// The request builder for [BareMetalSolution::submit_provisioning_config][super::super::client::BareMetalSolution::submit_provisioning_config] calls.
     #[derive(Clone, Debug)]
     pub struct SubmitProvisioningConfig(
         RequestBuilder<crate::model::SubmitProvisioningConfigRequest>,
@@ -2728,7 +2728,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_provisioning_config call.
+    /// The request builder for [BareMetalSolution::get_provisioning_config][super::super::client::BareMetalSolution::get_provisioning_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetProvisioningConfig(RequestBuilder<crate::model::GetProvisioningConfigRequest>);
 
@@ -2773,7 +2773,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::create_provisioning_config call.
+    /// The request builder for [BareMetalSolution::create_provisioning_config][super::super::client::BareMetalSolution::create_provisioning_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateProvisioningConfig(
         RequestBuilder<crate::model::CreateProvisioningConfigRequest>,
@@ -2837,7 +2837,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::update_provisioning_config call.
+    /// The request builder for [BareMetalSolution::update_provisioning_config][super::super::client::BareMetalSolution::update_provisioning_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProvisioningConfig(
         RequestBuilder<crate::model::UpdateProvisioningConfigRequest>,
@@ -2904,7 +2904,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::rename_network call.
+    /// The request builder for [BareMetalSolution::rename_network][super::super::client::BareMetalSolution::rename_network] calls.
     #[derive(Clone, Debug)]
     pub struct RenameNetwork(RequestBuilder<crate::model::RenameNetworkRequest>);
 
@@ -2952,7 +2952,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_os_images call.
+    /// The request builder for [BareMetalSolution::list_os_images][super::super::client::BareMetalSolution::list_os_images] calls.
     #[derive(Clone, Debug)]
     pub struct ListOSImages(RequestBuilder<crate::model::ListOSImagesRequest>);
 
@@ -3021,7 +3021,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::list_locations call.
+    /// The request builder for [BareMetalSolution::list_locations][super::super::client::BareMetalSolution::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3099,7 +3099,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_location call.
+    /// The request builder for [BareMetalSolution::get_location][super::super::client::BareMetalSolution::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3141,7 +3141,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for a BareMetalSolution::get_operation call.
+    /// The request builder for [BareMetalSolution::get_operation][super::super::client::BareMetalSolution::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::list_app_connections call.
+    /// The request builder for [AppConnectionsService::list_app_connections][super::super::client::AppConnectionsService::list_app_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListAppConnections(RequestBuilder<crate::model::ListAppConnectionsRequest>);
 
@@ -155,7 +155,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::get_app_connection call.
+    /// The request builder for [AppConnectionsService::get_app_connection][super::super::client::AppConnectionsService::get_app_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetAppConnection(RequestBuilder<crate::model::GetAppConnectionRequest>);
 
@@ -202,7 +202,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::create_app_connection call.
+    /// The request builder for [AppConnectionsService::create_app_connection][super::super::client::AppConnectionsService::create_app_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAppConnection(RequestBuilder<crate::model::CreateAppConnectionRequest>);
 
@@ -317,7 +317,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::update_app_connection call.
+    /// The request builder for [AppConnectionsService::update_app_connection][super::super::client::AppConnectionsService::update_app_connection] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAppConnection(RequestBuilder<crate::model::UpdateAppConnectionRequest>);
 
@@ -435,7 +435,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::delete_app_connection call.
+    /// The request builder for [AppConnectionsService::delete_app_connection][super::super::client::AppConnectionsService::delete_app_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAppConnection(RequestBuilder<crate::model::DeleteAppConnectionRequest>);
 
@@ -532,7 +532,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::resolve_app_connections call.
+    /// The request builder for [AppConnectionsService::resolve_app_connections][super::super::client::AppConnectionsService::resolve_app_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ResolveAppConnections(RequestBuilder<crate::model::ResolveAppConnectionsRequest>);
 
@@ -612,7 +612,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::list_locations call.
+    /// The request builder for [AppConnectionsService::list_locations][super::super::client::AppConnectionsService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -692,7 +692,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::get_location call.
+    /// The request builder for [AppConnectionsService::get_location][super::super::client::AppConnectionsService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -736,7 +736,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::set_iam_policy call.
+    /// The request builder for [AppConnectionsService::set_iam_policy][super::super::client::AppConnectionsService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -798,7 +798,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::get_iam_policy call.
+    /// The request builder for [AppConnectionsService::get_iam_policy][super::super::client::AppConnectionsService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -851,7 +851,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::test_iam_permissions call.
+    /// The request builder for [AppConnectionsService::test_iam_permissions][super::super::client::AppConnectionsService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -909,7 +909,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::list_operations call.
+    /// The request builder for [AppConnectionsService::list_operations][super::super::client::AppConnectionsService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -989,7 +989,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::get_operation call.
+    /// The request builder for [AppConnectionsService::get_operation][super::super::client::AppConnectionsService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1036,7 +1036,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::delete_operation call.
+    /// The request builder for [AppConnectionsService::delete_operation][super::super::client::AppConnectionsService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1083,7 +1083,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for a AppConnectionsService::cancel_operation call.
+    /// The request builder for [AppConnectionsService::cancel_operation][super::super::client::AppConnectionsService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::list_app_connectors call.
+    /// The request builder for [AppConnectorsService::list_app_connectors][super::super::client::AppConnectorsService::list_app_connectors] calls.
     #[derive(Clone, Debug)]
     pub struct ListAppConnectors(RequestBuilder<crate::model::ListAppConnectorsRequest>);
 
@@ -155,7 +155,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::get_app_connector call.
+    /// The request builder for [AppConnectorsService::get_app_connector][super::super::client::AppConnectorsService::get_app_connector] calls.
     #[derive(Clone, Debug)]
     pub struct GetAppConnector(RequestBuilder<crate::model::GetAppConnectorRequest>);
 
@@ -199,7 +199,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::create_app_connector call.
+    /// The request builder for [AppConnectorsService::create_app_connector][super::super::client::AppConnectorsService::create_app_connector] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAppConnector(RequestBuilder<crate::model::CreateAppConnectorRequest>);
 
@@ -314,7 +314,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::update_app_connector call.
+    /// The request builder for [AppConnectorsService::update_app_connector][super::super::client::AppConnectorsService::update_app_connector] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAppConnector(RequestBuilder<crate::model::UpdateAppConnectorRequest>);
 
@@ -426,7 +426,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::delete_app_connector call.
+    /// The request builder for [AppConnectorsService::delete_app_connector][super::super::client::AppConnectorsService::delete_app_connector] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAppConnector(RequestBuilder<crate::model::DeleteAppConnectorRequest>);
 
@@ -523,7 +523,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::report_status call.
+    /// The request builder for [AppConnectorsService::report_status][super::super::client::AppConnectorsService::report_status] calls.
     #[derive(Clone, Debug)]
     pub struct ReportStatus(RequestBuilder<crate::model::ReportStatusRequest>);
 
@@ -629,7 +629,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::list_locations call.
+    /// The request builder for [AppConnectorsService::list_locations][super::super::client::AppConnectorsService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -709,7 +709,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::get_location call.
+    /// The request builder for [AppConnectorsService::get_location][super::super::client::AppConnectorsService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -753,7 +753,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::set_iam_policy call.
+    /// The request builder for [AppConnectorsService::set_iam_policy][super::super::client::AppConnectorsService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -815,7 +815,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::get_iam_policy call.
+    /// The request builder for [AppConnectorsService::get_iam_policy][super::super::client::AppConnectorsService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -868,7 +868,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::test_iam_permissions call.
+    /// The request builder for [AppConnectorsService::test_iam_permissions][super::super::client::AppConnectorsService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -926,7 +926,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::list_operations call.
+    /// The request builder for [AppConnectorsService::list_operations][super::super::client::AppConnectorsService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1006,7 +1006,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::get_operation call.
+    /// The request builder for [AppConnectorsService::get_operation][super::super::client::AppConnectorsService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1053,7 +1053,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::delete_operation call.
+    /// The request builder for [AppConnectorsService::delete_operation][super::super::client::AppConnectorsService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1100,7 +1100,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for a AppConnectorsService::cancel_operation call.
+    /// The request builder for [AppConnectorsService::cancel_operation][super::super::client::AppConnectorsService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::list_app_gateways call.
+    /// The request builder for [AppGatewaysService::list_app_gateways][super::super::client::AppGatewaysService::list_app_gateways] calls.
     #[derive(Clone, Debug)]
     pub struct ListAppGateways(RequestBuilder<crate::model::ListAppGatewaysRequest>);
 
@@ -148,7 +148,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::get_app_gateway call.
+    /// The request builder for [AppGatewaysService::get_app_gateway][super::super::client::AppGatewaysService::get_app_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct GetAppGateway(RequestBuilder<crate::model::GetAppGatewayRequest>);
 
@@ -190,7 +190,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::create_app_gateway call.
+    /// The request builder for [AppGatewaysService::create_app_gateway][super::super::client::AppGatewaysService::create_app_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAppGateway(RequestBuilder<crate::model::CreateAppGatewayRequest>);
 
@@ -301,7 +301,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::delete_app_gateway call.
+    /// The request builder for [AppGatewaysService::delete_app_gateway][super::super::client::AppGatewaysService::delete_app_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAppGateway(RequestBuilder<crate::model::DeleteAppGatewayRequest>);
 
@@ -395,7 +395,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::list_locations call.
+    /// The request builder for [AppGatewaysService::list_locations][super::super::client::AppGatewaysService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -473,7 +473,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::get_location call.
+    /// The request builder for [AppGatewaysService::get_location][super::super::client::AppGatewaysService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -515,7 +515,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::set_iam_policy call.
+    /// The request builder for [AppGatewaysService::set_iam_policy][super::super::client::AppGatewaysService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -575,7 +575,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::get_iam_policy call.
+    /// The request builder for [AppGatewaysService::get_iam_policy][super::super::client::AppGatewaysService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -626,7 +626,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::test_iam_permissions call.
+    /// The request builder for [AppGatewaysService::test_iam_permissions][super::super::client::AppGatewaysService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -682,7 +682,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::list_operations call.
+    /// The request builder for [AppGatewaysService::list_operations][super::super::client::AppGatewaysService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -760,7 +760,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::get_operation call.
+    /// The request builder for [AppGatewaysService::get_operation][super::super::client::AppGatewaysService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -805,7 +805,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::delete_operation call.
+    /// The request builder for [AppGatewaysService::delete_operation][super::super::client::AppGatewaysService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -850,7 +850,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for a AppGatewaysService::cancel_operation call.
+    /// The request builder for [AppGatewaysService::cancel_operation][super::super::client::AppGatewaysService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::list_client_connector_services call.
+    /// The request builder for [ClientConnectorServicesService::list_client_connector_services][super::super::client::ClientConnectorServicesService::list_client_connector_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListClientConnectorServices(
         RequestBuilder<crate::model::ListClientConnectorServicesRequest>,
@@ -159,7 +159,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::get_client_connector_service call.
+    /// The request builder for [ClientConnectorServicesService::get_client_connector_service][super::super::client::ClientConnectorServicesService::get_client_connector_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetClientConnectorService(
         RequestBuilder<crate::model::GetClientConnectorServiceRequest>,
@@ -208,7 +208,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::create_client_connector_service call.
+    /// The request builder for [ClientConnectorServicesService::create_client_connector_service][super::super::client::ClientConnectorServicesService::create_client_connector_service] calls.
     #[derive(Clone, Debug)]
     pub struct CreateClientConnectorService(
         RequestBuilder<crate::model::CreateClientConnectorServiceRequest>,
@@ -332,7 +332,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::update_client_connector_service call.
+    /// The request builder for [ClientConnectorServicesService::update_client_connector_service][super::super::client::ClientConnectorServicesService::update_client_connector_service] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateClientConnectorService(
         RequestBuilder<crate::model::UpdateClientConnectorServiceRequest>,
@@ -456,7 +456,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::delete_client_connector_service call.
+    /// The request builder for [ClientConnectorServicesService::delete_client_connector_service][super::super::client::ClientConnectorServicesService::delete_client_connector_service] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteClientConnectorService(
         RequestBuilder<crate::model::DeleteClientConnectorServiceRequest>,
@@ -556,7 +556,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::list_locations call.
+    /// The request builder for [ClientConnectorServicesService::list_locations][super::super::client::ClientConnectorServicesService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -636,7 +636,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::get_location call.
+    /// The request builder for [ClientConnectorServicesService::get_location][super::super::client::ClientConnectorServicesService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -680,7 +680,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::set_iam_policy call.
+    /// The request builder for [ClientConnectorServicesService::set_iam_policy][super::super::client::ClientConnectorServicesService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -742,7 +742,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::get_iam_policy call.
+    /// The request builder for [ClientConnectorServicesService::get_iam_policy][super::super::client::ClientConnectorServicesService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -795,7 +795,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::test_iam_permissions call.
+    /// The request builder for [ClientConnectorServicesService::test_iam_permissions][super::super::client::ClientConnectorServicesService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -853,7 +853,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::list_operations call.
+    /// The request builder for [ClientConnectorServicesService::list_operations][super::super::client::ClientConnectorServicesService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -933,7 +933,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::get_operation call.
+    /// The request builder for [ClientConnectorServicesService::get_operation][super::super::client::ClientConnectorServicesService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -980,7 +980,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::delete_operation call.
+    /// The request builder for [ClientConnectorServicesService::delete_operation][super::super::client::ClientConnectorServicesService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1027,7 +1027,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for a ClientConnectorServicesService::cancel_operation call.
+    /// The request builder for [ClientConnectorServicesService::cancel_operation][super::super::client::ClientConnectorServicesService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::list_client_gateways call.
+    /// The request builder for [ClientGatewaysService::list_client_gateways][super::super::client::ClientGatewaysService::list_client_gateways] calls.
     #[derive(Clone, Debug)]
     pub struct ListClientGateways(RequestBuilder<crate::model::ListClientGatewaysRequest>);
 
@@ -155,7 +155,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::get_client_gateway call.
+    /// The request builder for [ClientGatewaysService::get_client_gateway][super::super::client::ClientGatewaysService::get_client_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct GetClientGateway(RequestBuilder<crate::model::GetClientGatewayRequest>);
 
@@ -202,7 +202,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::create_client_gateway call.
+    /// The request builder for [ClientGatewaysService::create_client_gateway][super::super::client::ClientGatewaysService::create_client_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct CreateClientGateway(RequestBuilder<crate::model::CreateClientGatewayRequest>);
 
@@ -317,7 +317,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::delete_client_gateway call.
+    /// The request builder for [ClientGatewaysService::delete_client_gateway][super::super::client::ClientGatewaysService::delete_client_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteClientGateway(RequestBuilder<crate::model::DeleteClientGatewayRequest>);
 
@@ -414,7 +414,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::list_locations call.
+    /// The request builder for [ClientGatewaysService::list_locations][super::super::client::ClientGatewaysService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -494,7 +494,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::get_location call.
+    /// The request builder for [ClientGatewaysService::get_location][super::super::client::ClientGatewaysService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -538,7 +538,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::set_iam_policy call.
+    /// The request builder for [ClientGatewaysService::set_iam_policy][super::super::client::ClientGatewaysService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -600,7 +600,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::get_iam_policy call.
+    /// The request builder for [ClientGatewaysService::get_iam_policy][super::super::client::ClientGatewaysService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -653,7 +653,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::test_iam_permissions call.
+    /// The request builder for [ClientGatewaysService::test_iam_permissions][super::super::client::ClientGatewaysService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -711,7 +711,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::list_operations call.
+    /// The request builder for [ClientGatewaysService::list_operations][super::super::client::ClientGatewaysService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -791,7 +791,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::get_operation call.
+    /// The request builder for [ClientGatewaysService::get_operation][super::super::client::ClientGatewaysService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -838,7 +838,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::delete_operation call.
+    /// The request builder for [ClientGatewaysService::delete_operation][super::super::client::ClientGatewaysService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -885,7 +885,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for a ClientGatewaysService::cancel_operation call.
+    /// The request builder for [ClientGatewaysService::cancel_operation][super::super::client::ClientGatewaysService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::list_data_exchanges call.
+    /// The request builder for [AnalyticsHubService::list_data_exchanges][super::super::client::AnalyticsHubService::list_data_exchanges] calls.
     #[derive(Clone, Debug)]
     pub struct ListDataExchanges(RequestBuilder<crate::model::ListDataExchangesRequest>);
 
@@ -139,7 +139,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::list_org_data_exchanges call.
+    /// The request builder for [AnalyticsHubService::list_org_data_exchanges][super::super::client::AnalyticsHubService::list_org_data_exchanges] calls.
     #[derive(Clone, Debug)]
     pub struct ListOrgDataExchanges(RequestBuilder<crate::model::ListOrgDataExchangesRequest>);
 
@@ -211,7 +211,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::get_data_exchange call.
+    /// The request builder for [AnalyticsHubService::get_data_exchange][super::super::client::AnalyticsHubService::get_data_exchange] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataExchange(RequestBuilder<crate::model::GetDataExchangeRequest>);
 
@@ -253,7 +253,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::create_data_exchange call.
+    /// The request builder for [AnalyticsHubService::create_data_exchange][super::super::client::AnalyticsHubService::create_data_exchange] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDataExchange(RequestBuilder<crate::model::CreateDataExchangeRequest>);
 
@@ -313,7 +313,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::update_data_exchange call.
+    /// The request builder for [AnalyticsHubService::update_data_exchange][super::super::client::AnalyticsHubService::update_data_exchange] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDataExchange(RequestBuilder<crate::model::UpdateDataExchangeRequest>);
 
@@ -370,7 +370,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::delete_data_exchange call.
+    /// The request builder for [AnalyticsHubService::delete_data_exchange][super::super::client::AnalyticsHubService::delete_data_exchange] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataExchange(RequestBuilder<crate::model::DeleteDataExchangeRequest>);
 
@@ -415,7 +415,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::list_listings call.
+    /// The request builder for [AnalyticsHubService::list_listings][super::super::client::AnalyticsHubService::list_listings] calls.
     #[derive(Clone, Debug)]
     pub struct ListListings(RequestBuilder<crate::model::ListListingsRequest>);
 
@@ -484,7 +484,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::get_listing call.
+    /// The request builder for [AnalyticsHubService::get_listing][super::super::client::AnalyticsHubService::get_listing] calls.
     #[derive(Clone, Debug)]
     pub struct GetListing(RequestBuilder<crate::model::GetListingRequest>);
 
@@ -526,7 +526,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::create_listing call.
+    /// The request builder for [AnalyticsHubService::create_listing][super::super::client::AnalyticsHubService::create_listing] calls.
     #[derive(Clone, Debug)]
     pub struct CreateListing(RequestBuilder<crate::model::CreateListingRequest>);
 
@@ -583,7 +583,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::update_listing call.
+    /// The request builder for [AnalyticsHubService::update_listing][super::super::client::AnalyticsHubService::update_listing] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateListing(RequestBuilder<crate::model::UpdateListingRequest>);
 
@@ -637,7 +637,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::delete_listing call.
+    /// The request builder for [AnalyticsHubService::delete_listing][super::super::client::AnalyticsHubService::delete_listing] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteListing(RequestBuilder<crate::model::DeleteListingRequest>);
 
@@ -679,7 +679,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::subscribe_listing call.
+    /// The request builder for [AnalyticsHubService::subscribe_listing][super::super::client::AnalyticsHubService::subscribe_listing] calls.
     #[derive(Clone, Debug)]
     pub struct SubscribeListing(RequestBuilder<crate::model::SubscribeListingRequest>);
 
@@ -735,7 +735,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::subscribe_data_exchange call.
+    /// The request builder for [AnalyticsHubService::subscribe_data_exchange][super::super::client::AnalyticsHubService::subscribe_data_exchange] calls.
     #[derive(Clone, Debug)]
     pub struct SubscribeDataExchange(RequestBuilder<crate::model::SubscribeDataExchangeRequest>);
 
@@ -850,7 +850,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::refresh_subscription call.
+    /// The request builder for [AnalyticsHubService::refresh_subscription][super::super::client::AnalyticsHubService::refresh_subscription] calls.
     #[derive(Clone, Debug)]
     pub struct RefreshSubscription(RequestBuilder<crate::model::RefreshSubscriptionRequest>);
 
@@ -936,7 +936,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::get_subscription call.
+    /// The request builder for [AnalyticsHubService::get_subscription][super::super::client::AnalyticsHubService::get_subscription] calls.
     #[derive(Clone, Debug)]
     pub struct GetSubscription(RequestBuilder<crate::model::GetSubscriptionRequest>);
 
@@ -978,7 +978,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::list_subscriptions call.
+    /// The request builder for [AnalyticsHubService::list_subscriptions][super::super::client::AnalyticsHubService::list_subscriptions] calls.
     #[derive(Clone, Debug)]
     pub struct ListSubscriptions(RequestBuilder<crate::model::ListSubscriptionsRequest>);
 
@@ -1056,7 +1056,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::list_shared_resource_subscriptions call.
+    /// The request builder for [AnalyticsHubService::list_shared_resource_subscriptions][super::super::client::AnalyticsHubService::list_shared_resource_subscriptions] calls.
     #[derive(Clone, Debug)]
     pub struct ListSharedResourceSubscriptions(
         RequestBuilder<crate::model::ListSharedResourceSubscriptionsRequest>,
@@ -1138,7 +1138,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::revoke_subscription call.
+    /// The request builder for [AnalyticsHubService::revoke_subscription][super::super::client::AnalyticsHubService::revoke_subscription] calls.
     #[derive(Clone, Debug)]
     pub struct RevokeSubscription(RequestBuilder<crate::model::RevokeSubscriptionRequest>);
 
@@ -1183,7 +1183,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::delete_subscription call.
+    /// The request builder for [AnalyticsHubService::delete_subscription][super::super::client::AnalyticsHubService::delete_subscription] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSubscription(RequestBuilder<crate::model::DeleteSubscriptionRequest>);
 
@@ -1263,7 +1263,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::get_iam_policy call.
+    /// The request builder for [AnalyticsHubService::get_iam_policy][super::super::client::AnalyticsHubService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1314,7 +1314,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::set_iam_policy call.
+    /// The request builder for [AnalyticsHubService::set_iam_policy][super::super::client::AnalyticsHubService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1374,7 +1374,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::test_iam_permissions call.
+    /// The request builder for [AnalyticsHubService::test_iam_permissions][super::super::client::AnalyticsHubService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1430,7 +1430,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for a AnalyticsHubService::get_operation call.
+    /// The request builder for [AnalyticsHubService::get_operation][super::super::client::AnalyticsHubService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/bigquery/connection/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::create_connection call.
+    /// The request builder for [ConnectionService::create_connection][super::super::client::ConnectionService::create_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -127,7 +127,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::get_connection call.
+    /// The request builder for [ConnectionService::get_connection][super::super::client::ConnectionService::get_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -169,7 +169,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::list_connections call.
+    /// The request builder for [ConnectionService::list_connections][super::super::client::ConnectionService::list_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -238,7 +238,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::update_connection call.
+    /// The request builder for [ConnectionService::update_connection][super::super::client::ConnectionService::update_connection] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 
@@ -301,7 +301,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::delete_connection call.
+    /// The request builder for [ConnectionService::delete_connection][super::super::client::ConnectionService::delete_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -346,7 +346,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::get_iam_policy call.
+    /// The request builder for [ConnectionService::get_iam_policy][super::super::client::ConnectionService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -397,7 +397,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::set_iam_policy call.
+    /// The request builder for [ConnectionService::set_iam_policy][super::super::client::ConnectionService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -457,7 +457,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for a ConnectionService::test_iam_permissions call.
+    /// The request builder for [ConnectionService::test_iam_permissions][super::super::client::ConnectionService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::create_data_policy call.
+    /// The request builder for [DataPolicyService::create_data_policy][super::super::client::DataPolicyService::create_data_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDataPolicy(RequestBuilder<crate::model::CreateDataPolicyRequest>);
 
@@ -121,7 +121,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::update_data_policy call.
+    /// The request builder for [DataPolicyService::update_data_policy][super::super::client::DataPolicyService::update_data_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDataPolicy(RequestBuilder<crate::model::UpdateDataPolicyRequest>);
 
@@ -178,7 +178,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::rename_data_policy call.
+    /// The request builder for [DataPolicyService::rename_data_policy][super::super::client::DataPolicyService::rename_data_policy] calls.
     #[derive(Clone, Debug)]
     pub struct RenameDataPolicy(RequestBuilder<crate::model::RenameDataPolicyRequest>);
 
@@ -229,7 +229,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::delete_data_policy call.
+    /// The request builder for [DataPolicyService::delete_data_policy][super::super::client::DataPolicyService::delete_data_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataPolicy(RequestBuilder<crate::model::DeleteDataPolicyRequest>);
 
@@ -274,7 +274,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::get_data_policy call.
+    /// The request builder for [DataPolicyService::get_data_policy][super::super::client::DataPolicyService::get_data_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataPolicy(RequestBuilder<crate::model::GetDataPolicyRequest>);
 
@@ -316,7 +316,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::list_data_policies call.
+    /// The request builder for [DataPolicyService::list_data_policies][super::super::client::DataPolicyService::list_data_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListDataPolicies(RequestBuilder<crate::model::ListDataPoliciesRequest>);
 
@@ -394,7 +394,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::get_iam_policy call.
+    /// The request builder for [DataPolicyService::get_iam_policy][super::super::client::DataPolicyService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -445,7 +445,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::set_iam_policy call.
+    /// The request builder for [DataPolicyService::set_iam_policy][super::super::client::DataPolicyService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -505,7 +505,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for a DataPolicyService::test_iam_permissions call.
+    /// The request builder for [DataPolicyService::test_iam_permissions][super::super::client::DataPolicyService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::get_data_source call.
+    /// The request builder for [DataTransferService::get_data_source][super::super::client::DataTransferService::get_data_source] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataSource(RequestBuilder<crate::model::GetDataSourceRequest>);
 
@@ -109,7 +109,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::list_data_sources call.
+    /// The request builder for [DataTransferService::list_data_sources][super::super::client::DataTransferService::list_data_sources] calls.
     #[derive(Clone, Debug)]
     pub struct ListDataSources(RequestBuilder<crate::model::ListDataSourcesRequest>);
 
@@ -178,7 +178,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::create_transfer_config call.
+    /// The request builder for [DataTransferService::create_transfer_config][super::super::client::DataTransferService::create_transfer_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTransferConfig(RequestBuilder<crate::model::CreateTransferConfigRequest>);
 
@@ -250,7 +250,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::update_transfer_config call.
+    /// The request builder for [DataTransferService::update_transfer_config][super::super::client::DataTransferService::update_transfer_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTransferConfig(RequestBuilder<crate::model::UpdateTransferConfigRequest>);
 
@@ -325,7 +325,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::delete_transfer_config call.
+    /// The request builder for [DataTransferService::delete_transfer_config][super::super::client::DataTransferService::delete_transfer_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTransferConfig(RequestBuilder<crate::model::DeleteTransferConfigRequest>);
 
@@ -370,7 +370,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::get_transfer_config call.
+    /// The request builder for [DataTransferService::get_transfer_config][super::super::client::DataTransferService::get_transfer_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetTransferConfig(RequestBuilder<crate::model::GetTransferConfigRequest>);
 
@@ -415,7 +415,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::list_transfer_configs call.
+    /// The request builder for [DataTransferService::list_transfer_configs][super::super::client::DataTransferService::list_transfer_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListTransferConfigs(RequestBuilder<crate::model::ListTransferConfigsRequest>);
 
@@ -498,7 +498,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::schedule_transfer_runs call.
+    /// The request builder for [DataTransferService::schedule_transfer_runs][super::super::client::DataTransferService::schedule_transfer_runs] calls.
     #[derive(Clone, Debug)]
     pub struct ScheduleTransferRuns(RequestBuilder<crate::model::ScheduleTransferRunsRequest>);
 
@@ -558,7 +558,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::start_manual_transfer_runs call.
+    /// The request builder for [DataTransferService::start_manual_transfer_runs][super::super::client::DataTransferService::start_manual_transfer_runs] calls.
     #[derive(Clone, Debug)]
     pub struct StartManualTransferRuns(
         RequestBuilder<crate::model::StartManualTransferRunsRequest>,
@@ -614,7 +614,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::get_transfer_run call.
+    /// The request builder for [DataTransferService::get_transfer_run][super::super::client::DataTransferService::get_transfer_run] calls.
     #[derive(Clone, Debug)]
     pub struct GetTransferRun(RequestBuilder<crate::model::GetTransferRunRequest>);
 
@@ -656,7 +656,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::delete_transfer_run call.
+    /// The request builder for [DataTransferService::delete_transfer_run][super::super::client::DataTransferService::delete_transfer_run] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTransferRun(RequestBuilder<crate::model::DeleteTransferRunRequest>);
 
@@ -701,7 +701,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::list_transfer_runs call.
+    /// The request builder for [DataTransferService::list_transfer_runs][super::super::client::DataTransferService::list_transfer_runs] calls.
     #[derive(Clone, Debug)]
     pub struct ListTransferRuns(RequestBuilder<crate::model::ListTransferRunsRequest>);
 
@@ -793,7 +793,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::list_transfer_logs call.
+    /// The request builder for [DataTransferService::list_transfer_logs][super::super::client::DataTransferService::list_transfer_logs] calls.
     #[derive(Clone, Debug)]
     pub struct ListTransferLogs(RequestBuilder<crate::model::ListTransferLogsRequest>);
 
@@ -876,7 +876,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::check_valid_creds call.
+    /// The request builder for [DataTransferService::check_valid_creds][super::super::client::DataTransferService::check_valid_creds] calls.
     #[derive(Clone, Debug)]
     pub struct CheckValidCreds(RequestBuilder<crate::model::CheckValidCredsRequest>);
 
@@ -918,7 +918,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::enroll_data_sources call.
+    /// The request builder for [DataTransferService::enroll_data_sources][super::super::client::DataTransferService::enroll_data_sources] calls.
     #[derive(Clone, Debug)]
     pub struct EnrollDataSources(RequestBuilder<crate::model::EnrollDataSourcesRequest>);
 
@@ -974,7 +974,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::unenroll_data_sources call.
+    /// The request builder for [DataTransferService::unenroll_data_sources][super::super::client::DataTransferService::unenroll_data_sources] calls.
     #[derive(Clone, Debug)]
     pub struct UnenrollDataSources(RequestBuilder<crate::model::UnenrollDataSourcesRequest>);
 
@@ -1030,7 +1030,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::list_locations call.
+    /// The request builder for [DataTransferService::list_locations][super::super::client::DataTransferService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1108,7 +1108,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for a DataTransferService::get_location call.
+    /// The request builder for [DataTransferService::get_location][super::super::client::DataTransferService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/bigquery/migration/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::create_migration_workflow call.
+    /// The request builder for [MigrationService::create_migration_workflow][super::super::client::MigrationService::create_migration_workflow] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMigrationWorkflow(
         RequestBuilder<crate::model::CreateMigrationWorkflowRequest>,
@@ -125,7 +125,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::get_migration_workflow call.
+    /// The request builder for [MigrationService::get_migration_workflow][super::super::client::MigrationService::get_migration_workflow] calls.
     #[derive(Clone, Debug)]
     pub struct GetMigrationWorkflow(RequestBuilder<crate::model::GetMigrationWorkflowRequest>);
 
@@ -176,7 +176,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::list_migration_workflows call.
+    /// The request builder for [MigrationService::list_migration_workflows][super::super::client::MigrationService::list_migration_workflows] calls.
     #[derive(Clone, Debug)]
     pub struct ListMigrationWorkflows(RequestBuilder<crate::model::ListMigrationWorkflowsRequest>);
 
@@ -256,7 +256,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::delete_migration_workflow call.
+    /// The request builder for [MigrationService::delete_migration_workflow][super::super::client::MigrationService::delete_migration_workflow] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMigrationWorkflow(
         RequestBuilder<crate::model::DeleteMigrationWorkflowRequest>,
@@ -303,7 +303,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::start_migration_workflow call.
+    /// The request builder for [MigrationService::start_migration_workflow][super::super::client::MigrationService::start_migration_workflow] calls.
     #[derive(Clone, Debug)]
     pub struct StartMigrationWorkflow(RequestBuilder<crate::model::StartMigrationWorkflowRequest>);
 
@@ -348,7 +348,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::get_migration_subtask call.
+    /// The request builder for [MigrationService::get_migration_subtask][super::super::client::MigrationService::get_migration_subtask] calls.
     #[derive(Clone, Debug)]
     pub struct GetMigrationSubtask(RequestBuilder<crate::model::GetMigrationSubtaskRequest>);
 
@@ -399,7 +399,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for a MigrationService::list_migration_subtasks call.
+    /// The request builder for [MigrationService::list_migration_subtasks][super::super::client::MigrationService::list_migration_subtasks] calls.
     #[derive(Clone, Debug)]
     pub struct ListMigrationSubtasks(RequestBuilder<crate::model::ListMigrationSubtasksRequest>);
 

--- a/src/generated/cloud/bigquery/reservation/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::create_reservation call.
+    /// The request builder for [ReservationService::create_reservation][super::super::client::ReservationService::create_reservation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateReservation(RequestBuilder<crate::model::CreateReservationRequest>);
 
@@ -127,7 +127,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::list_reservations call.
+    /// The request builder for [ReservationService::list_reservations][super::super::client::ReservationService::list_reservations] calls.
     #[derive(Clone, Debug)]
     pub struct ListReservations(RequestBuilder<crate::model::ListReservationsRequest>);
 
@@ -199,7 +199,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::get_reservation call.
+    /// The request builder for [ReservationService::get_reservation][super::super::client::ReservationService::get_reservation] calls.
     #[derive(Clone, Debug)]
     pub struct GetReservation(RequestBuilder<crate::model::GetReservationRequest>);
 
@@ -241,7 +241,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::delete_reservation call.
+    /// The request builder for [ReservationService::delete_reservation][super::super::client::ReservationService::delete_reservation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteReservation(RequestBuilder<crate::model::DeleteReservationRequest>);
 
@@ -286,7 +286,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::update_reservation call.
+    /// The request builder for [ReservationService::update_reservation][super::super::client::ReservationService::update_reservation] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateReservation(RequestBuilder<crate::model::UpdateReservationRequest>);
 
@@ -343,7 +343,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::failover_reservation call.
+    /// The request builder for [ReservationService::failover_reservation][super::super::client::ReservationService::failover_reservation] calls.
     #[derive(Clone, Debug)]
     pub struct FailoverReservation(RequestBuilder<crate::model::FailoverReservationRequest>);
 
@@ -388,7 +388,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::create_capacity_commitment call.
+    /// The request builder for [ReservationService::create_capacity_commitment][super::super::client::ReservationService::create_capacity_commitment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCapacityCommitment(
         RequestBuilder<crate::model::CreateCapacityCommitmentRequest>,
@@ -458,7 +458,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::list_capacity_commitments call.
+    /// The request builder for [ReservationService::list_capacity_commitments][super::super::client::ReservationService::list_capacity_commitments] calls.
     #[derive(Clone, Debug)]
     pub struct ListCapacityCommitments(
         RequestBuilder<crate::model::ListCapacityCommitmentsRequest>,
@@ -534,7 +534,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::get_capacity_commitment call.
+    /// The request builder for [ReservationService::get_capacity_commitment][super::super::client::ReservationService::get_capacity_commitment] calls.
     #[derive(Clone, Debug)]
     pub struct GetCapacityCommitment(RequestBuilder<crate::model::GetCapacityCommitmentRequest>);
 
@@ -579,7 +579,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::delete_capacity_commitment call.
+    /// The request builder for [ReservationService::delete_capacity_commitment][super::super::client::ReservationService::delete_capacity_commitment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCapacityCommitment(
         RequestBuilder<crate::model::DeleteCapacityCommitmentRequest>,
@@ -632,7 +632,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::update_capacity_commitment call.
+    /// The request builder for [ReservationService::update_capacity_commitment][super::super::client::ReservationService::update_capacity_commitment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCapacityCommitment(
         RequestBuilder<crate::model::UpdateCapacityCommitmentRequest>,
@@ -693,7 +693,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::split_capacity_commitment call.
+    /// The request builder for [ReservationService::split_capacity_commitment][super::super::client::ReservationService::split_capacity_commitment] calls.
     #[derive(Clone, Debug)]
     pub struct SplitCapacityCommitment(
         RequestBuilder<crate::model::SplitCapacityCommitmentRequest>,
@@ -746,7 +746,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::merge_capacity_commitments call.
+    /// The request builder for [ReservationService::merge_capacity_commitments][super::super::client::ReservationService::merge_capacity_commitments] calls.
     #[derive(Clone, Debug)]
     pub struct MergeCapacityCommitments(
         RequestBuilder<crate::model::MergeCapacityCommitmentsRequest>,
@@ -804,7 +804,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::create_assignment call.
+    /// The request builder for [ReservationService::create_assignment][super::super::client::ReservationService::create_assignment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAssignment(RequestBuilder<crate::model::CreateAssignmentRequest>);
 
@@ -864,7 +864,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::list_assignments call.
+    /// The request builder for [ReservationService::list_assignments][super::super::client::ReservationService::list_assignments] calls.
     #[derive(Clone, Debug)]
     pub struct ListAssignments(RequestBuilder<crate::model::ListAssignmentsRequest>);
 
@@ -933,7 +933,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::delete_assignment call.
+    /// The request builder for [ReservationService::delete_assignment][super::super::client::ReservationService::delete_assignment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAssignment(RequestBuilder<crate::model::DeleteAssignmentRequest>);
 
@@ -978,7 +978,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::search_assignments call.
+    /// The request builder for [ReservationService::search_assignments][super::super::client::ReservationService::search_assignments] calls.
     #[derive(Clone, Debug)]
     pub struct SearchAssignments(RequestBuilder<crate::model::SearchAssignmentsRequest>);
 
@@ -1056,7 +1056,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::search_all_assignments call.
+    /// The request builder for [ReservationService::search_all_assignments][super::super::client::ReservationService::search_all_assignments] calls.
     #[derive(Clone, Debug)]
     pub struct SearchAllAssignments(RequestBuilder<crate::model::SearchAllAssignmentsRequest>);
 
@@ -1134,7 +1134,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::move_assignment call.
+    /// The request builder for [ReservationService::move_assignment][super::super::client::ReservationService::move_assignment] calls.
     #[derive(Clone, Debug)]
     pub struct MoveAssignment(RequestBuilder<crate::model::MoveAssignmentRequest>);
 
@@ -1188,7 +1188,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::update_assignment call.
+    /// The request builder for [ReservationService::update_assignment][super::super::client::ReservationService::update_assignment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAssignment(RequestBuilder<crate::model::UpdateAssignmentRequest>);
 
@@ -1245,7 +1245,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::get_bi_reservation call.
+    /// The request builder for [ReservationService::get_bi_reservation][super::super::client::ReservationService::get_bi_reservation] calls.
     #[derive(Clone, Debug)]
     pub struct GetBiReservation(RequestBuilder<crate::model::GetBiReservationRequest>);
 
@@ -1290,7 +1290,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for a ReservationService::update_bi_reservation call.
+    /// The request builder for [ReservationService::update_bi_reservation][super::super::client::ReservationService::update_bi_reservation] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBiReservation(RequestBuilder<crate::model::UpdateBiReservationRequest>);
 

--- a/src/generated/cloud/bigquery/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::get_dataset call.
+    /// The request builder for [DatasetService::get_dataset][super::super::client::DatasetService::get_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataset(RequestBuilder<crate::model::GetDatasetRequest>);
 
@@ -130,7 +130,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::insert_dataset call.
+    /// The request builder for [DatasetService::insert_dataset][super::super::client::DatasetService::insert_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct InsertDataset(RequestBuilder<crate::model::InsertDatasetRequest>);
 
@@ -187,7 +187,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::patch_dataset call.
+    /// The request builder for [DatasetService::patch_dataset][super::super::client::DatasetService::patch_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct PatchDataset(RequestBuilder<crate::model::UpdateOrPatchDatasetRequest>);
 
@@ -253,7 +253,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::update_dataset call.
+    /// The request builder for [DatasetService::update_dataset][super::super::client::DatasetService::update_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDataset(RequestBuilder<crate::model::UpdateOrPatchDatasetRequest>);
 
@@ -319,7 +319,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::delete_dataset call.
+    /// The request builder for [DatasetService::delete_dataset][super::super::client::DatasetService::delete_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataset(RequestBuilder<crate::model::DeleteDatasetRequest>);
 
@@ -373,7 +373,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::list_datasets call.
+    /// The request builder for [DatasetService::list_datasets][super::super::client::DatasetService::list_datasets] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatasets(RequestBuilder<crate::model::ListDatasetsRequest>);
 
@@ -442,7 +442,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for a DatasetService::undelete_dataset call.
+    /// The request builder for [DatasetService::undelete_dataset][super::super::client::DatasetService::undelete_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteDataset(RequestBuilder<crate::model::UndeleteDatasetRequest>);
 
@@ -553,7 +553,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_model call.
+    /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -607,7 +607,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_models call.
+    /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -670,7 +670,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::patch_model call.
+    /// The request builder for [ModelService::patch_model][super::super::client::ModelService::patch_model] calls.
     #[derive(Clone, Debug)]
     pub struct PatchModel(RequestBuilder<crate::model::PatchModelRequest>);
 
@@ -733,7 +733,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::delete_model call.
+    /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -841,7 +841,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for a ProjectService::get_service_account call.
+    /// The request builder for [ProjectService::get_service_account][super::super::client::ProjectService::get_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceAccount(RequestBuilder<crate::model::GetServiceAccountRequest>);
 
@@ -940,7 +940,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for a RoutineService::get_routine call.
+    /// The request builder for [RoutineService::get_routine][super::super::client::RoutineService::get_routine] calls.
     #[derive(Clone, Debug)]
     pub struct GetRoutine(RequestBuilder<crate::model::GetRoutineRequest>);
 
@@ -994,7 +994,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for a RoutineService::insert_routine call.
+    /// The request builder for [RoutineService::insert_routine][super::super::client::RoutineService::insert_routine] calls.
     #[derive(Clone, Debug)]
     pub struct InsertRoutine(RequestBuilder<crate::model::InsertRoutineRequest>);
 
@@ -1051,7 +1051,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for a RoutineService::update_routine call.
+    /// The request builder for [RoutineService::update_routine][super::super::client::RoutineService::update_routine] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRoutine(RequestBuilder<crate::model::UpdateRoutineRequest>);
 
@@ -1114,7 +1114,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for a RoutineService::delete_routine call.
+    /// The request builder for [RoutineService::delete_routine][super::super::client::RoutineService::delete_routine] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRoutine(RequestBuilder<crate::model::DeleteRoutineRequest>);
 
@@ -1168,7 +1168,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for a RoutineService::list_routines call.
+    /// The request builder for [RoutineService::list_routines][super::super::client::RoutineService::list_routines] calls.
     #[derive(Clone, Debug)]
     pub struct ListRoutines(RequestBuilder<crate::model::ListRoutinesRequest>);
 
@@ -1293,7 +1293,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for a RowAccessPolicyService::list_row_access_policies call.
+    /// The request builder for [RowAccessPolicyService::list_row_access_policies][super::super::client::RowAccessPolicyService::list_row_access_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListRowAccessPolicies(RequestBuilder<crate::model::ListRowAccessPoliciesRequest>);
 
@@ -1379,7 +1379,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for a RowAccessPolicyService::get_row_access_policy call.
+    /// The request builder for [RowAccessPolicyService::get_row_access_policy][super::super::client::RowAccessPolicyService::get_row_access_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetRowAccessPolicy(RequestBuilder<crate::model::GetRowAccessPolicyRequest>);
 
@@ -1444,7 +1444,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for a RowAccessPolicyService::create_row_access_policy call.
+    /// The request builder for [RowAccessPolicyService::create_row_access_policy][super::super::client::RowAccessPolicyService::create_row_access_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRowAccessPolicy(RequestBuilder<crate::model::CreateRowAccessPolicyRequest>);
 
@@ -1514,7 +1514,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for a RowAccessPolicyService::update_row_access_policy call.
+    /// The request builder for [RowAccessPolicyService::update_row_access_policy][super::super::client::RowAccessPolicyService::update_row_access_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRowAccessPolicy(RequestBuilder<crate::model::UpdateRowAccessPolicyRequest>);
 
@@ -1590,7 +1590,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for a RowAccessPolicyService::delete_row_access_policy call.
+    /// The request builder for [RowAccessPolicyService::delete_row_access_policy][super::super::client::RowAccessPolicyService::delete_row_access_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRowAccessPolicy(RequestBuilder<crate::model::DeleteRowAccessPolicyRequest>);
 
@@ -1661,7 +1661,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for a RowAccessPolicyService::batch_delete_row_access_policies call.
+    /// The request builder for [RowAccessPolicyService::batch_delete_row_access_policies][super::super::client::RowAccessPolicyService::batch_delete_row_access_policies] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeleteRowAccessPolicies(
         RequestBuilder<crate::model::BatchDeleteRowAccessPoliciesRequest>,
@@ -1793,7 +1793,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for a TableService::get_table call.
+    /// The request builder for [TableService::get_table][super::super::client::TableService::get_table] calls.
     #[derive(Clone, Debug)]
     pub struct GetTable(RequestBuilder<crate::model::GetTableRequest>);
 
@@ -1862,7 +1862,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for a TableService::insert_table call.
+    /// The request builder for [TableService::insert_table][super::super::client::TableService::insert_table] calls.
     #[derive(Clone, Debug)]
     pub struct InsertTable(RequestBuilder<crate::model::InsertTableRequest>);
 
@@ -1919,7 +1919,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for a TableService::patch_table call.
+    /// The request builder for [TableService::patch_table][super::super::client::TableService::patch_table] calls.
     #[derive(Clone, Debug)]
     pub struct PatchTable(RequestBuilder<crate::model::UpdateOrPatchTableRequest>);
 
@@ -1991,7 +1991,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for a TableService::update_table call.
+    /// The request builder for [TableService::update_table][super::super::client::TableService::update_table] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTable(RequestBuilder<crate::model::UpdateOrPatchTableRequest>);
 
@@ -2063,7 +2063,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for a TableService::delete_table call.
+    /// The request builder for [TableService::delete_table][super::super::client::TableService::delete_table] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTable(RequestBuilder<crate::model::DeleteTableRequest>);
 
@@ -2117,7 +2117,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for a TableService::list_tables call.
+    /// The request builder for [TableService::list_tables][super::super::client::TableService::list_tables] calls.
     #[derive(Clone, Debug)]
     pub struct ListTables(RequestBuilder<crate::model::ListTablesRequest>);
 

--- a/src/generated/cloud/billing/v1/src/builder.rs
+++ b/src/generated/cloud/billing/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::get_billing_account call.
+    /// The request builder for [CloudBilling::get_billing_account][super::super::client::CloudBilling::get_billing_account] calls.
     #[derive(Clone, Debug)]
     pub struct GetBillingAccount(RequestBuilder<crate::model::GetBillingAccountRequest>);
 
@@ -112,7 +112,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::list_billing_accounts call.
+    /// The request builder for [CloudBilling::list_billing_accounts][super::super::client::CloudBilling::list_billing_accounts] calls.
     #[derive(Clone, Debug)]
     pub struct ListBillingAccounts(RequestBuilder<crate::model::ListBillingAccountsRequest>);
 
@@ -190,7 +190,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::update_billing_account call.
+    /// The request builder for [CloudBilling::update_billing_account][super::super::client::CloudBilling::update_billing_account] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBillingAccount(RequestBuilder<crate::model::UpdateBillingAccountRequest>);
 
@@ -253,7 +253,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::create_billing_account call.
+    /// The request builder for [CloudBilling::create_billing_account][super::super::client::CloudBilling::create_billing_account] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBillingAccount(RequestBuilder<crate::model::CreateBillingAccountRequest>);
 
@@ -307,7 +307,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::list_project_billing_info call.
+    /// The request builder for [CloudBilling::list_project_billing_info][super::super::client::CloudBilling::list_project_billing_info] calls.
     #[derive(Clone, Debug)]
     pub struct ListProjectBillingInfo(RequestBuilder<crate::model::ListProjectBillingInfoRequest>);
 
@@ -381,7 +381,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::get_project_billing_info call.
+    /// The request builder for [CloudBilling::get_project_billing_info][super::super::client::CloudBilling::get_project_billing_info] calls.
     #[derive(Clone, Debug)]
     pub struct GetProjectBillingInfo(RequestBuilder<crate::model::GetProjectBillingInfoRequest>);
 
@@ -426,7 +426,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::update_project_billing_info call.
+    /// The request builder for [CloudBilling::update_project_billing_info][super::super::client::CloudBilling::update_project_billing_info] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProjectBillingInfo(
         RequestBuilder<crate::model::UpdateProjectBillingInfoRequest>,
@@ -484,7 +484,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::get_iam_policy call.
+    /// The request builder for [CloudBilling::get_iam_policy][super::super::client::CloudBilling::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -535,7 +535,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::set_iam_policy call.
+    /// The request builder for [CloudBilling::set_iam_policy][super::super::client::CloudBilling::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -595,7 +595,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::test_iam_permissions call.
+    /// The request builder for [CloudBilling::test_iam_permissions][super::super::client::CloudBilling::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -651,7 +651,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for a CloudBilling::move_billing_account call.
+    /// The request builder for [CloudBilling::move_billing_account][super::super::client::CloudBilling::move_billing_account] calls.
     #[derive(Clone, Debug)]
     pub struct MoveBillingAccount(RequestBuilder<crate::model::MoveBillingAccountRequest>);
 
@@ -756,7 +756,7 @@ pub mod cloud_catalog {
         }
     }
 
-    /// The request builder for a CloudCatalog::list_services call.
+    /// The request builder for [CloudCatalog::list_services][super::super::client::CloudCatalog::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -819,7 +819,7 @@ pub mod cloud_catalog {
         }
     }
 
-    /// The request builder for a CloudCatalog::list_skus call.
+    /// The request builder for [CloudCatalog::list_skus][super::super::client::CloudCatalog::list_skus] calls.
     #[derive(Clone, Debug)]
     pub struct ListSkus(RequestBuilder<crate::model::ListSkusRequest>);
 

--- a/src/generated/cloud/binaryauthorization/v1/src/builder.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for a BinauthzManagementServiceV1::get_policy call.
+    /// The request builder for [BinauthzManagementServiceV1::get_policy][super::super::client::BinauthzManagementServiceV1::get_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetPolicy(RequestBuilder<crate::model::GetPolicyRequest>);
 
@@ -113,7 +113,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for a BinauthzManagementServiceV1::update_policy call.
+    /// The request builder for [BinauthzManagementServiceV1::update_policy][super::super::client::BinauthzManagementServiceV1::update_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePolicy(RequestBuilder<crate::model::UpdatePolicyRequest>);
 
@@ -160,7 +160,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for a BinauthzManagementServiceV1::create_attestor call.
+    /// The request builder for [BinauthzManagementServiceV1::create_attestor][super::super::client::BinauthzManagementServiceV1::create_attestor] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAttestor(RequestBuilder<crate::model::CreateAttestorRequest>);
 
@@ -219,7 +219,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for a BinauthzManagementServiceV1::get_attestor call.
+    /// The request builder for [BinauthzManagementServiceV1::get_attestor][super::super::client::BinauthzManagementServiceV1::get_attestor] calls.
     #[derive(Clone, Debug)]
     pub struct GetAttestor(RequestBuilder<crate::model::GetAttestorRequest>);
 
@@ -263,7 +263,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for a BinauthzManagementServiceV1::update_attestor call.
+    /// The request builder for [BinauthzManagementServiceV1::update_attestor][super::super::client::BinauthzManagementServiceV1::update_attestor] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAttestor(RequestBuilder<crate::model::UpdateAttestorRequest>);
 
@@ -310,7 +310,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for a BinauthzManagementServiceV1::list_attestors call.
+    /// The request builder for [BinauthzManagementServiceV1::list_attestors][super::super::client::BinauthzManagementServiceV1::list_attestors] calls.
     #[derive(Clone, Debug)]
     pub struct ListAttestors(RequestBuilder<crate::model::ListAttestorsRequest>);
 
@@ -381,7 +381,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for a BinauthzManagementServiceV1::delete_attestor call.
+    /// The request builder for [BinauthzManagementServiceV1::delete_attestor][super::super::client::BinauthzManagementServiceV1::delete_attestor] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAttestor(RequestBuilder<crate::model::DeleteAttestorRequest>);
 
@@ -479,7 +479,7 @@ pub mod system_policy_v_1 {
         }
     }
 
-    /// The request builder for a SystemPolicyV1::get_system_policy call.
+    /// The request builder for [SystemPolicyV1::get_system_policy][super::super::client::SystemPolicyV1::get_system_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetSystemPolicy(RequestBuilder<crate::model::GetSystemPolicyRequest>);
 
@@ -575,7 +575,7 @@ pub mod validation_helper_v_1 {
         }
     }
 
-    /// The request builder for a ValidationHelperV1::validate_attestation_occurrence call.
+    /// The request builder for [ValidationHelperV1::validate_attestation_occurrence][super::super::client::ValidationHelperV1::validate_attestation_occurrence] calls.
     #[derive(Clone, Debug)]
     pub struct ValidateAttestationOccurrence(
         RequestBuilder<crate::model::ValidateAttestationOccurrenceRequest>,

--- a/src/generated/cloud/certificatemanager/v1/src/builder.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::list_certificates call.
+    /// The request builder for [CertificateManager::list_certificates][super::super::client::CertificateManager::list_certificates] calls.
     #[derive(Clone, Debug)]
     pub struct ListCertificates(RequestBuilder<crate::model::ListCertificatesRequest>);
 
@@ -151,7 +151,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::get_certificate call.
+    /// The request builder for [CertificateManager::get_certificate][super::super::client::CertificateManager::get_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificate(RequestBuilder<crate::model::GetCertificateRequest>);
 
@@ -193,7 +193,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::create_certificate call.
+    /// The request builder for [CertificateManager::create_certificate][super::super::client::CertificateManager::create_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCertificate(RequestBuilder<crate::model::CreateCertificateRequest>);
 
@@ -291,7 +291,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::update_certificate call.
+    /// The request builder for [CertificateManager::update_certificate][super::super::client::CertificateManager::update_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCertificate(RequestBuilder<crate::model::UpdateCertificateRequest>);
 
@@ -386,7 +386,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::delete_certificate call.
+    /// The request builder for [CertificateManager::delete_certificate][super::super::client::CertificateManager::delete_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCertificate(RequestBuilder<crate::model::DeleteCertificateRequest>);
 
@@ -466,7 +466,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::list_certificate_maps call.
+    /// The request builder for [CertificateManager::list_certificate_maps][super::super::client::CertificateManager::list_certificate_maps] calls.
     #[derive(Clone, Debug)]
     pub struct ListCertificateMaps(RequestBuilder<crate::model::ListCertificateMapsRequest>);
 
@@ -550,7 +550,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::get_certificate_map call.
+    /// The request builder for [CertificateManager::get_certificate_map][super::super::client::CertificateManager::get_certificate_map] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificateMap(RequestBuilder<crate::model::GetCertificateMapRequest>);
 
@@ -595,7 +595,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::create_certificate_map call.
+    /// The request builder for [CertificateManager::create_certificate_map][super::super::client::CertificateManager::create_certificate_map] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCertificateMap(RequestBuilder<crate::model::CreateCertificateMapRequest>);
 
@@ -694,7 +694,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::update_certificate_map call.
+    /// The request builder for [CertificateManager::update_certificate_map][super::super::client::CertificateManager::update_certificate_map] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateMap(RequestBuilder<crate::model::UpdateCertificateMapRequest>);
 
@@ -790,7 +790,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::delete_certificate_map call.
+    /// The request builder for [CertificateManager::delete_certificate_map][super::super::client::CertificateManager::delete_certificate_map] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateMap(RequestBuilder<crate::model::DeleteCertificateMapRequest>);
 
@@ -870,7 +870,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::list_certificate_map_entries call.
+    /// The request builder for [CertificateManager::list_certificate_map_entries][super::super::client::CertificateManager::list_certificate_map_entries] calls.
     #[derive(Clone, Debug)]
     pub struct ListCertificateMapEntries(
         RequestBuilder<crate::model::ListCertificateMapEntriesRequest>,
@@ -958,7 +958,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::get_certificate_map_entry call.
+    /// The request builder for [CertificateManager::get_certificate_map_entry][super::super::client::CertificateManager::get_certificate_map_entry] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificateMapEntry(RequestBuilder<crate::model::GetCertificateMapEntryRequest>);
 
@@ -1003,7 +1003,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::create_certificate_map_entry call.
+    /// The request builder for [CertificateManager::create_certificate_map_entry][super::super::client::CertificateManager::create_certificate_map_entry] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCertificateMapEntry(
         RequestBuilder<crate::model::CreateCertificateMapEntryRequest>,
@@ -1106,7 +1106,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::update_certificate_map_entry call.
+    /// The request builder for [CertificateManager::update_certificate_map_entry][super::super::client::CertificateManager::update_certificate_map_entry] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateMapEntry(
         RequestBuilder<crate::model::UpdateCertificateMapEntryRequest>,
@@ -1206,7 +1206,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::delete_certificate_map_entry call.
+    /// The request builder for [CertificateManager::delete_certificate_map_entry][super::super::client::CertificateManager::delete_certificate_map_entry] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateMapEntry(
         RequestBuilder<crate::model::DeleteCertificateMapEntryRequest>,
@@ -1288,7 +1288,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::list_dns_authorizations call.
+    /// The request builder for [CertificateManager::list_dns_authorizations][super::super::client::CertificateManager::list_dns_authorizations] calls.
     #[derive(Clone, Debug)]
     pub struct ListDnsAuthorizations(RequestBuilder<crate::model::ListDnsAuthorizationsRequest>);
 
@@ -1372,7 +1372,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::get_dns_authorization call.
+    /// The request builder for [CertificateManager::get_dns_authorization][super::super::client::CertificateManager::get_dns_authorization] calls.
     #[derive(Clone, Debug)]
     pub struct GetDnsAuthorization(RequestBuilder<crate::model::GetDnsAuthorizationRequest>);
 
@@ -1417,7 +1417,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::create_dns_authorization call.
+    /// The request builder for [CertificateManager::create_dns_authorization][super::super::client::CertificateManager::create_dns_authorization] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDnsAuthorization(RequestBuilder<crate::model::CreateDnsAuthorizationRequest>);
 
@@ -1518,7 +1518,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::update_dns_authorization call.
+    /// The request builder for [CertificateManager::update_dns_authorization][super::super::client::CertificateManager::update_dns_authorization] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDnsAuthorization(RequestBuilder<crate::model::UpdateDnsAuthorizationRequest>);
 
@@ -1616,7 +1616,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::delete_dns_authorization call.
+    /// The request builder for [CertificateManager::delete_dns_authorization][super::super::client::CertificateManager::delete_dns_authorization] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDnsAuthorization(RequestBuilder<crate::model::DeleteDnsAuthorizationRequest>);
 
@@ -1696,7 +1696,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::list_certificate_issuance_configs call.
+    /// The request builder for [CertificateManager::list_certificate_issuance_configs][super::super::client::CertificateManager::list_certificate_issuance_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListCertificateIssuanceConfigs(
         RequestBuilder<crate::model::ListCertificateIssuanceConfigsRequest>,
@@ -1784,7 +1784,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::get_certificate_issuance_config call.
+    /// The request builder for [CertificateManager::get_certificate_issuance_config][super::super::client::CertificateManager::get_certificate_issuance_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificateIssuanceConfig(
         RequestBuilder<crate::model::GetCertificateIssuanceConfigRequest>,
@@ -1831,7 +1831,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::create_certificate_issuance_config call.
+    /// The request builder for [CertificateManager::create_certificate_issuance_config][super::super::client::CertificateManager::create_certificate_issuance_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCertificateIssuanceConfig(
         RequestBuilder<crate::model::CreateCertificateIssuanceConfigRequest>,
@@ -1939,7 +1939,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::delete_certificate_issuance_config call.
+    /// The request builder for [CertificateManager::delete_certificate_issuance_config][super::super::client::CertificateManager::delete_certificate_issuance_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateIssuanceConfig(
         RequestBuilder<crate::model::DeleteCertificateIssuanceConfigRequest>,
@@ -2021,7 +2021,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::list_trust_configs call.
+    /// The request builder for [CertificateManager::list_trust_configs][super::super::client::CertificateManager::list_trust_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListTrustConfigs(RequestBuilder<crate::model::ListTrustConfigsRequest>);
 
@@ -2105,7 +2105,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::get_trust_config call.
+    /// The request builder for [CertificateManager::get_trust_config][super::super::client::CertificateManager::get_trust_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetTrustConfig(RequestBuilder<crate::model::GetTrustConfigRequest>);
 
@@ -2147,7 +2147,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::create_trust_config call.
+    /// The request builder for [CertificateManager::create_trust_config][super::super::client::CertificateManager::create_trust_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTrustConfig(RequestBuilder<crate::model::CreateTrustConfigRequest>);
 
@@ -2245,7 +2245,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::update_trust_config call.
+    /// The request builder for [CertificateManager::update_trust_config][super::super::client::CertificateManager::update_trust_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTrustConfig(RequestBuilder<crate::model::UpdateTrustConfigRequest>);
 
@@ -2340,7 +2340,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::delete_trust_config call.
+    /// The request builder for [CertificateManager::delete_trust_config][super::super::client::CertificateManager::delete_trust_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTrustConfig(RequestBuilder<crate::model::DeleteTrustConfigRequest>);
 
@@ -2426,7 +2426,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::list_locations call.
+    /// The request builder for [CertificateManager::list_locations][super::super::client::CertificateManager::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2504,7 +2504,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::get_location call.
+    /// The request builder for [CertificateManager::get_location][super::super::client::CertificateManager::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2546,7 +2546,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::list_operations call.
+    /// The request builder for [CertificateManager::list_operations][super::super::client::CertificateManager::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2624,7 +2624,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::get_operation call.
+    /// The request builder for [CertificateManager::get_operation][super::super::client::CertificateManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2669,7 +2669,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::delete_operation call.
+    /// The request builder for [CertificateManager::delete_operation][super::super::client::CertificateManager::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2714,7 +2714,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for a CertificateManager::cancel_operation call.
+    /// The request builder for [CertificateManager::cancel_operation][super::super::client::CertificateManager::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/builder.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerCore::get_workload call.
+    /// The request builder for [CloudControlsPartnerCore::get_workload][super::super::client::CloudControlsPartnerCore::get_workload] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkload(RequestBuilder<crate::model::GetWorkloadRequest>);
 
@@ -113,7 +113,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerCore::list_workloads call.
+    /// The request builder for [CloudControlsPartnerCore::list_workloads][super::super::client::CloudControlsPartnerCore::list_workloads] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkloads(RequestBuilder<crate::model::ListWorkloadsRequest>);
 
@@ -196,7 +196,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerCore::get_customer call.
+    /// The request builder for [CloudControlsPartnerCore::get_customer][super::super::client::CloudControlsPartnerCore::get_customer] calls.
     #[derive(Clone, Debug)]
     pub struct GetCustomer(RequestBuilder<crate::model::GetCustomerRequest>);
 
@@ -240,7 +240,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerCore::list_customers call.
+    /// The request builder for [CloudControlsPartnerCore::list_customers][super::super::client::CloudControlsPartnerCore::list_customers] calls.
     #[derive(Clone, Debug)]
     pub struct ListCustomers(RequestBuilder<crate::model::ListCustomersRequest>);
 
@@ -323,7 +323,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerCore::get_ekm_connections call.
+    /// The request builder for [CloudControlsPartnerCore::get_ekm_connections][super::super::client::CloudControlsPartnerCore::get_ekm_connections] calls.
     #[derive(Clone, Debug)]
     pub struct GetEkmConnections(RequestBuilder<crate::model::GetEkmConnectionsRequest>);
 
@@ -370,7 +370,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerCore::get_partner_permissions call.
+    /// The request builder for [CloudControlsPartnerCore::get_partner_permissions][super::super::client::CloudControlsPartnerCore::get_partner_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct GetPartnerPermissions(RequestBuilder<crate::model::GetPartnerPermissionsRequest>);
 
@@ -417,7 +417,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerCore::list_access_approval_requests call.
+    /// The request builder for [CloudControlsPartnerCore::list_access_approval_requests][super::super::client::CloudControlsPartnerCore::list_access_approval_requests] calls.
     #[derive(Clone, Debug)]
     pub struct ListAccessApprovalRequests(
         RequestBuilder<crate::model::ListAccessApprovalRequestsRequest>,
@@ -507,7 +507,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerCore::get_partner call.
+    /// The request builder for [CloudControlsPartnerCore::get_partner][super::super::client::CloudControlsPartnerCore::get_partner] calls.
     #[derive(Clone, Debug)]
     pub struct GetPartner(RequestBuilder<crate::model::GetPartnerRequest>);
 
@@ -607,7 +607,7 @@ pub mod cloud_controls_partner_monitoring {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerMonitoring::list_violations call.
+    /// The request builder for [CloudControlsPartnerMonitoring::list_violations][super::super::client::CloudControlsPartnerMonitoring::list_violations] calls.
     #[derive(Clone, Debug)]
     pub struct ListViolations(RequestBuilder<crate::model::ListViolationsRequest>);
 
@@ -699,7 +699,7 @@ pub mod cloud_controls_partner_monitoring {
         }
     }
 
-    /// The request builder for a CloudControlsPartnerMonitoring::get_violation call.
+    /// The request builder for [CloudControlsPartnerMonitoring::get_violation][super::super::client::CloudControlsPartnerMonitoring::get_violation] calls.
     #[derive(Clone, Debug)]
     pub struct GetViolation(RequestBuilder<crate::model::GetViolationRequest>);
 

--- a/src/generated/cloud/clouddms/v1/src/builder.rs
+++ b/src/generated/cloud/clouddms/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::list_migration_jobs call.
+    /// The request builder for [DataMigrationService::list_migration_jobs][super::super::client::DataMigrationService::list_migration_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListMigrationJobs(RequestBuilder<crate::model::ListMigrationJobsRequest>);
 
@@ -155,7 +155,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::get_migration_job call.
+    /// The request builder for [DataMigrationService::get_migration_job][super::super::client::DataMigrationService::get_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetMigrationJob(RequestBuilder<crate::model::GetMigrationJobRequest>);
 
@@ -199,7 +199,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::create_migration_job call.
+    /// The request builder for [DataMigrationService::create_migration_job][super::super::client::DataMigrationService::create_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMigrationJob(RequestBuilder<crate::model::CreateMigrationJobRequest>);
 
@@ -305,7 +305,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::update_migration_job call.
+    /// The request builder for [DataMigrationService::update_migration_job][super::super::client::DataMigrationService::update_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMigrationJob(RequestBuilder<crate::model::UpdateMigrationJobRequest>);
 
@@ -408,7 +408,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::delete_migration_job call.
+    /// The request builder for [DataMigrationService::delete_migration_job][super::super::client::DataMigrationService::delete_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMigrationJob(RequestBuilder<crate::model::DeleteMigrationJobRequest>);
 
@@ -502,7 +502,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::start_migration_job call.
+    /// The request builder for [DataMigrationService::start_migration_job][super::super::client::DataMigrationService::start_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct StartMigrationJob(RequestBuilder<crate::model::StartMigrationJobRequest>);
 
@@ -593,7 +593,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::stop_migration_job call.
+    /// The request builder for [DataMigrationService::stop_migration_job][super::super::client::DataMigrationService::stop_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct StopMigrationJob(RequestBuilder<crate::model::StopMigrationJobRequest>);
 
@@ -678,7 +678,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::resume_migration_job call.
+    /// The request builder for [DataMigrationService::resume_migration_job][super::super::client::DataMigrationService::resume_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeMigrationJob(RequestBuilder<crate::model::ResumeMigrationJobRequest>);
 
@@ -763,7 +763,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::promote_migration_job call.
+    /// The request builder for [DataMigrationService::promote_migration_job][super::super::client::DataMigrationService::promote_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct PromoteMigrationJob(RequestBuilder<crate::model::PromoteMigrationJobRequest>);
 
@@ -848,7 +848,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::verify_migration_job call.
+    /// The request builder for [DataMigrationService::verify_migration_job][super::super::client::DataMigrationService::verify_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct VerifyMigrationJob(RequestBuilder<crate::model::VerifyMigrationJobRequest>);
 
@@ -951,7 +951,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::restart_migration_job call.
+    /// The request builder for [DataMigrationService::restart_migration_job][super::super::client::DataMigrationService::restart_migration_job] calls.
     #[derive(Clone, Debug)]
     pub struct RestartMigrationJob(RequestBuilder<crate::model::RestartMigrationJobRequest>);
 
@@ -1042,7 +1042,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::generate_ssh_script call.
+    /// The request builder for [DataMigrationService::generate_ssh_script][super::super::client::DataMigrationService::generate_ssh_script] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateSshScript(RequestBuilder<crate::model::GenerateSshScriptRequest>);
 
@@ -1112,7 +1112,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::generate_tcp_proxy_script call.
+    /// The request builder for [DataMigrationService::generate_tcp_proxy_script][super::super::client::DataMigrationService::generate_tcp_proxy_script] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateTcpProxyScript(RequestBuilder<crate::model::GenerateTcpProxyScriptRequest>);
 
@@ -1183,7 +1183,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::list_connection_profiles call.
+    /// The request builder for [DataMigrationService::list_connection_profiles][super::super::client::DataMigrationService::list_connection_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnectionProfiles(RequestBuilder<crate::model::ListConnectionProfilesRequest>);
 
@@ -1271,7 +1271,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::get_connection_profile call.
+    /// The request builder for [DataMigrationService::get_connection_profile][super::super::client::DataMigrationService::get_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnectionProfile(RequestBuilder<crate::model::GetConnectionProfileRequest>);
 
@@ -1318,7 +1318,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::create_connection_profile call.
+    /// The request builder for [DataMigrationService::create_connection_profile][super::super::client::DataMigrationService::create_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnectionProfile(
         RequestBuilder<crate::model::CreateConnectionProfileRequest>,
@@ -1441,7 +1441,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::update_connection_profile call.
+    /// The request builder for [DataMigrationService::update_connection_profile][super::super::client::DataMigrationService::update_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConnectionProfile(
         RequestBuilder<crate::model::UpdateConnectionProfileRequest>,
@@ -1561,7 +1561,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::delete_connection_profile call.
+    /// The request builder for [DataMigrationService::delete_connection_profile][super::super::client::DataMigrationService::delete_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnectionProfile(
         RequestBuilder<crate::model::DeleteConnectionProfileRequest>,
@@ -1657,7 +1657,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::create_private_connection call.
+    /// The request builder for [DataMigrationService::create_private_connection][super::super::client::DataMigrationService::create_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePrivateConnection(
         RequestBuilder<crate::model::CreatePrivateConnectionRequest>,
@@ -1774,7 +1774,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::get_private_connection call.
+    /// The request builder for [DataMigrationService::get_private_connection][super::super::client::DataMigrationService::get_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetPrivateConnection(RequestBuilder<crate::model::GetPrivateConnectionRequest>);
 
@@ -1821,7 +1821,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::list_private_connections call.
+    /// The request builder for [DataMigrationService::list_private_connections][super::super::client::DataMigrationService::list_private_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListPrivateConnections(RequestBuilder<crate::model::ListPrivateConnectionsRequest>);
 
@@ -1909,7 +1909,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::delete_private_connection call.
+    /// The request builder for [DataMigrationService::delete_private_connection][super::super::client::DataMigrationService::delete_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePrivateConnection(
         RequestBuilder<crate::model::DeletePrivateConnectionRequest>,
@@ -1999,7 +1999,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::get_conversion_workspace call.
+    /// The request builder for [DataMigrationService::get_conversion_workspace][super::super::client::DataMigrationService::get_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct GetConversionWorkspace(RequestBuilder<crate::model::GetConversionWorkspaceRequest>);
 
@@ -2046,7 +2046,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::list_conversion_workspaces call.
+    /// The request builder for [DataMigrationService::list_conversion_workspaces][super::super::client::DataMigrationService::list_conversion_workspaces] calls.
     #[derive(Clone, Debug)]
     pub struct ListConversionWorkspaces(
         RequestBuilder<crate::model::ListConversionWorkspacesRequest>,
@@ -2130,7 +2130,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::create_conversion_workspace call.
+    /// The request builder for [DataMigrationService::create_conversion_workspace][super::super::client::DataMigrationService::create_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConversionWorkspace(
         RequestBuilder<crate::model::CreateConversionWorkspaceRequest>,
@@ -2241,7 +2241,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::update_conversion_workspace call.
+    /// The request builder for [DataMigrationService::update_conversion_workspace][super::super::client::DataMigrationService::update_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConversionWorkspace(
         RequestBuilder<crate::model::UpdateConversionWorkspaceRequest>,
@@ -2349,7 +2349,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::delete_conversion_workspace call.
+    /// The request builder for [DataMigrationService::delete_conversion_workspace][super::super::client::DataMigrationService::delete_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConversionWorkspace(
         RequestBuilder<crate::model::DeleteConversionWorkspaceRequest>,
@@ -2445,7 +2445,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::create_mapping_rule call.
+    /// The request builder for [DataMigrationService::create_mapping_rule][super::super::client::DataMigrationService::create_mapping_rule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMappingRule(RequestBuilder<crate::model::CreateMappingRuleRequest>);
 
@@ -2513,7 +2513,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::delete_mapping_rule call.
+    /// The request builder for [DataMigrationService::delete_mapping_rule][super::super::client::DataMigrationService::delete_mapping_rule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMappingRule(RequestBuilder<crate::model::DeleteMappingRuleRequest>);
 
@@ -2566,7 +2566,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::list_mapping_rules call.
+    /// The request builder for [DataMigrationService::list_mapping_rules][super::super::client::DataMigrationService::list_mapping_rules] calls.
     #[derive(Clone, Debug)]
     pub struct ListMappingRules(RequestBuilder<crate::model::ListMappingRulesRequest>);
 
@@ -2640,7 +2640,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::get_mapping_rule call.
+    /// The request builder for [DataMigrationService::get_mapping_rule][super::super::client::DataMigrationService::get_mapping_rule] calls.
     #[derive(Clone, Debug)]
     pub struct GetMappingRule(RequestBuilder<crate::model::GetMappingRuleRequest>);
 
@@ -2684,7 +2684,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::seed_conversion_workspace call.
+    /// The request builder for [DataMigrationService::seed_conversion_workspace][super::super::client::DataMigrationService::seed_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct SeedConversionWorkspace(
         RequestBuilder<crate::model::SeedConversionWorkspaceRequest>,
@@ -2789,7 +2789,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::import_mapping_rules call.
+    /// The request builder for [DataMigrationService::import_mapping_rules][super::super::client::DataMigrationService::import_mapping_rules] calls.
     #[derive(Clone, Debug)]
     pub struct ImportMappingRules(RequestBuilder<crate::model::ImportMappingRulesRequest>);
 
@@ -2901,7 +2901,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::convert_conversion_workspace call.
+    /// The request builder for [DataMigrationService::convert_conversion_workspace][super::super::client::DataMigrationService::convert_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct ConvertConversionWorkspace(
         RequestBuilder<crate::model::ConvertConversionWorkspaceRequest>,
@@ -3007,7 +3007,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::commit_conversion_workspace call.
+    /// The request builder for [DataMigrationService::commit_conversion_workspace][super::super::client::DataMigrationService::commit_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct CommitConversionWorkspace(
         RequestBuilder<crate::model::CommitConversionWorkspaceRequest>,
@@ -3101,7 +3101,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::rollback_conversion_workspace call.
+    /// The request builder for [DataMigrationService::rollback_conversion_workspace][super::super::client::DataMigrationService::rollback_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct RollbackConversionWorkspace(
         RequestBuilder<crate::model::RollbackConversionWorkspaceRequest>,
@@ -3189,7 +3189,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::apply_conversion_workspace call.
+    /// The request builder for [DataMigrationService::apply_conversion_workspace][super::super::client::DataMigrationService::apply_conversion_workspace] calls.
     #[derive(Clone, Debug)]
     pub struct ApplyConversionWorkspace(
         RequestBuilder<crate::model::ApplyConversionWorkspaceRequest>,
@@ -3306,7 +3306,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::describe_database_entities call.
+    /// The request builder for [DataMigrationService::describe_database_entities][super::super::client::DataMigrationService::describe_database_entities] calls.
     #[derive(Clone, Debug)]
     pub struct DescribeDatabaseEntities(
         RequestBuilder<crate::model::DescribeDatabaseEntitiesRequest>,
@@ -3417,7 +3417,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::search_background_jobs call.
+    /// The request builder for [DataMigrationService::search_background_jobs][super::super::client::DataMigrationService::search_background_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct SearchBackgroundJobs(RequestBuilder<crate::model::SearchBackgroundJobsRequest>);
 
@@ -3485,7 +3485,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::describe_conversion_workspace_revisions call.
+    /// The request builder for [DataMigrationService::describe_conversion_workspace_revisions][super::super::client::DataMigrationService::describe_conversion_workspace_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct DescribeConversionWorkspaceRevisions(
         RequestBuilder<crate::model::DescribeConversionWorkspaceRevisionsRequest>,
@@ -3542,7 +3542,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::fetch_static_ips call.
+    /// The request builder for [DataMigrationService::fetch_static_ips][super::super::client::DataMigrationService::fetch_static_ips] calls.
     #[derive(Clone, Debug)]
     pub struct FetchStaticIps(RequestBuilder<crate::model::FetchStaticIpsRequest>);
 
@@ -3598,7 +3598,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::list_locations call.
+    /// The request builder for [DataMigrationService::list_locations][super::super::client::DataMigrationService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3678,7 +3678,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::get_location call.
+    /// The request builder for [DataMigrationService::get_location][super::super::client::DataMigrationService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3722,7 +3722,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::set_iam_policy call.
+    /// The request builder for [DataMigrationService::set_iam_policy][super::super::client::DataMigrationService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3784,7 +3784,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::get_iam_policy call.
+    /// The request builder for [DataMigrationService::get_iam_policy][super::super::client::DataMigrationService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3837,7 +3837,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::test_iam_permissions call.
+    /// The request builder for [DataMigrationService::test_iam_permissions][super::super::client::DataMigrationService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3895,7 +3895,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::list_operations call.
+    /// The request builder for [DataMigrationService::list_operations][super::super::client::DataMigrationService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3975,7 +3975,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::get_operation call.
+    /// The request builder for [DataMigrationService::get_operation][super::super::client::DataMigrationService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4022,7 +4022,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::delete_operation call.
+    /// The request builder for [DataMigrationService::delete_operation][super::super::client::DataMigrationService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4069,7 +4069,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for a DataMigrationService::cancel_operation call.
+    /// The request builder for [DataMigrationService::cancel_operation][super::super::client::DataMigrationService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for a LicenseManagementService::get_license_pool call.
+    /// The request builder for [LicenseManagementService::get_license_pool][super::super::client::LicenseManagementService::get_license_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetLicensePool(RequestBuilder<crate::model::GetLicensePoolRequest>);
 
@@ -113,7 +113,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for a LicenseManagementService::update_license_pool call.
+    /// The request builder for [LicenseManagementService::update_license_pool][super::super::client::LicenseManagementService::update_license_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateLicensePool(RequestBuilder<crate::model::UpdateLicensePoolRequest>);
 
@@ -172,7 +172,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for a LicenseManagementService::assign call.
+    /// The request builder for [LicenseManagementService::assign][super::super::client::LicenseManagementService::assign] calls.
     #[derive(Clone, Debug)]
     pub struct Assign(RequestBuilder<crate::model::AssignRequest>);
 
@@ -225,7 +225,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for a LicenseManagementService::unassign call.
+    /// The request builder for [LicenseManagementService::unassign][super::super::client::LicenseManagementService::unassign] calls.
     #[derive(Clone, Debug)]
     pub struct Unassign(RequestBuilder<crate::model::UnassignRequest>);
 
@@ -280,7 +280,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for a LicenseManagementService::enumerate_licensed_users call.
+    /// The request builder for [LicenseManagementService::enumerate_licensed_users][super::super::client::LicenseManagementService::enumerate_licensed_users] calls.
     #[derive(Clone, Debug)]
     pub struct EnumerateLicensedUsers(RequestBuilder<crate::model::EnumerateLicensedUsersRequest>);
 
@@ -356,7 +356,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for a LicenseManagementService::get_operation call.
+    /// The request builder for [LicenseManagementService::get_operation][super::super::client::LicenseManagementService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -459,7 +459,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for a ConsumerProcurementService::place_order call.
+    /// The request builder for [ConsumerProcurementService::place_order][super::super::client::ConsumerProcurementService::place_order] calls.
     #[derive(Clone, Debug)]
     pub struct PlaceOrder(RequestBuilder<crate::model::PlaceOrderRequest>);
 
@@ -563,7 +563,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for a ConsumerProcurementService::get_order call.
+    /// The request builder for [ConsumerProcurementService::get_order][super::super::client::ConsumerProcurementService::get_order] calls.
     #[derive(Clone, Debug)]
     pub struct GetOrder(RequestBuilder<crate::model::GetOrderRequest>);
 
@@ -607,7 +607,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for a ConsumerProcurementService::list_orders call.
+    /// The request builder for [ConsumerProcurementService::list_orders][super::super::client::ConsumerProcurementService::list_orders] calls.
     #[derive(Clone, Debug)]
     pub struct ListOrders(RequestBuilder<crate::model::ListOrdersRequest>);
 
@@ -684,7 +684,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for a ConsumerProcurementService::modify_order call.
+    /// The request builder for [ConsumerProcurementService::modify_order][super::super::client::ConsumerProcurementService::modify_order] calls.
     #[derive(Clone, Debug)]
     pub struct ModifyOrder(RequestBuilder<crate::model::ModifyOrderRequest>);
 
@@ -788,7 +788,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for a ConsumerProcurementService::cancel_order call.
+    /// The request builder for [ConsumerProcurementService::cancel_order][super::super::client::ConsumerProcurementService::cancel_order] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOrder(RequestBuilder<crate::model::CancelOrderRequest>);
 
@@ -886,7 +886,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for a ConsumerProcurementService::get_operation call.
+    /// The request builder for [ConsumerProcurementService::get_operation][super::super::client::ConsumerProcurementService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// The request builder for a ConfidentialComputing::create_challenge call.
+    /// The request builder for [ConfidentialComputing::create_challenge][super::super::client::ConfidentialComputing::create_challenge] calls.
     #[derive(Clone, Debug)]
     pub struct CreateChallenge(RequestBuilder<crate::model::CreateChallengeRequest>);
 
@@ -122,7 +122,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// The request builder for a ConfidentialComputing::verify_attestation call.
+    /// The request builder for [ConfidentialComputing::verify_attestation][super::super::client::ConfidentialComputing::verify_attestation] calls.
     #[derive(Clone, Debug)]
     pub struct VerifyAttestation(RequestBuilder<crate::model::VerifyAttestationRequest>);
 
@@ -224,7 +224,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// The request builder for a ConfidentialComputing::list_locations call.
+    /// The request builder for [ConfidentialComputing::list_locations][super::super::client::ConfidentialComputing::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -304,7 +304,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// The request builder for a ConfidentialComputing::get_location call.
+    /// The request builder for [ConfidentialComputing::get_location][super::super::client::ConfidentialComputing::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/config/v1/src/builder.rs
+++ b/src/generated/cloud/config/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::list_deployments call.
+    /// The request builder for [Config::list_deployments][super::super::client::Config::list_deployments] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -148,7 +148,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::get_deployment call.
+    /// The request builder for [Config::get_deployment][super::super::client::Config::get_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -190,7 +190,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::create_deployment call.
+    /// The request builder for [Config::create_deployment][super::super::client::Config::create_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDeployment(RequestBuilder<crate::model::CreateDeploymentRequest>);
 
@@ -294,7 +294,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::update_deployment call.
+    /// The request builder for [Config::update_deployment][super::super::client::Config::update_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDeployment(RequestBuilder<crate::model::UpdateDeploymentRequest>);
 
@@ -395,7 +395,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::delete_deployment call.
+    /// The request builder for [Config::delete_deployment][super::super::client::Config::delete_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDeployment(RequestBuilder<crate::model::DeleteDeploymentRequest>);
 
@@ -499,7 +499,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::list_revisions call.
+    /// The request builder for [Config::list_revisions][super::super::client::Config::list_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct ListRevisions(RequestBuilder<crate::model::ListRevisionsRequest>);
 
@@ -580,7 +580,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::get_revision call.
+    /// The request builder for [Config::get_revision][super::super::client::Config::get_revision] calls.
     #[derive(Clone, Debug)]
     pub struct GetRevision(RequestBuilder<crate::model::GetRevisionRequest>);
 
@@ -622,7 +622,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::get_resource call.
+    /// The request builder for [Config::get_resource][super::super::client::Config::get_resource] calls.
     #[derive(Clone, Debug)]
     pub struct GetResource(RequestBuilder<crate::model::GetResourceRequest>);
 
@@ -664,7 +664,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::list_resources call.
+    /// The request builder for [Config::list_resources][super::super::client::Config::list_resources] calls.
     #[derive(Clone, Debug)]
     pub struct ListResources(RequestBuilder<crate::model::ListResourcesRequest>);
 
@@ -745,7 +745,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::export_deployment_statefile call.
+    /// The request builder for [Config::export_deployment_statefile][super::super::client::Config::export_deployment_statefile] calls.
     #[derive(Clone, Debug)]
     pub struct ExportDeploymentStatefile(
         RequestBuilder<crate::model::ExportDeploymentStatefileRequest>,
@@ -798,7 +798,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::export_revision_statefile call.
+    /// The request builder for [Config::export_revision_statefile][super::super::client::Config::export_revision_statefile] calls.
     #[derive(Clone, Debug)]
     pub struct ExportRevisionStatefile(
         RequestBuilder<crate::model::ExportRevisionStatefileRequest>,
@@ -845,7 +845,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::import_statefile call.
+    /// The request builder for [Config::import_statefile][super::super::client::Config::import_statefile] calls.
     #[derive(Clone, Debug)]
     pub struct ImportStatefile(RequestBuilder<crate::model::ImportStatefileRequest>);
 
@@ -899,7 +899,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::delete_statefile call.
+    /// The request builder for [Config::delete_statefile][super::super::client::Config::delete_statefile] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteStatefile(RequestBuilder<crate::model::DeleteStatefileRequest>);
 
@@ -947,7 +947,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::lock_deployment call.
+    /// The request builder for [Config::lock_deployment][super::super::client::Config::lock_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct LockDeployment(RequestBuilder<crate::model::LockDeploymentRequest>);
 
@@ -1027,7 +1027,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::unlock_deployment call.
+    /// The request builder for [Config::unlock_deployment][super::super::client::Config::unlock_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct UnlockDeployment(RequestBuilder<crate::model::UnlockDeploymentRequest>);
 
@@ -1116,7 +1116,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::export_lock_info call.
+    /// The request builder for [Config::export_lock_info][super::super::client::Config::export_lock_info] calls.
     #[derive(Clone, Debug)]
     pub struct ExportLockInfo(RequestBuilder<crate::model::ExportLockInfoRequest>);
 
@@ -1158,7 +1158,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::create_preview call.
+    /// The request builder for [Config::create_preview][super::super::client::Config::create_preview] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePreview(RequestBuilder<crate::model::CreatePreviewRequest>);
 
@@ -1258,7 +1258,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::get_preview call.
+    /// The request builder for [Config::get_preview][super::super::client::Config::get_preview] calls.
     #[derive(Clone, Debug)]
     pub struct GetPreview(RequestBuilder<crate::model::GetPreviewRequest>);
 
@@ -1300,7 +1300,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::list_previews call.
+    /// The request builder for [Config::list_previews][super::super::client::Config::list_previews] calls.
     #[derive(Clone, Debug)]
     pub struct ListPreviews(RequestBuilder<crate::model::ListPreviewsRequest>);
 
@@ -1381,7 +1381,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::delete_preview call.
+    /// The request builder for [Config::delete_preview][super::super::client::Config::delete_preview] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePreview(RequestBuilder<crate::model::DeletePreviewRequest>);
 
@@ -1466,7 +1466,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::export_preview_result call.
+    /// The request builder for [Config::export_preview_result][super::super::client::Config::export_preview_result] calls.
     #[derive(Clone, Debug)]
     pub struct ExportPreviewResult(RequestBuilder<crate::model::ExportPreviewResultRequest>);
 
@@ -1511,7 +1511,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::list_terraform_versions call.
+    /// The request builder for [Config::list_terraform_versions][super::super::client::Config::list_terraform_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListTerraformVersions(RequestBuilder<crate::model::ListTerraformVersionsRequest>);
 
@@ -1595,7 +1595,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::get_terraform_version call.
+    /// The request builder for [Config::get_terraform_version][super::super::client::Config::get_terraform_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetTerraformVersion(RequestBuilder<crate::model::GetTerraformVersionRequest>);
 
@@ -1640,7 +1640,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::list_locations call.
+    /// The request builder for [Config::list_locations][super::super::client::Config::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1718,7 +1718,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::get_location call.
+    /// The request builder for [Config::get_location][super::super::client::Config::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1760,7 +1760,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::set_iam_policy call.
+    /// The request builder for [Config::set_iam_policy][super::super::client::Config::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1820,7 +1820,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::get_iam_policy call.
+    /// The request builder for [Config::get_iam_policy][super::super::client::Config::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1871,7 +1871,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::test_iam_permissions call.
+    /// The request builder for [Config::test_iam_permissions][super::super::client::Config::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1927,7 +1927,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::list_operations call.
+    /// The request builder for [Config::list_operations][super::super::client::Config::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2005,7 +2005,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::get_operation call.
+    /// The request builder for [Config::get_operation][super::super::client::Config::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2050,7 +2050,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::delete_operation call.
+    /// The request builder for [Config::delete_operation][super::super::client::Config::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2095,7 +2095,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for a Config::cancel_operation call.
+    /// The request builder for [Config::cancel_operation][super::super::client::Config::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/connectors/v1/src/builder.rs
+++ b/src/generated/cloud/connectors/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::list_connections call.
+    /// The request builder for [Connectors::list_connections][super::super::client::Connectors::list_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -154,7 +154,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_connection call.
+    /// The request builder for [Connectors::get_connection][super::super::client::Connectors::get_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -202,7 +202,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::create_connection call.
+    /// The request builder for [Connectors::create_connection][super::super::client::Connectors::create_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -300,7 +300,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::update_connection call.
+    /// The request builder for [Connectors::update_connection][super::super::client::Connectors::update_connection] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 
@@ -395,7 +395,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::delete_connection call.
+    /// The request builder for [Connectors::delete_connection][super::super::client::Connectors::delete_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -475,7 +475,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::list_providers call.
+    /// The request builder for [Connectors::list_providers][super::super::client::Connectors::list_providers] calls.
     #[derive(Clone, Debug)]
     pub struct ListProviders(RequestBuilder<crate::model::ListProvidersRequest>);
 
@@ -544,7 +544,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_provider call.
+    /// The request builder for [Connectors::get_provider][super::super::client::Connectors::get_provider] calls.
     #[derive(Clone, Debug)]
     pub struct GetProvider(RequestBuilder<crate::model::GetProviderRequest>);
 
@@ -586,7 +586,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::list_connectors call.
+    /// The request builder for [Connectors::list_connectors][super::super::client::Connectors::list_connectors] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnectors(RequestBuilder<crate::model::ListConnectorsRequest>);
 
@@ -655,7 +655,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_connector call.
+    /// The request builder for [Connectors::get_connector][super::super::client::Connectors::get_connector] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnector(RequestBuilder<crate::model::GetConnectorRequest>);
 
@@ -697,7 +697,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::list_connector_versions call.
+    /// The request builder for [Connectors::list_connector_versions][super::super::client::Connectors::list_connector_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnectorVersions(RequestBuilder<crate::model::ListConnectorVersionsRequest>);
 
@@ -775,7 +775,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_connector_version call.
+    /// The request builder for [Connectors::get_connector_version][super::super::client::Connectors::get_connector_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnectorVersion(RequestBuilder<crate::model::GetConnectorVersionRequest>);
 
@@ -826,7 +826,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_connection_schema_metadata call.
+    /// The request builder for [Connectors::get_connection_schema_metadata][super::super::client::Connectors::get_connection_schema_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnectionSchemaMetadata(
         RequestBuilder<crate::model::GetConnectionSchemaMetadataRequest>,
@@ -873,7 +873,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::refresh_connection_schema_metadata call.
+    /// The request builder for [Connectors::refresh_connection_schema_metadata][super::super::client::Connectors::refresh_connection_schema_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct RefreshConnectionSchemaMetadata(
         RequestBuilder<crate::model::RefreshConnectionSchemaMetadataRequest>,
@@ -961,7 +961,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::list_runtime_entity_schemas call.
+    /// The request builder for [Connectors::list_runtime_entity_schemas][super::super::client::Connectors::list_runtime_entity_schemas] calls.
     #[derive(Clone, Debug)]
     pub struct ListRuntimeEntitySchemas(
         RequestBuilder<crate::model::ListRuntimeEntitySchemasRequest>,
@@ -1043,7 +1043,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::list_runtime_action_schemas call.
+    /// The request builder for [Connectors::list_runtime_action_schemas][super::super::client::Connectors::list_runtime_action_schemas] calls.
     #[derive(Clone, Debug)]
     pub struct ListRuntimeActionSchemas(
         RequestBuilder<crate::model::ListRuntimeActionSchemasRequest>,
@@ -1125,7 +1125,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_runtime_config call.
+    /// The request builder for [Connectors::get_runtime_config][super::super::client::Connectors::get_runtime_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetRuntimeConfig(RequestBuilder<crate::model::GetRuntimeConfigRequest>);
 
@@ -1170,7 +1170,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_global_settings call.
+    /// The request builder for [Connectors::get_global_settings][super::super::client::Connectors::get_global_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetGlobalSettings(RequestBuilder<crate::model::GetGlobalSettingsRequest>);
 
@@ -1215,7 +1215,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::list_locations call.
+    /// The request builder for [Connectors::list_locations][super::super::client::Connectors::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1293,7 +1293,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_location call.
+    /// The request builder for [Connectors::get_location][super::super::client::Connectors::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1335,7 +1335,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::set_iam_policy call.
+    /// The request builder for [Connectors::set_iam_policy][super::super::client::Connectors::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1395,7 +1395,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_iam_policy call.
+    /// The request builder for [Connectors::get_iam_policy][super::super::client::Connectors::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1446,7 +1446,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::test_iam_permissions call.
+    /// The request builder for [Connectors::test_iam_permissions][super::super::client::Connectors::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1502,7 +1502,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::list_operations call.
+    /// The request builder for [Connectors::list_operations][super::super::client::Connectors::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1580,7 +1580,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::get_operation call.
+    /// The request builder for [Connectors::get_operation][super::super::client::Connectors::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1625,7 +1625,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::delete_operation call.
+    /// The request builder for [Connectors::delete_operation][super::super::client::Connectors::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1670,7 +1670,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for a Connectors::cancel_operation call.
+    /// The request builder for [Connectors::cancel_operation][super::super::client::Connectors::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_conversation call.
+    /// The request builder for [ContactCenterInsights::create_conversation][super::super::client::ContactCenterInsights::create_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConversation(RequestBuilder<crate::model::CreateConversationRequest>);
 
@@ -131,7 +131,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::upload_conversation call.
+    /// The request builder for [ContactCenterInsights::upload_conversation][super::super::client::ContactCenterInsights::upload_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct UploadConversation(RequestBuilder<crate::model::UploadConversationRequest>);
 
@@ -252,7 +252,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_conversation call.
+    /// The request builder for [ContactCenterInsights::update_conversation][super::super::client::ContactCenterInsights::update_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConversation(RequestBuilder<crate::model::UpdateConversationRequest>);
 
@@ -311,7 +311,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_conversation call.
+    /// The request builder for [ContactCenterInsights::get_conversation][super::super::client::ContactCenterInsights::get_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct GetConversation(RequestBuilder<crate::model::GetConversationRequest>);
 
@@ -361,7 +361,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_conversations call.
+    /// The request builder for [ContactCenterInsights::list_conversations][super::super::client::ContactCenterInsights::list_conversations] calls.
     #[derive(Clone, Debug)]
     pub struct ListConversations(RequestBuilder<crate::model::ListConversationsRequest>);
 
@@ -453,7 +453,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_conversation call.
+    /// The request builder for [ContactCenterInsights::delete_conversation][super::super::client::ContactCenterInsights::delete_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConversation(RequestBuilder<crate::model::DeleteConversationRequest>);
 
@@ -506,7 +506,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_analysis call.
+    /// The request builder for [ContactCenterInsights::create_analysis][super::super::client::ContactCenterInsights::create_analysis] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAnalysis(RequestBuilder<crate::model::CreateAnalysisRequest>);
 
@@ -600,7 +600,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_analysis call.
+    /// The request builder for [ContactCenterInsights::get_analysis][super::super::client::ContactCenterInsights::get_analysis] calls.
     #[derive(Clone, Debug)]
     pub struct GetAnalysis(RequestBuilder<crate::model::GetAnalysisRequest>);
 
@@ -644,7 +644,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_analyses call.
+    /// The request builder for [ContactCenterInsights::list_analyses][super::super::client::ContactCenterInsights::list_analyses] calls.
     #[derive(Clone, Debug)]
     pub struct ListAnalyses(RequestBuilder<crate::model::ListAnalysesRequest>);
 
@@ -721,7 +721,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_analysis call.
+    /// The request builder for [ContactCenterInsights::delete_analysis][super::super::client::ContactCenterInsights::delete_analysis] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAnalysis(RequestBuilder<crate::model::DeleteAnalysisRequest>);
 
@@ -765,7 +765,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::bulk_analyze_conversations call.
+    /// The request builder for [ContactCenterInsights::bulk_analyze_conversations][super::super::client::ContactCenterInsights::bulk_analyze_conversations] calls.
     #[derive(Clone, Debug)]
     pub struct BulkAnalyzeConversations(
         RequestBuilder<crate::model::BulkAnalyzeConversationsRequest>,
@@ -880,7 +880,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::bulk_delete_conversations call.
+    /// The request builder for [ContactCenterInsights::bulk_delete_conversations][super::super::client::ContactCenterInsights::bulk_delete_conversations] calls.
     #[derive(Clone, Debug)]
     pub struct BulkDeleteConversations(
         RequestBuilder<crate::model::BulkDeleteConversationsRequest>,
@@ -990,7 +990,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::ingest_conversations call.
+    /// The request builder for [ContactCenterInsights::ingest_conversations][super::super::client::ContactCenterInsights::ingest_conversations] calls.
     #[derive(Clone, Debug)]
     pub struct IngestConversations(RequestBuilder<crate::model::IngestConversationsRequest>);
 
@@ -1137,7 +1137,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::export_insights_data call.
+    /// The request builder for [ContactCenterInsights::export_insights_data][super::super::client::ContactCenterInsights::export_insights_data] calls.
     #[derive(Clone, Debug)]
     pub struct ExportInsightsData(RequestBuilder<crate::model::ExportInsightsDataRequest>);
 
@@ -1261,7 +1261,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_issue_model call.
+    /// The request builder for [ContactCenterInsights::create_issue_model][super::super::client::ContactCenterInsights::create_issue_model] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIssueModel(RequestBuilder<crate::model::CreateIssueModelRequest>);
 
@@ -1356,7 +1356,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_issue_model call.
+    /// The request builder for [ContactCenterInsights::update_issue_model][super::super::client::ContactCenterInsights::update_issue_model] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateIssueModel(RequestBuilder<crate::model::UpdateIssueModelRequest>);
 
@@ -1415,7 +1415,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_issue_model call.
+    /// The request builder for [ContactCenterInsights::get_issue_model][super::super::client::ContactCenterInsights::get_issue_model] calls.
     #[derive(Clone, Debug)]
     pub struct GetIssueModel(RequestBuilder<crate::model::GetIssueModelRequest>);
 
@@ -1459,7 +1459,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_issue_models call.
+    /// The request builder for [ContactCenterInsights::list_issue_models][super::super::client::ContactCenterInsights::list_issue_models] calls.
     #[derive(Clone, Debug)]
     pub struct ListIssueModels(RequestBuilder<crate::model::ListIssueModelsRequest>);
 
@@ -1503,7 +1503,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_issue_model call.
+    /// The request builder for [ContactCenterInsights::delete_issue_model][super::super::client::ContactCenterInsights::delete_issue_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIssueModel(RequestBuilder<crate::model::DeleteIssueModelRequest>);
 
@@ -1587,7 +1587,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::deploy_issue_model call.
+    /// The request builder for [ContactCenterInsights::deploy_issue_model][super::super::client::ContactCenterInsights::deploy_issue_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeployIssueModel(RequestBuilder<crate::model::DeployIssueModelRequest>);
 
@@ -1677,7 +1677,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::undeploy_issue_model call.
+    /// The request builder for [ContactCenterInsights::undeploy_issue_model][super::super::client::ContactCenterInsights::undeploy_issue_model] calls.
     #[derive(Clone, Debug)]
     pub struct UndeployIssueModel(RequestBuilder<crate::model::UndeployIssueModelRequest>);
 
@@ -1767,7 +1767,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::export_issue_model call.
+    /// The request builder for [ContactCenterInsights::export_issue_model][super::super::client::ContactCenterInsights::export_issue_model] calls.
     #[derive(Clone, Debug)]
     pub struct ExportIssueModel(RequestBuilder<crate::model::ExportIssueModelRequest>);
 
@@ -1868,7 +1868,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::import_issue_model call.
+    /// The request builder for [ContactCenterInsights::import_issue_model][super::super::client::ContactCenterInsights::import_issue_model] calls.
     #[derive(Clone, Debug)]
     pub struct ImportIssueModel(RequestBuilder<crate::model::ImportIssueModelRequest>);
 
@@ -1973,7 +1973,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_issue call.
+    /// The request builder for [ContactCenterInsights::get_issue][super::super::client::ContactCenterInsights::get_issue] calls.
     #[derive(Clone, Debug)]
     pub struct GetIssue(RequestBuilder<crate::model::GetIssueRequest>);
 
@@ -2017,7 +2017,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_issues call.
+    /// The request builder for [ContactCenterInsights::list_issues][super::super::client::ContactCenterInsights::list_issues] calls.
     #[derive(Clone, Debug)]
     pub struct ListIssues(RequestBuilder<crate::model::ListIssuesRequest>);
 
@@ -2061,7 +2061,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_issue call.
+    /// The request builder for [ContactCenterInsights::update_issue][super::super::client::ContactCenterInsights::update_issue] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateIssue(RequestBuilder<crate::model::UpdateIssueRequest>);
 
@@ -2117,7 +2117,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_issue call.
+    /// The request builder for [ContactCenterInsights::delete_issue][super::super::client::ContactCenterInsights::delete_issue] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIssue(RequestBuilder<crate::model::DeleteIssueRequest>);
 
@@ -2161,7 +2161,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::calculate_issue_model_stats call.
+    /// The request builder for [ContactCenterInsights::calculate_issue_model_stats][super::super::client::ContactCenterInsights::calculate_issue_model_stats] calls.
     #[derive(Clone, Debug)]
     pub struct CalculateIssueModelStats(
         RequestBuilder<crate::model::CalculateIssueModelStatsRequest>,
@@ -2210,7 +2210,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_phrase_matcher call.
+    /// The request builder for [ContactCenterInsights::create_phrase_matcher][super::super::client::ContactCenterInsights::create_phrase_matcher] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePhraseMatcher(RequestBuilder<crate::model::CreatePhraseMatcherRequest>);
 
@@ -2266,7 +2266,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_phrase_matcher call.
+    /// The request builder for [ContactCenterInsights::get_phrase_matcher][super::super::client::ContactCenterInsights::get_phrase_matcher] calls.
     #[derive(Clone, Debug)]
     pub struct GetPhraseMatcher(RequestBuilder<crate::model::GetPhraseMatcherRequest>);
 
@@ -2313,7 +2313,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_phrase_matchers call.
+    /// The request builder for [ContactCenterInsights::list_phrase_matchers][super::super::client::ContactCenterInsights::list_phrase_matchers] calls.
     #[derive(Clone, Debug)]
     pub struct ListPhraseMatchers(RequestBuilder<crate::model::ListPhraseMatchersRequest>);
 
@@ -2393,7 +2393,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_phrase_matcher call.
+    /// The request builder for [ContactCenterInsights::delete_phrase_matcher][super::super::client::ContactCenterInsights::delete_phrase_matcher] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePhraseMatcher(RequestBuilder<crate::model::DeletePhraseMatcherRequest>);
 
@@ -2440,7 +2440,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_phrase_matcher call.
+    /// The request builder for [ContactCenterInsights::update_phrase_matcher][super::super::client::ContactCenterInsights::update_phrase_matcher] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePhraseMatcher(RequestBuilder<crate::model::UpdatePhraseMatcherRequest>);
 
@@ -2499,7 +2499,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::calculate_stats call.
+    /// The request builder for [ContactCenterInsights::calculate_stats][super::super::client::ContactCenterInsights::calculate_stats] calls.
     #[derive(Clone, Debug)]
     pub struct CalculateStats(RequestBuilder<crate::model::CalculateStatsRequest>);
 
@@ -2549,7 +2549,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_settings call.
+    /// The request builder for [ContactCenterInsights::get_settings][super::super::client::ContactCenterInsights::get_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetSettings(RequestBuilder<crate::model::GetSettingsRequest>);
 
@@ -2593,7 +2593,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_settings call.
+    /// The request builder for [ContactCenterInsights::update_settings][super::super::client::ContactCenterInsights::update_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSettings(RequestBuilder<crate::model::UpdateSettingsRequest>);
 
@@ -2649,7 +2649,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_analysis_rule call.
+    /// The request builder for [ContactCenterInsights::create_analysis_rule][super::super::client::ContactCenterInsights::create_analysis_rule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAnalysisRule(RequestBuilder<crate::model::CreateAnalysisRuleRequest>);
 
@@ -2705,7 +2705,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_analysis_rule call.
+    /// The request builder for [ContactCenterInsights::get_analysis_rule][super::super::client::ContactCenterInsights::get_analysis_rule] calls.
     #[derive(Clone, Debug)]
     pub struct GetAnalysisRule(RequestBuilder<crate::model::GetAnalysisRuleRequest>);
 
@@ -2749,7 +2749,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_analysis_rules call.
+    /// The request builder for [ContactCenterInsights::list_analysis_rules][super::super::client::ContactCenterInsights::list_analysis_rules] calls.
     #[derive(Clone, Debug)]
     pub struct ListAnalysisRules(RequestBuilder<crate::model::ListAnalysisRulesRequest>);
 
@@ -2823,7 +2823,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_analysis_rule call.
+    /// The request builder for [ContactCenterInsights::update_analysis_rule][super::super::client::ContactCenterInsights::update_analysis_rule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAnalysisRule(RequestBuilder<crate::model::UpdateAnalysisRuleRequest>);
 
@@ -2882,7 +2882,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_analysis_rule call.
+    /// The request builder for [ContactCenterInsights::delete_analysis_rule][super::super::client::ContactCenterInsights::delete_analysis_rule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAnalysisRule(RequestBuilder<crate::model::DeleteAnalysisRuleRequest>);
 
@@ -2929,7 +2929,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_encryption_spec call.
+    /// The request builder for [ContactCenterInsights::get_encryption_spec][super::super::client::ContactCenterInsights::get_encryption_spec] calls.
     #[derive(Clone, Debug)]
     pub struct GetEncryptionSpec(RequestBuilder<crate::model::GetEncryptionSpecRequest>);
 
@@ -2976,7 +2976,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::initialize_encryption_spec call.
+    /// The request builder for [ContactCenterInsights::initialize_encryption_spec][super::super::client::ContactCenterInsights::initialize_encryption_spec] calls.
     #[derive(Clone, Debug)]
     pub struct InitializeEncryptionSpec(
         RequestBuilder<crate::model::InitializeEncryptionSpecRequest>,
@@ -3071,7 +3071,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_view call.
+    /// The request builder for [ContactCenterInsights::create_view][super::super::client::ContactCenterInsights::create_view] calls.
     #[derive(Clone, Debug)]
     pub struct CreateView(RequestBuilder<crate::model::CreateViewRequest>);
 
@@ -3121,7 +3121,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_view call.
+    /// The request builder for [ContactCenterInsights::get_view][super::super::client::ContactCenterInsights::get_view] calls.
     #[derive(Clone, Debug)]
     pub struct GetView(RequestBuilder<crate::model::GetViewRequest>);
 
@@ -3165,7 +3165,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_views call.
+    /// The request builder for [ContactCenterInsights::list_views][super::super::client::ContactCenterInsights::list_views] calls.
     #[derive(Clone, Debug)]
     pub struct ListViews(RequestBuilder<crate::model::ListViewsRequest>);
 
@@ -3235,7 +3235,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_view call.
+    /// The request builder for [ContactCenterInsights::update_view][super::super::client::ContactCenterInsights::update_view] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateView(RequestBuilder<crate::model::UpdateViewRequest>);
 
@@ -3288,7 +3288,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_view call.
+    /// The request builder for [ContactCenterInsights::delete_view][super::super::client::ContactCenterInsights::delete_view] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteView(RequestBuilder<crate::model::DeleteViewRequest>);
 
@@ -3332,7 +3332,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::query_metrics call.
+    /// The request builder for [ContactCenterInsights::query_metrics][super::super::client::ContactCenterInsights::query_metrics] calls.
     #[derive(Clone, Debug)]
     pub struct QueryMetrics(RequestBuilder<crate::model::QueryMetricsRequest>);
 
@@ -3454,7 +3454,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_qa_question call.
+    /// The request builder for [ContactCenterInsights::create_qa_question][super::super::client::ContactCenterInsights::create_qa_question] calls.
     #[derive(Clone, Debug)]
     pub struct CreateQaQuestion(RequestBuilder<crate::model::CreateQaQuestionRequest>);
 
@@ -3516,7 +3516,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_qa_question call.
+    /// The request builder for [ContactCenterInsights::get_qa_question][super::super::client::ContactCenterInsights::get_qa_question] calls.
     #[derive(Clone, Debug)]
     pub struct GetQaQuestion(RequestBuilder<crate::model::GetQaQuestionRequest>);
 
@@ -3560,7 +3560,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_qa_question call.
+    /// The request builder for [ContactCenterInsights::update_qa_question][super::super::client::ContactCenterInsights::update_qa_question] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateQaQuestion(RequestBuilder<crate::model::UpdateQaQuestionRequest>);
 
@@ -3619,7 +3619,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_qa_question call.
+    /// The request builder for [ContactCenterInsights::delete_qa_question][super::super::client::ContactCenterInsights::delete_qa_question] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteQaQuestion(RequestBuilder<crate::model::DeleteQaQuestionRequest>);
 
@@ -3666,7 +3666,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_qa_questions call.
+    /// The request builder for [ContactCenterInsights::list_qa_questions][super::super::client::ContactCenterInsights::list_qa_questions] calls.
     #[derive(Clone, Debug)]
     pub struct ListQaQuestions(RequestBuilder<crate::model::ListQaQuestionsRequest>);
 
@@ -3737,7 +3737,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_qa_scorecard call.
+    /// The request builder for [ContactCenterInsights::create_qa_scorecard][super::super::client::ContactCenterInsights::create_qa_scorecard] calls.
     #[derive(Clone, Debug)]
     pub struct CreateQaScorecard(RequestBuilder<crate::model::CreateQaScorecardRequest>);
 
@@ -3799,7 +3799,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_qa_scorecard call.
+    /// The request builder for [ContactCenterInsights::get_qa_scorecard][super::super::client::ContactCenterInsights::get_qa_scorecard] calls.
     #[derive(Clone, Debug)]
     pub struct GetQaScorecard(RequestBuilder<crate::model::GetQaScorecardRequest>);
 
@@ -3843,7 +3843,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_qa_scorecard call.
+    /// The request builder for [ContactCenterInsights::update_qa_scorecard][super::super::client::ContactCenterInsights::update_qa_scorecard] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateQaScorecard(RequestBuilder<crate::model::UpdateQaScorecardRequest>);
 
@@ -3902,7 +3902,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_qa_scorecard call.
+    /// The request builder for [ContactCenterInsights::delete_qa_scorecard][super::super::client::ContactCenterInsights::delete_qa_scorecard] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteQaScorecard(RequestBuilder<crate::model::DeleteQaScorecardRequest>);
 
@@ -3955,7 +3955,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_qa_scorecards call.
+    /// The request builder for [ContactCenterInsights::list_qa_scorecards][super::super::client::ContactCenterInsights::list_qa_scorecards] calls.
     #[derive(Clone, Debug)]
     pub struct ListQaScorecards(RequestBuilder<crate::model::ListQaScorecardsRequest>);
 
@@ -4029,7 +4029,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_qa_scorecard_revision call.
+    /// The request builder for [ContactCenterInsights::create_qa_scorecard_revision][super::super::client::ContactCenterInsights::create_qa_scorecard_revision] calls.
     #[derive(Clone, Debug)]
     pub struct CreateQaScorecardRevision(
         RequestBuilder<crate::model::CreateQaScorecardRevisionRequest>,
@@ -4095,7 +4095,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_qa_scorecard_revision call.
+    /// The request builder for [ContactCenterInsights::get_qa_scorecard_revision][super::super::client::ContactCenterInsights::get_qa_scorecard_revision] calls.
     #[derive(Clone, Debug)]
     pub struct GetQaScorecardRevision(RequestBuilder<crate::model::GetQaScorecardRevisionRequest>);
 
@@ -4142,7 +4142,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::tune_qa_scorecard_revision call.
+    /// The request builder for [ContactCenterInsights::tune_qa_scorecard_revision][super::super::client::ContactCenterInsights::tune_qa_scorecard_revision] calls.
     #[derive(Clone, Debug)]
     pub struct TuneQaScorecardRevision(
         RequestBuilder<crate::model::TuneQaScorecardRevisionRequest>,
@@ -4246,7 +4246,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::deploy_qa_scorecard_revision call.
+    /// The request builder for [ContactCenterInsights::deploy_qa_scorecard_revision][super::super::client::ContactCenterInsights::deploy_qa_scorecard_revision] calls.
     #[derive(Clone, Debug)]
     pub struct DeployQaScorecardRevision(
         RequestBuilder<crate::model::DeployQaScorecardRevisionRequest>,
@@ -4295,7 +4295,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::undeploy_qa_scorecard_revision call.
+    /// The request builder for [ContactCenterInsights::undeploy_qa_scorecard_revision][super::super::client::ContactCenterInsights::undeploy_qa_scorecard_revision] calls.
     #[derive(Clone, Debug)]
     pub struct UndeployQaScorecardRevision(
         RequestBuilder<crate::model::UndeployQaScorecardRevisionRequest>,
@@ -4344,7 +4344,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_qa_scorecard_revision call.
+    /// The request builder for [ContactCenterInsights::delete_qa_scorecard_revision][super::super::client::ContactCenterInsights::delete_qa_scorecard_revision] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteQaScorecardRevision(
         RequestBuilder<crate::model::DeleteQaScorecardRevisionRequest>,
@@ -4399,7 +4399,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_qa_scorecard_revisions call.
+    /// The request builder for [ContactCenterInsights::list_qa_scorecard_revisions][super::super::client::ContactCenterInsights::list_qa_scorecard_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct ListQaScorecardRevisions(
         RequestBuilder<crate::model::ListQaScorecardRevisionsRequest>,
@@ -4483,7 +4483,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::create_feedback_label call.
+    /// The request builder for [ContactCenterInsights::create_feedback_label][super::super::client::ContactCenterInsights::create_feedback_label] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeedbackLabel(RequestBuilder<crate::model::CreateFeedbackLabelRequest>);
 
@@ -4545,7 +4545,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_feedback_labels call.
+    /// The request builder for [ContactCenterInsights::list_feedback_labels][super::super::client::ContactCenterInsights::list_feedback_labels] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeedbackLabels(RequestBuilder<crate::model::ListFeedbackLabelsRequest>);
 
@@ -4625,7 +4625,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_feedback_label call.
+    /// The request builder for [ContactCenterInsights::get_feedback_label][super::super::client::ContactCenterInsights::get_feedback_label] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeedbackLabel(RequestBuilder<crate::model::GetFeedbackLabelRequest>);
 
@@ -4672,7 +4672,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::update_feedback_label call.
+    /// The request builder for [ContactCenterInsights::update_feedback_label][super::super::client::ContactCenterInsights::update_feedback_label] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeedbackLabel(RequestBuilder<crate::model::UpdateFeedbackLabelRequest>);
 
@@ -4731,7 +4731,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::delete_feedback_label call.
+    /// The request builder for [ContactCenterInsights::delete_feedback_label][super::super::client::ContactCenterInsights::delete_feedback_label] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeedbackLabel(RequestBuilder<crate::model::DeleteFeedbackLabelRequest>);
 
@@ -4778,7 +4778,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_all_feedback_labels call.
+    /// The request builder for [ContactCenterInsights::list_all_feedback_labels][super::super::client::ContactCenterInsights::list_all_feedback_labels] calls.
     #[derive(Clone, Debug)]
     pub struct ListAllFeedbackLabels(RequestBuilder<crate::model::ListAllFeedbackLabelsRequest>);
 
@@ -4858,7 +4858,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::bulk_upload_feedback_labels call.
+    /// The request builder for [ContactCenterInsights::bulk_upload_feedback_labels][super::super::client::ContactCenterInsights::bulk_upload_feedback_labels] calls.
     #[derive(Clone, Debug)]
     pub struct BulkUploadFeedbackLabels(
         RequestBuilder<crate::model::BulkUploadFeedbackLabelsRequest>,
@@ -4967,7 +4967,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::bulk_download_feedback_labels call.
+    /// The request builder for [ContactCenterInsights::bulk_download_feedback_labels][super::super::client::ContactCenterInsights::bulk_download_feedback_labels] calls.
     #[derive(Clone, Debug)]
     pub struct BulkDownloadFeedbackLabels(
         RequestBuilder<crate::model::BulkDownloadFeedbackLabelsRequest>,
@@ -5110,7 +5110,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::list_operations call.
+    /// The request builder for [ContactCenterInsights::list_operations][super::super::client::ContactCenterInsights::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5190,7 +5190,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::get_operation call.
+    /// The request builder for [ContactCenterInsights::get_operation][super::super::client::ContactCenterInsights::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5237,7 +5237,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for a ContactCenterInsights::cancel_operation call.
+    /// The request builder for [ContactCenterInsights::cancel_operation][super::super::client::ContactCenterInsights::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::process_open_lineage_run_event call.
+    /// The request builder for [Lineage::process_open_lineage_run_event][super::super::client::Lineage::process_open_lineage_run_event] calls.
     #[derive(Clone, Debug)]
     pub struct ProcessOpenLineageRunEvent(
         RequestBuilder<crate::model::ProcessOpenLineageRunEventRequest>,
@@ -126,7 +126,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::create_process call.
+    /// The request builder for [Lineage::create_process][super::super::client::Lineage::create_process] calls.
     #[derive(Clone, Debug)]
     pub struct CreateProcess(RequestBuilder<crate::model::CreateProcessRequest>);
 
@@ -183,7 +183,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::update_process call.
+    /// The request builder for [Lineage::update_process][super::super::client::Lineage::update_process] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProcess(RequestBuilder<crate::model::UpdateProcessRequest>);
 
@@ -243,7 +243,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::get_process call.
+    /// The request builder for [Lineage::get_process][super::super::client::Lineage::get_process] calls.
     #[derive(Clone, Debug)]
     pub struct GetProcess(RequestBuilder<crate::model::GetProcessRequest>);
 
@@ -285,7 +285,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::list_processes call.
+    /// The request builder for [Lineage::list_processes][super::super::client::Lineage::list_processes] calls.
     #[derive(Clone, Debug)]
     pub struct ListProcesses(RequestBuilder<crate::model::ListProcessesRequest>);
 
@@ -354,7 +354,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::delete_process call.
+    /// The request builder for [Lineage::delete_process][super::super::client::Lineage::delete_process] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteProcess(RequestBuilder<crate::model::DeleteProcessRequest>);
 
@@ -437,7 +437,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::create_run call.
+    /// The request builder for [Lineage::create_run][super::super::client::Lineage::create_run] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRun(RequestBuilder<crate::model::CreateRunRequest>);
 
@@ -491,7 +491,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::update_run call.
+    /// The request builder for [Lineage::update_run][super::super::client::Lineage::update_run] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRun(RequestBuilder<crate::model::UpdateRunRequest>);
 
@@ -548,7 +548,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::get_run call.
+    /// The request builder for [Lineage::get_run][super::super::client::Lineage::get_run] calls.
     #[derive(Clone, Debug)]
     pub struct GetRun(RequestBuilder<crate::model::GetRunRequest>);
 
@@ -588,7 +588,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::list_runs call.
+    /// The request builder for [Lineage::list_runs][super::super::client::Lineage::list_runs] calls.
     #[derive(Clone, Debug)]
     pub struct ListRuns(RequestBuilder<crate::model::ListRunsRequest>);
 
@@ -656,7 +656,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::delete_run call.
+    /// The request builder for [Lineage::delete_run][super::super::client::Lineage::delete_run] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRun(RequestBuilder<crate::model::DeleteRunRequest>);
 
@@ -739,7 +739,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::create_lineage_event call.
+    /// The request builder for [Lineage::create_lineage_event][super::super::client::Lineage::create_lineage_event] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLineageEvent(RequestBuilder<crate::model::CreateLineageEventRequest>);
 
@@ -799,7 +799,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::get_lineage_event call.
+    /// The request builder for [Lineage::get_lineage_event][super::super::client::Lineage::get_lineage_event] calls.
     #[derive(Clone, Debug)]
     pub struct GetLineageEvent(RequestBuilder<crate::model::GetLineageEventRequest>);
 
@@ -841,7 +841,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::list_lineage_events call.
+    /// The request builder for [Lineage::list_lineage_events][super::super::client::Lineage::list_lineage_events] calls.
     #[derive(Clone, Debug)]
     pub struct ListLineageEvents(RequestBuilder<crate::model::ListLineageEventsRequest>);
 
@@ -913,7 +913,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::delete_lineage_event call.
+    /// The request builder for [Lineage::delete_lineage_event][super::super::client::Lineage::delete_lineage_event] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLineageEvent(RequestBuilder<crate::model::DeleteLineageEventRequest>);
 
@@ -964,7 +964,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::search_links call.
+    /// The request builder for [Lineage::search_links][super::super::client::Lineage::search_links] calls.
     #[derive(Clone, Debug)]
     pub struct SearchLinks(RequestBuilder<crate::model::SearchLinksRequest>);
 
@@ -1042,7 +1042,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::batch_search_link_processes call.
+    /// The request builder for [Lineage::batch_search_link_processes][super::super::client::Lineage::batch_search_link_processes] calls.
     #[derive(Clone, Debug)]
     pub struct BatchSearchLinkProcesses(
         RequestBuilder<crate::model::BatchSearchLinkProcessesRequest>,
@@ -1129,7 +1129,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::list_operations call.
+    /// The request builder for [Lineage::list_operations][super::super::client::Lineage::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1207,7 +1207,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::get_operation call.
+    /// The request builder for [Lineage::get_operation][super::super::client::Lineage::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1252,7 +1252,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::delete_operation call.
+    /// The request builder for [Lineage::delete_operation][super::super::client::Lineage::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1297,7 +1297,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for a Lineage::cancel_operation call.
+    /// The request builder for [Lineage::cancel_operation][super::super::client::Lineage::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/datacatalog/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::search_catalog call.
+    /// The request builder for [DataCatalog::search_catalog][super::super::client::DataCatalog::search_catalog] calls.
     #[derive(Clone, Debug)]
     pub struct SearchCatalog(RequestBuilder<crate::model::SearchCatalogRequest>);
 
@@ -159,7 +159,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::create_entry_group call.
+    /// The request builder for [DataCatalog::create_entry_group][super::super::client::DataCatalog::create_entry_group] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEntryGroup(RequestBuilder<crate::model::CreateEntryGroupRequest>);
 
@@ -219,7 +219,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::get_entry_group call.
+    /// The request builder for [DataCatalog::get_entry_group][super::super::client::DataCatalog::get_entry_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetEntryGroup(RequestBuilder<crate::model::GetEntryGroupRequest>);
 
@@ -267,7 +267,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::update_entry_group call.
+    /// The request builder for [DataCatalog::update_entry_group][super::super::client::DataCatalog::update_entry_group] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEntryGroup(RequestBuilder<crate::model::UpdateEntryGroupRequest>);
 
@@ -324,7 +324,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::delete_entry_group call.
+    /// The request builder for [DataCatalog::delete_entry_group][super::super::client::DataCatalog::delete_entry_group] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEntryGroup(RequestBuilder<crate::model::DeleteEntryGroupRequest>);
 
@@ -375,7 +375,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::list_entry_groups call.
+    /// The request builder for [DataCatalog::list_entry_groups][super::super::client::DataCatalog::list_entry_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListEntryGroups(RequestBuilder<crate::model::ListEntryGroupsRequest>);
 
@@ -444,7 +444,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::create_entry call.
+    /// The request builder for [DataCatalog::create_entry][super::super::client::DataCatalog::create_entry] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEntry(RequestBuilder<crate::model::CreateEntryRequest>);
 
@@ -501,7 +501,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::update_entry call.
+    /// The request builder for [DataCatalog::update_entry][super::super::client::DataCatalog::update_entry] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEntry(RequestBuilder<crate::model::UpdateEntryRequest>);
 
@@ -555,7 +555,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::delete_entry call.
+    /// The request builder for [DataCatalog::delete_entry][super::super::client::DataCatalog::delete_entry] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEntry(RequestBuilder<crate::model::DeleteEntryRequest>);
 
@@ -597,7 +597,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::get_entry call.
+    /// The request builder for [DataCatalog::get_entry][super::super::client::DataCatalog::get_entry] calls.
     #[derive(Clone, Debug)]
     pub struct GetEntry(RequestBuilder<crate::model::GetEntryRequest>);
 
@@ -639,7 +639,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::lookup_entry call.
+    /// The request builder for [DataCatalog::lookup_entry][super::super::client::DataCatalog::lookup_entry] calls.
     #[derive(Clone, Debug)]
     pub struct LookupEntry(RequestBuilder<crate::model::LookupEntryRequest>);
 
@@ -696,7 +696,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::list_entries call.
+    /// The request builder for [DataCatalog::list_entries][super::super::client::DataCatalog::list_entries] calls.
     #[derive(Clone, Debug)]
     pub struct ListEntries(RequestBuilder<crate::model::ListEntriesRequest>);
 
@@ -771,7 +771,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::modify_entry_overview call.
+    /// The request builder for [DataCatalog::modify_entry_overview][super::super::client::DataCatalog::modify_entry_overview] calls.
     #[derive(Clone, Debug)]
     pub struct ModifyEntryOverview(RequestBuilder<crate::model::ModifyEntryOverviewRequest>);
 
@@ -825,7 +825,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::modify_entry_contacts call.
+    /// The request builder for [DataCatalog::modify_entry_contacts][super::super::client::DataCatalog::modify_entry_contacts] calls.
     #[derive(Clone, Debug)]
     pub struct ModifyEntryContacts(RequestBuilder<crate::model::ModifyEntryContactsRequest>);
 
@@ -879,7 +879,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::create_tag_template call.
+    /// The request builder for [DataCatalog::create_tag_template][super::super::client::DataCatalog::create_tag_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTagTemplate(RequestBuilder<crate::model::CreateTagTemplateRequest>);
 
@@ -939,7 +939,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::get_tag_template call.
+    /// The request builder for [DataCatalog::get_tag_template][super::super::client::DataCatalog::get_tag_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetTagTemplate(RequestBuilder<crate::model::GetTagTemplateRequest>);
 
@@ -981,7 +981,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::update_tag_template call.
+    /// The request builder for [DataCatalog::update_tag_template][super::super::client::DataCatalog::update_tag_template] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTagTemplate(RequestBuilder<crate::model::UpdateTagTemplateRequest>);
 
@@ -1038,7 +1038,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::delete_tag_template call.
+    /// The request builder for [DataCatalog::delete_tag_template][super::super::client::DataCatalog::delete_tag_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTagTemplate(RequestBuilder<crate::model::DeleteTagTemplateRequest>);
 
@@ -1089,7 +1089,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::create_tag_template_field call.
+    /// The request builder for [DataCatalog::create_tag_template_field][super::super::client::DataCatalog::create_tag_template_field] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTagTemplateField(RequestBuilder<crate::model::CreateTagTemplateFieldRequest>);
 
@@ -1151,7 +1151,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::update_tag_template_field call.
+    /// The request builder for [DataCatalog::update_tag_template_field][super::super::client::DataCatalog::update_tag_template_field] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTagTemplateField(RequestBuilder<crate::model::UpdateTagTemplateFieldRequest>);
 
@@ -1216,7 +1216,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::rename_tag_template_field call.
+    /// The request builder for [DataCatalog::rename_tag_template_field][super::super::client::DataCatalog::rename_tag_template_field] calls.
     #[derive(Clone, Debug)]
     pub struct RenameTagTemplateField(RequestBuilder<crate::model::RenameTagTemplateFieldRequest>);
 
@@ -1267,7 +1267,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::rename_tag_template_field_enum_value call.
+    /// The request builder for [DataCatalog::rename_tag_template_field_enum_value][super::super::client::DataCatalog::rename_tag_template_field_enum_value] calls.
     #[derive(Clone, Debug)]
     pub struct RenameTagTemplateFieldEnumValue(
         RequestBuilder<crate::model::RenameTagTemplateFieldEnumValueRequest>,
@@ -1323,7 +1323,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::delete_tag_template_field call.
+    /// The request builder for [DataCatalog::delete_tag_template_field][super::super::client::DataCatalog::delete_tag_template_field] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTagTemplateField(RequestBuilder<crate::model::DeleteTagTemplateFieldRequest>);
 
@@ -1374,7 +1374,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::create_tag call.
+    /// The request builder for [DataCatalog::create_tag][super::super::client::DataCatalog::create_tag] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTag(RequestBuilder<crate::model::CreateTagRequest>);
 
@@ -1422,7 +1422,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::update_tag call.
+    /// The request builder for [DataCatalog::update_tag][super::super::client::DataCatalog::update_tag] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTag(RequestBuilder<crate::model::UpdateTagRequest>);
 
@@ -1473,7 +1473,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::delete_tag call.
+    /// The request builder for [DataCatalog::delete_tag][super::super::client::DataCatalog::delete_tag] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTag(RequestBuilder<crate::model::DeleteTagRequest>);
 
@@ -1515,7 +1515,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::list_tags call.
+    /// The request builder for [DataCatalog::list_tags][super::super::client::DataCatalog::list_tags] calls.
     #[derive(Clone, Debug)]
     pub struct ListTags(RequestBuilder<crate::model::ListTagsRequest>);
 
@@ -1583,7 +1583,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::reconcile_tags call.
+    /// The request builder for [DataCatalog::reconcile_tags][super::super::client::DataCatalog::reconcile_tags] calls.
     #[derive(Clone, Debug)]
     pub struct ReconcileTags(RequestBuilder<crate::model::ReconcileTagsRequest>);
 
@@ -1689,7 +1689,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::star_entry call.
+    /// The request builder for [DataCatalog::star_entry][super::super::client::DataCatalog::star_entry] calls.
     #[derive(Clone, Debug)]
     pub struct StarEntry(RequestBuilder<crate::model::StarEntryRequest>);
 
@@ -1731,7 +1731,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::unstar_entry call.
+    /// The request builder for [DataCatalog::unstar_entry][super::super::client::DataCatalog::unstar_entry] calls.
     #[derive(Clone, Debug)]
     pub struct UnstarEntry(RequestBuilder<crate::model::UnstarEntryRequest>);
 
@@ -1773,7 +1773,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::set_iam_policy call.
+    /// The request builder for [DataCatalog::set_iam_policy][super::super::client::DataCatalog::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1833,7 +1833,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::get_iam_policy call.
+    /// The request builder for [DataCatalog::get_iam_policy][super::super::client::DataCatalog::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1884,7 +1884,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::test_iam_permissions call.
+    /// The request builder for [DataCatalog::test_iam_permissions][super::super::client::DataCatalog::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1940,7 +1940,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::import_entries call.
+    /// The request builder for [DataCatalog::import_entries][super::super::client::DataCatalog::import_entries] calls.
     #[derive(Clone, Debug)]
     pub struct ImportEntries(RequestBuilder<crate::model::ImportEntriesRequest>);
 
@@ -2038,7 +2038,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::set_config call.
+    /// The request builder for [DataCatalog::set_config][super::super::client::DataCatalog::set_config] calls.
     #[derive(Clone, Debug)]
     pub struct SetConfig(RequestBuilder<crate::model::SetConfigRequest>);
 
@@ -2091,7 +2091,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::retrieve_config call.
+    /// The request builder for [DataCatalog::retrieve_config][super::super::client::DataCatalog::retrieve_config] calls.
     #[derive(Clone, Debug)]
     pub struct RetrieveConfig(RequestBuilder<crate::model::RetrieveConfigRequest>);
 
@@ -2133,7 +2133,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::retrieve_effective_config call.
+    /// The request builder for [DataCatalog::retrieve_effective_config][super::super::client::DataCatalog::retrieve_effective_config] calls.
     #[derive(Clone, Debug)]
     pub struct RetrieveEffectiveConfig(
         RequestBuilder<crate::model::RetrieveEffectiveConfigRequest>,
@@ -2180,7 +2180,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::list_operations call.
+    /// The request builder for [DataCatalog::list_operations][super::super::client::DataCatalog::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2258,7 +2258,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::get_operation call.
+    /// The request builder for [DataCatalog::get_operation][super::super::client::DataCatalog::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2303,7 +2303,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::delete_operation call.
+    /// The request builder for [DataCatalog::delete_operation][super::super::client::DataCatalog::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2348,7 +2348,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for a DataCatalog::cancel_operation call.
+    /// The request builder for [DataCatalog::cancel_operation][super::super::client::DataCatalog::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2447,7 +2447,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::create_taxonomy call.
+    /// The request builder for [PolicyTagManager::create_taxonomy][super::super::client::PolicyTagManager::create_taxonomy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTaxonomy(RequestBuilder<crate::model::CreateTaxonomyRequest>);
 
@@ -2498,7 +2498,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::delete_taxonomy call.
+    /// The request builder for [PolicyTagManager::delete_taxonomy][super::super::client::PolicyTagManager::delete_taxonomy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTaxonomy(RequestBuilder<crate::model::DeleteTaxonomyRequest>);
 
@@ -2540,7 +2540,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::update_taxonomy call.
+    /// The request builder for [PolicyTagManager::update_taxonomy][super::super::client::PolicyTagManager::update_taxonomy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTaxonomy(RequestBuilder<crate::model::UpdateTaxonomyRequest>);
 
@@ -2594,7 +2594,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::list_taxonomies call.
+    /// The request builder for [PolicyTagManager::list_taxonomies][super::super::client::PolicyTagManager::list_taxonomies] calls.
     #[derive(Clone, Debug)]
     pub struct ListTaxonomies(RequestBuilder<crate::model::ListTaxonomiesRequest>);
 
@@ -2669,7 +2669,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::get_taxonomy call.
+    /// The request builder for [PolicyTagManager::get_taxonomy][super::super::client::PolicyTagManager::get_taxonomy] calls.
     #[derive(Clone, Debug)]
     pub struct GetTaxonomy(RequestBuilder<crate::model::GetTaxonomyRequest>);
 
@@ -2711,7 +2711,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::create_policy_tag call.
+    /// The request builder for [PolicyTagManager::create_policy_tag][super::super::client::PolicyTagManager::create_policy_tag] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePolicyTag(RequestBuilder<crate::model::CreatePolicyTagRequest>);
 
@@ -2762,7 +2762,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::delete_policy_tag call.
+    /// The request builder for [PolicyTagManager::delete_policy_tag][super::super::client::PolicyTagManager::delete_policy_tag] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePolicyTag(RequestBuilder<crate::model::DeletePolicyTagRequest>);
 
@@ -2804,7 +2804,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::update_policy_tag call.
+    /// The request builder for [PolicyTagManager::update_policy_tag][super::super::client::PolicyTagManager::update_policy_tag] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePolicyTag(RequestBuilder<crate::model::UpdatePolicyTagRequest>);
 
@@ -2858,7 +2858,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::list_policy_tags call.
+    /// The request builder for [PolicyTagManager::list_policy_tags][super::super::client::PolicyTagManager::list_policy_tags] calls.
     #[derive(Clone, Debug)]
     pub struct ListPolicyTags(RequestBuilder<crate::model::ListPolicyTagsRequest>);
 
@@ -2927,7 +2927,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::get_policy_tag call.
+    /// The request builder for [PolicyTagManager::get_policy_tag][super::super::client::PolicyTagManager::get_policy_tag] calls.
     #[derive(Clone, Debug)]
     pub struct GetPolicyTag(RequestBuilder<crate::model::GetPolicyTagRequest>);
 
@@ -2969,7 +2969,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::get_iam_policy call.
+    /// The request builder for [PolicyTagManager::get_iam_policy][super::super::client::PolicyTagManager::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3020,7 +3020,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::set_iam_policy call.
+    /// The request builder for [PolicyTagManager::set_iam_policy][super::super::client::PolicyTagManager::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3080,7 +3080,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::test_iam_permissions call.
+    /// The request builder for [PolicyTagManager::test_iam_permissions][super::super::client::PolicyTagManager::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3136,7 +3136,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::list_operations call.
+    /// The request builder for [PolicyTagManager::list_operations][super::super::client::PolicyTagManager::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3214,7 +3214,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::get_operation call.
+    /// The request builder for [PolicyTagManager::get_operation][super::super::client::PolicyTagManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3259,7 +3259,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::delete_operation call.
+    /// The request builder for [PolicyTagManager::delete_operation][super::super::client::PolicyTagManager::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3304,7 +3304,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for a PolicyTagManager::cancel_operation call.
+    /// The request builder for [PolicyTagManager::cancel_operation][super::super::client::PolicyTagManager::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3405,7 +3405,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for a PolicyTagManagerSerialization::replace_taxonomy call.
+    /// The request builder for [PolicyTagManagerSerialization::replace_taxonomy][super::super::client::PolicyTagManagerSerialization::replace_taxonomy] calls.
     #[derive(Clone, Debug)]
     pub struct ReplaceTaxonomy(RequestBuilder<crate::model::ReplaceTaxonomyRequest>);
 
@@ -3460,7 +3460,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for a PolicyTagManagerSerialization::import_taxonomies call.
+    /// The request builder for [PolicyTagManagerSerialization::import_taxonomies][super::super::client::PolicyTagManagerSerialization::import_taxonomies] calls.
     #[derive(Clone, Debug)]
     pub struct ImportTaxonomies(RequestBuilder<crate::model::ImportTaxonomiesRequest>);
 
@@ -3516,7 +3516,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for a PolicyTagManagerSerialization::export_taxonomies call.
+    /// The request builder for [PolicyTagManagerSerialization::export_taxonomies][super::super::client::PolicyTagManagerSerialization::export_taxonomies] calls.
     #[derive(Clone, Debug)]
     pub struct ExportTaxonomies(RequestBuilder<crate::model::ExportTaxonomiesRequest>);
 
@@ -3585,7 +3585,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for a PolicyTagManagerSerialization::list_operations call.
+    /// The request builder for [PolicyTagManagerSerialization::list_operations][super::super::client::PolicyTagManagerSerialization::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3665,7 +3665,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for a PolicyTagManagerSerialization::get_operation call.
+    /// The request builder for [PolicyTagManagerSerialization::get_operation][super::super::client::PolicyTagManagerSerialization::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3712,7 +3712,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for a PolicyTagManagerSerialization::delete_operation call.
+    /// The request builder for [PolicyTagManagerSerialization::delete_operation][super::super::client::PolicyTagManagerSerialization::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3759,7 +3759,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for a PolicyTagManagerSerialization::cancel_operation call.
+    /// The request builder for [PolicyTagManagerSerialization::cancel_operation][super::super::client::PolicyTagManagerSerialization::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/datafusion/v1/src/builder.rs
+++ b/src/generated/cloud/datafusion/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::list_available_versions call.
+    /// The request builder for [DataFusion::list_available_versions][super::super::client::DataFusion::list_available_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListAvailableVersions(RequestBuilder<crate::model::ListAvailableVersionsRequest>);
 
@@ -145,7 +145,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::list_instances call.
+    /// The request builder for [DataFusion::list_instances][super::super::client::DataFusion::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -226,7 +226,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::get_instance call.
+    /// The request builder for [DataFusion::get_instance][super::super::client::DataFusion::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -268,7 +268,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::create_instance call.
+    /// The request builder for [DataFusion::create_instance][super::super::client::DataFusion::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -363,7 +363,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::delete_instance call.
+    /// The request builder for [DataFusion::delete_instance][super::super::client::DataFusion::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -440,7 +440,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::update_instance call.
+    /// The request builder for [DataFusion::update_instance][super::super::client::DataFusion::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -532,7 +532,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::restart_instance call.
+    /// The request builder for [DataFusion::restart_instance][super::super::client::DataFusion::restart_instance] calls.
     #[derive(Clone, Debug)]
     pub struct RestartInstance(RequestBuilder<crate::model::RestartInstanceRequest>);
 
@@ -612,7 +612,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::list_operations call.
+    /// The request builder for [DataFusion::list_operations][super::super::client::DataFusion::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -690,7 +690,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::get_operation call.
+    /// The request builder for [DataFusion::get_operation][super::super::client::DataFusion::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -735,7 +735,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::delete_operation call.
+    /// The request builder for [DataFusion::delete_operation][super::super::client::DataFusion::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -780,7 +780,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for a DataFusion::cancel_operation call.
+    /// The request builder for [DataFusion::cancel_operation][super::super::client::DataFusion::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/dataproc/v1/src/builder.rs
+++ b/src/generated/cloud/dataproc/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::create_autoscaling_policy call.
+    /// The request builder for [AutoscalingPolicyService::create_autoscaling_policy][super::super::client::AutoscalingPolicyService::create_autoscaling_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAutoscalingPolicy(
         RequestBuilder<crate::model::CreateAutoscalingPolicyRequest>,
@@ -127,7 +127,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::update_autoscaling_policy call.
+    /// The request builder for [AutoscalingPolicyService::update_autoscaling_policy][super::super::client::AutoscalingPolicyService::update_autoscaling_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAutoscalingPolicy(
         RequestBuilder<crate::model::UpdateAutoscalingPolicyRequest>,
@@ -179,7 +179,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::get_autoscaling_policy call.
+    /// The request builder for [AutoscalingPolicyService::get_autoscaling_policy][super::super::client::AutoscalingPolicyService::get_autoscaling_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetAutoscalingPolicy(RequestBuilder<crate::model::GetAutoscalingPolicyRequest>);
 
@@ -226,7 +226,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::list_autoscaling_policies call.
+    /// The request builder for [AutoscalingPolicyService::list_autoscaling_policies][super::super::client::AutoscalingPolicyService::list_autoscaling_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListAutoscalingPolicies(
         RequestBuilder<crate::model::ListAutoscalingPoliciesRequest>,
@@ -304,7 +304,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::delete_autoscaling_policy call.
+    /// The request builder for [AutoscalingPolicyService::delete_autoscaling_policy][super::super::client::AutoscalingPolicyService::delete_autoscaling_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAutoscalingPolicy(
         RequestBuilder<crate::model::DeleteAutoscalingPolicyRequest>,
@@ -353,7 +353,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::set_iam_policy call.
+    /// The request builder for [AutoscalingPolicyService::set_iam_policy][super::super::client::AutoscalingPolicyService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -415,7 +415,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::get_iam_policy call.
+    /// The request builder for [AutoscalingPolicyService::get_iam_policy][super::super::client::AutoscalingPolicyService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -468,7 +468,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::test_iam_permissions call.
+    /// The request builder for [AutoscalingPolicyService::test_iam_permissions][super::super::client::AutoscalingPolicyService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -526,7 +526,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::list_operations call.
+    /// The request builder for [AutoscalingPolicyService::list_operations][super::super::client::AutoscalingPolicyService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -606,7 +606,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::get_operation call.
+    /// The request builder for [AutoscalingPolicyService::get_operation][super::super::client::AutoscalingPolicyService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -653,7 +653,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::delete_operation call.
+    /// The request builder for [AutoscalingPolicyService::delete_operation][super::super::client::AutoscalingPolicyService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -700,7 +700,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for a AutoscalingPolicyService::cancel_operation call.
+    /// The request builder for [AutoscalingPolicyService::cancel_operation][super::super::client::AutoscalingPolicyService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -801,7 +801,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::create_batch call.
+    /// The request builder for [BatchController::create_batch][super::super::client::BatchController::create_batch] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBatch(RequestBuilder<crate::model::CreateBatchRequest>);
 
@@ -902,7 +902,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::get_batch call.
+    /// The request builder for [BatchController::get_batch][super::super::client::BatchController::get_batch] calls.
     #[derive(Clone, Debug)]
     pub struct GetBatch(RequestBuilder<crate::model::GetBatchRequest>);
 
@@ -944,7 +944,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::list_batches call.
+    /// The request builder for [BatchController::list_batches][super::super::client::BatchController::list_batches] calls.
     #[derive(Clone, Debug)]
     pub struct ListBatches(RequestBuilder<crate::model::ListBatchesRequest>);
 
@@ -1025,7 +1025,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::delete_batch call.
+    /// The request builder for [BatchController::delete_batch][super::super::client::BatchController::delete_batch] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBatch(RequestBuilder<crate::model::DeleteBatchRequest>);
 
@@ -1067,7 +1067,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::set_iam_policy call.
+    /// The request builder for [BatchController::set_iam_policy][super::super::client::BatchController::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1127,7 +1127,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::get_iam_policy call.
+    /// The request builder for [BatchController::get_iam_policy][super::super::client::BatchController::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1178,7 +1178,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::test_iam_permissions call.
+    /// The request builder for [BatchController::test_iam_permissions][super::super::client::BatchController::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1234,7 +1234,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::list_operations call.
+    /// The request builder for [BatchController::list_operations][super::super::client::BatchController::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1312,7 +1312,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::get_operation call.
+    /// The request builder for [BatchController::get_operation][super::super::client::BatchController::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1357,7 +1357,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::delete_operation call.
+    /// The request builder for [BatchController::delete_operation][super::super::client::BatchController::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1402,7 +1402,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for a BatchController::cancel_operation call.
+    /// The request builder for [BatchController::cancel_operation][super::super::client::BatchController::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1501,7 +1501,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::create_cluster call.
+    /// The request builder for [ClusterController::create_cluster][super::super::client::ClusterController::create_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -1612,7 +1612,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::update_cluster call.
+    /// The request builder for [ClusterController::update_cluster][super::super::client::ClusterController::update_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -1738,7 +1738,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::stop_cluster call.
+    /// The request builder for [ClusterController::stop_cluster][super::super::client::ClusterController::stop_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct StopCluster(RequestBuilder<crate::model::StopClusterRequest>);
 
@@ -1843,7 +1843,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::start_cluster call.
+    /// The request builder for [ClusterController::start_cluster][super::super::client::ClusterController::start_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct StartCluster(RequestBuilder<crate::model::StartClusterRequest>);
 
@@ -1948,7 +1948,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::delete_cluster call.
+    /// The request builder for [ClusterController::delete_cluster][super::super::client::ClusterController::delete_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -2051,7 +2051,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::get_cluster call.
+    /// The request builder for [ClusterController::get_cluster][super::super::client::ClusterController::get_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -2105,7 +2105,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::list_clusters call.
+    /// The request builder for [ClusterController::list_clusters][super::super::client::ClusterController::list_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -2186,7 +2186,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::diagnose_cluster call.
+    /// The request builder for [ClusterController::diagnose_cluster][super::super::client::ClusterController::diagnose_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DiagnoseCluster(RequestBuilder<crate::model::DiagnoseClusterRequest>);
 
@@ -2329,7 +2329,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::set_iam_policy call.
+    /// The request builder for [ClusterController::set_iam_policy][super::super::client::ClusterController::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2389,7 +2389,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::get_iam_policy call.
+    /// The request builder for [ClusterController::get_iam_policy][super::super::client::ClusterController::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2440,7 +2440,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::test_iam_permissions call.
+    /// The request builder for [ClusterController::test_iam_permissions][super::super::client::ClusterController::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2496,7 +2496,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::list_operations call.
+    /// The request builder for [ClusterController::list_operations][super::super::client::ClusterController::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2574,7 +2574,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::get_operation call.
+    /// The request builder for [ClusterController::get_operation][super::super::client::ClusterController::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2619,7 +2619,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::delete_operation call.
+    /// The request builder for [ClusterController::delete_operation][super::super::client::ClusterController::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2664,7 +2664,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for a ClusterController::cancel_operation call.
+    /// The request builder for [ClusterController::cancel_operation][super::super::client::ClusterController::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2763,7 +2763,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::submit_job call.
+    /// The request builder for [JobController::submit_job][super::super::client::JobController::submit_job] calls.
     #[derive(Clone, Debug)]
     pub struct SubmitJob(RequestBuilder<crate::model::SubmitJobRequest>);
 
@@ -2823,7 +2823,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::submit_job_as_operation call.
+    /// The request builder for [JobController::submit_job_as_operation][super::super::client::JobController::submit_job_as_operation] calls.
     #[derive(Clone, Debug)]
     pub struct SubmitJobAsOperation(RequestBuilder<crate::model::SubmitJobRequest>);
 
@@ -2918,7 +2918,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::get_job call.
+    /// The request builder for [JobController::get_job][super::super::client::JobController::get_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -2970,7 +2970,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::list_jobs call.
+    /// The request builder for [JobController::list_jobs][super::super::client::JobController::list_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -3065,7 +3065,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::update_job call.
+    /// The request builder for [JobController::update_job][super::super::client::JobController::update_job] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateJob(RequestBuilder<crate::model::UpdateJobRequest>);
 
@@ -3134,7 +3134,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::cancel_job call.
+    /// The request builder for [JobController::cancel_job][super::super::client::JobController::cancel_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelJob(RequestBuilder<crate::model::CancelJobRequest>);
 
@@ -3188,7 +3188,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::delete_job call.
+    /// The request builder for [JobController::delete_job][super::super::client::JobController::delete_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -3242,7 +3242,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::set_iam_policy call.
+    /// The request builder for [JobController::set_iam_policy][super::super::client::JobController::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3302,7 +3302,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::get_iam_policy call.
+    /// The request builder for [JobController::get_iam_policy][super::super::client::JobController::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3353,7 +3353,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::test_iam_permissions call.
+    /// The request builder for [JobController::test_iam_permissions][super::super::client::JobController::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3409,7 +3409,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::list_operations call.
+    /// The request builder for [JobController::list_operations][super::super::client::JobController::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3487,7 +3487,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::get_operation call.
+    /// The request builder for [JobController::get_operation][super::super::client::JobController::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3532,7 +3532,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::delete_operation call.
+    /// The request builder for [JobController::delete_operation][super::super::client::JobController::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3577,7 +3577,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for a JobController::cancel_operation call.
+    /// The request builder for [JobController::cancel_operation][super::super::client::JobController::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3676,7 +3676,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::create_node_group call.
+    /// The request builder for [NodeGroupController::create_node_group][super::super::client::NodeGroupController::create_node_group] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNodeGroup(RequestBuilder<crate::model::CreateNodeGroupRequest>);
 
@@ -3778,7 +3778,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::resize_node_group call.
+    /// The request builder for [NodeGroupController::resize_node_group][super::super::client::NodeGroupController::resize_node_group] calls.
     #[derive(Clone, Debug)]
     pub struct ResizeNodeGroup(RequestBuilder<crate::model::ResizeNodeGroupRequest>);
 
@@ -3880,7 +3880,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::get_node_group call.
+    /// The request builder for [NodeGroupController::get_node_group][super::super::client::NodeGroupController::get_node_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetNodeGroup(RequestBuilder<crate::model::GetNodeGroupRequest>);
 
@@ -3922,7 +3922,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::set_iam_policy call.
+    /// The request builder for [NodeGroupController::set_iam_policy][super::super::client::NodeGroupController::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3982,7 +3982,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::get_iam_policy call.
+    /// The request builder for [NodeGroupController::get_iam_policy][super::super::client::NodeGroupController::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4033,7 +4033,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::test_iam_permissions call.
+    /// The request builder for [NodeGroupController::test_iam_permissions][super::super::client::NodeGroupController::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4089,7 +4089,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::list_operations call.
+    /// The request builder for [NodeGroupController::list_operations][super::super::client::NodeGroupController::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4167,7 +4167,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::get_operation call.
+    /// The request builder for [NodeGroupController::get_operation][super::super::client::NodeGroupController::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4212,7 +4212,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::delete_operation call.
+    /// The request builder for [NodeGroupController::delete_operation][super::super::client::NodeGroupController::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4257,7 +4257,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for a NodeGroupController::cancel_operation call.
+    /// The request builder for [NodeGroupController::cancel_operation][super::super::client::NodeGroupController::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4358,7 +4358,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::create_session_template call.
+    /// The request builder for [SessionTemplateController::create_session_template][super::super::client::SessionTemplateController::create_session_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSessionTemplate(RequestBuilder<crate::model::CreateSessionTemplateRequest>);
 
@@ -4414,7 +4414,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::update_session_template call.
+    /// The request builder for [SessionTemplateController::update_session_template][super::super::client::SessionTemplateController::update_session_template] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSessionTemplate(RequestBuilder<crate::model::UpdateSessionTemplateRequest>);
 
@@ -4464,7 +4464,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::get_session_template call.
+    /// The request builder for [SessionTemplateController::get_session_template][super::super::client::SessionTemplateController::get_session_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetSessionTemplate(RequestBuilder<crate::model::GetSessionTemplateRequest>);
 
@@ -4511,7 +4511,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::list_session_templates call.
+    /// The request builder for [SessionTemplateController::list_session_templates][super::super::client::SessionTemplateController::list_session_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListSessionTemplates(RequestBuilder<crate::model::ListSessionTemplatesRequest>);
 
@@ -4591,7 +4591,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::delete_session_template call.
+    /// The request builder for [SessionTemplateController::delete_session_template][super::super::client::SessionTemplateController::delete_session_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSessionTemplate(RequestBuilder<crate::model::DeleteSessionTemplateRequest>);
 
@@ -4638,7 +4638,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::set_iam_policy call.
+    /// The request builder for [SessionTemplateController::set_iam_policy][super::super::client::SessionTemplateController::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4700,7 +4700,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::get_iam_policy call.
+    /// The request builder for [SessionTemplateController::get_iam_policy][super::super::client::SessionTemplateController::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4753,7 +4753,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::test_iam_permissions call.
+    /// The request builder for [SessionTemplateController::test_iam_permissions][super::super::client::SessionTemplateController::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4811,7 +4811,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::list_operations call.
+    /// The request builder for [SessionTemplateController::list_operations][super::super::client::SessionTemplateController::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4891,7 +4891,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::get_operation call.
+    /// The request builder for [SessionTemplateController::get_operation][super::super::client::SessionTemplateController::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4938,7 +4938,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::delete_operation call.
+    /// The request builder for [SessionTemplateController::delete_operation][super::super::client::SessionTemplateController::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4985,7 +4985,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for a SessionTemplateController::cancel_operation call.
+    /// The request builder for [SessionTemplateController::cancel_operation][super::super::client::SessionTemplateController::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5086,7 +5086,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::create_session call.
+    /// The request builder for [SessionController::create_session][super::super::client::SessionController::create_session] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSession(RequestBuilder<crate::model::CreateSessionRequest>);
 
@@ -5188,7 +5188,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::get_session call.
+    /// The request builder for [SessionController::get_session][super::super::client::SessionController::get_session] calls.
     #[derive(Clone, Debug)]
     pub struct GetSession(RequestBuilder<crate::model::GetSessionRequest>);
 
@@ -5230,7 +5230,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::list_sessions call.
+    /// The request builder for [SessionController::list_sessions][super::super::client::SessionController::list_sessions] calls.
     #[derive(Clone, Debug)]
     pub struct ListSessions(RequestBuilder<crate::model::ListSessionsRequest>);
 
@@ -5305,7 +5305,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::terminate_session call.
+    /// The request builder for [SessionController::terminate_session][super::super::client::SessionController::terminate_session] calls.
     #[derive(Clone, Debug)]
     pub struct TerminateSession(RequestBuilder<crate::model::TerminateSessionRequest>);
 
@@ -5395,7 +5395,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::delete_session call.
+    /// The request builder for [SessionController::delete_session][super::super::client::SessionController::delete_session] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSession(RequestBuilder<crate::model::DeleteSessionRequest>);
 
@@ -5482,7 +5482,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::set_iam_policy call.
+    /// The request builder for [SessionController::set_iam_policy][super::super::client::SessionController::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -5542,7 +5542,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::get_iam_policy call.
+    /// The request builder for [SessionController::get_iam_policy][super::super::client::SessionController::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -5593,7 +5593,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::test_iam_permissions call.
+    /// The request builder for [SessionController::test_iam_permissions][super::super::client::SessionController::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5649,7 +5649,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::list_operations call.
+    /// The request builder for [SessionController::list_operations][super::super::client::SessionController::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5727,7 +5727,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::get_operation call.
+    /// The request builder for [SessionController::get_operation][super::super::client::SessionController::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5772,7 +5772,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::delete_operation call.
+    /// The request builder for [SessionController::delete_operation][super::super::client::SessionController::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5817,7 +5817,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for a SessionController::cancel_operation call.
+    /// The request builder for [SessionController::cancel_operation][super::super::client::SessionController::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5918,7 +5918,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::create_workflow_template call.
+    /// The request builder for [WorkflowTemplateService::create_workflow_template][super::super::client::WorkflowTemplateService::create_workflow_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWorkflowTemplate(RequestBuilder<crate::model::CreateWorkflowTemplateRequest>);
 
@@ -5974,7 +5974,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::get_workflow_template call.
+    /// The request builder for [WorkflowTemplateService::get_workflow_template][super::super::client::WorkflowTemplateService::get_workflow_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkflowTemplate(RequestBuilder<crate::model::GetWorkflowTemplateRequest>);
 
@@ -6027,7 +6027,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::instantiate_workflow_template call.
+    /// The request builder for [WorkflowTemplateService::instantiate_workflow_template][super::super::client::WorkflowTemplateService::instantiate_workflow_template] calls.
     #[derive(Clone, Debug)]
     pub struct InstantiateWorkflowTemplate(
         RequestBuilder<crate::model::InstantiateWorkflowTemplateRequest>,
@@ -6134,7 +6134,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::instantiate_inline_workflow_template call.
+    /// The request builder for [WorkflowTemplateService::instantiate_inline_workflow_template][super::super::client::WorkflowTemplateService::instantiate_inline_workflow_template] calls.
     #[derive(Clone, Debug)]
     pub struct InstantiateInlineWorkflowTemplate(
         RequestBuilder<crate::model::InstantiateInlineWorkflowTemplateRequest>,
@@ -6233,7 +6233,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::update_workflow_template call.
+    /// The request builder for [WorkflowTemplateService::update_workflow_template][super::super::client::WorkflowTemplateService::update_workflow_template] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWorkflowTemplate(RequestBuilder<crate::model::UpdateWorkflowTemplateRequest>);
 
@@ -6283,7 +6283,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::list_workflow_templates call.
+    /// The request builder for [WorkflowTemplateService::list_workflow_templates][super::super::client::WorkflowTemplateService::list_workflow_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkflowTemplates(RequestBuilder<crate::model::ListWorkflowTemplatesRequest>);
 
@@ -6357,7 +6357,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::delete_workflow_template call.
+    /// The request builder for [WorkflowTemplateService::delete_workflow_template][super::super::client::WorkflowTemplateService::delete_workflow_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWorkflowTemplate(RequestBuilder<crate::model::DeleteWorkflowTemplateRequest>);
 
@@ -6410,7 +6410,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::set_iam_policy call.
+    /// The request builder for [WorkflowTemplateService::set_iam_policy][super::super::client::WorkflowTemplateService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -6472,7 +6472,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::get_iam_policy call.
+    /// The request builder for [WorkflowTemplateService::get_iam_policy][super::super::client::WorkflowTemplateService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -6525,7 +6525,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::test_iam_permissions call.
+    /// The request builder for [WorkflowTemplateService::test_iam_permissions][super::super::client::WorkflowTemplateService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -6583,7 +6583,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::list_operations call.
+    /// The request builder for [WorkflowTemplateService::list_operations][super::super::client::WorkflowTemplateService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6663,7 +6663,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::get_operation call.
+    /// The request builder for [WorkflowTemplateService::get_operation][super::super::client::WorkflowTemplateService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6710,7 +6710,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::delete_operation call.
+    /// The request builder for [WorkflowTemplateService::delete_operation][super::super::client::WorkflowTemplateService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -6757,7 +6757,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for a WorkflowTemplateService::cancel_operation call.
+    /// The request builder for [WorkflowTemplateService::cancel_operation][super::super::client::WorkflowTemplateService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/datastream/v1/src/builder.rs
+++ b/src/generated/cloud/datastream/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::list_connection_profiles call.
+    /// The request builder for [Datastream::list_connection_profiles][super::super::client::Datastream::list_connection_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnectionProfiles(RequestBuilder<crate::model::ListConnectionProfilesRequest>);
 
@@ -153,7 +153,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::get_connection_profile call.
+    /// The request builder for [Datastream::get_connection_profile][super::super::client::Datastream::get_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnectionProfile(RequestBuilder<crate::model::GetConnectionProfileRequest>);
 
@@ -198,7 +198,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::create_connection_profile call.
+    /// The request builder for [Datastream::create_connection_profile][super::super::client::Datastream::create_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnectionProfile(
         RequestBuilder<crate::model::CreateConnectionProfileRequest>,
@@ -319,7 +319,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::update_connection_profile call.
+    /// The request builder for [Datastream::update_connection_profile][super::super::client::Datastream::update_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConnectionProfile(
         RequestBuilder<crate::model::UpdateConnectionProfileRequest>,
@@ -437,7 +437,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::delete_connection_profile call.
+    /// The request builder for [Datastream::delete_connection_profile][super::super::client::Datastream::delete_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnectionProfile(
         RequestBuilder<crate::model::DeleteConnectionProfileRequest>,
@@ -525,7 +525,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::discover_connection_profile call.
+    /// The request builder for [Datastream::discover_connection_profile][super::super::client::Datastream::discover_connection_profile] calls.
     #[derive(Clone, Debug)]
     pub struct DiscoverConnectionProfile(
         RequestBuilder<crate::model::DiscoverConnectionProfileRequest>,
@@ -605,7 +605,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::list_streams call.
+    /// The request builder for [Datastream::list_streams][super::super::client::Datastream::list_streams] calls.
     #[derive(Clone, Debug)]
     pub struct ListStreams(RequestBuilder<crate::model::ListStreamsRequest>);
 
@@ -686,7 +686,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::get_stream call.
+    /// The request builder for [Datastream::get_stream][super::super::client::Datastream::get_stream] calls.
     #[derive(Clone, Debug)]
     pub struct GetStream(RequestBuilder<crate::model::GetStreamRequest>);
 
@@ -728,7 +728,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::create_stream call.
+    /// The request builder for [Datastream::create_stream][super::super::client::Datastream::create_stream] calls.
     #[derive(Clone, Debug)]
     pub struct CreateStream(RequestBuilder<crate::model::CreateStreamRequest>);
 
@@ -840,7 +840,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::update_stream call.
+    /// The request builder for [Datastream::update_stream][super::super::client::Datastream::update_stream] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateStream(RequestBuilder<crate::model::UpdateStreamRequest>);
 
@@ -949,7 +949,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::delete_stream call.
+    /// The request builder for [Datastream::delete_stream][super::super::client::Datastream::delete_stream] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteStream(RequestBuilder<crate::model::DeleteStreamRequest>);
 
@@ -1032,7 +1032,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::run_stream call.
+    /// The request builder for [Datastream::run_stream][super::super::client::Datastream::run_stream] calls.
     #[derive(Clone, Debug)]
     pub struct RunStream(RequestBuilder<crate::model::RunStreamRequest>);
 
@@ -1126,7 +1126,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::get_stream_object call.
+    /// The request builder for [Datastream::get_stream_object][super::super::client::Datastream::get_stream_object] calls.
     #[derive(Clone, Debug)]
     pub struct GetStreamObject(RequestBuilder<crate::model::GetStreamObjectRequest>);
 
@@ -1168,7 +1168,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::lookup_stream_object call.
+    /// The request builder for [Datastream::lookup_stream_object][super::super::client::Datastream::lookup_stream_object] calls.
     #[derive(Clone, Debug)]
     pub struct LookupStreamObject(RequestBuilder<crate::model::LookupStreamObjectRequest>);
 
@@ -1224,7 +1224,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::list_stream_objects call.
+    /// The request builder for [Datastream::list_stream_objects][super::super::client::Datastream::list_stream_objects] calls.
     #[derive(Clone, Debug)]
     pub struct ListStreamObjects(RequestBuilder<crate::model::ListStreamObjectsRequest>);
 
@@ -1296,7 +1296,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::start_backfill_job call.
+    /// The request builder for [Datastream::start_backfill_job][super::super::client::Datastream::start_backfill_job] calls.
     #[derive(Clone, Debug)]
     pub struct StartBackfillJob(RequestBuilder<crate::model::StartBackfillJobRequest>);
 
@@ -1341,7 +1341,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::stop_backfill_job call.
+    /// The request builder for [Datastream::stop_backfill_job][super::super::client::Datastream::stop_backfill_job] calls.
     #[derive(Clone, Debug)]
     pub struct StopBackfillJob(RequestBuilder<crate::model::StopBackfillJobRequest>);
 
@@ -1383,7 +1383,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::fetch_static_ips call.
+    /// The request builder for [Datastream::fetch_static_ips][super::super::client::Datastream::fetch_static_ips] calls.
     #[derive(Clone, Debug)]
     pub struct FetchStaticIps(RequestBuilder<crate::model::FetchStaticIpsRequest>);
 
@@ -1437,7 +1437,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::create_private_connection call.
+    /// The request builder for [Datastream::create_private_connection][super::super::client::Datastream::create_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePrivateConnection(
         RequestBuilder<crate::model::CreatePrivateConnectionRequest>,
@@ -1552,7 +1552,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::get_private_connection call.
+    /// The request builder for [Datastream::get_private_connection][super::super::client::Datastream::get_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetPrivateConnection(RequestBuilder<crate::model::GetPrivateConnectionRequest>);
 
@@ -1597,7 +1597,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::list_private_connections call.
+    /// The request builder for [Datastream::list_private_connections][super::super::client::Datastream::list_private_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListPrivateConnections(RequestBuilder<crate::model::ListPrivateConnectionsRequest>);
 
@@ -1683,7 +1683,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::delete_private_connection call.
+    /// The request builder for [Datastream::delete_private_connection][super::super::client::Datastream::delete_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePrivateConnection(
         RequestBuilder<crate::model::DeletePrivateConnectionRequest>,
@@ -1777,7 +1777,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::create_route call.
+    /// The request builder for [Datastream::create_route][super::super::client::Datastream::create_route] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRoute(RequestBuilder<crate::model::CreateRouteRequest>);
 
@@ -1877,7 +1877,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::get_route call.
+    /// The request builder for [Datastream::get_route][super::super::client::Datastream::get_route] calls.
     #[derive(Clone, Debug)]
     pub struct GetRoute(RequestBuilder<crate::model::GetRouteRequest>);
 
@@ -1919,7 +1919,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::list_routes call.
+    /// The request builder for [Datastream::list_routes][super::super::client::Datastream::list_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListRoutes(RequestBuilder<crate::model::ListRoutesRequest>);
 
@@ -2000,7 +2000,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::delete_route call.
+    /// The request builder for [Datastream::delete_route][super::super::client::Datastream::delete_route] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRoute(RequestBuilder<crate::model::DeleteRouteRequest>);
 
@@ -2083,7 +2083,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::list_locations call.
+    /// The request builder for [Datastream::list_locations][super::super::client::Datastream::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2161,7 +2161,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::get_location call.
+    /// The request builder for [Datastream::get_location][super::super::client::Datastream::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2203,7 +2203,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::list_operations call.
+    /// The request builder for [Datastream::list_operations][super::super::client::Datastream::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2281,7 +2281,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::get_operation call.
+    /// The request builder for [Datastream::get_operation][super::super::client::Datastream::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2326,7 +2326,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::delete_operation call.
+    /// The request builder for [Datastream::delete_operation][super::super::client::Datastream::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2371,7 +2371,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for a Datastream::cancel_operation call.
+    /// The request builder for [Datastream::cancel_operation][super::super::client::Datastream::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/deploy/v1/src/builder.rs
+++ b/src/generated/cloud/deploy/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_delivery_pipelines call.
+    /// The request builder for [CloudDeploy::list_delivery_pipelines][super::super::client::CloudDeploy::list_delivery_pipelines] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeliveryPipelines(RequestBuilder<crate::model::ListDeliveryPipelinesRequest>);
 
@@ -151,7 +151,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_delivery_pipeline call.
+    /// The request builder for [CloudDeploy::get_delivery_pipeline][super::super::client::CloudDeploy::get_delivery_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeliveryPipeline(RequestBuilder<crate::model::GetDeliveryPipelineRequest>);
 
@@ -196,7 +196,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::create_delivery_pipeline call.
+    /// The request builder for [CloudDeploy::create_delivery_pipeline][super::super::client::CloudDeploy::create_delivery_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDeliveryPipeline(RequestBuilder<crate::model::CreateDeliveryPipelineRequest>);
 
@@ -309,7 +309,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::update_delivery_pipeline call.
+    /// The request builder for [CloudDeploy::update_delivery_pipeline][super::super::client::CloudDeploy::update_delivery_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDeliveryPipeline(RequestBuilder<crate::model::UpdateDeliveryPipelineRequest>);
 
@@ -425,7 +425,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::delete_delivery_pipeline call.
+    /// The request builder for [CloudDeploy::delete_delivery_pipeline][super::super::client::CloudDeploy::delete_delivery_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDeliveryPipeline(RequestBuilder<crate::model::DeleteDeliveryPipelineRequest>);
 
@@ -535,7 +535,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_targets call.
+    /// The request builder for [CloudDeploy::list_targets][super::super::client::CloudDeploy::list_targets] calls.
     #[derive(Clone, Debug)]
     pub struct ListTargets(RequestBuilder<crate::model::ListTargetsRequest>);
 
@@ -616,7 +616,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::rollback_target call.
+    /// The request builder for [CloudDeploy::rollback_target][super::super::client::CloudDeploy::rollback_target] calls.
     #[derive(Clone, Debug)]
     pub struct RollbackTarget(RequestBuilder<crate::model::RollbackTargetRequest>);
 
@@ -710,7 +710,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_target call.
+    /// The request builder for [CloudDeploy::get_target][super::super::client::CloudDeploy::get_target] calls.
     #[derive(Clone, Debug)]
     pub struct GetTarget(RequestBuilder<crate::model::GetTargetRequest>);
 
@@ -752,7 +752,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::create_target call.
+    /// The request builder for [CloudDeploy::create_target][super::super::client::CloudDeploy::create_target] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTarget(RequestBuilder<crate::model::CreateTargetRequest>);
 
@@ -858,7 +858,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::update_target call.
+    /// The request builder for [CloudDeploy::update_target][super::super::client::CloudDeploy::update_target] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTarget(RequestBuilder<crate::model::UpdateTargetRequest>);
 
@@ -967,7 +967,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::delete_target call.
+    /// The request builder for [CloudDeploy::delete_target][super::super::client::CloudDeploy::delete_target] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTarget(RequestBuilder<crate::model::DeleteTargetRequest>);
 
@@ -1068,7 +1068,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_custom_target_types call.
+    /// The request builder for [CloudDeploy::list_custom_target_types][super::super::client::CloudDeploy::list_custom_target_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListCustomTargetTypes(RequestBuilder<crate::model::ListCustomTargetTypesRequest>);
 
@@ -1152,7 +1152,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_custom_target_type call.
+    /// The request builder for [CloudDeploy::get_custom_target_type][super::super::client::CloudDeploy::get_custom_target_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetCustomTargetType(RequestBuilder<crate::model::GetCustomTargetTypeRequest>);
 
@@ -1197,7 +1197,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::create_custom_target_type call.
+    /// The request builder for [CloudDeploy::create_custom_target_type][super::super::client::CloudDeploy::create_custom_target_type] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCustomTargetType(RequestBuilder<crate::model::CreateCustomTargetTypeRequest>);
 
@@ -1310,7 +1310,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::update_custom_target_type call.
+    /// The request builder for [CloudDeploy::update_custom_target_type][super::super::client::CloudDeploy::update_custom_target_type] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCustomTargetType(RequestBuilder<crate::model::UpdateCustomTargetTypeRequest>);
 
@@ -1426,7 +1426,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::delete_custom_target_type call.
+    /// The request builder for [CloudDeploy::delete_custom_target_type][super::super::client::CloudDeploy::delete_custom_target_type] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCustomTargetType(RequestBuilder<crate::model::DeleteCustomTargetTypeRequest>);
 
@@ -1530,7 +1530,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_releases call.
+    /// The request builder for [CloudDeploy::list_releases][super::super::client::CloudDeploy::list_releases] calls.
     #[derive(Clone, Debug)]
     pub struct ListReleases(RequestBuilder<crate::model::ListReleasesRequest>);
 
@@ -1611,7 +1611,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_release call.
+    /// The request builder for [CloudDeploy::get_release][super::super::client::CloudDeploy::get_release] calls.
     #[derive(Clone, Debug)]
     pub struct GetRelease(RequestBuilder<crate::model::GetReleaseRequest>);
 
@@ -1653,7 +1653,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::create_release call.
+    /// The request builder for [CloudDeploy::create_release][super::super::client::CloudDeploy::create_release] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRelease(RequestBuilder<crate::model::CreateReleaseRequest>);
 
@@ -1770,7 +1770,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::abandon_release call.
+    /// The request builder for [CloudDeploy::abandon_release][super::super::client::CloudDeploy::abandon_release] calls.
     #[derive(Clone, Debug)]
     pub struct AbandonRelease(RequestBuilder<crate::model::AbandonReleaseRequest>);
 
@@ -1812,7 +1812,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::create_deploy_policy call.
+    /// The request builder for [CloudDeploy::create_deploy_policy][super::super::client::CloudDeploy::create_deploy_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDeployPolicy(RequestBuilder<crate::model::CreateDeployPolicyRequest>);
 
@@ -1922,7 +1922,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::update_deploy_policy call.
+    /// The request builder for [CloudDeploy::update_deploy_policy][super::super::client::CloudDeploy::update_deploy_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDeployPolicy(RequestBuilder<crate::model::UpdateDeployPolicyRequest>);
 
@@ -2035,7 +2035,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::delete_deploy_policy call.
+    /// The request builder for [CloudDeploy::delete_deploy_policy][super::super::client::CloudDeploy::delete_deploy_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDeployPolicy(RequestBuilder<crate::model::DeleteDeployPolicyRequest>);
 
@@ -2139,7 +2139,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_deploy_policies call.
+    /// The request builder for [CloudDeploy::list_deploy_policies][super::super::client::CloudDeploy::list_deploy_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeployPolicies(RequestBuilder<crate::model::ListDeployPoliciesRequest>);
 
@@ -2223,7 +2223,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_deploy_policy call.
+    /// The request builder for [CloudDeploy::get_deploy_policy][super::super::client::CloudDeploy::get_deploy_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeployPolicy(RequestBuilder<crate::model::GetDeployPolicyRequest>);
 
@@ -2265,7 +2265,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::approve_rollout call.
+    /// The request builder for [CloudDeploy::approve_rollout][super::super::client::CloudDeploy::approve_rollout] calls.
     #[derive(Clone, Debug)]
     pub struct ApproveRollout(RequestBuilder<crate::model::ApproveRolloutRequest>);
 
@@ -2324,7 +2324,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::advance_rollout call.
+    /// The request builder for [CloudDeploy::advance_rollout][super::super::client::CloudDeploy::advance_rollout] calls.
     #[derive(Clone, Debug)]
     pub struct AdvanceRollout(RequestBuilder<crate::model::AdvanceRolloutRequest>);
 
@@ -2383,7 +2383,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::cancel_rollout call.
+    /// The request builder for [CloudDeploy::cancel_rollout][super::super::client::CloudDeploy::cancel_rollout] calls.
     #[derive(Clone, Debug)]
     pub struct CancelRollout(RequestBuilder<crate::model::CancelRolloutRequest>);
 
@@ -2436,7 +2436,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_rollouts call.
+    /// The request builder for [CloudDeploy::list_rollouts][super::super::client::CloudDeploy::list_rollouts] calls.
     #[derive(Clone, Debug)]
     pub struct ListRollouts(RequestBuilder<crate::model::ListRolloutsRequest>);
 
@@ -2517,7 +2517,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_rollout call.
+    /// The request builder for [CloudDeploy::get_rollout][super::super::client::CloudDeploy::get_rollout] calls.
     #[derive(Clone, Debug)]
     pub struct GetRollout(RequestBuilder<crate::model::GetRolloutRequest>);
 
@@ -2559,7 +2559,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::create_rollout call.
+    /// The request builder for [CloudDeploy::create_rollout][super::super::client::CloudDeploy::create_rollout] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRollout(RequestBuilder<crate::model::CreateRolloutRequest>);
 
@@ -2682,7 +2682,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::ignore_job call.
+    /// The request builder for [CloudDeploy::ignore_job][super::super::client::CloudDeploy::ignore_job] calls.
     #[derive(Clone, Debug)]
     pub struct IgnoreJob(RequestBuilder<crate::model::IgnoreJobRequest>);
 
@@ -2747,7 +2747,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::retry_job call.
+    /// The request builder for [CloudDeploy::retry_job][super::super::client::CloudDeploy::retry_job] calls.
     #[derive(Clone, Debug)]
     pub struct RetryJob(RequestBuilder<crate::model::RetryJobRequest>);
 
@@ -2812,7 +2812,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_job_runs call.
+    /// The request builder for [CloudDeploy::list_job_runs][super::super::client::CloudDeploy::list_job_runs] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobRuns(RequestBuilder<crate::model::ListJobRunsRequest>);
 
@@ -2893,7 +2893,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_job_run call.
+    /// The request builder for [CloudDeploy::get_job_run][super::super::client::CloudDeploy::get_job_run] calls.
     #[derive(Clone, Debug)]
     pub struct GetJobRun(RequestBuilder<crate::model::GetJobRunRequest>);
 
@@ -2935,7 +2935,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::terminate_job_run call.
+    /// The request builder for [CloudDeploy::terminate_job_run][super::super::client::CloudDeploy::terminate_job_run] calls.
     #[derive(Clone, Debug)]
     pub struct TerminateJobRun(RequestBuilder<crate::model::TerminateJobRunRequest>);
 
@@ -2988,7 +2988,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_config call.
+    /// The request builder for [CloudDeploy::get_config][super::super::client::CloudDeploy::get_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetConfig(RequestBuilder<crate::model::GetConfigRequest>);
 
@@ -3030,7 +3030,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::create_automation call.
+    /// The request builder for [CloudDeploy::create_automation][super::super::client::CloudDeploy::create_automation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAutomation(RequestBuilder<crate::model::CreateAutomationRequest>);
 
@@ -3140,7 +3140,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::update_automation call.
+    /// The request builder for [CloudDeploy::update_automation][super::super::client::CloudDeploy::update_automation] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAutomation(RequestBuilder<crate::model::UpdateAutomationRequest>);
 
@@ -3253,7 +3253,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::delete_automation call.
+    /// The request builder for [CloudDeploy::delete_automation][super::super::client::CloudDeploy::delete_automation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAutomation(RequestBuilder<crate::model::DeleteAutomationRequest>);
 
@@ -3357,7 +3357,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_automation call.
+    /// The request builder for [CloudDeploy::get_automation][super::super::client::CloudDeploy::get_automation] calls.
     #[derive(Clone, Debug)]
     pub struct GetAutomation(RequestBuilder<crate::model::GetAutomationRequest>);
 
@@ -3399,7 +3399,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_automations call.
+    /// The request builder for [CloudDeploy::list_automations][super::super::client::CloudDeploy::list_automations] calls.
     #[derive(Clone, Debug)]
     pub struct ListAutomations(RequestBuilder<crate::model::ListAutomationsRequest>);
 
@@ -3480,7 +3480,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_automation_run call.
+    /// The request builder for [CloudDeploy::get_automation_run][super::super::client::CloudDeploy::get_automation_run] calls.
     #[derive(Clone, Debug)]
     pub struct GetAutomationRun(RequestBuilder<crate::model::GetAutomationRunRequest>);
 
@@ -3525,7 +3525,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_automation_runs call.
+    /// The request builder for [CloudDeploy::list_automation_runs][super::super::client::CloudDeploy::list_automation_runs] calls.
     #[derive(Clone, Debug)]
     pub struct ListAutomationRuns(RequestBuilder<crate::model::ListAutomationRunsRequest>);
 
@@ -3609,7 +3609,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::cancel_automation_run call.
+    /// The request builder for [CloudDeploy::cancel_automation_run][super::super::client::CloudDeploy::cancel_automation_run] calls.
     #[derive(Clone, Debug)]
     pub struct CancelAutomationRun(RequestBuilder<crate::model::CancelAutomationRunRequest>);
 
@@ -3654,7 +3654,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_locations call.
+    /// The request builder for [CloudDeploy::list_locations][super::super::client::CloudDeploy::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3732,7 +3732,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_location call.
+    /// The request builder for [CloudDeploy::get_location][super::super::client::CloudDeploy::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3774,7 +3774,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::set_iam_policy call.
+    /// The request builder for [CloudDeploy::set_iam_policy][super::super::client::CloudDeploy::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3834,7 +3834,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_iam_policy call.
+    /// The request builder for [CloudDeploy::get_iam_policy][super::super::client::CloudDeploy::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3885,7 +3885,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::test_iam_permissions call.
+    /// The request builder for [CloudDeploy::test_iam_permissions][super::super::client::CloudDeploy::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3941,7 +3941,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::list_operations call.
+    /// The request builder for [CloudDeploy::list_operations][super::super::client::CloudDeploy::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4019,7 +4019,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::get_operation call.
+    /// The request builder for [CloudDeploy::get_operation][super::super::client::CloudDeploy::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4064,7 +4064,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::delete_operation call.
+    /// The request builder for [CloudDeploy::delete_operation][super::super::client::CloudDeploy::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4109,7 +4109,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for a CloudDeploy::cancel_operation call.
+    /// The request builder for [CloudDeploy::cancel_operation][super::super::client::CloudDeploy::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/developerconnect/v1/src/builder.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::list_connections call.
+    /// The request builder for [DeveloperConnect::list_connections][super::super::client::DeveloperConnect::list_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -148,7 +148,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::get_connection call.
+    /// The request builder for [DeveloperConnect::get_connection][super::super::client::DeveloperConnect::get_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -190,7 +190,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::create_connection call.
+    /// The request builder for [DeveloperConnect::create_connection][super::super::client::DeveloperConnect::create_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -300,7 +300,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::update_connection call.
+    /// The request builder for [DeveloperConnect::update_connection][super::super::client::DeveloperConnect::update_connection] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 
@@ -413,7 +413,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::delete_connection call.
+    /// The request builder for [DeveloperConnect::delete_connection][super::super::client::DeveloperConnect::delete_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -511,7 +511,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::create_git_repository_link call.
+    /// The request builder for [DeveloperConnect::create_git_repository_link][super::super::client::DeveloperConnect::create_git_repository_link] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGitRepositoryLink(
         RequestBuilder<crate::model::CreateGitRepositoryLinkRequest>,
@@ -626,7 +626,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::delete_git_repository_link call.
+    /// The request builder for [DeveloperConnect::delete_git_repository_link][super::super::client::DeveloperConnect::delete_git_repository_link] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGitRepositoryLink(
         RequestBuilder<crate::model::DeleteGitRepositoryLinkRequest>,
@@ -726,7 +726,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::list_git_repository_links call.
+    /// The request builder for [DeveloperConnect::list_git_repository_links][super::super::client::DeveloperConnect::list_git_repository_links] calls.
     #[derive(Clone, Debug)]
     pub struct ListGitRepositoryLinks(RequestBuilder<crate::model::ListGitRepositoryLinksRequest>);
 
@@ -812,7 +812,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::get_git_repository_link call.
+    /// The request builder for [DeveloperConnect::get_git_repository_link][super::super::client::DeveloperConnect::get_git_repository_link] calls.
     #[derive(Clone, Debug)]
     pub struct GetGitRepositoryLink(RequestBuilder<crate::model::GetGitRepositoryLinkRequest>);
 
@@ -857,7 +857,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::fetch_read_write_token call.
+    /// The request builder for [DeveloperConnect::fetch_read_write_token][super::super::client::DeveloperConnect::fetch_read_write_token] calls.
     #[derive(Clone, Debug)]
     pub struct FetchReadWriteToken(RequestBuilder<crate::model::FetchReadWriteTokenRequest>);
 
@@ -902,7 +902,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::fetch_read_token call.
+    /// The request builder for [DeveloperConnect::fetch_read_token][super::super::client::DeveloperConnect::fetch_read_token] calls.
     #[derive(Clone, Debug)]
     pub struct FetchReadToken(RequestBuilder<crate::model::FetchReadTokenRequest>);
 
@@ -944,7 +944,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::fetch_linkable_git_repositories call.
+    /// The request builder for [DeveloperConnect::fetch_linkable_git_repositories][super::super::client::DeveloperConnect::fetch_linkable_git_repositories] calls.
     #[derive(Clone, Debug)]
     pub struct FetchLinkableGitRepositories(
         RequestBuilder<crate::model::FetchLinkableGitRepositoriesRequest>,
@@ -1020,7 +1020,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::fetch_git_hub_installations call.
+    /// The request builder for [DeveloperConnect::fetch_git_hub_installations][super::super::client::DeveloperConnect::fetch_git_hub_installations] calls.
     #[derive(Clone, Debug)]
     pub struct FetchGitHubInstallations(
         RequestBuilder<crate::model::FetchGitHubInstallationsRequest>,
@@ -1067,7 +1067,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::fetch_git_refs call.
+    /// The request builder for [DeveloperConnect::fetch_git_refs][super::super::client::DeveloperConnect::fetch_git_refs] calls.
     #[derive(Clone, Debug)]
     pub struct FetchGitRefs(RequestBuilder<crate::model::FetchGitRefsRequest>);
 
@@ -1130,7 +1130,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::list_locations call.
+    /// The request builder for [DeveloperConnect::list_locations][super::super::client::DeveloperConnect::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1208,7 +1208,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::get_location call.
+    /// The request builder for [DeveloperConnect::get_location][super::super::client::DeveloperConnect::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1250,7 +1250,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::list_operations call.
+    /// The request builder for [DeveloperConnect::list_operations][super::super::client::DeveloperConnect::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1328,7 +1328,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::get_operation call.
+    /// The request builder for [DeveloperConnect::get_operation][super::super::client::DeveloperConnect::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1373,7 +1373,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::delete_operation call.
+    /// The request builder for [DeveloperConnect::delete_operation][super::super::client::DeveloperConnect::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1418,7 +1418,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for a DeveloperConnect::cancel_operation call.
+    /// The request builder for [DeveloperConnect::cancel_operation][super::super::client::DeveloperConnect::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
@@ -67,7 +67,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::list_agents call.
+    /// The request builder for [Agents::list_agents][super::super::client::Agents::list_agents] calls.
     #[derive(Clone, Debug)]
     pub struct ListAgents(RequestBuilder<crate::model::ListAgentsRequest>);
 
@@ -136,7 +136,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_agent call.
+    /// The request builder for [Agents::get_agent][super::super::client::Agents::get_agent] calls.
     #[derive(Clone, Debug)]
     pub struct GetAgent(RequestBuilder<crate::model::GetAgentRequest>);
 
@@ -178,7 +178,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::create_agent call.
+    /// The request builder for [Agents::create_agent][super::super::client::Agents::create_agent] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAgent(RequestBuilder<crate::model::CreateAgentRequest>);
 
@@ -229,7 +229,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::update_agent call.
+    /// The request builder for [Agents::update_agent][super::super::client::Agents::update_agent] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAgent(RequestBuilder<crate::model::UpdateAgentRequest>);
 
@@ -283,7 +283,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::delete_agent call.
+    /// The request builder for [Agents::delete_agent][super::super::client::Agents::delete_agent] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAgent(RequestBuilder<crate::model::DeleteAgentRequest>);
 
@@ -325,7 +325,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::export_agent call.
+    /// The request builder for [Agents::export_agent][super::super::client::Agents::export_agent] calls.
     #[derive(Clone, Debug)]
     pub struct ExportAgent(RequestBuilder<crate::model::ExportAgentRequest>);
 
@@ -440,7 +440,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::restore_agent call.
+    /// The request builder for [Agents::restore_agent][super::super::client::Agents::restore_agent] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreAgent(RequestBuilder<crate::model::RestoreAgentRequest>);
 
@@ -535,7 +535,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::validate_agent call.
+    /// The request builder for [Agents::validate_agent][super::super::client::Agents::validate_agent] calls.
     #[derive(Clone, Debug)]
     pub struct ValidateAgent(RequestBuilder<crate::model::ValidateAgentRequest>);
 
@@ -583,7 +583,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_agent_validation_result call.
+    /// The request builder for [Agents::get_agent_validation_result][super::super::client::Agents::get_agent_validation_result] calls.
     #[derive(Clone, Debug)]
     pub struct GetAgentValidationResult(
         RequestBuilder<crate::model::GetAgentValidationResultRequest>,
@@ -636,7 +636,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_generative_settings call.
+    /// The request builder for [Agents::get_generative_settings][super::super::client::Agents::get_generative_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetGenerativeSettings(RequestBuilder<crate::model::GetGenerativeSettingsRequest>);
 
@@ -687,7 +687,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::update_generative_settings call.
+    /// The request builder for [Agents::update_generative_settings][super::super::client::Agents::update_generative_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGenerativeSettings(
         RequestBuilder<crate::model::UpdateGenerativeSettingsRequest>,
@@ -748,7 +748,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::list_locations call.
+    /// The request builder for [Agents::list_locations][super::super::client::Agents::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -826,7 +826,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_location call.
+    /// The request builder for [Agents::get_location][super::super::client::Agents::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -868,7 +868,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::list_operations call.
+    /// The request builder for [Agents::list_operations][super::super::client::Agents::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -946,7 +946,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_operation call.
+    /// The request builder for [Agents::get_operation][super::super::client::Agents::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -991,7 +991,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::cancel_operation call.
+    /// The request builder for [Agents::cancel_operation][super::super::client::Agents::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1090,7 +1090,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for a Changelogs::list_changelogs call.
+    /// The request builder for [Changelogs::list_changelogs][super::super::client::Changelogs::list_changelogs] calls.
     #[derive(Clone, Debug)]
     pub struct ListChangelogs(RequestBuilder<crate::model::ListChangelogsRequest>);
 
@@ -1165,7 +1165,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for a Changelogs::get_changelog call.
+    /// The request builder for [Changelogs::get_changelog][super::super::client::Changelogs::get_changelog] calls.
     #[derive(Clone, Debug)]
     pub struct GetChangelog(RequestBuilder<crate::model::GetChangelogRequest>);
 
@@ -1207,7 +1207,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for a Changelogs::list_locations call.
+    /// The request builder for [Changelogs::list_locations][super::super::client::Changelogs::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1285,7 +1285,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for a Changelogs::get_location call.
+    /// The request builder for [Changelogs::get_location][super::super::client::Changelogs::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1327,7 +1327,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for a Changelogs::list_operations call.
+    /// The request builder for [Changelogs::list_operations][super::super::client::Changelogs::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1405,7 +1405,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for a Changelogs::get_operation call.
+    /// The request builder for [Changelogs::get_operation][super::super::client::Changelogs::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1450,7 +1450,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for a Changelogs::cancel_operation call.
+    /// The request builder for [Changelogs::cancel_operation][super::super::client::Changelogs::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1549,7 +1549,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for a Deployments::list_deployments call.
+    /// The request builder for [Deployments::list_deployments][super::super::client::Deployments::list_deployments] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -1618,7 +1618,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for a Deployments::get_deployment call.
+    /// The request builder for [Deployments::get_deployment][super::super::client::Deployments::get_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -1660,7 +1660,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for a Deployments::list_locations call.
+    /// The request builder for [Deployments::list_locations][super::super::client::Deployments::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1738,7 +1738,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for a Deployments::get_location call.
+    /// The request builder for [Deployments::get_location][super::super::client::Deployments::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1780,7 +1780,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for a Deployments::list_operations call.
+    /// The request builder for [Deployments::list_operations][super::super::client::Deployments::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1858,7 +1858,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for a Deployments::get_operation call.
+    /// The request builder for [Deployments::get_operation][super::super::client::Deployments::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1903,7 +1903,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for a Deployments::cancel_operation call.
+    /// The request builder for [Deployments::cancel_operation][super::super::client::Deployments::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2002,7 +2002,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::get_entity_type call.
+    /// The request builder for [EntityTypes::get_entity_type][super::super::client::EntityTypes::get_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetEntityType(RequestBuilder<crate::model::GetEntityTypeRequest>);
 
@@ -2050,7 +2050,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::create_entity_type call.
+    /// The request builder for [EntityTypes::create_entity_type][super::super::client::EntityTypes::create_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEntityType(RequestBuilder<crate::model::CreateEntityTypeRequest>);
 
@@ -2110,7 +2110,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::update_entity_type call.
+    /// The request builder for [EntityTypes::update_entity_type][super::super::client::EntityTypes::update_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEntityType(RequestBuilder<crate::model::UpdateEntityTypeRequest>);
 
@@ -2173,7 +2173,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::delete_entity_type call.
+    /// The request builder for [EntityTypes::delete_entity_type][super::super::client::EntityTypes::delete_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEntityType(RequestBuilder<crate::model::DeleteEntityTypeRequest>);
 
@@ -2224,7 +2224,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::list_entity_types call.
+    /// The request builder for [EntityTypes::list_entity_types][super::super::client::EntityTypes::list_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListEntityTypes(RequestBuilder<crate::model::ListEntityTypesRequest>);
 
@@ -2299,7 +2299,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::export_entity_types call.
+    /// The request builder for [EntityTypes::export_entity_types][super::super::client::EntityTypes::export_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct ExportEntityTypes(RequestBuilder<crate::model::ExportEntityTypesRequest>);
 
@@ -2424,7 +2424,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::import_entity_types call.
+    /// The request builder for [EntityTypes::import_entity_types][super::super::client::EntityTypes::import_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct ImportEntityTypes(RequestBuilder<crate::model::ImportEntityTypesRequest>);
 
@@ -2538,7 +2538,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::list_locations call.
+    /// The request builder for [EntityTypes::list_locations][super::super::client::EntityTypes::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2616,7 +2616,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::get_location call.
+    /// The request builder for [EntityTypes::get_location][super::super::client::EntityTypes::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2658,7 +2658,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::list_operations call.
+    /// The request builder for [EntityTypes::list_operations][super::super::client::EntityTypes::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2736,7 +2736,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::get_operation call.
+    /// The request builder for [EntityTypes::get_operation][super::super::client::EntityTypes::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2781,7 +2781,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::cancel_operation call.
+    /// The request builder for [EntityTypes::cancel_operation][super::super::client::EntityTypes::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2880,7 +2880,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_environments call.
+    /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
     #[derive(Clone, Debug)]
     pub struct ListEnvironments(RequestBuilder<crate::model::ListEnvironmentsRequest>);
 
@@ -2952,7 +2952,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_environment call.
+    /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -2994,7 +2994,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::create_environment call.
+    /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEnvironment(RequestBuilder<crate::model::CreateEnvironmentRequest>);
 
@@ -3083,7 +3083,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::update_environment call.
+    /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEnvironment(RequestBuilder<crate::model::UpdateEnvironmentRequest>);
 
@@ -3175,7 +3175,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::delete_environment call.
+    /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEnvironment(RequestBuilder<crate::model::DeleteEnvironmentRequest>);
 
@@ -3220,7 +3220,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::lookup_environment_history call.
+    /// The request builder for [Environments::lookup_environment_history][super::super::client::Environments::lookup_environment_history] calls.
     #[derive(Clone, Debug)]
     pub struct LookupEnvironmentHistory(
         RequestBuilder<crate::model::LookupEnvironmentHistoryRequest>,
@@ -3296,7 +3296,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::run_continuous_test call.
+    /// The request builder for [Environments::run_continuous_test][super::super::client::Environments::run_continuous_test] calls.
     #[derive(Clone, Debug)]
     pub struct RunContinuousTest(RequestBuilder<crate::model::RunContinuousTestRequest>);
 
@@ -3384,7 +3384,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_continuous_test_results call.
+    /// The request builder for [Environments::list_continuous_test_results][super::super::client::Environments::list_continuous_test_results] calls.
     #[derive(Clone, Debug)]
     pub struct ListContinuousTestResults(
         RequestBuilder<crate::model::ListContinuousTestResultsRequest>,
@@ -3460,7 +3460,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::deploy_flow call.
+    /// The request builder for [Environments::deploy_flow][super::super::client::Environments::deploy_flow] calls.
     #[derive(Clone, Debug)]
     pub struct DeployFlow(RequestBuilder<crate::model::DeployFlowRequest>);
 
@@ -3547,7 +3547,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_locations call.
+    /// The request builder for [Environments::list_locations][super::super::client::Environments::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3625,7 +3625,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_location call.
+    /// The request builder for [Environments::get_location][super::super::client::Environments::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3667,7 +3667,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_operations call.
+    /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3745,7 +3745,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_operation call.
+    /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3790,7 +3790,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::cancel_operation call.
+    /// The request builder for [Environments::cancel_operation][super::super::client::Environments::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3889,7 +3889,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::list_experiments call.
+    /// The request builder for [Experiments::list_experiments][super::super::client::Experiments::list_experiments] calls.
     #[derive(Clone, Debug)]
     pub struct ListExperiments(RequestBuilder<crate::model::ListExperimentsRequest>);
 
@@ -3958,7 +3958,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::get_experiment call.
+    /// The request builder for [Experiments::get_experiment][super::super::client::Experiments::get_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct GetExperiment(RequestBuilder<crate::model::GetExperimentRequest>);
 
@@ -4000,7 +4000,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::create_experiment call.
+    /// The request builder for [Experiments::create_experiment][super::super::client::Experiments::create_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateExperiment(RequestBuilder<crate::model::CreateExperimentRequest>);
 
@@ -4054,7 +4054,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::update_experiment call.
+    /// The request builder for [Experiments::update_experiment][super::super::client::Experiments::update_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateExperiment(RequestBuilder<crate::model::UpdateExperimentRequest>);
 
@@ -4111,7 +4111,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::delete_experiment call.
+    /// The request builder for [Experiments::delete_experiment][super::super::client::Experiments::delete_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteExperiment(RequestBuilder<crate::model::DeleteExperimentRequest>);
 
@@ -4156,7 +4156,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::start_experiment call.
+    /// The request builder for [Experiments::start_experiment][super::super::client::Experiments::start_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct StartExperiment(RequestBuilder<crate::model::StartExperimentRequest>);
 
@@ -4198,7 +4198,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::stop_experiment call.
+    /// The request builder for [Experiments::stop_experiment][super::super::client::Experiments::stop_experiment] calls.
     #[derive(Clone, Debug)]
     pub struct StopExperiment(RequestBuilder<crate::model::StopExperimentRequest>);
 
@@ -4240,7 +4240,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::list_locations call.
+    /// The request builder for [Experiments::list_locations][super::super::client::Experiments::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4318,7 +4318,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::get_location call.
+    /// The request builder for [Experiments::get_location][super::super::client::Experiments::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4360,7 +4360,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::list_operations call.
+    /// The request builder for [Experiments::list_operations][super::super::client::Experiments::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4438,7 +4438,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::get_operation call.
+    /// The request builder for [Experiments::get_operation][super::super::client::Experiments::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4483,7 +4483,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for a Experiments::cancel_operation call.
+    /// The request builder for [Experiments::cancel_operation][super::super::client::Experiments::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4582,7 +4582,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::create_flow call.
+    /// The request builder for [Flows::create_flow][super::super::client::Flows::create_flow] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFlow(RequestBuilder<crate::model::CreateFlowRequest>);
 
@@ -4636,7 +4636,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::delete_flow call.
+    /// The request builder for [Flows::delete_flow][super::super::client::Flows::delete_flow] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFlow(RequestBuilder<crate::model::DeleteFlowRequest>);
 
@@ -4684,7 +4684,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::list_flows call.
+    /// The request builder for [Flows::list_flows][super::super::client::Flows::list_flows] calls.
     #[derive(Clone, Debug)]
     pub struct ListFlows(RequestBuilder<crate::model::ListFlowsRequest>);
 
@@ -4758,7 +4758,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::get_flow call.
+    /// The request builder for [Flows::get_flow][super::super::client::Flows::get_flow] calls.
     #[derive(Clone, Debug)]
     pub struct GetFlow(RequestBuilder<crate::model::GetFlowRequest>);
 
@@ -4806,7 +4806,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::update_flow call.
+    /// The request builder for [Flows::update_flow][super::super::client::Flows::update_flow] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFlow(RequestBuilder<crate::model::UpdateFlowRequest>);
 
@@ -4863,7 +4863,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::train_flow call.
+    /// The request builder for [Flows::train_flow][super::super::client::Flows::train_flow] calls.
     #[derive(Clone, Debug)]
     pub struct TrainFlow(RequestBuilder<crate::model::TrainFlowRequest>);
 
@@ -4940,7 +4940,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::validate_flow call.
+    /// The request builder for [Flows::validate_flow][super::super::client::Flows::validate_flow] calls.
     #[derive(Clone, Debug)]
     pub struct ValidateFlow(RequestBuilder<crate::model::ValidateFlowRequest>);
 
@@ -4988,7 +4988,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::get_flow_validation_result call.
+    /// The request builder for [Flows::get_flow_validation_result][super::super::client::Flows::get_flow_validation_result] calls.
     #[derive(Clone, Debug)]
     pub struct GetFlowValidationResult(
         RequestBuilder<crate::model::GetFlowValidationResultRequest>,
@@ -5041,7 +5041,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::import_flow call.
+    /// The request builder for [Flows::import_flow][super::super::client::Flows::import_flow] calls.
     #[derive(Clone, Debug)]
     pub struct ImportFlow(RequestBuilder<crate::model::ImportFlowRequest>);
 
@@ -5147,7 +5147,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::export_flow call.
+    /// The request builder for [Flows::export_flow][super::super::client::Flows::export_flow] calls.
     #[derive(Clone, Debug)]
     pub struct ExportFlow(RequestBuilder<crate::model::ExportFlowRequest>);
 
@@ -5236,7 +5236,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::list_locations call.
+    /// The request builder for [Flows::list_locations][super::super::client::Flows::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5314,7 +5314,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::get_location call.
+    /// The request builder for [Flows::get_location][super::super::client::Flows::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5356,7 +5356,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::list_operations call.
+    /// The request builder for [Flows::list_operations][super::super::client::Flows::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5434,7 +5434,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::get_operation call.
+    /// The request builder for [Flows::get_operation][super::super::client::Flows::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5479,7 +5479,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for a Flows::cancel_operation call.
+    /// The request builder for [Flows::cancel_operation][super::super::client::Flows::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5578,7 +5578,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::list_generators call.
+    /// The request builder for [Generators::list_generators][super::super::client::Generators::list_generators] calls.
     #[derive(Clone, Debug)]
     pub struct ListGenerators(RequestBuilder<crate::model::ListGeneratorsRequest>);
 
@@ -5653,7 +5653,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::get_generator call.
+    /// The request builder for [Generators::get_generator][super::super::client::Generators::get_generator] calls.
     #[derive(Clone, Debug)]
     pub struct GetGenerator(RequestBuilder<crate::model::GetGeneratorRequest>);
 
@@ -5701,7 +5701,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::create_generator call.
+    /// The request builder for [Generators::create_generator][super::super::client::Generators::create_generator] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGenerator(RequestBuilder<crate::model::CreateGeneratorRequest>);
 
@@ -5758,7 +5758,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::update_generator call.
+    /// The request builder for [Generators::update_generator][super::super::client::Generators::update_generator] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGenerator(RequestBuilder<crate::model::UpdateGeneratorRequest>);
 
@@ -5818,7 +5818,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::delete_generator call.
+    /// The request builder for [Generators::delete_generator][super::super::client::Generators::delete_generator] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGenerator(RequestBuilder<crate::model::DeleteGeneratorRequest>);
 
@@ -5866,7 +5866,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::list_locations call.
+    /// The request builder for [Generators::list_locations][super::super::client::Generators::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5944,7 +5944,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::get_location call.
+    /// The request builder for [Generators::get_location][super::super::client::Generators::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5986,7 +5986,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::list_operations call.
+    /// The request builder for [Generators::list_operations][super::super::client::Generators::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6064,7 +6064,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::get_operation call.
+    /// The request builder for [Generators::get_operation][super::super::client::Generators::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6109,7 +6109,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::cancel_operation call.
+    /// The request builder for [Generators::cancel_operation][super::super::client::Generators::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6208,7 +6208,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::list_intents call.
+    /// The request builder for [Intents::list_intents][super::super::client::Intents::list_intents] calls.
     #[derive(Clone, Debug)]
     pub struct ListIntents(RequestBuilder<crate::model::ListIntentsRequest>);
 
@@ -6289,7 +6289,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::get_intent call.
+    /// The request builder for [Intents::get_intent][super::super::client::Intents::get_intent] calls.
     #[derive(Clone, Debug)]
     pub struct GetIntent(RequestBuilder<crate::model::GetIntentRequest>);
 
@@ -6337,7 +6337,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::create_intent call.
+    /// The request builder for [Intents::create_intent][super::super::client::Intents::create_intent] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIntent(RequestBuilder<crate::model::CreateIntentRequest>);
 
@@ -6394,7 +6394,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::update_intent call.
+    /// The request builder for [Intents::update_intent][super::super::client::Intents::update_intent] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateIntent(RequestBuilder<crate::model::UpdateIntentRequest>);
 
@@ -6454,7 +6454,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::delete_intent call.
+    /// The request builder for [Intents::delete_intent][super::super::client::Intents::delete_intent] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIntent(RequestBuilder<crate::model::DeleteIntentRequest>);
 
@@ -6496,7 +6496,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::import_intents call.
+    /// The request builder for [Intents::import_intents][super::super::client::Intents::import_intents] calls.
     #[derive(Clone, Debug)]
     pub struct ImportIntents(RequestBuilder<crate::model::ImportIntentsRequest>);
 
@@ -6597,7 +6597,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::export_intents call.
+    /// The request builder for [Intents::export_intents][super::super::client::Intents::export_intents] calls.
     #[derive(Clone, Debug)]
     pub struct ExportIntents(RequestBuilder<crate::model::ExportIntentsRequest>);
 
@@ -6711,7 +6711,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::list_locations call.
+    /// The request builder for [Intents::list_locations][super::super::client::Intents::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6789,7 +6789,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::get_location call.
+    /// The request builder for [Intents::get_location][super::super::client::Intents::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6831,7 +6831,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::list_operations call.
+    /// The request builder for [Intents::list_operations][super::super::client::Intents::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6909,7 +6909,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::get_operation call.
+    /// The request builder for [Intents::get_operation][super::super::client::Intents::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6954,7 +6954,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::cancel_operation call.
+    /// The request builder for [Intents::cancel_operation][super::super::client::Intents::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7053,7 +7053,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::list_pages call.
+    /// The request builder for [Pages::list_pages][super::super::client::Pages::list_pages] calls.
     #[derive(Clone, Debug)]
     pub struct ListPages(RequestBuilder<crate::model::ListPagesRequest>);
 
@@ -7127,7 +7127,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::get_page call.
+    /// The request builder for [Pages::get_page][super::super::client::Pages::get_page] calls.
     #[derive(Clone, Debug)]
     pub struct GetPage(RequestBuilder<crate::model::GetPageRequest>);
 
@@ -7175,7 +7175,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::create_page call.
+    /// The request builder for [Pages::create_page][super::super::client::Pages::create_page] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePage(RequestBuilder<crate::model::CreatePageRequest>);
 
@@ -7229,7 +7229,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::update_page call.
+    /// The request builder for [Pages::update_page][super::super::client::Pages::update_page] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePage(RequestBuilder<crate::model::UpdatePageRequest>);
 
@@ -7286,7 +7286,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::delete_page call.
+    /// The request builder for [Pages::delete_page][super::super::client::Pages::delete_page] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePage(RequestBuilder<crate::model::DeletePageRequest>);
 
@@ -7334,7 +7334,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::list_locations call.
+    /// The request builder for [Pages::list_locations][super::super::client::Pages::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -7412,7 +7412,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::get_location call.
+    /// The request builder for [Pages::get_location][super::super::client::Pages::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -7454,7 +7454,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::list_operations call.
+    /// The request builder for [Pages::list_operations][super::super::client::Pages::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7532,7 +7532,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::get_operation call.
+    /// The request builder for [Pages::get_operation][super::super::client::Pages::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7577,7 +7577,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for a Pages::cancel_operation call.
+    /// The request builder for [Pages::cancel_operation][super::super::client::Pages::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7678,7 +7678,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::create_security_settings call.
+    /// The request builder for [SecuritySettingsService::create_security_settings][super::super::client::SecuritySettingsService::create_security_settings] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecuritySettings(RequestBuilder<crate::model::CreateSecuritySettingsRequest>);
 
@@ -7736,7 +7736,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::get_security_settings call.
+    /// The request builder for [SecuritySettingsService::get_security_settings][super::super::client::SecuritySettingsService::get_security_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecuritySettings(RequestBuilder<crate::model::GetSecuritySettingsRequest>);
 
@@ -7783,7 +7783,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::update_security_settings call.
+    /// The request builder for [SecuritySettingsService::update_security_settings][super::super::client::SecuritySettingsService::update_security_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecuritySettings(RequestBuilder<crate::model::UpdateSecuritySettingsRequest>);
 
@@ -7844,7 +7844,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::list_security_settings call.
+    /// The request builder for [SecuritySettingsService::list_security_settings][super::super::client::SecuritySettingsService::list_security_settings] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecuritySettings(RequestBuilder<crate::model::ListSecuritySettingsRequest>);
 
@@ -7918,7 +7918,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::delete_security_settings call.
+    /// The request builder for [SecuritySettingsService::delete_security_settings][super::super::client::SecuritySettingsService::delete_security_settings] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecuritySettings(RequestBuilder<crate::model::DeleteSecuritySettingsRequest>);
 
@@ -7965,7 +7965,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::list_locations call.
+    /// The request builder for [SecuritySettingsService::list_locations][super::super::client::SecuritySettingsService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -8045,7 +8045,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::get_location call.
+    /// The request builder for [SecuritySettingsService::get_location][super::super::client::SecuritySettingsService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -8089,7 +8089,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::list_operations call.
+    /// The request builder for [SecuritySettingsService::list_operations][super::super::client::SecuritySettingsService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8169,7 +8169,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::get_operation call.
+    /// The request builder for [SecuritySettingsService::get_operation][super::super::client::SecuritySettingsService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8216,7 +8216,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for a SecuritySettingsService::cancel_operation call.
+    /// The request builder for [SecuritySettingsService::cancel_operation][super::super::client::SecuritySettingsService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8317,7 +8317,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::detect_intent call.
+    /// The request builder for [Sessions::detect_intent][super::super::client::Sessions::detect_intent] calls.
     #[derive(Clone, Debug)]
     pub struct DetectIntent(RequestBuilder<crate::model::DetectIntentRequest>);
 
@@ -8388,7 +8388,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::match_intent call.
+    /// The request builder for [Sessions::match_intent][super::super::client::Sessions::match_intent] calls.
     #[derive(Clone, Debug)]
     pub struct MatchIntent(RequestBuilder<crate::model::MatchIntentRequest>);
 
@@ -8454,7 +8454,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::fulfill_intent call.
+    /// The request builder for [Sessions::fulfill_intent][super::super::client::Sessions::fulfill_intent] calls.
     #[derive(Clone, Debug)]
     pub struct FulfillIntent(RequestBuilder<crate::model::FulfillIntentRequest>);
 
@@ -8521,7 +8521,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::submit_answer_feedback call.
+    /// The request builder for [Sessions::submit_answer_feedback][super::super::client::Sessions::submit_answer_feedback] calls.
     #[derive(Clone, Debug)]
     pub struct SubmitAnswerFeedback(RequestBuilder<crate::model::SubmitAnswerFeedbackRequest>);
 
@@ -8590,7 +8590,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::list_locations call.
+    /// The request builder for [Sessions::list_locations][super::super::client::Sessions::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -8668,7 +8668,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::get_location call.
+    /// The request builder for [Sessions::get_location][super::super::client::Sessions::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -8710,7 +8710,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::list_operations call.
+    /// The request builder for [Sessions::list_operations][super::super::client::Sessions::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8788,7 +8788,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::get_operation call.
+    /// The request builder for [Sessions::get_operation][super::super::client::Sessions::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8833,7 +8833,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::cancel_operation call.
+    /// The request builder for [Sessions::cancel_operation][super::super::client::Sessions::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8932,7 +8932,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::list_session_entity_types call.
+    /// The request builder for [SessionEntityTypes::list_session_entity_types][super::super::client::SessionEntityTypes::list_session_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListSessionEntityTypes(RequestBuilder<crate::model::ListSessionEntityTypesRequest>);
 
@@ -9006,7 +9006,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::get_session_entity_type call.
+    /// The request builder for [SessionEntityTypes::get_session_entity_type][super::super::client::SessionEntityTypes::get_session_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetSessionEntityType(RequestBuilder<crate::model::GetSessionEntityTypeRequest>);
 
@@ -9051,7 +9051,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::create_session_entity_type call.
+    /// The request builder for [SessionEntityTypes::create_session_entity_type][super::super::client::SessionEntityTypes::create_session_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSessionEntityType(
         RequestBuilder<crate::model::CreateSessionEntityTypeRequest>,
@@ -9109,7 +9109,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::update_session_entity_type call.
+    /// The request builder for [SessionEntityTypes::update_session_entity_type][super::super::client::SessionEntityTypes::update_session_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSessionEntityType(
         RequestBuilder<crate::model::UpdateSessionEntityTypeRequest>,
@@ -9170,7 +9170,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::delete_session_entity_type call.
+    /// The request builder for [SessionEntityTypes::delete_session_entity_type][super::super::client::SessionEntityTypes::delete_session_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSessionEntityType(
         RequestBuilder<crate::model::DeleteSessionEntityTypeRequest>,
@@ -9217,7 +9217,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::list_locations call.
+    /// The request builder for [SessionEntityTypes::list_locations][super::super::client::SessionEntityTypes::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -9295,7 +9295,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::get_location call.
+    /// The request builder for [SessionEntityTypes::get_location][super::super::client::SessionEntityTypes::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -9337,7 +9337,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::list_operations call.
+    /// The request builder for [SessionEntityTypes::list_operations][super::super::client::SessionEntityTypes::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9415,7 +9415,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::get_operation call.
+    /// The request builder for [SessionEntityTypes::get_operation][super::super::client::SessionEntityTypes::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9460,7 +9460,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::cancel_operation call.
+    /// The request builder for [SessionEntityTypes::cancel_operation][super::super::client::SessionEntityTypes::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9559,7 +9559,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::list_test_cases call.
+    /// The request builder for [TestCases::list_test_cases][super::super::client::TestCases::list_test_cases] calls.
     #[derive(Clone, Debug)]
     pub struct ListTestCases(RequestBuilder<crate::model::ListTestCasesRequest>);
 
@@ -9637,7 +9637,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::batch_delete_test_cases call.
+    /// The request builder for [TestCases::batch_delete_test_cases][super::super::client::TestCases::batch_delete_test_cases] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeleteTestCases(RequestBuilder<crate::model::BatchDeleteTestCasesRequest>);
 
@@ -9693,7 +9693,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::get_test_case call.
+    /// The request builder for [TestCases::get_test_case][super::super::client::TestCases::get_test_case] calls.
     #[derive(Clone, Debug)]
     pub struct GetTestCase(RequestBuilder<crate::model::GetTestCaseRequest>);
 
@@ -9735,7 +9735,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::create_test_case call.
+    /// The request builder for [TestCases::create_test_case][super::super::client::TestCases::create_test_case] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTestCase(RequestBuilder<crate::model::CreateTestCaseRequest>);
 
@@ -9786,7 +9786,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::update_test_case call.
+    /// The request builder for [TestCases::update_test_case][super::super::client::TestCases::update_test_case] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTestCase(RequestBuilder<crate::model::UpdateTestCaseRequest>);
 
@@ -9840,7 +9840,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::run_test_case call.
+    /// The request builder for [TestCases::run_test_case][super::super::client::TestCases::run_test_case] calls.
     #[derive(Clone, Debug)]
     pub struct RunTestCase(RequestBuilder<crate::model::RunTestCaseRequest>);
 
@@ -9929,7 +9929,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::batch_run_test_cases call.
+    /// The request builder for [TestCases::batch_run_test_cases][super::super::client::TestCases::batch_run_test_cases] calls.
     #[derive(Clone, Debug)]
     pub struct BatchRunTestCases(RequestBuilder<crate::model::BatchRunTestCasesRequest>);
 
@@ -10034,7 +10034,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::calculate_coverage call.
+    /// The request builder for [TestCases::calculate_coverage][super::super::client::TestCases::calculate_coverage] calls.
     #[derive(Clone, Debug)]
     pub struct CalculateCoverage(RequestBuilder<crate::model::CalculateCoverageRequest>);
 
@@ -10088,7 +10088,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::import_test_cases call.
+    /// The request builder for [TestCases::import_test_cases][super::super::client::TestCases::import_test_cases] calls.
     #[derive(Clone, Debug)]
     pub struct ImportTestCases(RequestBuilder<crate::model::ImportTestCasesRequest>);
 
@@ -10180,7 +10180,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::export_test_cases call.
+    /// The request builder for [TestCases::export_test_cases][super::super::client::TestCases::export_test_cases] calls.
     #[derive(Clone, Debug)]
     pub struct ExportTestCases(RequestBuilder<crate::model::ExportTestCasesRequest>);
 
@@ -10289,7 +10289,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::list_test_case_results call.
+    /// The request builder for [TestCases::list_test_case_results][super::super::client::TestCases::list_test_case_results] calls.
     #[derive(Clone, Debug)]
     pub struct ListTestCaseResults(RequestBuilder<crate::model::ListTestCaseResultsRequest>);
 
@@ -10367,7 +10367,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::get_test_case_result call.
+    /// The request builder for [TestCases::get_test_case_result][super::super::client::TestCases::get_test_case_result] calls.
     #[derive(Clone, Debug)]
     pub struct GetTestCaseResult(RequestBuilder<crate::model::GetTestCaseResultRequest>);
 
@@ -10412,7 +10412,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::list_locations call.
+    /// The request builder for [TestCases::list_locations][super::super::client::TestCases::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -10490,7 +10490,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::get_location call.
+    /// The request builder for [TestCases::get_location][super::super::client::TestCases::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -10532,7 +10532,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::list_operations call.
+    /// The request builder for [TestCases::list_operations][super::super::client::TestCases::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -10610,7 +10610,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::get_operation call.
+    /// The request builder for [TestCases::get_operation][super::super::client::TestCases::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -10655,7 +10655,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for a TestCases::cancel_operation call.
+    /// The request builder for [TestCases::cancel_operation][super::super::client::TestCases::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -10756,7 +10756,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::list_transition_route_groups call.
+    /// The request builder for [TransitionRouteGroups::list_transition_route_groups][super::super::client::TransitionRouteGroups::list_transition_route_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListTransitionRouteGroups(
         RequestBuilder<crate::model::ListTransitionRouteGroupsRequest>,
@@ -10840,7 +10840,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::get_transition_route_group call.
+    /// The request builder for [TransitionRouteGroups::get_transition_route_group][super::super::client::TransitionRouteGroups::get_transition_route_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetTransitionRouteGroup(
         RequestBuilder<crate::model::GetTransitionRouteGroupRequest>,
@@ -10895,7 +10895,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::create_transition_route_group call.
+    /// The request builder for [TransitionRouteGroups::create_transition_route_group][super::super::client::TransitionRouteGroups::create_transition_route_group] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTransitionRouteGroup(
         RequestBuilder<crate::model::CreateTransitionRouteGroupRequest>,
@@ -10961,7 +10961,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::update_transition_route_group call.
+    /// The request builder for [TransitionRouteGroups::update_transition_route_group][super::super::client::TransitionRouteGroups::update_transition_route_group] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTransitionRouteGroup(
         RequestBuilder<crate::model::UpdateTransitionRouteGroupRequest>,
@@ -11030,7 +11030,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::delete_transition_route_group call.
+    /// The request builder for [TransitionRouteGroups::delete_transition_route_group][super::super::client::TransitionRouteGroups::delete_transition_route_group] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTransitionRouteGroup(
         RequestBuilder<crate::model::DeleteTransitionRouteGroupRequest>,
@@ -11085,7 +11085,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::list_locations call.
+    /// The request builder for [TransitionRouteGroups::list_locations][super::super::client::TransitionRouteGroups::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -11165,7 +11165,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::get_location call.
+    /// The request builder for [TransitionRouteGroups::get_location][super::super::client::TransitionRouteGroups::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -11209,7 +11209,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::list_operations call.
+    /// The request builder for [TransitionRouteGroups::list_operations][super::super::client::TransitionRouteGroups::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -11289,7 +11289,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::get_operation call.
+    /// The request builder for [TransitionRouteGroups::get_operation][super::super::client::TransitionRouteGroups::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -11336,7 +11336,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for a TransitionRouteGroups::cancel_operation call.
+    /// The request builder for [TransitionRouteGroups::cancel_operation][super::super::client::TransitionRouteGroups::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -11437,7 +11437,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::list_versions call.
+    /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -11506,7 +11506,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::get_version call.
+    /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -11548,7 +11548,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::create_version call.
+    /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVersion(RequestBuilder<crate::model::CreateVersionRequest>);
 
@@ -11638,7 +11638,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::update_version call.
+    /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -11692,7 +11692,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::delete_version call.
+    /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -11734,7 +11734,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::load_version call.
+    /// The request builder for [Versions::load_version][super::super::client::Versions::load_version] calls.
     #[derive(Clone, Debug)]
     pub struct LoadVersion(RequestBuilder<crate::model::LoadVersionRequest>);
 
@@ -11817,7 +11817,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::compare_versions call.
+    /// The request builder for [Versions::compare_versions][super::super::client::Versions::compare_versions] calls.
     #[derive(Clone, Debug)]
     pub struct CompareVersions(RequestBuilder<crate::model::CompareVersionsRequest>);
 
@@ -11871,7 +11871,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::list_locations call.
+    /// The request builder for [Versions::list_locations][super::super::client::Versions::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -11949,7 +11949,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::get_location call.
+    /// The request builder for [Versions::get_location][super::super::client::Versions::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -11991,7 +11991,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::list_operations call.
+    /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -12069,7 +12069,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::get_operation call.
+    /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -12114,7 +12114,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::cancel_operation call.
+    /// The request builder for [Versions::cancel_operation][super::super::client::Versions::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -12213,7 +12213,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::list_webhooks call.
+    /// The request builder for [Webhooks::list_webhooks][super::super::client::Webhooks::list_webhooks] calls.
     #[derive(Clone, Debug)]
     pub struct ListWebhooks(RequestBuilder<crate::model::ListWebhooksRequest>);
 
@@ -12282,7 +12282,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::get_webhook call.
+    /// The request builder for [Webhooks::get_webhook][super::super::client::Webhooks::get_webhook] calls.
     #[derive(Clone, Debug)]
     pub struct GetWebhook(RequestBuilder<crate::model::GetWebhookRequest>);
 
@@ -12324,7 +12324,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::create_webhook call.
+    /// The request builder for [Webhooks::create_webhook][super::super::client::Webhooks::create_webhook] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWebhook(RequestBuilder<crate::model::CreateWebhookRequest>);
 
@@ -12375,7 +12375,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::update_webhook call.
+    /// The request builder for [Webhooks::update_webhook][super::super::client::Webhooks::update_webhook] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWebhook(RequestBuilder<crate::model::UpdateWebhookRequest>);
 
@@ -12429,7 +12429,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::delete_webhook call.
+    /// The request builder for [Webhooks::delete_webhook][super::super::client::Webhooks::delete_webhook] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWebhook(RequestBuilder<crate::model::DeleteWebhookRequest>);
 
@@ -12477,7 +12477,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::list_locations call.
+    /// The request builder for [Webhooks::list_locations][super::super::client::Webhooks::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12555,7 +12555,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::get_location call.
+    /// The request builder for [Webhooks::get_location][super::super::client::Webhooks::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12597,7 +12597,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::list_operations call.
+    /// The request builder for [Webhooks::list_operations][super::super::client::Webhooks::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -12675,7 +12675,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::get_operation call.
+    /// The request builder for [Webhooks::get_operation][super::super::client::Webhooks::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -12720,7 +12720,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for a Webhooks::cancel_operation call.
+    /// The request builder for [Webhooks::cancel_operation][super::super::client::Webhooks::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/dialogflow/v2/src/builder.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_agent call.
+    /// The request builder for [Agents::get_agent][super::super::client::Agents::get_agent] calls.
     #[derive(Clone, Debug)]
     pub struct GetAgent(RequestBuilder<crate::model::GetAgentRequest>);
 
@@ -109,7 +109,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::set_agent call.
+    /// The request builder for [Agents::set_agent][super::super::client::Agents::set_agent] calls.
     #[derive(Clone, Debug)]
     pub struct SetAgent(RequestBuilder<crate::model::SetAgentRequest>);
 
@@ -163,7 +163,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::delete_agent call.
+    /// The request builder for [Agents::delete_agent][super::super::client::Agents::delete_agent] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAgent(RequestBuilder<crate::model::DeleteAgentRequest>);
 
@@ -205,7 +205,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::search_agents call.
+    /// The request builder for [Agents::search_agents][super::super::client::Agents::search_agents] calls.
     #[derive(Clone, Debug)]
     pub struct SearchAgents(RequestBuilder<crate::model::SearchAgentsRequest>);
 
@@ -274,7 +274,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::train_agent call.
+    /// The request builder for [Agents::train_agent][super::super::client::Agents::train_agent] calls.
     #[derive(Clone, Debug)]
     pub struct TrainAgent(RequestBuilder<crate::model::TrainAgentRequest>);
 
@@ -351,7 +351,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::export_agent call.
+    /// The request builder for [Agents::export_agent][super::super::client::Agents::export_agent] calls.
     #[derive(Clone, Debug)]
     pub struct ExportAgent(RequestBuilder<crate::model::ExportAgentRequest>);
 
@@ -434,7 +434,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::import_agent call.
+    /// The request builder for [Agents::import_agent][super::super::client::Agents::import_agent] calls.
     #[derive(Clone, Debug)]
     pub struct ImportAgent(RequestBuilder<crate::model::ImportAgentRequest>);
 
@@ -520,7 +520,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::restore_agent call.
+    /// The request builder for [Agents::restore_agent][super::super::client::Agents::restore_agent] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreAgent(RequestBuilder<crate::model::RestoreAgentRequest>);
 
@@ -606,7 +606,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_validation_result call.
+    /// The request builder for [Agents::get_validation_result][super::super::client::Agents::get_validation_result] calls.
     #[derive(Clone, Debug)]
     pub struct GetValidationResult(RequestBuilder<crate::model::GetValidationResultRequest>);
 
@@ -657,7 +657,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::list_locations call.
+    /// The request builder for [Agents::list_locations][super::super::client::Agents::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -735,7 +735,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_location call.
+    /// The request builder for [Agents::get_location][super::super::client::Agents::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -777,7 +777,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::list_operations call.
+    /// The request builder for [Agents::list_operations][super::super::client::Agents::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -855,7 +855,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::get_operation call.
+    /// The request builder for [Agents::get_operation][super::super::client::Agents::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -900,7 +900,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for a Agents::cancel_operation call.
+    /// The request builder for [Agents::cancel_operation][super::super::client::Agents::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -999,7 +999,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for a AnswerRecords::list_answer_records call.
+    /// The request builder for [AnswerRecords::list_answer_records][super::super::client::AnswerRecords::list_answer_records] calls.
     #[derive(Clone, Debug)]
     pub struct ListAnswerRecords(RequestBuilder<crate::model::ListAnswerRecordsRequest>);
 
@@ -1077,7 +1077,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for a AnswerRecords::update_answer_record call.
+    /// The request builder for [AnswerRecords::update_answer_record][super::super::client::AnswerRecords::update_answer_record] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAnswerRecord(RequestBuilder<crate::model::UpdateAnswerRecordRequest>);
 
@@ -1134,7 +1134,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for a AnswerRecords::list_locations call.
+    /// The request builder for [AnswerRecords::list_locations][super::super::client::AnswerRecords::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1212,7 +1212,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for a AnswerRecords::get_location call.
+    /// The request builder for [AnswerRecords::get_location][super::super::client::AnswerRecords::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1254,7 +1254,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for a AnswerRecords::list_operations call.
+    /// The request builder for [AnswerRecords::list_operations][super::super::client::AnswerRecords::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1332,7 +1332,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for a AnswerRecords::get_operation call.
+    /// The request builder for [AnswerRecords::get_operation][super::super::client::AnswerRecords::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1377,7 +1377,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for a AnswerRecords::cancel_operation call.
+    /// The request builder for [AnswerRecords::cancel_operation][super::super::client::AnswerRecords::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1476,7 +1476,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::list_contexts call.
+    /// The request builder for [Contexts::list_contexts][super::super::client::Contexts::list_contexts] calls.
     #[derive(Clone, Debug)]
     pub struct ListContexts(RequestBuilder<crate::model::ListContextsRequest>);
 
@@ -1545,7 +1545,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::get_context call.
+    /// The request builder for [Contexts::get_context][super::super::client::Contexts::get_context] calls.
     #[derive(Clone, Debug)]
     pub struct GetContext(RequestBuilder<crate::model::GetContextRequest>);
 
@@ -1587,7 +1587,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::create_context call.
+    /// The request builder for [Contexts::create_context][super::super::client::Contexts::create_context] calls.
     #[derive(Clone, Debug)]
     pub struct CreateContext(RequestBuilder<crate::model::CreateContextRequest>);
 
@@ -1638,7 +1638,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::update_context call.
+    /// The request builder for [Contexts::update_context][super::super::client::Contexts::update_context] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateContext(RequestBuilder<crate::model::UpdateContextRequest>);
 
@@ -1692,7 +1692,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::delete_context call.
+    /// The request builder for [Contexts::delete_context][super::super::client::Contexts::delete_context] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteContext(RequestBuilder<crate::model::DeleteContextRequest>);
 
@@ -1734,7 +1734,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::delete_all_contexts call.
+    /// The request builder for [Contexts::delete_all_contexts][super::super::client::Contexts::delete_all_contexts] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAllContexts(RequestBuilder<crate::model::DeleteAllContextsRequest>);
 
@@ -1779,7 +1779,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::list_locations call.
+    /// The request builder for [Contexts::list_locations][super::super::client::Contexts::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1857,7 +1857,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::get_location call.
+    /// The request builder for [Contexts::get_location][super::super::client::Contexts::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1899,7 +1899,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::list_operations call.
+    /// The request builder for [Contexts::list_operations][super::super::client::Contexts::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1977,7 +1977,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::get_operation call.
+    /// The request builder for [Contexts::get_operation][super::super::client::Contexts::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2022,7 +2022,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for a Contexts::cancel_operation call.
+    /// The request builder for [Contexts::cancel_operation][super::super::client::Contexts::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2121,7 +2121,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::create_conversation call.
+    /// The request builder for [Conversations::create_conversation][super::super::client::Conversations::create_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConversation(RequestBuilder<crate::model::CreateConversationRequest>);
 
@@ -2181,7 +2181,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::list_conversations call.
+    /// The request builder for [Conversations::list_conversations][super::super::client::Conversations::list_conversations] calls.
     #[derive(Clone, Debug)]
     pub struct ListConversations(RequestBuilder<crate::model::ListConversationsRequest>);
 
@@ -2259,7 +2259,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::get_conversation call.
+    /// The request builder for [Conversations::get_conversation][super::super::client::Conversations::get_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct GetConversation(RequestBuilder<crate::model::GetConversationRequest>);
 
@@ -2301,7 +2301,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::complete_conversation call.
+    /// The request builder for [Conversations::complete_conversation][super::super::client::Conversations::complete_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct CompleteConversation(RequestBuilder<crate::model::CompleteConversationRequest>);
 
@@ -2346,7 +2346,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::ingest_context_references call.
+    /// The request builder for [Conversations::ingest_context_references][super::super::client::Conversations::ingest_context_references] calls.
     #[derive(Clone, Debug)]
     pub struct IngestContextReferences(
         RequestBuilder<crate::model::IngestContextReferencesRequest>,
@@ -2405,7 +2405,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::list_messages call.
+    /// The request builder for [Conversations::list_messages][super::super::client::Conversations::list_messages] calls.
     #[derive(Clone, Debug)]
     pub struct ListMessages(RequestBuilder<crate::model::ListMessagesRequest>);
 
@@ -2480,7 +2480,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::suggest_conversation_summary call.
+    /// The request builder for [Conversations::suggest_conversation_summary][super::super::client::Conversations::suggest_conversation_summary] calls.
     #[derive(Clone, Debug)]
     pub struct SuggestConversationSummary(
         RequestBuilder<crate::model::SuggestConversationSummaryRequest>,
@@ -2550,7 +2550,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::generate_stateless_summary call.
+    /// The request builder for [Conversations::generate_stateless_summary][super::super::client::Conversations::generate_stateless_summary] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateStatelessSummary(
         RequestBuilder<crate::model::GenerateStatelessSummaryRequest>,
@@ -2629,7 +2629,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::generate_stateless_suggestion call.
+    /// The request builder for [Conversations::generate_stateless_suggestion][super::super::client::Conversations::generate_stateless_suggestion] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateStatelessSuggestion(
         RequestBuilder<crate::model::GenerateStatelessSuggestionRequest>,
@@ -2721,7 +2721,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::search_knowledge call.
+    /// The request builder for [Conversations::search_knowledge][super::super::client::Conversations::search_knowledge] calls.
     #[derive(Clone, Debug)]
     pub struct SearchKnowledge(RequestBuilder<crate::model::SearchKnowledgeRequest>);
 
@@ -2831,7 +2831,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::generate_suggestions call.
+    /// The request builder for [Conversations::generate_suggestions][super::super::client::Conversations::generate_suggestions] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateSuggestions(RequestBuilder<crate::model::GenerateSuggestionsRequest>);
 
@@ -2893,7 +2893,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::list_locations call.
+    /// The request builder for [Conversations::list_locations][super::super::client::Conversations::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2971,7 +2971,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::get_location call.
+    /// The request builder for [Conversations::get_location][super::super::client::Conversations::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3013,7 +3013,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::list_operations call.
+    /// The request builder for [Conversations::list_operations][super::super::client::Conversations::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3091,7 +3091,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::get_operation call.
+    /// The request builder for [Conversations::get_operation][super::super::client::Conversations::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3136,7 +3136,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for a Conversations::cancel_operation call.
+    /// The request builder for [Conversations::cancel_operation][super::super::client::Conversations::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3237,7 +3237,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::create_conversation_dataset call.
+    /// The request builder for [ConversationDatasets::create_conversation_dataset][super::super::client::ConversationDatasets::create_conversation_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConversationDataset(
         RequestBuilder<crate::model::CreateConversationDatasetRequest>,
@@ -3340,7 +3340,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::get_conversation_dataset call.
+    /// The request builder for [ConversationDatasets::get_conversation_dataset][super::super::client::ConversationDatasets::get_conversation_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct GetConversationDataset(RequestBuilder<crate::model::GetConversationDatasetRequest>);
 
@@ -3387,7 +3387,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::list_conversation_datasets call.
+    /// The request builder for [ConversationDatasets::list_conversation_datasets][super::super::client::ConversationDatasets::list_conversation_datasets] calls.
     #[derive(Clone, Debug)]
     pub struct ListConversationDatasets(
         RequestBuilder<crate::model::ListConversationDatasetsRequest>,
@@ -3465,7 +3465,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::delete_conversation_dataset call.
+    /// The request builder for [ConversationDatasets::delete_conversation_dataset][super::super::client::ConversationDatasets::delete_conversation_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConversationDataset(
         RequestBuilder<crate::model::DeleteConversationDatasetRequest>,
@@ -3555,7 +3555,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::import_conversation_data call.
+    /// The request builder for [ConversationDatasets::import_conversation_data][super::super::client::ConversationDatasets::import_conversation_data] calls.
     #[derive(Clone, Debug)]
     pub struct ImportConversationData(RequestBuilder<crate::model::ImportConversationDataRequest>);
 
@@ -3654,7 +3654,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::list_locations call.
+    /// The request builder for [ConversationDatasets::list_locations][super::super::client::ConversationDatasets::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3734,7 +3734,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::get_location call.
+    /// The request builder for [ConversationDatasets::get_location][super::super::client::ConversationDatasets::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3778,7 +3778,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::list_operations call.
+    /// The request builder for [ConversationDatasets::list_operations][super::super::client::ConversationDatasets::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3858,7 +3858,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::get_operation call.
+    /// The request builder for [ConversationDatasets::get_operation][super::super::client::ConversationDatasets::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3905,7 +3905,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for a ConversationDatasets::cancel_operation call.
+    /// The request builder for [ConversationDatasets::cancel_operation][super::super::client::ConversationDatasets::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4006,7 +4006,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::create_conversation_model call.
+    /// The request builder for [ConversationModels::create_conversation_model][super::super::client::ConversationModels::create_conversation_model] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConversationModel(
         RequestBuilder<crate::model::CreateConversationModelRequest>,
@@ -4107,7 +4107,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::get_conversation_model call.
+    /// The request builder for [ConversationModels::get_conversation_model][super::super::client::ConversationModels::get_conversation_model] calls.
     #[derive(Clone, Debug)]
     pub struct GetConversationModel(RequestBuilder<crate::model::GetConversationModelRequest>);
 
@@ -4152,7 +4152,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::list_conversation_models call.
+    /// The request builder for [ConversationModels::list_conversation_models][super::super::client::ConversationModels::list_conversation_models] calls.
     #[derive(Clone, Debug)]
     pub struct ListConversationModels(RequestBuilder<crate::model::ListConversationModelsRequest>);
 
@@ -4226,7 +4226,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::delete_conversation_model call.
+    /// The request builder for [ConversationModels::delete_conversation_model][super::super::client::ConversationModels::delete_conversation_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConversationModel(
         RequestBuilder<crate::model::DeleteConversationModelRequest>,
@@ -4312,7 +4312,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::deploy_conversation_model call.
+    /// The request builder for [ConversationModels::deploy_conversation_model][super::super::client::ConversationModels::deploy_conversation_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeployConversationModel(
         RequestBuilder<crate::model::DeployConversationModelRequest>,
@@ -4398,7 +4398,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::undeploy_conversation_model call.
+    /// The request builder for [ConversationModels::undeploy_conversation_model][super::super::client::ConversationModels::undeploy_conversation_model] calls.
     #[derive(Clone, Debug)]
     pub struct UndeployConversationModel(
         RequestBuilder<crate::model::UndeployConversationModelRequest>,
@@ -4486,7 +4486,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::get_conversation_model_evaluation call.
+    /// The request builder for [ConversationModels::get_conversation_model_evaluation][super::super::client::ConversationModels::get_conversation_model_evaluation] calls.
     #[derive(Clone, Debug)]
     pub struct GetConversationModelEvaluation(
         RequestBuilder<crate::model::GetConversationModelEvaluationRequest>,
@@ -4533,7 +4533,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::list_conversation_model_evaluations call.
+    /// The request builder for [ConversationModels::list_conversation_model_evaluations][super::super::client::ConversationModels::list_conversation_model_evaluations] calls.
     #[derive(Clone, Debug)]
     pub struct ListConversationModelEvaluations(
         RequestBuilder<crate::model::ListConversationModelEvaluationsRequest>,
@@ -4609,7 +4609,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::create_conversation_model_evaluation call.
+    /// The request builder for [ConversationModels::create_conversation_model_evaluation][super::super::client::ConversationModels::create_conversation_model_evaluation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConversationModelEvaluation(
         RequestBuilder<crate::model::CreateConversationModelEvaluationRequest>,
@@ -4710,7 +4710,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::list_locations call.
+    /// The request builder for [ConversationModels::list_locations][super::super::client::ConversationModels::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4788,7 +4788,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::get_location call.
+    /// The request builder for [ConversationModels::get_location][super::super::client::ConversationModels::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4830,7 +4830,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::list_operations call.
+    /// The request builder for [ConversationModels::list_operations][super::super::client::ConversationModels::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4908,7 +4908,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::get_operation call.
+    /// The request builder for [ConversationModels::get_operation][super::super::client::ConversationModels::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4953,7 +4953,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for a ConversationModels::cancel_operation call.
+    /// The request builder for [ConversationModels::cancel_operation][super::super::client::ConversationModels::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5054,7 +5054,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::list_conversation_profiles call.
+    /// The request builder for [ConversationProfiles::list_conversation_profiles][super::super::client::ConversationProfiles::list_conversation_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListConversationProfiles(
         RequestBuilder<crate::model::ListConversationProfilesRequest>,
@@ -5132,7 +5132,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::get_conversation_profile call.
+    /// The request builder for [ConversationProfiles::get_conversation_profile][super::super::client::ConversationProfiles::get_conversation_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetConversationProfile(RequestBuilder<crate::model::GetConversationProfileRequest>);
 
@@ -5179,7 +5179,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::create_conversation_profile call.
+    /// The request builder for [ConversationProfiles::create_conversation_profile][super::super::client::ConversationProfiles::create_conversation_profile] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConversationProfile(
         RequestBuilder<crate::model::CreateConversationProfileRequest>,
@@ -5239,7 +5239,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::update_conversation_profile call.
+    /// The request builder for [ConversationProfiles::update_conversation_profile][super::super::client::ConversationProfiles::update_conversation_profile] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConversationProfile(
         RequestBuilder<crate::model::UpdateConversationProfileRequest>,
@@ -5302,7 +5302,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::delete_conversation_profile call.
+    /// The request builder for [ConversationProfiles::delete_conversation_profile][super::super::client::ConversationProfiles::delete_conversation_profile] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConversationProfile(
         RequestBuilder<crate::model::DeleteConversationProfileRequest>,
@@ -5351,7 +5351,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::set_suggestion_feature_config call.
+    /// The request builder for [ConversationProfiles::set_suggestion_feature_config][super::super::client::ConversationProfiles::set_suggestion_feature_config] calls.
     #[derive(Clone, Debug)]
     pub struct SetSuggestionFeatureConfig(
         RequestBuilder<crate::model::SetSuggestionFeatureConfigRequest>,
@@ -5467,7 +5467,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::clear_suggestion_feature_config call.
+    /// The request builder for [ConversationProfiles::clear_suggestion_feature_config][super::super::client::ConversationProfiles::clear_suggestion_feature_config] calls.
     #[derive(Clone, Debug)]
     pub struct ClearSuggestionFeatureConfig(
         RequestBuilder<crate::model::ClearSuggestionFeatureConfigRequest>,
@@ -5577,7 +5577,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::list_locations call.
+    /// The request builder for [ConversationProfiles::list_locations][super::super::client::ConversationProfiles::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5657,7 +5657,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::get_location call.
+    /// The request builder for [ConversationProfiles::get_location][super::super::client::ConversationProfiles::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5701,7 +5701,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::list_operations call.
+    /// The request builder for [ConversationProfiles::list_operations][super::super::client::ConversationProfiles::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5781,7 +5781,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::get_operation call.
+    /// The request builder for [ConversationProfiles::get_operation][super::super::client::ConversationProfiles::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5828,7 +5828,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for a ConversationProfiles::cancel_operation call.
+    /// The request builder for [ConversationProfiles::cancel_operation][super::super::client::ConversationProfiles::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5929,7 +5929,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::list_documents call.
+    /// The request builder for [Documents::list_documents][super::super::client::Documents::list_documents] calls.
     #[derive(Clone, Debug)]
     pub struct ListDocuments(RequestBuilder<crate::model::ListDocumentsRequest>);
 
@@ -6004,7 +6004,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::get_document call.
+    /// The request builder for [Documents::get_document][super::super::client::Documents::get_document] calls.
     #[derive(Clone, Debug)]
     pub struct GetDocument(RequestBuilder<crate::model::GetDocumentRequest>);
 
@@ -6046,7 +6046,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::create_document call.
+    /// The request builder for [Documents::create_document][super::super::client::Documents::create_document] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDocument(RequestBuilder<crate::model::CreateDocumentRequest>);
 
@@ -6136,7 +6136,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::import_documents call.
+    /// The request builder for [Documents::import_documents][super::super::client::Documents::import_documents] calls.
     #[derive(Clone, Debug)]
     pub struct ImportDocuments(RequestBuilder<crate::model::ImportDocumentsRequest>);
 
@@ -6247,7 +6247,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::delete_document call.
+    /// The request builder for [Documents::delete_document][super::super::client::Documents::delete_document] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDocument(RequestBuilder<crate::model::DeleteDocumentRequest>);
 
@@ -6326,7 +6326,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::update_document call.
+    /// The request builder for [Documents::update_document][super::super::client::Documents::update_document] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDocument(RequestBuilder<crate::model::UpdateDocumentRequest>);
 
@@ -6419,7 +6419,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::reload_document call.
+    /// The request builder for [Documents::reload_document][super::super::client::Documents::reload_document] calls.
     #[derive(Clone, Debug)]
     pub struct ReloadDocument(RequestBuilder<crate::model::ReloadDocumentRequest>);
 
@@ -6521,7 +6521,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::export_document call.
+    /// The request builder for [Documents::export_document][super::super::client::Documents::export_document] calls.
     #[derive(Clone, Debug)]
     pub struct ExportDocument(RequestBuilder<crate::model::ExportDocumentRequest>);
 
@@ -6625,7 +6625,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::list_locations call.
+    /// The request builder for [Documents::list_locations][super::super::client::Documents::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6703,7 +6703,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::get_location call.
+    /// The request builder for [Documents::get_location][super::super::client::Documents::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6745,7 +6745,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::list_operations call.
+    /// The request builder for [Documents::list_operations][super::super::client::Documents::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6823,7 +6823,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::get_operation call.
+    /// The request builder for [Documents::get_operation][super::super::client::Documents::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6868,7 +6868,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for a Documents::cancel_operation call.
+    /// The request builder for [Documents::cancel_operation][super::super::client::Documents::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6969,7 +6969,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for a EncryptionSpecService::get_encryption_spec call.
+    /// The request builder for [EncryptionSpecService::get_encryption_spec][super::super::client::EncryptionSpecService::get_encryption_spec] calls.
     #[derive(Clone, Debug)]
     pub struct GetEncryptionSpec(RequestBuilder<crate::model::GetEncryptionSpecRequest>);
 
@@ -7016,7 +7016,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for a EncryptionSpecService::initialize_encryption_spec call.
+    /// The request builder for [EncryptionSpecService::initialize_encryption_spec][super::super::client::EncryptionSpecService::initialize_encryption_spec] calls.
     #[derive(Clone, Debug)]
     pub struct InitializeEncryptionSpec(
         RequestBuilder<crate::model::InitializeEncryptionSpecRequest>,
@@ -7111,7 +7111,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for a EncryptionSpecService::list_locations call.
+    /// The request builder for [EncryptionSpecService::list_locations][super::super::client::EncryptionSpecService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -7191,7 +7191,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for a EncryptionSpecService::get_location call.
+    /// The request builder for [EncryptionSpecService::get_location][super::super::client::EncryptionSpecService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -7235,7 +7235,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for a EncryptionSpecService::list_operations call.
+    /// The request builder for [EncryptionSpecService::list_operations][super::super::client::EncryptionSpecService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7315,7 +7315,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for a EncryptionSpecService::get_operation call.
+    /// The request builder for [EncryptionSpecService::get_operation][super::super::client::EncryptionSpecService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7362,7 +7362,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for a EncryptionSpecService::cancel_operation call.
+    /// The request builder for [EncryptionSpecService::cancel_operation][super::super::client::EncryptionSpecService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7463,7 +7463,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::list_entity_types call.
+    /// The request builder for [EntityTypes::list_entity_types][super::super::client::EntityTypes::list_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListEntityTypes(RequestBuilder<crate::model::ListEntityTypesRequest>);
 
@@ -7538,7 +7538,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::get_entity_type call.
+    /// The request builder for [EntityTypes::get_entity_type][super::super::client::EntityTypes::get_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetEntityType(RequestBuilder<crate::model::GetEntityTypeRequest>);
 
@@ -7586,7 +7586,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::create_entity_type call.
+    /// The request builder for [EntityTypes::create_entity_type][super::super::client::EntityTypes::create_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEntityType(RequestBuilder<crate::model::CreateEntityTypeRequest>);
 
@@ -7646,7 +7646,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::update_entity_type call.
+    /// The request builder for [EntityTypes::update_entity_type][super::super::client::EntityTypes::update_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEntityType(RequestBuilder<crate::model::UpdateEntityTypeRequest>);
 
@@ -7709,7 +7709,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::delete_entity_type call.
+    /// The request builder for [EntityTypes::delete_entity_type][super::super::client::EntityTypes::delete_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEntityType(RequestBuilder<crate::model::DeleteEntityTypeRequest>);
 
@@ -7754,7 +7754,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::batch_update_entity_types call.
+    /// The request builder for [EntityTypes::batch_update_entity_types][super::super::client::EntityTypes::batch_update_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct BatchUpdateEntityTypes(RequestBuilder<crate::model::BatchUpdateEntityTypesRequest>);
 
@@ -7863,7 +7863,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::batch_delete_entity_types call.
+    /// The request builder for [EntityTypes::batch_delete_entity_types][super::super::client::EntityTypes::batch_delete_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeleteEntityTypes(RequestBuilder<crate::model::BatchDeleteEntityTypesRequest>);
 
@@ -7954,7 +7954,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::batch_create_entities call.
+    /// The request builder for [EntityTypes::batch_create_entities][super::super::client::EntityTypes::batch_create_entities] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateEntities(RequestBuilder<crate::model::BatchCreateEntitiesRequest>);
 
@@ -8051,7 +8051,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::batch_update_entities call.
+    /// The request builder for [EntityTypes::batch_update_entities][super::super::client::EntityTypes::batch_update_entities] calls.
     #[derive(Clone, Debug)]
     pub struct BatchUpdateEntities(RequestBuilder<crate::model::BatchUpdateEntitiesRequest>);
 
@@ -8157,7 +8157,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::batch_delete_entities call.
+    /// The request builder for [EntityTypes::batch_delete_entities][super::super::client::EntityTypes::batch_delete_entities] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeleteEntities(RequestBuilder<crate::model::BatchDeleteEntitiesRequest>);
 
@@ -8254,7 +8254,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::list_locations call.
+    /// The request builder for [EntityTypes::list_locations][super::super::client::EntityTypes::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -8332,7 +8332,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::get_location call.
+    /// The request builder for [EntityTypes::get_location][super::super::client::EntityTypes::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -8374,7 +8374,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::list_operations call.
+    /// The request builder for [EntityTypes::list_operations][super::super::client::EntityTypes::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8452,7 +8452,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::get_operation call.
+    /// The request builder for [EntityTypes::get_operation][super::super::client::EntityTypes::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8497,7 +8497,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for a EntityTypes::cancel_operation call.
+    /// The request builder for [EntityTypes::cancel_operation][super::super::client::EntityTypes::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8596,7 +8596,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_environments call.
+    /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
     #[derive(Clone, Debug)]
     pub struct ListEnvironments(RequestBuilder<crate::model::ListEnvironmentsRequest>);
 
@@ -8668,7 +8668,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_environment call.
+    /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -8710,7 +8710,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::create_environment call.
+    /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEnvironment(RequestBuilder<crate::model::CreateEnvironmentRequest>);
 
@@ -8770,7 +8770,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::update_environment call.
+    /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEnvironment(RequestBuilder<crate::model::UpdateEnvironmentRequest>);
 
@@ -8833,7 +8833,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::delete_environment call.
+    /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEnvironment(RequestBuilder<crate::model::DeleteEnvironmentRequest>);
 
@@ -8878,7 +8878,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_environment_history call.
+    /// The request builder for [Environments::get_environment_history][super::super::client::Environments::get_environment_history] calls.
     #[derive(Clone, Debug)]
     pub struct GetEnvironmentHistory(RequestBuilder<crate::model::GetEnvironmentHistoryRequest>);
 
@@ -8950,7 +8950,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_locations call.
+    /// The request builder for [Environments::list_locations][super::super::client::Environments::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -9028,7 +9028,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_location call.
+    /// The request builder for [Environments::get_location][super::super::client::Environments::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -9070,7 +9070,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_operations call.
+    /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9148,7 +9148,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_operation call.
+    /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9193,7 +9193,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::cancel_operation call.
+    /// The request builder for [Environments::cancel_operation][super::super::client::Environments::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9292,7 +9292,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for a Fulfillments::get_fulfillment call.
+    /// The request builder for [Fulfillments::get_fulfillment][super::super::client::Fulfillments::get_fulfillment] calls.
     #[derive(Clone, Debug)]
     pub struct GetFulfillment(RequestBuilder<crate::model::GetFulfillmentRequest>);
 
@@ -9334,7 +9334,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for a Fulfillments::update_fulfillment call.
+    /// The request builder for [Fulfillments::update_fulfillment][super::super::client::Fulfillments::update_fulfillment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFulfillment(RequestBuilder<crate::model::UpdateFulfillmentRequest>);
 
@@ -9391,7 +9391,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for a Fulfillments::list_locations call.
+    /// The request builder for [Fulfillments::list_locations][super::super::client::Fulfillments::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -9469,7 +9469,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for a Fulfillments::get_location call.
+    /// The request builder for [Fulfillments::get_location][super::super::client::Fulfillments::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -9511,7 +9511,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for a Fulfillments::list_operations call.
+    /// The request builder for [Fulfillments::list_operations][super::super::client::Fulfillments::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9589,7 +9589,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for a Fulfillments::get_operation call.
+    /// The request builder for [Fulfillments::get_operation][super::super::client::Fulfillments::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9634,7 +9634,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for a Fulfillments::cancel_operation call.
+    /// The request builder for [Fulfillments::cancel_operation][super::super::client::Fulfillments::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9733,7 +9733,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::create_generator call.
+    /// The request builder for [Generators::create_generator][super::super::client::Generators::create_generator] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGenerator(RequestBuilder<crate::model::CreateGeneratorRequest>);
 
@@ -9790,7 +9790,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::get_generator call.
+    /// The request builder for [Generators::get_generator][super::super::client::Generators::get_generator] calls.
     #[derive(Clone, Debug)]
     pub struct GetGenerator(RequestBuilder<crate::model::GetGeneratorRequest>);
 
@@ -9832,7 +9832,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::list_generators call.
+    /// The request builder for [Generators::list_generators][super::super::client::Generators::list_generators] calls.
     #[derive(Clone, Debug)]
     pub struct ListGenerators(RequestBuilder<crate::model::ListGeneratorsRequest>);
 
@@ -9901,7 +9901,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::delete_generator call.
+    /// The request builder for [Generators::delete_generator][super::super::client::Generators::delete_generator] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGenerator(RequestBuilder<crate::model::DeleteGeneratorRequest>);
 
@@ -9943,7 +9943,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::update_generator call.
+    /// The request builder for [Generators::update_generator][super::super::client::Generators::update_generator] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGenerator(RequestBuilder<crate::model::UpdateGeneratorRequest>);
 
@@ -9997,7 +9997,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::list_locations call.
+    /// The request builder for [Generators::list_locations][super::super::client::Generators::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -10075,7 +10075,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::get_location call.
+    /// The request builder for [Generators::get_location][super::super::client::Generators::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -10117,7 +10117,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::list_operations call.
+    /// The request builder for [Generators::list_operations][super::super::client::Generators::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -10195,7 +10195,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::get_operation call.
+    /// The request builder for [Generators::get_operation][super::super::client::Generators::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -10240,7 +10240,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for a Generators::cancel_operation call.
+    /// The request builder for [Generators::cancel_operation][super::super::client::Generators::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -10339,7 +10339,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::list_intents call.
+    /// The request builder for [Intents::list_intents][super::super::client::Intents::list_intents] calls.
     #[derive(Clone, Debug)]
     pub struct ListIntents(RequestBuilder<crate::model::ListIntentsRequest>);
 
@@ -10420,7 +10420,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::get_intent call.
+    /// The request builder for [Intents::get_intent][super::super::client::Intents::get_intent] calls.
     #[derive(Clone, Debug)]
     pub struct GetIntent(RequestBuilder<crate::model::GetIntentRequest>);
 
@@ -10474,7 +10474,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::create_intent call.
+    /// The request builder for [Intents::create_intent][super::super::client::Intents::create_intent] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIntent(RequestBuilder<crate::model::CreateIntentRequest>);
 
@@ -10537,7 +10537,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::update_intent call.
+    /// The request builder for [Intents::update_intent][super::super::client::Intents::update_intent] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateIntent(RequestBuilder<crate::model::UpdateIntentRequest>);
 
@@ -10603,7 +10603,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::delete_intent call.
+    /// The request builder for [Intents::delete_intent][super::super::client::Intents::delete_intent] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIntent(RequestBuilder<crate::model::DeleteIntentRequest>);
 
@@ -10645,7 +10645,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::batch_update_intents call.
+    /// The request builder for [Intents::batch_update_intents][super::super::client::Intents::batch_update_intents] calls.
     #[derive(Clone, Debug)]
     pub struct BatchUpdateIntents(RequestBuilder<crate::model::BatchUpdateIntentsRequest>);
 
@@ -10759,7 +10759,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::batch_delete_intents call.
+    /// The request builder for [Intents::batch_delete_intents][super::super::client::Intents::batch_delete_intents] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeleteIntents(RequestBuilder<crate::model::BatchDeleteIntentsRequest>);
 
@@ -10850,7 +10850,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::list_locations call.
+    /// The request builder for [Intents::list_locations][super::super::client::Intents::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -10928,7 +10928,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::get_location call.
+    /// The request builder for [Intents::get_location][super::super::client::Intents::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -10970,7 +10970,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::list_operations call.
+    /// The request builder for [Intents::list_operations][super::super::client::Intents::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -11048,7 +11048,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::get_operation call.
+    /// The request builder for [Intents::get_operation][super::super::client::Intents::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -11093,7 +11093,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for a Intents::cancel_operation call.
+    /// The request builder for [Intents::cancel_operation][super::super::client::Intents::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -11192,7 +11192,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::list_knowledge_bases call.
+    /// The request builder for [KnowledgeBases::list_knowledge_bases][super::super::client::KnowledgeBases::list_knowledge_bases] calls.
     #[derive(Clone, Debug)]
     pub struct ListKnowledgeBases(RequestBuilder<crate::model::ListKnowledgeBasesRequest>);
 
@@ -11270,7 +11270,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::get_knowledge_base call.
+    /// The request builder for [KnowledgeBases::get_knowledge_base][super::super::client::KnowledgeBases::get_knowledge_base] calls.
     #[derive(Clone, Debug)]
     pub struct GetKnowledgeBase(RequestBuilder<crate::model::GetKnowledgeBaseRequest>);
 
@@ -11315,7 +11315,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::create_knowledge_base call.
+    /// The request builder for [KnowledgeBases::create_knowledge_base][super::super::client::KnowledgeBases::create_knowledge_base] calls.
     #[derive(Clone, Debug)]
     pub struct CreateKnowledgeBase(RequestBuilder<crate::model::CreateKnowledgeBaseRequest>);
 
@@ -11369,7 +11369,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::delete_knowledge_base call.
+    /// The request builder for [KnowledgeBases::delete_knowledge_base][super::super::client::KnowledgeBases::delete_knowledge_base] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteKnowledgeBase(RequestBuilder<crate::model::DeleteKnowledgeBaseRequest>);
 
@@ -11420,7 +11420,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::update_knowledge_base call.
+    /// The request builder for [KnowledgeBases::update_knowledge_base][super::super::client::KnowledgeBases::update_knowledge_base] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateKnowledgeBase(RequestBuilder<crate::model::UpdateKnowledgeBaseRequest>);
 
@@ -11477,7 +11477,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::list_locations call.
+    /// The request builder for [KnowledgeBases::list_locations][super::super::client::KnowledgeBases::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -11555,7 +11555,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::get_location call.
+    /// The request builder for [KnowledgeBases::get_location][super::super::client::KnowledgeBases::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -11597,7 +11597,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::list_operations call.
+    /// The request builder for [KnowledgeBases::list_operations][super::super::client::KnowledgeBases::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -11675,7 +11675,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::get_operation call.
+    /// The request builder for [KnowledgeBases::get_operation][super::super::client::KnowledgeBases::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -11720,7 +11720,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for a KnowledgeBases::cancel_operation call.
+    /// The request builder for [KnowledgeBases::cancel_operation][super::super::client::KnowledgeBases::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -11819,7 +11819,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::create_participant call.
+    /// The request builder for [Participants::create_participant][super::super::client::Participants::create_participant] calls.
     #[derive(Clone, Debug)]
     pub struct CreateParticipant(RequestBuilder<crate::model::CreateParticipantRequest>);
 
@@ -11873,7 +11873,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::get_participant call.
+    /// The request builder for [Participants::get_participant][super::super::client::Participants::get_participant] calls.
     #[derive(Clone, Debug)]
     pub struct GetParticipant(RequestBuilder<crate::model::GetParticipantRequest>);
 
@@ -11915,7 +11915,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::list_participants call.
+    /// The request builder for [Participants::list_participants][super::super::client::Participants::list_participants] calls.
     #[derive(Clone, Debug)]
     pub struct ListParticipants(RequestBuilder<crate::model::ListParticipantsRequest>);
 
@@ -11987,7 +11987,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::update_participant call.
+    /// The request builder for [Participants::update_participant][super::super::client::Participants::update_participant] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateParticipant(RequestBuilder<crate::model::UpdateParticipantRequest>);
 
@@ -12044,7 +12044,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::analyze_content call.
+    /// The request builder for [Participants::analyze_content][super::super::client::Participants::analyze_content] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeContent(RequestBuilder<crate::model::AnalyzeContentRequest>);
 
@@ -12141,7 +12141,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::suggest_articles call.
+    /// The request builder for [Participants::suggest_articles][super::super::client::Participants::suggest_articles] calls.
     #[derive(Clone, Debug)]
     pub struct SuggestArticles(RequestBuilder<crate::model::SuggestArticlesRequest>);
 
@@ -12206,7 +12206,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::suggest_faq_answers call.
+    /// The request builder for [Participants::suggest_faq_answers][super::super::client::Participants::suggest_faq_answers] calls.
     #[derive(Clone, Debug)]
     pub struct SuggestFaqAnswers(RequestBuilder<crate::model::SuggestFaqAnswersRequest>);
 
@@ -12274,7 +12274,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::suggest_smart_replies call.
+    /// The request builder for [Participants::suggest_smart_replies][super::super::client::Participants::suggest_smart_replies] calls.
     #[derive(Clone, Debug)]
     pub struct SuggestSmartReplies(RequestBuilder<crate::model::SuggestSmartRepliesRequest>);
 
@@ -12340,7 +12340,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::suggest_knowledge_assist call.
+    /// The request builder for [Participants::suggest_knowledge_assist][super::super::client::Participants::suggest_knowledge_assist] calls.
     #[derive(Clone, Debug)]
     pub struct SuggestKnowledgeAssist(RequestBuilder<crate::model::SuggestKnowledgeAssistRequest>);
 
@@ -12403,7 +12403,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::list_locations call.
+    /// The request builder for [Participants::list_locations][super::super::client::Participants::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12481,7 +12481,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::get_location call.
+    /// The request builder for [Participants::get_location][super::super::client::Participants::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12523,7 +12523,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::list_operations call.
+    /// The request builder for [Participants::list_operations][super::super::client::Participants::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -12601,7 +12601,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::get_operation call.
+    /// The request builder for [Participants::get_operation][super::super::client::Participants::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -12646,7 +12646,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for a Participants::cancel_operation call.
+    /// The request builder for [Participants::cancel_operation][super::super::client::Participants::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -12745,7 +12745,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::detect_intent call.
+    /// The request builder for [Sessions::detect_intent][super::super::client::Sessions::detect_intent] calls.
     #[derive(Clone, Debug)]
     pub struct DetectIntent(RequestBuilder<crate::model::DetectIntentRequest>);
 
@@ -12831,7 +12831,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::list_locations call.
+    /// The request builder for [Sessions::list_locations][super::super::client::Sessions::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12909,7 +12909,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::get_location call.
+    /// The request builder for [Sessions::get_location][super::super::client::Sessions::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12951,7 +12951,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::list_operations call.
+    /// The request builder for [Sessions::list_operations][super::super::client::Sessions::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -13029,7 +13029,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::get_operation call.
+    /// The request builder for [Sessions::get_operation][super::super::client::Sessions::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -13074,7 +13074,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for a Sessions::cancel_operation call.
+    /// The request builder for [Sessions::cancel_operation][super::super::client::Sessions::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -13173,7 +13173,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::list_session_entity_types call.
+    /// The request builder for [SessionEntityTypes::list_session_entity_types][super::super::client::SessionEntityTypes::list_session_entity_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListSessionEntityTypes(RequestBuilder<crate::model::ListSessionEntityTypesRequest>);
 
@@ -13247,7 +13247,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::get_session_entity_type call.
+    /// The request builder for [SessionEntityTypes::get_session_entity_type][super::super::client::SessionEntityTypes::get_session_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetSessionEntityType(RequestBuilder<crate::model::GetSessionEntityTypeRequest>);
 
@@ -13292,7 +13292,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::create_session_entity_type call.
+    /// The request builder for [SessionEntityTypes::create_session_entity_type][super::super::client::SessionEntityTypes::create_session_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSessionEntityType(
         RequestBuilder<crate::model::CreateSessionEntityTypeRequest>,
@@ -13350,7 +13350,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::update_session_entity_type call.
+    /// The request builder for [SessionEntityTypes::update_session_entity_type][super::super::client::SessionEntityTypes::update_session_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSessionEntityType(
         RequestBuilder<crate::model::UpdateSessionEntityTypeRequest>,
@@ -13411,7 +13411,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::delete_session_entity_type call.
+    /// The request builder for [SessionEntityTypes::delete_session_entity_type][super::super::client::SessionEntityTypes::delete_session_entity_type] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSessionEntityType(
         RequestBuilder<crate::model::DeleteSessionEntityTypeRequest>,
@@ -13458,7 +13458,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::list_locations call.
+    /// The request builder for [SessionEntityTypes::list_locations][super::super::client::SessionEntityTypes::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -13536,7 +13536,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::get_location call.
+    /// The request builder for [SessionEntityTypes::get_location][super::super::client::SessionEntityTypes::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -13578,7 +13578,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::list_operations call.
+    /// The request builder for [SessionEntityTypes::list_operations][super::super::client::SessionEntityTypes::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -13656,7 +13656,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::get_operation call.
+    /// The request builder for [SessionEntityTypes::get_operation][super::super::client::SessionEntityTypes::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -13701,7 +13701,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for a SessionEntityTypes::cancel_operation call.
+    /// The request builder for [SessionEntityTypes::cancel_operation][super::super::client::SessionEntityTypes::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -13800,7 +13800,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::list_versions call.
+    /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -13869,7 +13869,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::get_version call.
+    /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -13911,7 +13911,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::create_version call.
+    /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVersion(RequestBuilder<crate::model::CreateVersionRequest>);
 
@@ -13962,7 +13962,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::update_version call.
+    /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -14016,7 +14016,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::delete_version call.
+    /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -14058,7 +14058,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::list_locations call.
+    /// The request builder for [Versions::list_locations][super::super::client::Versions::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -14136,7 +14136,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::get_location call.
+    /// The request builder for [Versions::get_location][super::super::client::Versions::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -14178,7 +14178,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::list_operations call.
+    /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -14256,7 +14256,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::get_operation call.
+    /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -14301,7 +14301,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for a Versions::cancel_operation call.
+    /// The request builder for [Versions::cancel_operation][super::super::client::Versions::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/discoveryengine/v1/src/builder.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::complete_query call.
+    /// The request builder for [CompletionService::complete_query][super::super::client::CompletionService::complete_query] calls.
     #[derive(Clone, Debug)]
     pub struct CompleteQuery(RequestBuilder<crate::model::CompleteQueryRequest>);
 
@@ -133,7 +133,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::import_suggestion_deny_list_entries call.
+    /// The request builder for [CompletionService::import_suggestion_deny_list_entries][super::super::client::CompletionService::import_suggestion_deny_list_entries] calls.
     #[derive(Clone, Debug)]
     pub struct ImportSuggestionDenyListEntries(
         RequestBuilder<crate::model::ImportSuggestionDenyListEntriesRequest>,
@@ -234,7 +234,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::purge_suggestion_deny_list_entries call.
+    /// The request builder for [CompletionService::purge_suggestion_deny_list_entries][super::super::client::CompletionService::purge_suggestion_deny_list_entries] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeSuggestionDenyListEntries(
         RequestBuilder<crate::model::PurgeSuggestionDenyListEntriesRequest>,
@@ -324,7 +324,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::import_completion_suggestions call.
+    /// The request builder for [CompletionService::import_completion_suggestions][super::super::client::CompletionService::import_completion_suggestions] calls.
     #[derive(Clone, Debug)]
     pub struct ImportCompletionSuggestions(
         RequestBuilder<crate::model::ImportCompletionSuggestionsRequest>,
@@ -434,7 +434,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::purge_completion_suggestions call.
+    /// The request builder for [CompletionService::purge_completion_suggestions][super::super::client::CompletionService::purge_completion_suggestions] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeCompletionSuggestions(
         RequestBuilder<crate::model::PurgeCompletionSuggestionsRequest>,
@@ -524,7 +524,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::list_operations call.
+    /// The request builder for [CompletionService::list_operations][super::super::client::CompletionService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -602,7 +602,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::get_operation call.
+    /// The request builder for [CompletionService::get_operation][super::super::client::CompletionService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -647,7 +647,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::cancel_operation call.
+    /// The request builder for [CompletionService::cancel_operation][super::super::client::CompletionService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -746,7 +746,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::create_control call.
+    /// The request builder for [ControlService::create_control][super::super::client::ControlService::create_control] calls.
     #[derive(Clone, Debug)]
     pub struct CreateControl(RequestBuilder<crate::model::CreateControlRequest>);
 
@@ -803,7 +803,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::delete_control call.
+    /// The request builder for [ControlService::delete_control][super::super::client::ControlService::delete_control] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteControl(RequestBuilder<crate::model::DeleteControlRequest>);
 
@@ -845,7 +845,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::update_control call.
+    /// The request builder for [ControlService::update_control][super::super::client::ControlService::update_control] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateControl(RequestBuilder<crate::model::UpdateControlRequest>);
 
@@ -899,7 +899,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::get_control call.
+    /// The request builder for [ControlService::get_control][super::super::client::ControlService::get_control] calls.
     #[derive(Clone, Debug)]
     pub struct GetControl(RequestBuilder<crate::model::GetControlRequest>);
 
@@ -941,7 +941,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::list_controls call.
+    /// The request builder for [ControlService::list_controls][super::super::client::ControlService::list_controls] calls.
     #[derive(Clone, Debug)]
     pub struct ListControls(RequestBuilder<crate::model::ListControlsRequest>);
 
@@ -1016,7 +1016,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::list_operations call.
+    /// The request builder for [ControlService::list_operations][super::super::client::ControlService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1094,7 +1094,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::get_operation call.
+    /// The request builder for [ControlService::get_operation][super::super::client::ControlService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1139,7 +1139,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::cancel_operation call.
+    /// The request builder for [ControlService::cancel_operation][super::super::client::ControlService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1240,7 +1240,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::converse_conversation call.
+    /// The request builder for [ConversationalSearchService::converse_conversation][super::super::client::ConversationalSearchService::converse_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct ConverseConversation(RequestBuilder<crate::model::ConverseConversationRequest>);
 
@@ -1358,7 +1358,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::create_conversation call.
+    /// The request builder for [ConversationalSearchService::create_conversation][super::super::client::ConversationalSearchService::create_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConversation(RequestBuilder<crate::model::CreateConversationRequest>);
 
@@ -1414,7 +1414,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::delete_conversation call.
+    /// The request builder for [ConversationalSearchService::delete_conversation][super::super::client::ConversationalSearchService::delete_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConversation(RequestBuilder<crate::model::DeleteConversationRequest>);
 
@@ -1461,7 +1461,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::update_conversation call.
+    /// The request builder for [ConversationalSearchService::update_conversation][super::super::client::ConversationalSearchService::update_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConversation(RequestBuilder<crate::model::UpdateConversationRequest>);
 
@@ -1520,7 +1520,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::get_conversation call.
+    /// The request builder for [ConversationalSearchService::get_conversation][super::super::client::ConversationalSearchService::get_conversation] calls.
     #[derive(Clone, Debug)]
     pub struct GetConversation(RequestBuilder<crate::model::GetConversationRequest>);
 
@@ -1564,7 +1564,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::list_conversations call.
+    /// The request builder for [ConversationalSearchService::list_conversations][super::super::client::ConversationalSearchService::list_conversations] calls.
     #[derive(Clone, Debug)]
     pub struct ListConversations(RequestBuilder<crate::model::ListConversationsRequest>);
 
@@ -1650,7 +1650,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::answer_query call.
+    /// The request builder for [ConversationalSearchService::answer_query][super::super::client::ConversationalSearchService::answer_query] calls.
     #[derive(Clone, Debug)]
     pub struct AnswerQuery(RequestBuilder<crate::model::AnswerQueryRequest>);
 
@@ -1809,7 +1809,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::get_answer call.
+    /// The request builder for [ConversationalSearchService::get_answer][super::super::client::ConversationalSearchService::get_answer] calls.
     #[derive(Clone, Debug)]
     pub struct GetAnswer(RequestBuilder<crate::model::GetAnswerRequest>);
 
@@ -1853,7 +1853,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::create_session call.
+    /// The request builder for [ConversationalSearchService::create_session][super::super::client::ConversationalSearchService::create_session] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSession(RequestBuilder<crate::model::CreateSessionRequest>);
 
@@ -1906,7 +1906,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::delete_session call.
+    /// The request builder for [ConversationalSearchService::delete_session][super::super::client::ConversationalSearchService::delete_session] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSession(RequestBuilder<crate::model::DeleteSessionRequest>);
 
@@ -1950,7 +1950,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::update_session call.
+    /// The request builder for [ConversationalSearchService::update_session][super::super::client::ConversationalSearchService::update_session] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSession(RequestBuilder<crate::model::UpdateSessionRequest>);
 
@@ -2006,7 +2006,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::get_session call.
+    /// The request builder for [ConversationalSearchService::get_session][super::super::client::ConversationalSearchService::get_session] calls.
     #[derive(Clone, Debug)]
     pub struct GetSession(RequestBuilder<crate::model::GetSessionRequest>);
 
@@ -2056,7 +2056,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::list_sessions call.
+    /// The request builder for [ConversationalSearchService::list_sessions][super::super::client::ConversationalSearchService::list_sessions] calls.
     #[derive(Clone, Debug)]
     pub struct ListSessions(RequestBuilder<crate::model::ListSessionsRequest>);
 
@@ -2139,7 +2139,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::list_operations call.
+    /// The request builder for [ConversationalSearchService::list_operations][super::super::client::ConversationalSearchService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2219,7 +2219,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::get_operation call.
+    /// The request builder for [ConversationalSearchService::get_operation][super::super::client::ConversationalSearchService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2266,7 +2266,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for a ConversationalSearchService::cancel_operation call.
+    /// The request builder for [ConversationalSearchService::cancel_operation][super::super::client::ConversationalSearchService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2367,7 +2367,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for a DataStoreService::create_data_store call.
+    /// The request builder for [DataStoreService::create_data_store][super::super::client::DataStoreService::create_data_store] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDataStore(RequestBuilder<crate::model::CreateDataStoreRequest>);
 
@@ -2475,7 +2475,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for a DataStoreService::get_data_store call.
+    /// The request builder for [DataStoreService::get_data_store][super::super::client::DataStoreService::get_data_store] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataStore(RequestBuilder<crate::model::GetDataStoreRequest>);
 
@@ -2517,7 +2517,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for a DataStoreService::list_data_stores call.
+    /// The request builder for [DataStoreService::list_data_stores][super::super::client::DataStoreService::list_data_stores] calls.
     #[derive(Clone, Debug)]
     pub struct ListDataStores(RequestBuilder<crate::model::ListDataStoresRequest>);
 
@@ -2592,7 +2592,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for a DataStoreService::delete_data_store call.
+    /// The request builder for [DataStoreService::delete_data_store][super::super::client::DataStoreService::delete_data_store] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataStore(RequestBuilder<crate::model::DeleteDataStoreRequest>);
 
@@ -2669,7 +2669,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for a DataStoreService::update_data_store call.
+    /// The request builder for [DataStoreService::update_data_store][super::super::client::DataStoreService::update_data_store] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDataStore(RequestBuilder<crate::model::UpdateDataStoreRequest>);
 
@@ -2723,7 +2723,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for a DataStoreService::list_operations call.
+    /// The request builder for [DataStoreService::list_operations][super::super::client::DataStoreService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2801,7 +2801,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for a DataStoreService::get_operation call.
+    /// The request builder for [DataStoreService::get_operation][super::super::client::DataStoreService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2846,7 +2846,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for a DataStoreService::cancel_operation call.
+    /// The request builder for [DataStoreService::cancel_operation][super::super::client::DataStoreService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2945,7 +2945,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::get_document call.
+    /// The request builder for [DocumentService::get_document][super::super::client::DocumentService::get_document] calls.
     #[derive(Clone, Debug)]
     pub struct GetDocument(RequestBuilder<crate::model::GetDocumentRequest>);
 
@@ -2987,7 +2987,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::list_documents call.
+    /// The request builder for [DocumentService::list_documents][super::super::client::DocumentService::list_documents] calls.
     #[derive(Clone, Debug)]
     pub struct ListDocuments(RequestBuilder<crate::model::ListDocumentsRequest>);
 
@@ -3056,7 +3056,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::create_document call.
+    /// The request builder for [DocumentService::create_document][super::super::client::DocumentService::create_document] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDocument(RequestBuilder<crate::model::CreateDocumentRequest>);
 
@@ -3113,7 +3113,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::update_document call.
+    /// The request builder for [DocumentService::update_document][super::super::client::DocumentService::update_document] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDocument(RequestBuilder<crate::model::UpdateDocumentRequest>);
 
@@ -3173,7 +3173,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::delete_document call.
+    /// The request builder for [DocumentService::delete_document][super::super::client::DocumentService::delete_document] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDocument(RequestBuilder<crate::model::DeleteDocumentRequest>);
 
@@ -3215,7 +3215,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::import_documents call.
+    /// The request builder for [DocumentService::import_documents][super::super::client::DocumentService::import_documents] calls.
     #[derive(Clone, Debug)]
     pub struct ImportDocuments(RequestBuilder<crate::model::ImportDocumentsRequest>);
 
@@ -3354,7 +3354,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::purge_documents call.
+    /// The request builder for [DocumentService::purge_documents][super::super::client::DocumentService::purge_documents] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeDocuments(RequestBuilder<crate::model::PurgeDocumentsRequest>);
 
@@ -3467,7 +3467,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::batch_get_documents_metadata call.
+    /// The request builder for [DocumentService::batch_get_documents_metadata][super::super::client::DocumentService::batch_get_documents_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct BatchGetDocumentsMetadata(
         RequestBuilder<crate::model::BatchGetDocumentsMetadataRequest>,
@@ -3525,7 +3525,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::list_operations call.
+    /// The request builder for [DocumentService::list_operations][super::super::client::DocumentService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3603,7 +3603,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::get_operation call.
+    /// The request builder for [DocumentService::get_operation][super::super::client::DocumentService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3648,7 +3648,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for a DocumentService::cancel_operation call.
+    /// The request builder for [DocumentService::cancel_operation][super::super::client::DocumentService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3747,7 +3747,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for a EngineService::create_engine call.
+    /// The request builder for [EngineService::create_engine][super::super::client::EngineService::create_engine] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEngine(RequestBuilder<crate::model::CreateEngineRequest>);
 
@@ -3842,7 +3842,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for a EngineService::delete_engine call.
+    /// The request builder for [EngineService::delete_engine][super::super::client::EngineService::delete_engine] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEngine(RequestBuilder<crate::model::DeleteEngineRequest>);
 
@@ -3919,7 +3919,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for a EngineService::update_engine call.
+    /// The request builder for [EngineService::update_engine][super::super::client::EngineService::update_engine] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEngine(RequestBuilder<crate::model::UpdateEngineRequest>);
 
@@ -3973,7 +3973,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for a EngineService::get_engine call.
+    /// The request builder for [EngineService::get_engine][super::super::client::EngineService::get_engine] calls.
     #[derive(Clone, Debug)]
     pub struct GetEngine(RequestBuilder<crate::model::GetEngineRequest>);
 
@@ -4015,7 +4015,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for a EngineService::list_engines call.
+    /// The request builder for [EngineService::list_engines][super::super::client::EngineService::list_engines] calls.
     #[derive(Clone, Debug)]
     pub struct ListEngines(RequestBuilder<crate::model::ListEnginesRequest>);
 
@@ -4090,7 +4090,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for a EngineService::list_operations call.
+    /// The request builder for [EngineService::list_operations][super::super::client::EngineService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4168,7 +4168,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for a EngineService::get_operation call.
+    /// The request builder for [EngineService::get_operation][super::super::client::EngineService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4213,7 +4213,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for a EngineService::cancel_operation call.
+    /// The request builder for [EngineService::cancel_operation][super::super::client::EngineService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4314,7 +4314,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for a GroundedGenerationService::generate_grounded_content call.
+    /// The request builder for [GroundedGenerationService::generate_grounded_content][super::super::client::GroundedGenerationService::generate_grounded_content] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateGroundedContent(
         RequestBuilder<crate::model::GenerateGroundedContentRequest>,
@@ -4424,7 +4424,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for a GroundedGenerationService::check_grounding call.
+    /// The request builder for [GroundedGenerationService::check_grounding][super::super::client::GroundedGenerationService::check_grounding] calls.
     #[derive(Clone, Debug)]
     pub struct CheckGrounding(RequestBuilder<crate::model::CheckGroundingRequest>);
 
@@ -4507,7 +4507,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for a GroundedGenerationService::list_operations call.
+    /// The request builder for [GroundedGenerationService::list_operations][super::super::client::GroundedGenerationService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4587,7 +4587,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for a GroundedGenerationService::get_operation call.
+    /// The request builder for [GroundedGenerationService::get_operation][super::super::client::GroundedGenerationService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4634,7 +4634,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for a GroundedGenerationService::cancel_operation call.
+    /// The request builder for [GroundedGenerationService::cancel_operation][super::super::client::GroundedGenerationService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4735,7 +4735,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for a ProjectService::provision_project call.
+    /// The request builder for [ProjectService::provision_project][super::super::client::ProjectService::provision_project] calls.
     #[derive(Clone, Debug)]
     pub struct ProvisionProject(RequestBuilder<crate::model::ProvisionProjectRequest>);
 
@@ -4831,7 +4831,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for a ProjectService::list_operations call.
+    /// The request builder for [ProjectService::list_operations][super::super::client::ProjectService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4909,7 +4909,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for a ProjectService::get_operation call.
+    /// The request builder for [ProjectService::get_operation][super::super::client::ProjectService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4954,7 +4954,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for a ProjectService::cancel_operation call.
+    /// The request builder for [ProjectService::cancel_operation][super::super::client::ProjectService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5053,7 +5053,7 @@ pub mod rank_service {
         }
     }
 
-    /// The request builder for a RankService::rank call.
+    /// The request builder for [RankService::rank][super::super::client::RankService::rank] calls.
     #[derive(Clone, Debug)]
     pub struct Rank(RequestBuilder<crate::model::RankRequest>);
 
@@ -5139,7 +5139,7 @@ pub mod rank_service {
         }
     }
 
-    /// The request builder for a RankService::list_operations call.
+    /// The request builder for [RankService::list_operations][super::super::client::RankService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5217,7 +5217,7 @@ pub mod rank_service {
         }
     }
 
-    /// The request builder for a RankService::get_operation call.
+    /// The request builder for [RankService::get_operation][super::super::client::RankService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5262,7 +5262,7 @@ pub mod rank_service {
         }
     }
 
-    /// The request builder for a RankService::cancel_operation call.
+    /// The request builder for [RankService::cancel_operation][super::super::client::RankService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5363,7 +5363,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// The request builder for a RecommendationService::recommend call.
+    /// The request builder for [RecommendationService::recommend][super::super::client::RecommendationService::recommend] calls.
     #[derive(Clone, Debug)]
     pub struct Recommend(RequestBuilder<crate::model::RecommendRequest>);
 
@@ -5456,7 +5456,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// The request builder for a RecommendationService::list_operations call.
+    /// The request builder for [RecommendationService::list_operations][super::super::client::RecommendationService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5536,7 +5536,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// The request builder for a RecommendationService::get_operation call.
+    /// The request builder for [RecommendationService::get_operation][super::super::client::RecommendationService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5583,7 +5583,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// The request builder for a RecommendationService::cancel_operation call.
+    /// The request builder for [RecommendationService::cancel_operation][super::super::client::RecommendationService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5684,7 +5684,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for a SchemaService::get_schema call.
+    /// The request builder for [SchemaService::get_schema][super::super::client::SchemaService::get_schema] calls.
     #[derive(Clone, Debug)]
     pub struct GetSchema(RequestBuilder<crate::model::GetSchemaRequest>);
 
@@ -5726,7 +5726,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for a SchemaService::list_schemas call.
+    /// The request builder for [SchemaService::list_schemas][super::super::client::SchemaService::list_schemas] calls.
     #[derive(Clone, Debug)]
     pub struct ListSchemas(RequestBuilder<crate::model::ListSchemasRequest>);
 
@@ -5795,7 +5795,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for a SchemaService::create_schema call.
+    /// The request builder for [SchemaService::create_schema][super::super::client::SchemaService::create_schema] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSchema(RequestBuilder<crate::model::CreateSchemaRequest>);
 
@@ -5890,7 +5890,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for a SchemaService::update_schema call.
+    /// The request builder for [SchemaService::update_schema][super::super::client::SchemaService::update_schema] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSchema(RequestBuilder<crate::model::UpdateSchemaRequest>);
 
@@ -5979,7 +5979,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for a SchemaService::delete_schema call.
+    /// The request builder for [SchemaService::delete_schema][super::super::client::SchemaService::delete_schema] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSchema(RequestBuilder<crate::model::DeleteSchemaRequest>);
 
@@ -6056,7 +6056,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for a SchemaService::list_operations call.
+    /// The request builder for [SchemaService::list_operations][super::super::client::SchemaService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6134,7 +6134,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for a SchemaService::get_operation call.
+    /// The request builder for [SchemaService::get_operation][super::super::client::SchemaService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6179,7 +6179,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for a SchemaService::cancel_operation call.
+    /// The request builder for [SchemaService::cancel_operation][super::super::client::SchemaService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6278,7 +6278,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for a SearchService::search call.
+    /// The request builder for [SearchService::search][super::super::client::SearchService::search] calls.
     #[derive(Clone, Debug)]
     pub struct Search(RequestBuilder<crate::model::SearchRequest>);
 
@@ -6573,7 +6573,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for a SearchService::search_lite call.
+    /// The request builder for [SearchService::search_lite][super::super::client::SearchService::search_lite] calls.
     #[derive(Clone, Debug)]
     pub struct SearchLite(RequestBuilder<crate::model::SearchRequest>);
 
@@ -6870,7 +6870,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for a SearchService::list_operations call.
+    /// The request builder for [SearchService::list_operations][super::super::client::SearchService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6948,7 +6948,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for a SearchService::get_operation call.
+    /// The request builder for [SearchService::get_operation][super::super::client::SearchService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6993,7 +6993,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for a SearchService::cancel_operation call.
+    /// The request builder for [SearchService::cancel_operation][super::super::client::SearchService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7092,7 +7092,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for a SearchTuningService::train_custom_model call.
+    /// The request builder for [SearchTuningService::train_custom_model][super::super::client::SearchTuningService::train_custom_model] calls.
     #[derive(Clone, Debug)]
     pub struct TrainCustomModel(RequestBuilder<crate::model::TrainCustomModelRequest>);
 
@@ -7212,7 +7212,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for a SearchTuningService::list_custom_models call.
+    /// The request builder for [SearchTuningService::list_custom_models][super::super::client::SearchTuningService::list_custom_models] calls.
     #[derive(Clone, Debug)]
     pub struct ListCustomModels(RequestBuilder<crate::model::ListCustomModelsRequest>);
 
@@ -7257,7 +7257,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for a SearchTuningService::list_operations call.
+    /// The request builder for [SearchTuningService::list_operations][super::super::client::SearchTuningService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7335,7 +7335,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for a SearchTuningService::get_operation call.
+    /// The request builder for [SearchTuningService::get_operation][super::super::client::SearchTuningService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7380,7 +7380,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for a SearchTuningService::cancel_operation call.
+    /// The request builder for [SearchTuningService::cancel_operation][super::super::client::SearchTuningService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7481,7 +7481,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::update_serving_config call.
+    /// The request builder for [ServingConfigService::update_serving_config][super::super::client::ServingConfigService::update_serving_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServingConfig(RequestBuilder<crate::model::UpdateServingConfigRequest>);
 
@@ -7540,7 +7540,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::list_operations call.
+    /// The request builder for [ServingConfigService::list_operations][super::super::client::ServingConfigService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7620,7 +7620,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::get_operation call.
+    /// The request builder for [ServingConfigService::get_operation][super::super::client::ServingConfigService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7667,7 +7667,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::cancel_operation call.
+    /// The request builder for [ServingConfigService::cancel_operation][super::super::client::ServingConfigService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7770,7 +7770,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::get_site_search_engine call.
+    /// The request builder for [SiteSearchEngineService::get_site_search_engine][super::super::client::SiteSearchEngineService::get_site_search_engine] calls.
     #[derive(Clone, Debug)]
     pub struct GetSiteSearchEngine(RequestBuilder<crate::model::GetSiteSearchEngineRequest>);
 
@@ -7817,7 +7817,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::create_target_site call.
+    /// The request builder for [SiteSearchEngineService::create_target_site][super::super::client::SiteSearchEngineService::create_target_site] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTargetSite(RequestBuilder<crate::model::CreateTargetSiteRequest>);
 
@@ -7912,7 +7912,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::batch_create_target_sites call.
+    /// The request builder for [SiteSearchEngineService::batch_create_target_sites][super::super::client::SiteSearchEngineService::batch_create_target_sites] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateTargetSites(RequestBuilder<crate::model::BatchCreateTargetSitesRequest>);
 
@@ -8013,7 +8013,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::get_target_site call.
+    /// The request builder for [SiteSearchEngineService::get_target_site][super::super::client::SiteSearchEngineService::get_target_site] calls.
     #[derive(Clone, Debug)]
     pub struct GetTargetSite(RequestBuilder<crate::model::GetTargetSiteRequest>);
 
@@ -8057,7 +8057,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::update_target_site call.
+    /// The request builder for [SiteSearchEngineService::update_target_site][super::super::client::SiteSearchEngineService::update_target_site] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTargetSite(RequestBuilder<crate::model::UpdateTargetSiteRequest>);
 
@@ -8146,7 +8146,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::delete_target_site call.
+    /// The request builder for [SiteSearchEngineService::delete_target_site][super::super::client::SiteSearchEngineService::delete_target_site] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTargetSite(RequestBuilder<crate::model::DeleteTargetSiteRequest>);
 
@@ -8230,7 +8230,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::list_target_sites call.
+    /// The request builder for [SiteSearchEngineService::list_target_sites][super::super::client::SiteSearchEngineService::list_target_sites] calls.
     #[derive(Clone, Debug)]
     pub struct ListTargetSites(RequestBuilder<crate::model::ListTargetSitesRequest>);
 
@@ -8301,7 +8301,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::create_sitemap call.
+    /// The request builder for [SiteSearchEngineService::create_sitemap][super::super::client::SiteSearchEngineService::create_sitemap] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSitemap(RequestBuilder<crate::model::CreateSitemapRequest>);
 
@@ -8392,7 +8392,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::delete_sitemap call.
+    /// The request builder for [SiteSearchEngineService::delete_sitemap][super::super::client::SiteSearchEngineService::delete_sitemap] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSitemap(RequestBuilder<crate::model::DeleteSitemapRequest>);
 
@@ -8471,7 +8471,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::fetch_sitemaps call.
+    /// The request builder for [SiteSearchEngineService::fetch_sitemaps][super::super::client::SiteSearchEngineService::fetch_sitemaps] calls.
     #[derive(Clone, Debug)]
     pub struct FetchSitemaps(RequestBuilder<crate::model::FetchSitemapsRequest>);
 
@@ -8526,7 +8526,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::enable_advanced_site_search call.
+    /// The request builder for [SiteSearchEngineService::enable_advanced_site_search][super::super::client::SiteSearchEngineService::enable_advanced_site_search] calls.
     #[derive(Clone, Debug)]
     pub struct EnableAdvancedSiteSearch(
         RequestBuilder<crate::model::EnableAdvancedSiteSearchRequest>,
@@ -8618,7 +8618,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::disable_advanced_site_search call.
+    /// The request builder for [SiteSearchEngineService::disable_advanced_site_search][super::super::client::SiteSearchEngineService::disable_advanced_site_search] calls.
     #[derive(Clone, Debug)]
     pub struct DisableAdvancedSiteSearch(
         RequestBuilder<crate::model::DisableAdvancedSiteSearchRequest>,
@@ -8710,7 +8710,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::recrawl_uris call.
+    /// The request builder for [SiteSearchEngineService::recrawl_uris][super::super::client::SiteSearchEngineService::recrawl_uris] calls.
     #[derive(Clone, Debug)]
     pub struct RecrawlUris(RequestBuilder<crate::model::RecrawlUrisRequest>);
 
@@ -8812,7 +8812,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::batch_verify_target_sites call.
+    /// The request builder for [SiteSearchEngineService::batch_verify_target_sites][super::super::client::SiteSearchEngineService::batch_verify_target_sites] calls.
     #[derive(Clone, Debug)]
     pub struct BatchVerifyTargetSites(RequestBuilder<crate::model::BatchVerifyTargetSitesRequest>);
 
@@ -8902,7 +8902,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::fetch_domain_verification_status call.
+    /// The request builder for [SiteSearchEngineService::fetch_domain_verification_status][super::super::client::SiteSearchEngineService::fetch_domain_verification_status] calls.
     #[derive(Clone, Debug)]
     pub struct FetchDomainVerificationStatus(
         RequestBuilder<crate::model::FetchDomainVerificationStatusRequest>,
@@ -8980,7 +8980,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::list_operations call.
+    /// The request builder for [SiteSearchEngineService::list_operations][super::super::client::SiteSearchEngineService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9060,7 +9060,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::get_operation call.
+    /// The request builder for [SiteSearchEngineService::get_operation][super::super::client::SiteSearchEngineService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9107,7 +9107,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for a SiteSearchEngineService::cancel_operation call.
+    /// The request builder for [SiteSearchEngineService::cancel_operation][super::super::client::SiteSearchEngineService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9208,7 +9208,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::write_user_event call.
+    /// The request builder for [UserEventService::write_user_event][super::super::client::UserEventService::write_user_event] calls.
     #[derive(Clone, Debug)]
     pub struct WriteUserEvent(RequestBuilder<crate::model::WriteUserEventRequest>);
 
@@ -9265,7 +9265,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::collect_user_event call.
+    /// The request builder for [UserEventService::collect_user_event][super::super::client::UserEventService::collect_user_event] calls.
     #[derive(Clone, Debug)]
     pub struct CollectUserEvent(RequestBuilder<crate::model::CollectUserEventRequest>);
 
@@ -9328,7 +9328,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::purge_user_events call.
+    /// The request builder for [UserEventService::purge_user_events][super::super::client::UserEventService::purge_user_events] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeUserEvents(RequestBuilder<crate::model::PurgeUserEventsRequest>);
 
@@ -9423,7 +9423,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::import_user_events call.
+    /// The request builder for [UserEventService::import_user_events][super::super::client::UserEventService::import_user_events] calls.
     #[derive(Clone, Debug)]
     pub struct ImportUserEvents(RequestBuilder<crate::model::ImportUserEventsRequest>);
 
@@ -9529,7 +9529,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::list_operations call.
+    /// The request builder for [UserEventService::list_operations][super::super::client::UserEventService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9607,7 +9607,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::get_operation call.
+    /// The request builder for [UserEventService::get_operation][super::super::client::UserEventService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9652,7 +9652,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::cancel_operation call.
+    /// The request builder for [UserEventService::cancel_operation][super::super::client::UserEventService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/documentai/v1/src/builder.rs
+++ b/src/generated/cloud/documentai/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::process_document call.
+    /// The request builder for [DocumentProcessorService::process_document][super::super::client::DocumentProcessorService::process_document] calls.
     #[derive(Clone, Debug)]
     pub struct ProcessDocument(RequestBuilder<crate::model::ProcessRequest>);
 
@@ -163,7 +163,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::batch_process_documents call.
+    /// The request builder for [DocumentProcessorService::batch_process_documents][super::super::client::DocumentProcessorService::batch_process_documents] calls.
     #[derive(Clone, Debug)]
     pub struct BatchProcessDocuments(RequestBuilder<crate::model::BatchProcessRequest>);
 
@@ -296,7 +296,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::fetch_processor_types call.
+    /// The request builder for [DocumentProcessorService::fetch_processor_types][super::super::client::DocumentProcessorService::fetch_processor_types] calls.
     #[derive(Clone, Debug)]
     pub struct FetchProcessorTypes(RequestBuilder<crate::model::FetchProcessorTypesRequest>);
 
@@ -343,7 +343,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::list_processor_types call.
+    /// The request builder for [DocumentProcessorService::list_processor_types][super::super::client::DocumentProcessorService::list_processor_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListProcessorTypes(RequestBuilder<crate::model::ListProcessorTypesRequest>);
 
@@ -417,7 +417,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::get_processor_type call.
+    /// The request builder for [DocumentProcessorService::get_processor_type][super::super::client::DocumentProcessorService::get_processor_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetProcessorType(RequestBuilder<crate::model::GetProcessorTypeRequest>);
 
@@ -464,7 +464,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::list_processors call.
+    /// The request builder for [DocumentProcessorService::list_processors][super::super::client::DocumentProcessorService::list_processors] calls.
     #[derive(Clone, Debug)]
     pub struct ListProcessors(RequestBuilder<crate::model::ListProcessorsRequest>);
 
@@ -535,7 +535,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::get_processor call.
+    /// The request builder for [DocumentProcessorService::get_processor][super::super::client::DocumentProcessorService::get_processor] calls.
     #[derive(Clone, Debug)]
     pub struct GetProcessor(RequestBuilder<crate::model::GetProcessorRequest>);
 
@@ -579,7 +579,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::train_processor_version call.
+    /// The request builder for [DocumentProcessorService::train_processor_version][super::super::client::DocumentProcessorService::train_processor_version] calls.
     #[derive(Clone, Debug)]
     pub struct TrainProcessorVersion(RequestBuilder<crate::model::TrainProcessorVersionRequest>);
 
@@ -717,7 +717,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::get_processor_version call.
+    /// The request builder for [DocumentProcessorService::get_processor_version][super::super::client::DocumentProcessorService::get_processor_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetProcessorVersion(RequestBuilder<crate::model::GetProcessorVersionRequest>);
 
@@ -764,7 +764,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::list_processor_versions call.
+    /// The request builder for [DocumentProcessorService::list_processor_versions][super::super::client::DocumentProcessorService::list_processor_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListProcessorVersions(RequestBuilder<crate::model::ListProcessorVersionsRequest>);
 
@@ -838,7 +838,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::delete_processor_version call.
+    /// The request builder for [DocumentProcessorService::delete_processor_version][super::super::client::DocumentProcessorService::delete_processor_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteProcessorVersion(RequestBuilder<crate::model::DeleteProcessorVersionRequest>);
 
@@ -923,7 +923,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::deploy_processor_version call.
+    /// The request builder for [DocumentProcessorService::deploy_processor_version][super::super::client::DocumentProcessorService::deploy_processor_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeployProcessorVersion(RequestBuilder<crate::model::DeployProcessorVersionRequest>);
 
@@ -1013,7 +1013,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::undeploy_processor_version call.
+    /// The request builder for [DocumentProcessorService::undeploy_processor_version][super::super::client::DocumentProcessorService::undeploy_processor_version] calls.
     #[derive(Clone, Debug)]
     pub struct UndeployProcessorVersion(
         RequestBuilder<crate::model::UndeployProcessorVersionRequest>,
@@ -1105,7 +1105,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::create_processor call.
+    /// The request builder for [DocumentProcessorService::create_processor][super::super::client::DocumentProcessorService::create_processor] calls.
     #[derive(Clone, Debug)]
     pub struct CreateProcessor(RequestBuilder<crate::model::CreateProcessorRequest>);
 
@@ -1158,7 +1158,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::delete_processor call.
+    /// The request builder for [DocumentProcessorService::delete_processor][super::super::client::DocumentProcessorService::delete_processor] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteProcessor(RequestBuilder<crate::model::DeleteProcessorRequest>);
 
@@ -1237,7 +1237,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::enable_processor call.
+    /// The request builder for [DocumentProcessorService::enable_processor][super::super::client::DocumentProcessorService::enable_processor] calls.
     #[derive(Clone, Debug)]
     pub struct EnableProcessor(RequestBuilder<crate::model::EnableProcessorRequest>);
 
@@ -1322,7 +1322,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::disable_processor call.
+    /// The request builder for [DocumentProcessorService::disable_processor][super::super::client::DocumentProcessorService::disable_processor] calls.
     #[derive(Clone, Debug)]
     pub struct DisableProcessor(RequestBuilder<crate::model::DisableProcessorRequest>);
 
@@ -1412,7 +1412,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::set_default_processor_version call.
+    /// The request builder for [DocumentProcessorService::set_default_processor_version][super::super::client::DocumentProcessorService::set_default_processor_version] calls.
     #[derive(Clone, Debug)]
     pub struct SetDefaultProcessorVersion(
         RequestBuilder<crate::model::SetDefaultProcessorVersionRequest>,
@@ -1510,7 +1510,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::review_document call.
+    /// The request builder for [DocumentProcessorService::review_document][super::super::client::DocumentProcessorService::review_document] calls.
     #[derive(Clone, Debug)]
     pub struct ReviewDocument(RequestBuilder<crate::model::ReviewDocumentRequest>);
 
@@ -1630,7 +1630,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::evaluate_processor_version call.
+    /// The request builder for [DocumentProcessorService::evaluate_processor_version][super::super::client::DocumentProcessorService::evaluate_processor_version] calls.
     #[derive(Clone, Debug)]
     pub struct EvaluateProcessorVersion(
         RequestBuilder<crate::model::EvaluateProcessorVersionRequest>,
@@ -1733,7 +1733,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::get_evaluation call.
+    /// The request builder for [DocumentProcessorService::get_evaluation][super::super::client::DocumentProcessorService::get_evaluation] calls.
     #[derive(Clone, Debug)]
     pub struct GetEvaluation(RequestBuilder<crate::model::GetEvaluationRequest>);
 
@@ -1777,7 +1777,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::list_evaluations call.
+    /// The request builder for [DocumentProcessorService::list_evaluations][super::super::client::DocumentProcessorService::list_evaluations] calls.
     #[derive(Clone, Debug)]
     pub struct ListEvaluations(RequestBuilder<crate::model::ListEvaluationsRequest>);
 
@@ -1848,7 +1848,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::list_locations call.
+    /// The request builder for [DocumentProcessorService::list_locations][super::super::client::DocumentProcessorService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1928,7 +1928,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::get_location call.
+    /// The request builder for [DocumentProcessorService::get_location][super::super::client::DocumentProcessorService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1972,7 +1972,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::list_operations call.
+    /// The request builder for [DocumentProcessorService::list_operations][super::super::client::DocumentProcessorService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2052,7 +2052,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::get_operation call.
+    /// The request builder for [DocumentProcessorService::get_operation][super::super::client::DocumentProcessorService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2099,7 +2099,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for a DocumentProcessorService::cancel_operation call.
+    /// The request builder for [DocumentProcessorService::cancel_operation][super::super::client::DocumentProcessorService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/domains/v1/src/builder.rs
+++ b/src/generated/cloud/domains/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::search_domains call.
+    /// The request builder for [Domains::search_domains][super::super::client::Domains::search_domains] calls.
     #[derive(Clone, Debug)]
     pub struct SearchDomains(RequestBuilder<crate::model::SearchDomainsRequest>);
 
@@ -115,7 +115,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::retrieve_register_parameters call.
+    /// The request builder for [Domains::retrieve_register_parameters][super::super::client::Domains::retrieve_register_parameters] calls.
     #[derive(Clone, Debug)]
     pub struct RetrieveRegisterParameters(
         RequestBuilder<crate::model::RetrieveRegisterParametersRequest>,
@@ -168,7 +168,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::register_domain call.
+    /// The request builder for [Domains::register_domain][super::super::client::Domains::register_domain] calls.
     #[derive(Clone, Debug)]
     pub struct RegisterDomain(RequestBuilder<crate::model::RegisterDomainRequest>);
 
@@ -294,7 +294,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::retrieve_transfer_parameters call.
+    /// The request builder for [Domains::retrieve_transfer_parameters][super::super::client::Domains::retrieve_transfer_parameters] calls.
     #[derive(Clone, Debug)]
     pub struct RetrieveTransferParameters(
         RequestBuilder<crate::model::RetrieveTransferParametersRequest>,
@@ -347,7 +347,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::transfer_domain call.
+    /// The request builder for [Domains::transfer_domain][super::super::client::Domains::transfer_domain] calls.
     #[derive(Clone, Debug)]
     pub struct TransferDomain(RequestBuilder<crate::model::TransferDomainRequest>);
 
@@ -473,7 +473,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::list_registrations call.
+    /// The request builder for [Domains::list_registrations][super::super::client::Domains::list_registrations] calls.
     #[derive(Clone, Debug)]
     pub struct ListRegistrations(RequestBuilder<crate::model::ListRegistrationsRequest>);
 
@@ -551,7 +551,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::get_registration call.
+    /// The request builder for [Domains::get_registration][super::super::client::Domains::get_registration] calls.
     #[derive(Clone, Debug)]
     pub struct GetRegistration(RequestBuilder<crate::model::GetRegistrationRequest>);
 
@@ -593,7 +593,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::update_registration call.
+    /// The request builder for [Domains::update_registration][super::super::client::Domains::update_registration] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRegistration(RequestBuilder<crate::model::UpdateRegistrationRequest>);
 
@@ -688,7 +688,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::configure_management_settings call.
+    /// The request builder for [Domains::configure_management_settings][super::super::client::Domains::configure_management_settings] calls.
     #[derive(Clone, Debug)]
     pub struct ConfigureManagementSettings(
         RequestBuilder<crate::model::ConfigureManagementSettingsRequest>,
@@ -793,7 +793,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::configure_dns_settings call.
+    /// The request builder for [Domains::configure_dns_settings][super::super::client::Domains::configure_dns_settings] calls.
     #[derive(Clone, Debug)]
     pub struct ConfigureDnsSettings(RequestBuilder<crate::model::ConfigureDnsSettingsRequest>);
 
@@ -900,7 +900,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::configure_contact_settings call.
+    /// The request builder for [Domains::configure_contact_settings][super::super::client::Domains::configure_contact_settings] calls.
     #[derive(Clone, Debug)]
     pub struct ConfigureContactSettings(
         RequestBuilder<crate::model::ConfigureContactSettingsRequest>,
@@ -1020,7 +1020,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::export_registration call.
+    /// The request builder for [Domains::export_registration][super::super::client::Domains::export_registration] calls.
     #[derive(Clone, Debug)]
     pub struct ExportRegistration(RequestBuilder<crate::model::ExportRegistrationRequest>);
 
@@ -1103,7 +1103,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::delete_registration call.
+    /// The request builder for [Domains::delete_registration][super::super::client::Domains::delete_registration] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRegistration(RequestBuilder<crate::model::DeleteRegistrationRequest>);
 
@@ -1183,7 +1183,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::retrieve_authorization_code call.
+    /// The request builder for [Domains::retrieve_authorization_code][super::super::client::Domains::retrieve_authorization_code] calls.
     #[derive(Clone, Debug)]
     pub struct RetrieveAuthorizationCode(
         RequestBuilder<crate::model::RetrieveAuthorizationCodeRequest>,
@@ -1230,7 +1230,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::reset_authorization_code call.
+    /// The request builder for [Domains::reset_authorization_code][super::super::client::Domains::reset_authorization_code] calls.
     #[derive(Clone, Debug)]
     pub struct ResetAuthorizationCode(RequestBuilder<crate::model::ResetAuthorizationCodeRequest>);
 
@@ -1275,7 +1275,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::list_operations call.
+    /// The request builder for [Domains::list_operations][super::super::client::Domains::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1353,7 +1353,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for a Domains::get_operation call.
+    /// The request builder for [Domains::get_operation][super::super::client::Domains::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/edgecontainer/v1/src/builder.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::list_clusters call.
+    /// The request builder for [EdgeContainer::list_clusters][super::super::client::EdgeContainer::list_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -148,7 +148,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::get_cluster call.
+    /// The request builder for [EdgeContainer::get_cluster][super::super::client::EdgeContainer::get_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -190,7 +190,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::create_cluster call.
+    /// The request builder for [EdgeContainer::create_cluster][super::super::client::EdgeContainer::create_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -290,7 +290,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::update_cluster call.
+    /// The request builder for [EdgeContainer::update_cluster][super::super::client::EdgeContainer::update_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -387,7 +387,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::upgrade_cluster call.
+    /// The request builder for [EdgeContainer::upgrade_cluster][super::super::client::EdgeContainer::upgrade_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpgradeCluster(RequestBuilder<crate::model::UpgradeClusterRequest>);
 
@@ -487,7 +487,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::delete_cluster call.
+    /// The request builder for [EdgeContainer::delete_cluster][super::super::client::EdgeContainer::delete_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -570,7 +570,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::generate_access_token call.
+    /// The request builder for [EdgeContainer::generate_access_token][super::super::client::EdgeContainer::generate_access_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAccessToken(RequestBuilder<crate::model::GenerateAccessTokenRequest>);
 
@@ -615,7 +615,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::generate_offline_credential call.
+    /// The request builder for [EdgeContainer::generate_offline_credential][super::super::client::EdgeContainer::generate_offline_credential] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateOfflineCredential(
         RequestBuilder<crate::model::GenerateOfflineCredentialRequest>,
@@ -662,7 +662,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::list_node_pools call.
+    /// The request builder for [EdgeContainer::list_node_pools][super::super::client::EdgeContainer::list_node_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListNodePools(RequestBuilder<crate::model::ListNodePoolsRequest>);
 
@@ -743,7 +743,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::get_node_pool call.
+    /// The request builder for [EdgeContainer::get_node_pool][super::super::client::EdgeContainer::get_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetNodePool(RequestBuilder<crate::model::GetNodePoolRequest>);
 
@@ -785,7 +785,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::create_node_pool call.
+    /// The request builder for [EdgeContainer::create_node_pool][super::super::client::EdgeContainer::create_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNodePool(RequestBuilder<crate::model::CreateNodePoolRequest>);
 
@@ -886,7 +886,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::update_node_pool call.
+    /// The request builder for [EdgeContainer::update_node_pool][super::super::client::EdgeContainer::update_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNodePool(RequestBuilder<crate::model::UpdateNodePoolRequest>);
 
@@ -984,7 +984,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::delete_node_pool call.
+    /// The request builder for [EdgeContainer::delete_node_pool][super::super::client::EdgeContainer::delete_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNodePool(RequestBuilder<crate::model::DeleteNodePoolRequest>);
 
@@ -1067,7 +1067,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::list_machines call.
+    /// The request builder for [EdgeContainer::list_machines][super::super::client::EdgeContainer::list_machines] calls.
     #[derive(Clone, Debug)]
     pub struct ListMachines(RequestBuilder<crate::model::ListMachinesRequest>);
 
@@ -1148,7 +1148,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::get_machine call.
+    /// The request builder for [EdgeContainer::get_machine][super::super::client::EdgeContainer::get_machine] calls.
     #[derive(Clone, Debug)]
     pub struct GetMachine(RequestBuilder<crate::model::GetMachineRequest>);
 
@@ -1190,7 +1190,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::list_vpn_connections call.
+    /// The request builder for [EdgeContainer::list_vpn_connections][super::super::client::EdgeContainer::list_vpn_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListVpnConnections(RequestBuilder<crate::model::ListVpnConnectionsRequest>);
 
@@ -1274,7 +1274,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::get_vpn_connection call.
+    /// The request builder for [EdgeContainer::get_vpn_connection][super::super::client::EdgeContainer::get_vpn_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetVpnConnection(RequestBuilder<crate::model::GetVpnConnectionRequest>);
 
@@ -1319,7 +1319,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::create_vpn_connection call.
+    /// The request builder for [EdgeContainer::create_vpn_connection][super::super::client::EdgeContainer::create_vpn_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVpnConnection(RequestBuilder<crate::model::CreateVpnConnectionRequest>);
 
@@ -1424,7 +1424,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::delete_vpn_connection call.
+    /// The request builder for [EdgeContainer::delete_vpn_connection][super::super::client::EdgeContainer::delete_vpn_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVpnConnection(RequestBuilder<crate::model::DeleteVpnConnectionRequest>);
 
@@ -1510,7 +1510,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::get_server_config call.
+    /// The request builder for [EdgeContainer::get_server_config][super::super::client::EdgeContainer::get_server_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetServerConfig(RequestBuilder<crate::model::GetServerConfigRequest>);
 
@@ -1552,7 +1552,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::list_locations call.
+    /// The request builder for [EdgeContainer::list_locations][super::super::client::EdgeContainer::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1630,7 +1630,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::get_location call.
+    /// The request builder for [EdgeContainer::get_location][super::super::client::EdgeContainer::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1672,7 +1672,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::list_operations call.
+    /// The request builder for [EdgeContainer::list_operations][super::super::client::EdgeContainer::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1750,7 +1750,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::get_operation call.
+    /// The request builder for [EdgeContainer::get_operation][super::super::client::EdgeContainer::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1795,7 +1795,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::delete_operation call.
+    /// The request builder for [EdgeContainer::delete_operation][super::super::client::EdgeContainer::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1840,7 +1840,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for a EdgeContainer::cancel_operation call.
+    /// The request builder for [EdgeContainer::cancel_operation][super::super::client::EdgeContainer::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/edgenetwork/v1/src/builder.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::initialize_zone call.
+    /// The request builder for [EdgeNetwork::initialize_zone][super::super::client::EdgeNetwork::initialize_zone] calls.
     #[derive(Clone, Debug)]
     pub struct InitializeZone(RequestBuilder<crate::model::InitializeZoneRequest>);
 
@@ -109,7 +109,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::list_zones call.
+    /// The request builder for [EdgeNetwork::list_zones][super::super::client::EdgeNetwork::list_zones] calls.
     #[derive(Clone, Debug)]
     pub struct ListZones(RequestBuilder<crate::model::ListZonesRequest>);
 
@@ -189,7 +189,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::get_zone call.
+    /// The request builder for [EdgeNetwork::get_zone][super::super::client::EdgeNetwork::get_zone] calls.
     #[derive(Clone, Debug)]
     pub struct GetZone(RequestBuilder<crate::model::GetZoneRequest>);
 
@@ -231,7 +231,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::list_networks call.
+    /// The request builder for [EdgeNetwork::list_networks][super::super::client::EdgeNetwork::list_networks] calls.
     #[derive(Clone, Debug)]
     pub struct ListNetworks(RequestBuilder<crate::model::ListNetworksRequest>);
 
@@ -312,7 +312,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::get_network call.
+    /// The request builder for [EdgeNetwork::get_network][super::super::client::EdgeNetwork::get_network] calls.
     #[derive(Clone, Debug)]
     pub struct GetNetwork(RequestBuilder<crate::model::GetNetworkRequest>);
 
@@ -354,7 +354,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::diagnose_network call.
+    /// The request builder for [EdgeNetwork::diagnose_network][super::super::client::EdgeNetwork::diagnose_network] calls.
     #[derive(Clone, Debug)]
     pub struct DiagnoseNetwork(RequestBuilder<crate::model::DiagnoseNetworkRequest>);
 
@@ -396,7 +396,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::create_network call.
+    /// The request builder for [EdgeNetwork::create_network][super::super::client::EdgeNetwork::create_network] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNetwork(RequestBuilder<crate::model::CreateNetworkRequest>);
 
@@ -496,7 +496,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::delete_network call.
+    /// The request builder for [EdgeNetwork::delete_network][super::super::client::EdgeNetwork::delete_network] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNetwork(RequestBuilder<crate::model::DeleteNetworkRequest>);
 
@@ -579,7 +579,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::list_subnets call.
+    /// The request builder for [EdgeNetwork::list_subnets][super::super::client::EdgeNetwork::list_subnets] calls.
     #[derive(Clone, Debug)]
     pub struct ListSubnets(RequestBuilder<crate::model::ListSubnetsRequest>);
 
@@ -660,7 +660,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::get_subnet call.
+    /// The request builder for [EdgeNetwork::get_subnet][super::super::client::EdgeNetwork::get_subnet] calls.
     #[derive(Clone, Debug)]
     pub struct GetSubnet(RequestBuilder<crate::model::GetSubnetRequest>);
 
@@ -702,7 +702,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::create_subnet call.
+    /// The request builder for [EdgeNetwork::create_subnet][super::super::client::EdgeNetwork::create_subnet] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSubnet(RequestBuilder<crate::model::CreateSubnetRequest>);
 
@@ -802,7 +802,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::update_subnet call.
+    /// The request builder for [EdgeNetwork::update_subnet][super::super::client::EdgeNetwork::update_subnet] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSubnet(RequestBuilder<crate::model::UpdateSubnetRequest>);
 
@@ -899,7 +899,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::delete_subnet call.
+    /// The request builder for [EdgeNetwork::delete_subnet][super::super::client::EdgeNetwork::delete_subnet] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSubnet(RequestBuilder<crate::model::DeleteSubnetRequest>);
 
@@ -982,7 +982,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::list_interconnects call.
+    /// The request builder for [EdgeNetwork::list_interconnects][super::super::client::EdgeNetwork::list_interconnects] calls.
     #[derive(Clone, Debug)]
     pub struct ListInterconnects(RequestBuilder<crate::model::ListInterconnectsRequest>);
 
@@ -1066,7 +1066,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::get_interconnect call.
+    /// The request builder for [EdgeNetwork::get_interconnect][super::super::client::EdgeNetwork::get_interconnect] calls.
     #[derive(Clone, Debug)]
     pub struct GetInterconnect(RequestBuilder<crate::model::GetInterconnectRequest>);
 
@@ -1108,7 +1108,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::diagnose_interconnect call.
+    /// The request builder for [EdgeNetwork::diagnose_interconnect][super::super::client::EdgeNetwork::diagnose_interconnect] calls.
     #[derive(Clone, Debug)]
     pub struct DiagnoseInterconnect(RequestBuilder<crate::model::DiagnoseInterconnectRequest>);
 
@@ -1153,7 +1153,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::list_interconnect_attachments call.
+    /// The request builder for [EdgeNetwork::list_interconnect_attachments][super::super::client::EdgeNetwork::list_interconnect_attachments] calls.
     #[derive(Clone, Debug)]
     pub struct ListInterconnectAttachments(
         RequestBuilder<crate::model::ListInterconnectAttachmentsRequest>,
@@ -1241,7 +1241,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::get_interconnect_attachment call.
+    /// The request builder for [EdgeNetwork::get_interconnect_attachment][super::super::client::EdgeNetwork::get_interconnect_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct GetInterconnectAttachment(
         RequestBuilder<crate::model::GetInterconnectAttachmentRequest>,
@@ -1288,7 +1288,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::create_interconnect_attachment call.
+    /// The request builder for [EdgeNetwork::create_interconnect_attachment][super::super::client::EdgeNetwork::create_interconnect_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInterconnectAttachment(
         RequestBuilder<crate::model::CreateInterconnectAttachmentRequest>,
@@ -1402,7 +1402,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::delete_interconnect_attachment call.
+    /// The request builder for [EdgeNetwork::delete_interconnect_attachment][super::super::client::EdgeNetwork::delete_interconnect_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInterconnectAttachment(
         RequestBuilder<crate::model::DeleteInterconnectAttachmentRequest>,
@@ -1490,7 +1490,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::list_routers call.
+    /// The request builder for [EdgeNetwork::list_routers][super::super::client::EdgeNetwork::list_routers] calls.
     #[derive(Clone, Debug)]
     pub struct ListRouters(RequestBuilder<crate::model::ListRoutersRequest>);
 
@@ -1571,7 +1571,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::get_router call.
+    /// The request builder for [EdgeNetwork::get_router][super::super::client::EdgeNetwork::get_router] calls.
     #[derive(Clone, Debug)]
     pub struct GetRouter(RequestBuilder<crate::model::GetRouterRequest>);
 
@@ -1613,7 +1613,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::diagnose_router call.
+    /// The request builder for [EdgeNetwork::diagnose_router][super::super::client::EdgeNetwork::diagnose_router] calls.
     #[derive(Clone, Debug)]
     pub struct DiagnoseRouter(RequestBuilder<crate::model::DiagnoseRouterRequest>);
 
@@ -1655,7 +1655,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::create_router call.
+    /// The request builder for [EdgeNetwork::create_router][super::super::client::EdgeNetwork::create_router] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRouter(RequestBuilder<crate::model::CreateRouterRequest>);
 
@@ -1755,7 +1755,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::update_router call.
+    /// The request builder for [EdgeNetwork::update_router][super::super::client::EdgeNetwork::update_router] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRouter(RequestBuilder<crate::model::UpdateRouterRequest>);
 
@@ -1852,7 +1852,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::delete_router call.
+    /// The request builder for [EdgeNetwork::delete_router][super::super::client::EdgeNetwork::delete_router] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRouter(RequestBuilder<crate::model::DeleteRouterRequest>);
 
@@ -1935,7 +1935,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::list_locations call.
+    /// The request builder for [EdgeNetwork::list_locations][super::super::client::EdgeNetwork::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2013,7 +2013,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::get_location call.
+    /// The request builder for [EdgeNetwork::get_location][super::super::client::EdgeNetwork::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2055,7 +2055,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::list_operations call.
+    /// The request builder for [EdgeNetwork::list_operations][super::super::client::EdgeNetwork::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2133,7 +2133,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::get_operation call.
+    /// The request builder for [EdgeNetwork::get_operation][super::super::client::EdgeNetwork::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2178,7 +2178,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::delete_operation call.
+    /// The request builder for [EdgeNetwork::delete_operation][super::super::client::EdgeNetwork::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2223,7 +2223,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for a EdgeNetwork::cancel_operation call.
+    /// The request builder for [EdgeNetwork::cancel_operation][super::super::client::EdgeNetwork::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/essentialcontacts/v1/src/builder.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for a EssentialContactsService::create_contact call.
+    /// The request builder for [EssentialContactsService::create_contact][super::super::client::EssentialContactsService::create_contact] calls.
     #[derive(Clone, Debug)]
     pub struct CreateContact(RequestBuilder<crate::model::CreateContactRequest>);
 
@@ -122,7 +122,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for a EssentialContactsService::update_contact call.
+    /// The request builder for [EssentialContactsService::update_contact][super::super::client::EssentialContactsService::update_contact] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateContact(RequestBuilder<crate::model::UpdateContactRequest>);
 
@@ -178,7 +178,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for a EssentialContactsService::list_contacts call.
+    /// The request builder for [EssentialContactsService::list_contacts][super::super::client::EssentialContactsService::list_contacts] calls.
     #[derive(Clone, Debug)]
     pub struct ListContacts(RequestBuilder<crate::model::ListContactsRequest>);
 
@@ -249,7 +249,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for a EssentialContactsService::get_contact call.
+    /// The request builder for [EssentialContactsService::get_contact][super::super::client::EssentialContactsService::get_contact] calls.
     #[derive(Clone, Debug)]
     pub struct GetContact(RequestBuilder<crate::model::GetContactRequest>);
 
@@ -293,7 +293,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for a EssentialContactsService::delete_contact call.
+    /// The request builder for [EssentialContactsService::delete_contact][super::super::client::EssentialContactsService::delete_contact] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteContact(RequestBuilder<crate::model::DeleteContactRequest>);
 
@@ -337,7 +337,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for a EssentialContactsService::compute_contacts call.
+    /// The request builder for [EssentialContactsService::compute_contacts][super::super::client::EssentialContactsService::compute_contacts] calls.
     #[derive(Clone, Debug)]
     pub struct ComputeContacts(RequestBuilder<crate::model::ComputeContactsRequest>);
 
@@ -419,7 +419,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for a EssentialContactsService::send_test_message call.
+    /// The request builder for [EssentialContactsService::send_test_message][super::super::client::EssentialContactsService::send_test_message] calls.
     #[derive(Clone, Debug)]
     pub struct SendTestMessage(RequestBuilder<crate::model::SendTestMessageRequest>);
 

--- a/src/generated/cloud/eventarc/v1/src/builder.rs
+++ b/src/generated/cloud/eventarc/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_trigger call.
+    /// The request builder for [Eventarc::get_trigger][super::super::client::Eventarc::get_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct GetTrigger(RequestBuilder<crate::model::GetTriggerRequest>);
 
@@ -109,7 +109,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_triggers call.
+    /// The request builder for [Eventarc::list_triggers][super::super::client::Eventarc::list_triggers] calls.
     #[derive(Clone, Debug)]
     pub struct ListTriggers(RequestBuilder<crate::model::ListTriggersRequest>);
 
@@ -190,7 +190,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::create_trigger call.
+    /// The request builder for [Eventarc::create_trigger][super::super::client::Eventarc::create_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTrigger(RequestBuilder<crate::model::CreateTriggerRequest>);
 
@@ -290,7 +290,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::update_trigger call.
+    /// The request builder for [Eventarc::update_trigger][super::super::client::Eventarc::update_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTrigger(RequestBuilder<crate::model::UpdateTriggerRequest>);
 
@@ -393,7 +393,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::delete_trigger call.
+    /// The request builder for [Eventarc::delete_trigger][super::super::client::Eventarc::delete_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTrigger(RequestBuilder<crate::model::DeleteTriggerRequest>);
 
@@ -490,7 +490,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_channel call.
+    /// The request builder for [Eventarc::get_channel][super::super::client::Eventarc::get_channel] calls.
     #[derive(Clone, Debug)]
     pub struct GetChannel(RequestBuilder<crate::model::GetChannelRequest>);
 
@@ -532,7 +532,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_channels call.
+    /// The request builder for [Eventarc::list_channels][super::super::client::Eventarc::list_channels] calls.
     #[derive(Clone, Debug)]
     pub struct ListChannels(RequestBuilder<crate::model::ListChannelsRequest>);
 
@@ -607,7 +607,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::create_channel call.
+    /// The request builder for [Eventarc::create_channel][super::super::client::Eventarc::create_channel] calls.
     #[derive(Clone, Debug)]
     pub struct CreateChannel(RequestBuilder<crate::model::CreateChannelRequest>);
 
@@ -707,7 +707,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::update_channel call.
+    /// The request builder for [Eventarc::update_channel][super::super::client::Eventarc::update_channel] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateChannel(RequestBuilder<crate::model::UpdateChannelRequest>);
 
@@ -804,7 +804,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::delete_channel call.
+    /// The request builder for [Eventarc::delete_channel][super::super::client::Eventarc::delete_channel] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteChannel(RequestBuilder<crate::model::DeleteChannelRequest>);
 
@@ -889,7 +889,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_provider call.
+    /// The request builder for [Eventarc::get_provider][super::super::client::Eventarc::get_provider] calls.
     #[derive(Clone, Debug)]
     pub struct GetProvider(RequestBuilder<crate::model::GetProviderRequest>);
 
@@ -931,7 +931,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_providers call.
+    /// The request builder for [Eventarc::list_providers][super::super::client::Eventarc::list_providers] calls.
     #[derive(Clone, Debug)]
     pub struct ListProviders(RequestBuilder<crate::model::ListProvidersRequest>);
 
@@ -1012,7 +1012,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_channel_connection call.
+    /// The request builder for [Eventarc::get_channel_connection][super::super::client::Eventarc::get_channel_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetChannelConnection(RequestBuilder<crate::model::GetChannelConnectionRequest>);
 
@@ -1057,7 +1057,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_channel_connections call.
+    /// The request builder for [Eventarc::list_channel_connections][super::super::client::Eventarc::list_channel_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListChannelConnections(RequestBuilder<crate::model::ListChannelConnectionsRequest>);
 
@@ -1131,7 +1131,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::create_channel_connection call.
+    /// The request builder for [Eventarc::create_channel_connection][super::super::client::Eventarc::create_channel_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateChannelConnection(
         RequestBuilder<crate::model::CreateChannelConnectionRequest>,
@@ -1234,7 +1234,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::delete_channel_connection call.
+    /// The request builder for [Eventarc::delete_channel_connection][super::super::client::Eventarc::delete_channel_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteChannelConnection(
         RequestBuilder<crate::model::DeleteChannelConnectionRequest>,
@@ -1320,7 +1320,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_google_channel_config call.
+    /// The request builder for [Eventarc::get_google_channel_config][super::super::client::Eventarc::get_google_channel_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetGoogleChannelConfig(RequestBuilder<crate::model::GetGoogleChannelConfigRequest>);
 
@@ -1365,7 +1365,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::update_google_channel_config call.
+    /// The request builder for [Eventarc::update_google_channel_config][super::super::client::Eventarc::update_google_channel_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGoogleChannelConfig(
         RequestBuilder<crate::model::UpdateGoogleChannelConfigRequest>,
@@ -1426,7 +1426,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_message_bus call.
+    /// The request builder for [Eventarc::get_message_bus][super::super::client::Eventarc::get_message_bus] calls.
     #[derive(Clone, Debug)]
     pub struct GetMessageBus(RequestBuilder<crate::model::GetMessageBusRequest>);
 
@@ -1468,7 +1468,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_message_buses call.
+    /// The request builder for [Eventarc::list_message_buses][super::super::client::Eventarc::list_message_buses] calls.
     #[derive(Clone, Debug)]
     pub struct ListMessageBuses(RequestBuilder<crate::model::ListMessageBusesRequest>);
 
@@ -1552,7 +1552,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_message_bus_enrollments call.
+    /// The request builder for [Eventarc::list_message_bus_enrollments][super::super::client::Eventarc::list_message_bus_enrollments] calls.
     #[derive(Clone, Debug)]
     pub struct ListMessageBusEnrollments(
         RequestBuilder<crate::model::ListMessageBusEnrollmentsRequest>,
@@ -1611,7 +1611,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::create_message_bus call.
+    /// The request builder for [Eventarc::create_message_bus][super::super::client::Eventarc::create_message_bus] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMessageBus(RequestBuilder<crate::model::CreateMessageBusRequest>);
 
@@ -1715,7 +1715,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::update_message_bus call.
+    /// The request builder for [Eventarc::update_message_bus][super::super::client::Eventarc::update_message_bus] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMessageBus(RequestBuilder<crate::model::UpdateMessageBusRequest>);
 
@@ -1822,7 +1822,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::delete_message_bus call.
+    /// The request builder for [Eventarc::delete_message_bus][super::super::client::Eventarc::delete_message_bus] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMessageBus(RequestBuilder<crate::model::DeleteMessageBusRequest>);
 
@@ -1923,7 +1923,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_enrollment call.
+    /// The request builder for [Eventarc::get_enrollment][super::super::client::Eventarc::get_enrollment] calls.
     #[derive(Clone, Debug)]
     pub struct GetEnrollment(RequestBuilder<crate::model::GetEnrollmentRequest>);
 
@@ -1965,7 +1965,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_enrollments call.
+    /// The request builder for [Eventarc::list_enrollments][super::super::client::Eventarc::list_enrollments] calls.
     #[derive(Clone, Debug)]
     pub struct ListEnrollments(RequestBuilder<crate::model::ListEnrollmentsRequest>);
 
@@ -2046,7 +2046,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::create_enrollment call.
+    /// The request builder for [Eventarc::create_enrollment][super::super::client::Eventarc::create_enrollment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEnrollment(RequestBuilder<crate::model::CreateEnrollmentRequest>);
 
@@ -2150,7 +2150,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::update_enrollment call.
+    /// The request builder for [Eventarc::update_enrollment][super::super::client::Eventarc::update_enrollment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEnrollment(RequestBuilder<crate::model::UpdateEnrollmentRequest>);
 
@@ -2257,7 +2257,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::delete_enrollment call.
+    /// The request builder for [Eventarc::delete_enrollment][super::super::client::Eventarc::delete_enrollment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEnrollment(RequestBuilder<crate::model::DeleteEnrollmentRequest>);
 
@@ -2358,7 +2358,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_pipeline call.
+    /// The request builder for [Eventarc::get_pipeline][super::super::client::Eventarc::get_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct GetPipeline(RequestBuilder<crate::model::GetPipelineRequest>);
 
@@ -2400,7 +2400,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_pipelines call.
+    /// The request builder for [Eventarc::list_pipelines][super::super::client::Eventarc::list_pipelines] calls.
     #[derive(Clone, Debug)]
     pub struct ListPipelines(RequestBuilder<crate::model::ListPipelinesRequest>);
 
@@ -2481,7 +2481,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::create_pipeline call.
+    /// The request builder for [Eventarc::create_pipeline][super::super::client::Eventarc::create_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePipeline(RequestBuilder<crate::model::CreatePipelineRequest>);
 
@@ -2582,7 +2582,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::update_pipeline call.
+    /// The request builder for [Eventarc::update_pipeline][super::super::client::Eventarc::update_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePipeline(RequestBuilder<crate::model::UpdatePipelineRequest>);
 
@@ -2686,7 +2686,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::delete_pipeline call.
+    /// The request builder for [Eventarc::delete_pipeline][super::super::client::Eventarc::delete_pipeline] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePipeline(RequestBuilder<crate::model::DeletePipelineRequest>);
 
@@ -2784,7 +2784,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_google_api_source call.
+    /// The request builder for [Eventarc::get_google_api_source][super::super::client::Eventarc::get_google_api_source] calls.
     #[derive(Clone, Debug)]
     pub struct GetGoogleApiSource(RequestBuilder<crate::model::GetGoogleApiSourceRequest>);
 
@@ -2829,7 +2829,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_google_api_sources call.
+    /// The request builder for [Eventarc::list_google_api_sources][super::super::client::Eventarc::list_google_api_sources] calls.
     #[derive(Clone, Debug)]
     pub struct ListGoogleApiSources(RequestBuilder<crate::model::ListGoogleApiSourcesRequest>);
 
@@ -2913,7 +2913,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::create_google_api_source call.
+    /// The request builder for [Eventarc::create_google_api_source][super::super::client::Eventarc::create_google_api_source] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGoogleApiSource(RequestBuilder<crate::model::CreateGoogleApiSourceRequest>);
 
@@ -3020,7 +3020,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::update_google_api_source call.
+    /// The request builder for [Eventarc::update_google_api_source][super::super::client::Eventarc::update_google_api_source] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGoogleApiSource(RequestBuilder<crate::model::UpdateGoogleApiSourceRequest>);
 
@@ -3130,7 +3130,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::delete_google_api_source call.
+    /// The request builder for [Eventarc::delete_google_api_source][super::super::client::Eventarc::delete_google_api_source] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGoogleApiSource(RequestBuilder<crate::model::DeleteGoogleApiSourceRequest>);
 
@@ -3232,7 +3232,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_locations call.
+    /// The request builder for [Eventarc::list_locations][super::super::client::Eventarc::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3310,7 +3310,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_location call.
+    /// The request builder for [Eventarc::get_location][super::super::client::Eventarc::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3352,7 +3352,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::set_iam_policy call.
+    /// The request builder for [Eventarc::set_iam_policy][super::super::client::Eventarc::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3412,7 +3412,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_iam_policy call.
+    /// The request builder for [Eventarc::get_iam_policy][super::super::client::Eventarc::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3463,7 +3463,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::test_iam_permissions call.
+    /// The request builder for [Eventarc::test_iam_permissions][super::super::client::Eventarc::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3519,7 +3519,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::list_operations call.
+    /// The request builder for [Eventarc::list_operations][super::super::client::Eventarc::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3597,7 +3597,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::get_operation call.
+    /// The request builder for [Eventarc::get_operation][super::super::client::Eventarc::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3642,7 +3642,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::delete_operation call.
+    /// The request builder for [Eventarc::delete_operation][super::super::client::Eventarc::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3687,7 +3687,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for a Eventarc::cancel_operation call.
+    /// The request builder for [Eventarc::cancel_operation][super::super::client::Eventarc::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/filestore/v1/src/builder.rs
+++ b/src/generated/cloud/filestore/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::list_instances call.
+    /// The request builder for [CloudFilestoreManager::list_instances][super::super::client::CloudFilestoreManager::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -152,7 +152,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::get_instance call.
+    /// The request builder for [CloudFilestoreManager::get_instance][super::super::client::CloudFilestoreManager::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -196,7 +196,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::create_instance call.
+    /// The request builder for [CloudFilestoreManager::create_instance][super::super::client::CloudFilestoreManager::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -294,7 +294,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::update_instance call.
+    /// The request builder for [CloudFilestoreManager::update_instance][super::super::client::CloudFilestoreManager::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -389,7 +389,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::restore_instance call.
+    /// The request builder for [CloudFilestoreManager::restore_instance][super::super::client::CloudFilestoreManager::restore_instance] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreInstance(RequestBuilder<crate::model::RestoreInstanceRequest>);
 
@@ -487,7 +487,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::revert_instance call.
+    /// The request builder for [CloudFilestoreManager::revert_instance][super::super::client::CloudFilestoreManager::revert_instance] calls.
     #[derive(Clone, Debug)]
     pub struct RevertInstance(RequestBuilder<crate::model::RevertInstanceRequest>);
 
@@ -576,7 +576,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::delete_instance call.
+    /// The request builder for [CloudFilestoreManager::delete_instance][super::super::client::CloudFilestoreManager::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -663,7 +663,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::list_snapshots call.
+    /// The request builder for [CloudFilestoreManager::list_snapshots][super::super::client::CloudFilestoreManager::list_snapshots] calls.
     #[derive(Clone, Debug)]
     pub struct ListSnapshots(RequestBuilder<crate::model::ListSnapshotsRequest>);
 
@@ -752,7 +752,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::get_snapshot call.
+    /// The request builder for [CloudFilestoreManager::get_snapshot][super::super::client::CloudFilestoreManager::get_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct GetSnapshot(RequestBuilder<crate::model::GetSnapshotRequest>);
 
@@ -796,7 +796,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::create_snapshot call.
+    /// The request builder for [CloudFilestoreManager::create_snapshot][super::super::client::CloudFilestoreManager::create_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSnapshot(RequestBuilder<crate::model::CreateSnapshotRequest>);
 
@@ -894,7 +894,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::delete_snapshot call.
+    /// The request builder for [CloudFilestoreManager::delete_snapshot][super::super::client::CloudFilestoreManager::delete_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSnapshot(RequestBuilder<crate::model::DeleteSnapshotRequest>);
 
@@ -975,7 +975,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::update_snapshot call.
+    /// The request builder for [CloudFilestoreManager::update_snapshot][super::super::client::CloudFilestoreManager::update_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSnapshot(RequestBuilder<crate::model::UpdateSnapshotRequest>);
 
@@ -1070,7 +1070,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::list_backups call.
+    /// The request builder for [CloudFilestoreManager::list_backups][super::super::client::CloudFilestoreManager::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1153,7 +1153,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::get_backup call.
+    /// The request builder for [CloudFilestoreManager::get_backup][super::super::client::CloudFilestoreManager::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1197,7 +1197,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::create_backup call.
+    /// The request builder for [CloudFilestoreManager::create_backup][super::super::client::CloudFilestoreManager::create_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -1295,7 +1295,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::delete_backup call.
+    /// The request builder for [CloudFilestoreManager::delete_backup][super::super::client::CloudFilestoreManager::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1376,7 +1376,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::update_backup call.
+    /// The request builder for [CloudFilestoreManager::update_backup][super::super::client::CloudFilestoreManager::update_backup] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -1471,7 +1471,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::promote_replica call.
+    /// The request builder for [CloudFilestoreManager::promote_replica][super::super::client::CloudFilestoreManager::promote_replica] calls.
     #[derive(Clone, Debug)]
     pub struct PromoteReplica(RequestBuilder<crate::model::PromoteReplicaRequest>);
 
@@ -1560,7 +1560,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::list_locations call.
+    /// The request builder for [CloudFilestoreManager::list_locations][super::super::client::CloudFilestoreManager::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1640,7 +1640,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::get_location call.
+    /// The request builder for [CloudFilestoreManager::get_location][super::super::client::CloudFilestoreManager::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1684,7 +1684,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::list_operations call.
+    /// The request builder for [CloudFilestoreManager::list_operations][super::super::client::CloudFilestoreManager::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1764,7 +1764,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::get_operation call.
+    /// The request builder for [CloudFilestoreManager::get_operation][super::super::client::CloudFilestoreManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1811,7 +1811,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::delete_operation call.
+    /// The request builder for [CloudFilestoreManager::delete_operation][super::super::client::CloudFilestoreManager::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1858,7 +1858,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for a CloudFilestoreManager::cancel_operation call.
+    /// The request builder for [CloudFilestoreManager::cancel_operation][super::super::client::CloudFilestoreManager::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/financialservices/v1/src/builder.rs
+++ b/src/generated/cloud/financialservices/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_instances call.
+    /// The request builder for [Aml::list_instances][super::super::client::Aml::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -148,7 +148,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_instance call.
+    /// The request builder for [Aml::get_instance][super::super::client::Aml::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -190,7 +190,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::create_instance call.
+    /// The request builder for [Aml::create_instance][super::super::client::Aml::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -291,7 +291,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::update_instance call.
+    /// The request builder for [Aml::update_instance][super::super::client::Aml::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -389,7 +389,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::delete_instance call.
+    /// The request builder for [Aml::delete_instance][super::super::client::Aml::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -472,7 +472,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::import_registered_parties call.
+    /// The request builder for [Aml::import_registered_parties][super::super::client::Aml::import_registered_parties] calls.
     #[derive(Clone, Debug)]
     pub struct ImportRegisteredParties(
         RequestBuilder<crate::model::ImportRegisteredPartiesRequest>,
@@ -594,7 +594,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::export_registered_parties call.
+    /// The request builder for [Aml::export_registered_parties][super::super::client::Aml::export_registered_parties] calls.
     #[derive(Clone, Debug)]
     pub struct ExportRegisteredParties(
         RequestBuilder<crate::model::ExportRegisteredPartiesRequest>,
@@ -699,7 +699,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_datasets call.
+    /// The request builder for [Aml::list_datasets][super::super::client::Aml::list_datasets] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatasets(RequestBuilder<crate::model::ListDatasetsRequest>);
 
@@ -780,7 +780,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_dataset call.
+    /// The request builder for [Aml::get_dataset][super::super::client::Aml::get_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataset(RequestBuilder<crate::model::GetDatasetRequest>);
 
@@ -822,7 +822,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::create_dataset call.
+    /// The request builder for [Aml::create_dataset][super::super::client::Aml::create_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDataset(RequestBuilder<crate::model::CreateDatasetRequest>);
 
@@ -922,7 +922,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::update_dataset call.
+    /// The request builder for [Aml::update_dataset][super::super::client::Aml::update_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDataset(RequestBuilder<crate::model::UpdateDatasetRequest>);
 
@@ -1019,7 +1019,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::delete_dataset call.
+    /// The request builder for [Aml::delete_dataset][super::super::client::Aml::delete_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataset(RequestBuilder<crate::model::DeleteDatasetRequest>);
 
@@ -1102,7 +1102,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_models call.
+    /// The request builder for [Aml::list_models][super::super::client::Aml::list_models] calls.
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -1183,7 +1183,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_model call.
+    /// The request builder for [Aml::get_model][super::super::client::Aml::get_model] calls.
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -1225,7 +1225,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::create_model call.
+    /// The request builder for [Aml::create_model][super::super::client::Aml::create_model] calls.
     #[derive(Clone, Debug)]
     pub struct CreateModel(RequestBuilder<crate::model::CreateModelRequest>);
 
@@ -1325,7 +1325,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::update_model call.
+    /// The request builder for [Aml::update_model][super::super::client::Aml::update_model] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateModel(RequestBuilder<crate::model::UpdateModelRequest>);
 
@@ -1422,7 +1422,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::export_model_metadata call.
+    /// The request builder for [Aml::export_model_metadata][super::super::client::Aml::export_model_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct ExportModelMetadata(RequestBuilder<crate::model::ExportModelMetadataRequest>);
 
@@ -1519,7 +1519,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::delete_model call.
+    /// The request builder for [Aml::delete_model][super::super::client::Aml::delete_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -1602,7 +1602,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_engine_configs call.
+    /// The request builder for [Aml::list_engine_configs][super::super::client::Aml::list_engine_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListEngineConfigs(RequestBuilder<crate::model::ListEngineConfigsRequest>);
 
@@ -1686,7 +1686,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_engine_config call.
+    /// The request builder for [Aml::get_engine_config][super::super::client::Aml::get_engine_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetEngineConfig(RequestBuilder<crate::model::GetEngineConfigRequest>);
 
@@ -1728,7 +1728,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::create_engine_config call.
+    /// The request builder for [Aml::create_engine_config][super::super::client::Aml::create_engine_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEngineConfig(RequestBuilder<crate::model::CreateEngineConfigRequest>);
 
@@ -1832,7 +1832,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::update_engine_config call.
+    /// The request builder for [Aml::update_engine_config][super::super::client::Aml::update_engine_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEngineConfig(RequestBuilder<crate::model::UpdateEngineConfigRequest>);
 
@@ -1933,7 +1933,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::export_engine_config_metadata call.
+    /// The request builder for [Aml::export_engine_config_metadata][super::super::client::Aml::export_engine_config_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct ExportEngineConfigMetadata(
         RequestBuilder<crate::model::ExportEngineConfigMetadataRequest>,
@@ -2034,7 +2034,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::delete_engine_config call.
+    /// The request builder for [Aml::delete_engine_config][super::super::client::Aml::delete_engine_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEngineConfig(RequestBuilder<crate::model::DeleteEngineConfigRequest>);
 
@@ -2120,7 +2120,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_engine_version call.
+    /// The request builder for [Aml::get_engine_version][super::super::client::Aml::get_engine_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetEngineVersion(RequestBuilder<crate::model::GetEngineVersionRequest>);
 
@@ -2165,7 +2165,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_engine_versions call.
+    /// The request builder for [Aml::list_engine_versions][super::super::client::Aml::list_engine_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListEngineVersions(RequestBuilder<crate::model::ListEngineVersionsRequest>);
 
@@ -2249,7 +2249,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_prediction_results call.
+    /// The request builder for [Aml::list_prediction_results][super::super::client::Aml::list_prediction_results] calls.
     #[derive(Clone, Debug)]
     pub struct ListPredictionResults(RequestBuilder<crate::model::ListPredictionResultsRequest>);
 
@@ -2333,7 +2333,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_prediction_result call.
+    /// The request builder for [Aml::get_prediction_result][super::super::client::Aml::get_prediction_result] calls.
     #[derive(Clone, Debug)]
     pub struct GetPredictionResult(RequestBuilder<crate::model::GetPredictionResultRequest>);
 
@@ -2378,7 +2378,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::create_prediction_result call.
+    /// The request builder for [Aml::create_prediction_result][super::super::client::Aml::create_prediction_result] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePredictionResult(RequestBuilder<crate::model::CreatePredictionResultRequest>);
 
@@ -2485,7 +2485,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::update_prediction_result call.
+    /// The request builder for [Aml::update_prediction_result][super::super::client::Aml::update_prediction_result] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePredictionResult(RequestBuilder<crate::model::UpdatePredictionResultRequest>);
 
@@ -2589,7 +2589,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::export_prediction_result_metadata call.
+    /// The request builder for [Aml::export_prediction_result_metadata][super::super::client::Aml::export_prediction_result_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct ExportPredictionResultMetadata(
         RequestBuilder<crate::model::ExportPredictionResultMetadataRequest>,
@@ -2690,7 +2690,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::delete_prediction_result call.
+    /// The request builder for [Aml::delete_prediction_result][super::super::client::Aml::delete_prediction_result] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePredictionResult(RequestBuilder<crate::model::DeletePredictionResultRequest>);
 
@@ -2776,7 +2776,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_backtest_results call.
+    /// The request builder for [Aml::list_backtest_results][super::super::client::Aml::list_backtest_results] calls.
     #[derive(Clone, Debug)]
     pub struct ListBacktestResults(RequestBuilder<crate::model::ListBacktestResultsRequest>);
 
@@ -2860,7 +2860,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_backtest_result call.
+    /// The request builder for [Aml::get_backtest_result][super::super::client::Aml::get_backtest_result] calls.
     #[derive(Clone, Debug)]
     pub struct GetBacktestResult(RequestBuilder<crate::model::GetBacktestResultRequest>);
 
@@ -2905,7 +2905,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::create_backtest_result call.
+    /// The request builder for [Aml::create_backtest_result][super::super::client::Aml::create_backtest_result] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBacktestResult(RequestBuilder<crate::model::CreateBacktestResultRequest>);
 
@@ -3010,7 +3010,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::update_backtest_result call.
+    /// The request builder for [Aml::update_backtest_result][super::super::client::Aml::update_backtest_result] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBacktestResult(RequestBuilder<crate::model::UpdateBacktestResultRequest>);
 
@@ -3112,7 +3112,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::export_backtest_result_metadata call.
+    /// The request builder for [Aml::export_backtest_result_metadata][super::super::client::Aml::export_backtest_result_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct ExportBacktestResultMetadata(
         RequestBuilder<crate::model::ExportBacktestResultMetadataRequest>,
@@ -3213,7 +3213,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::delete_backtest_result call.
+    /// The request builder for [Aml::delete_backtest_result][super::super::client::Aml::delete_backtest_result] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBacktestResult(RequestBuilder<crate::model::DeleteBacktestResultRequest>);
 
@@ -3299,7 +3299,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_locations call.
+    /// The request builder for [Aml::list_locations][super::super::client::Aml::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3377,7 +3377,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_location call.
+    /// The request builder for [Aml::get_location][super::super::client::Aml::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3419,7 +3419,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::list_operations call.
+    /// The request builder for [Aml::list_operations][super::super::client::Aml::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3497,7 +3497,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::get_operation call.
+    /// The request builder for [Aml::get_operation][super::super::client::Aml::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3542,7 +3542,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::delete_operation call.
+    /// The request builder for [Aml::delete_operation][super::super::client::Aml::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3587,7 +3587,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for a Aml::cancel_operation call.
+    /// The request builder for [Aml::cancel_operation][super::super::client::Aml::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/functions/v2/src/builder.rs
+++ b/src/generated/cloud/functions/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::get_function call.
+    /// The request builder for [FunctionService::get_function][super::super::client::FunctionService::get_function] calls.
     #[derive(Clone, Debug)]
     pub struct GetFunction(RequestBuilder<crate::model::GetFunctionRequest>);
 
@@ -115,7 +115,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::list_functions call.
+    /// The request builder for [FunctionService::list_functions][super::super::client::FunctionService::list_functions] calls.
     #[derive(Clone, Debug)]
     pub struct ListFunctions(RequestBuilder<crate::model::ListFunctionsRequest>);
 
@@ -196,7 +196,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::create_function call.
+    /// The request builder for [FunctionService::create_function][super::super::client::FunctionService::create_function] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFunction(RequestBuilder<crate::model::CreateFunctionRequest>);
 
@@ -291,7 +291,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::update_function call.
+    /// The request builder for [FunctionService::update_function][super::super::client::FunctionService::update_function] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFunction(RequestBuilder<crate::model::UpdateFunctionRequest>);
 
@@ -383,7 +383,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::delete_function call.
+    /// The request builder for [FunctionService::delete_function][super::super::client::FunctionService::delete_function] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFunction(RequestBuilder<crate::model::DeleteFunctionRequest>);
 
@@ -460,7 +460,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::generate_upload_url call.
+    /// The request builder for [FunctionService::generate_upload_url][super::super::client::FunctionService::generate_upload_url] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateUploadUrl(RequestBuilder<crate::model::GenerateUploadUrlRequest>);
 
@@ -517,7 +517,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::generate_download_url call.
+    /// The request builder for [FunctionService::generate_download_url][super::super::client::FunctionService::generate_download_url] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateDownloadUrl(RequestBuilder<crate::model::GenerateDownloadUrlRequest>);
 
@@ -562,7 +562,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::list_runtimes call.
+    /// The request builder for [FunctionService::list_runtimes][super::super::client::FunctionService::list_runtimes] calls.
     #[derive(Clone, Debug)]
     pub struct ListRuntimes(RequestBuilder<crate::model::ListRuntimesRequest>);
 
@@ -610,7 +610,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::list_locations call.
+    /// The request builder for [FunctionService::list_locations][super::super::client::FunctionService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -688,7 +688,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::set_iam_policy call.
+    /// The request builder for [FunctionService::set_iam_policy][super::super::client::FunctionService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -748,7 +748,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::get_iam_policy call.
+    /// The request builder for [FunctionService::get_iam_policy][super::super::client::FunctionService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -799,7 +799,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::test_iam_permissions call.
+    /// The request builder for [FunctionService::test_iam_permissions][super::super::client::FunctionService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -855,7 +855,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::list_operations call.
+    /// The request builder for [FunctionService::list_operations][super::super::client::FunctionService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -933,7 +933,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for a FunctionService::get_operation call.
+    /// The request builder for [FunctionService::get_operation][super::super::client::FunctionService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/gkebackup/v1/src/builder.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::create_backup_plan call.
+    /// The request builder for [BackupForGKE::create_backup_plan][super::super::client::BackupForGKE::create_backup_plan] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackupPlan(RequestBuilder<crate::model::CreateBackupPlanRequest>);
 
@@ -165,7 +165,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::list_backup_plans call.
+    /// The request builder for [BackupForGKE::list_backup_plans][super::super::client::BackupForGKE::list_backup_plans] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupPlans(RequestBuilder<crate::model::ListBackupPlansRequest>);
 
@@ -246,7 +246,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_backup_plan call.
+    /// The request builder for [BackupForGKE::get_backup_plan][super::super::client::BackupForGKE::get_backup_plan] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupPlan(RequestBuilder<crate::model::GetBackupPlanRequest>);
 
@@ -288,7 +288,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::update_backup_plan call.
+    /// The request builder for [BackupForGKE::update_backup_plan][super::super::client::BackupForGKE::update_backup_plan] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackupPlan(RequestBuilder<crate::model::UpdateBackupPlanRequest>);
 
@@ -383,7 +383,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::delete_backup_plan call.
+    /// The request builder for [BackupForGKE::delete_backup_plan][super::super::client::BackupForGKE::delete_backup_plan] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackupPlan(RequestBuilder<crate::model::DeleteBackupPlanRequest>);
 
@@ -469,7 +469,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::create_backup call.
+    /// The request builder for [BackupForGKE::create_backup][super::super::client::BackupForGKE::create_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -563,7 +563,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::list_backups call.
+    /// The request builder for [BackupForGKE::list_backups][super::super::client::BackupForGKE::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -644,7 +644,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_backup call.
+    /// The request builder for [BackupForGKE::get_backup][super::super::client::BackupForGKE::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -686,7 +686,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::update_backup call.
+    /// The request builder for [BackupForGKE::update_backup][super::super::client::BackupForGKE::update_backup] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -777,7 +777,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::delete_backup call.
+    /// The request builder for [BackupForGKE::delete_backup][super::super::client::BackupForGKE::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -866,7 +866,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::list_volume_backups call.
+    /// The request builder for [BackupForGKE::list_volume_backups][super::super::client::BackupForGKE::list_volume_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListVolumeBackups(RequestBuilder<crate::model::ListVolumeBackupsRequest>);
 
@@ -950,7 +950,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_volume_backup call.
+    /// The request builder for [BackupForGKE::get_volume_backup][super::super::client::BackupForGKE::get_volume_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetVolumeBackup(RequestBuilder<crate::model::GetVolumeBackupRequest>);
 
@@ -992,7 +992,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::create_restore_plan call.
+    /// The request builder for [BackupForGKE::create_restore_plan][super::super::client::BackupForGKE::create_restore_plan] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRestorePlan(RequestBuilder<crate::model::CreateRestorePlanRequest>);
 
@@ -1090,7 +1090,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::list_restore_plans call.
+    /// The request builder for [BackupForGKE::list_restore_plans][super::super::client::BackupForGKE::list_restore_plans] calls.
     #[derive(Clone, Debug)]
     pub struct ListRestorePlans(RequestBuilder<crate::model::ListRestorePlansRequest>);
 
@@ -1174,7 +1174,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_restore_plan call.
+    /// The request builder for [BackupForGKE::get_restore_plan][super::super::client::BackupForGKE::get_restore_plan] calls.
     #[derive(Clone, Debug)]
     pub struct GetRestorePlan(RequestBuilder<crate::model::GetRestorePlanRequest>);
 
@@ -1216,7 +1216,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::update_restore_plan call.
+    /// The request builder for [BackupForGKE::update_restore_plan][super::super::client::BackupForGKE::update_restore_plan] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRestorePlan(RequestBuilder<crate::model::UpdateRestorePlanRequest>);
 
@@ -1311,7 +1311,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::delete_restore_plan call.
+    /// The request builder for [BackupForGKE::delete_restore_plan][super::super::client::BackupForGKE::delete_restore_plan] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRestorePlan(RequestBuilder<crate::model::DeleteRestorePlanRequest>);
 
@@ -1403,7 +1403,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::create_restore call.
+    /// The request builder for [BackupForGKE::create_restore][super::super::client::BackupForGKE::create_restore] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRestore(RequestBuilder<crate::model::CreateRestoreRequest>);
 
@@ -1497,7 +1497,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::list_restores call.
+    /// The request builder for [BackupForGKE::list_restores][super::super::client::BackupForGKE::list_restores] calls.
     #[derive(Clone, Debug)]
     pub struct ListRestores(RequestBuilder<crate::model::ListRestoresRequest>);
 
@@ -1578,7 +1578,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_restore call.
+    /// The request builder for [BackupForGKE::get_restore][super::super::client::BackupForGKE::get_restore] calls.
     #[derive(Clone, Debug)]
     pub struct GetRestore(RequestBuilder<crate::model::GetRestoreRequest>);
 
@@ -1620,7 +1620,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::update_restore call.
+    /// The request builder for [BackupForGKE::update_restore][super::super::client::BackupForGKE::update_restore] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRestore(RequestBuilder<crate::model::UpdateRestoreRequest>);
 
@@ -1711,7 +1711,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::delete_restore call.
+    /// The request builder for [BackupForGKE::delete_restore][super::super::client::BackupForGKE::delete_restore] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRestore(RequestBuilder<crate::model::DeleteRestoreRequest>);
 
@@ -1800,7 +1800,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::list_volume_restores call.
+    /// The request builder for [BackupForGKE::list_volume_restores][super::super::client::BackupForGKE::list_volume_restores] calls.
     #[derive(Clone, Debug)]
     pub struct ListVolumeRestores(RequestBuilder<crate::model::ListVolumeRestoresRequest>);
 
@@ -1884,7 +1884,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_volume_restore call.
+    /// The request builder for [BackupForGKE::get_volume_restore][super::super::client::BackupForGKE::get_volume_restore] calls.
     #[derive(Clone, Debug)]
     pub struct GetVolumeRestore(RequestBuilder<crate::model::GetVolumeRestoreRequest>);
 
@@ -1929,7 +1929,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_backup_index_download_url call.
+    /// The request builder for [BackupForGKE::get_backup_index_download_url][super::super::client::BackupForGKE::get_backup_index_download_url] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupIndexDownloadUrl(
         RequestBuilder<crate::model::GetBackupIndexDownloadUrlRequest>,
@@ -1976,7 +1976,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::list_locations call.
+    /// The request builder for [BackupForGKE::list_locations][super::super::client::BackupForGKE::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2054,7 +2054,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_location call.
+    /// The request builder for [BackupForGKE::get_location][super::super::client::BackupForGKE::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2096,7 +2096,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::set_iam_policy call.
+    /// The request builder for [BackupForGKE::set_iam_policy][super::super::client::BackupForGKE::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2156,7 +2156,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_iam_policy call.
+    /// The request builder for [BackupForGKE::get_iam_policy][super::super::client::BackupForGKE::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2207,7 +2207,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::test_iam_permissions call.
+    /// The request builder for [BackupForGKE::test_iam_permissions][super::super::client::BackupForGKE::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2263,7 +2263,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::list_operations call.
+    /// The request builder for [BackupForGKE::list_operations][super::super::client::BackupForGKE::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2341,7 +2341,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::get_operation call.
+    /// The request builder for [BackupForGKE::get_operation][super::super::client::BackupForGKE::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2386,7 +2386,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::delete_operation call.
+    /// The request builder for [BackupForGKE::delete_operation][super::super::client::BackupForGKE::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2431,7 +2431,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for a BackupForGKE::cancel_operation call.
+    /// The request builder for [BackupForGKE::cancel_operation][super::super::client::BackupForGKE::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/builder.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod gateway_control {
         }
     }
 
-    /// The request builder for a GatewayControl::generate_credentials call.
+    /// The request builder for [GatewayControl::generate_credentials][super::super::client::GatewayControl::generate_credentials] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateCredentials(RequestBuilder<crate::model::GenerateCredentialsRequest>);
 

--- a/src/generated/cloud/gkehub/v1/src/builder.rs
+++ b/src/generated/cloud/gkehub/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::list_memberships call.
+    /// The request builder for [GkeHub::list_memberships][super::super::client::GkeHub::list_memberships] calls.
     #[derive(Clone, Debug)]
     pub struct ListMemberships(RequestBuilder<crate::model::ListMembershipsRequest>);
 
@@ -148,7 +148,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::list_features call.
+    /// The request builder for [GkeHub::list_features][super::super::client::GkeHub::list_features] calls.
     #[derive(Clone, Debug)]
     pub struct ListFeatures(RequestBuilder<crate::model::ListFeaturesRequest>);
 
@@ -229,7 +229,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::get_membership call.
+    /// The request builder for [GkeHub::get_membership][super::super::client::GkeHub::get_membership] calls.
     #[derive(Clone, Debug)]
     pub struct GetMembership(RequestBuilder<crate::model::GetMembershipRequest>);
 
@@ -271,7 +271,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::get_feature call.
+    /// The request builder for [GkeHub::get_feature][super::super::client::GkeHub::get_feature] calls.
     #[derive(Clone, Debug)]
     pub struct GetFeature(RequestBuilder<crate::model::GetFeatureRequest>);
 
@@ -313,7 +313,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::create_membership call.
+    /// The request builder for [GkeHub::create_membership][super::super::client::GkeHub::create_membership] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMembership(RequestBuilder<crate::model::CreateMembershipRequest>);
 
@@ -417,7 +417,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::create_feature call.
+    /// The request builder for [GkeHub::create_feature][super::super::client::GkeHub::create_feature] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFeature(RequestBuilder<crate::model::CreateFeatureRequest>);
 
@@ -517,7 +517,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::delete_membership call.
+    /// The request builder for [GkeHub::delete_membership][super::super::client::GkeHub::delete_membership] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMembership(RequestBuilder<crate::model::DeleteMembershipRequest>);
 
@@ -609,7 +609,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::delete_feature call.
+    /// The request builder for [GkeHub::delete_feature][super::super::client::GkeHub::delete_feature] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFeature(RequestBuilder<crate::model::DeleteFeatureRequest>);
 
@@ -698,7 +698,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::update_membership call.
+    /// The request builder for [GkeHub::update_membership][super::super::client::GkeHub::update_membership] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMembership(RequestBuilder<crate::model::UpdateMembershipRequest>);
 
@@ -805,7 +805,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::update_feature call.
+    /// The request builder for [GkeHub::update_feature][super::super::client::GkeHub::update_feature] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFeature(RequestBuilder<crate::model::UpdateFeatureRequest>);
 
@@ -908,7 +908,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::generate_connect_manifest call.
+    /// The request builder for [GkeHub::generate_connect_manifest][super::super::client::GkeHub::generate_connect_manifest] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateConnectManifest(
         RequestBuilder<crate::model::GenerateConnectManifestRequest>,
@@ -991,7 +991,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::list_operations call.
+    /// The request builder for [GkeHub::list_operations][super::super::client::GkeHub::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1069,7 +1069,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::get_operation call.
+    /// The request builder for [GkeHub::get_operation][super::super::client::GkeHub::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1114,7 +1114,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::delete_operation call.
+    /// The request builder for [GkeHub::delete_operation][super::super::client::GkeHub::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1159,7 +1159,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for a GkeHub::cancel_operation call.
+    /// The request builder for [GkeHub::cancel_operation][super::super::client::GkeHub::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/gkemulticloud/v1/src/builder.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::create_attached_cluster call.
+    /// The request builder for [AttachedClusters::create_attached_cluster][super::super::client::AttachedClusters::create_attached_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAttachedCluster(RequestBuilder<crate::model::CreateAttachedClusterRequest>);
 
@@ -172,7 +172,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::update_attached_cluster call.
+    /// The request builder for [AttachedClusters::update_attached_cluster][super::super::client::AttachedClusters::update_attached_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAttachedCluster(RequestBuilder<crate::model::UpdateAttachedClusterRequest>);
 
@@ -274,7 +274,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::import_attached_cluster call.
+    /// The request builder for [AttachedClusters::import_attached_cluster][super::super::client::AttachedClusters::import_attached_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct ImportAttachedCluster(RequestBuilder<crate::model::ImportAttachedClusterRequest>);
 
@@ -391,7 +391,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::get_attached_cluster call.
+    /// The request builder for [AttachedClusters::get_attached_cluster][super::super::client::AttachedClusters::get_attached_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetAttachedCluster(RequestBuilder<crate::model::GetAttachedClusterRequest>);
 
@@ -436,7 +436,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::list_attached_clusters call.
+    /// The request builder for [AttachedClusters::list_attached_clusters][super::super::client::AttachedClusters::list_attached_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListAttachedClusters(RequestBuilder<crate::model::ListAttachedClustersRequest>);
 
@@ -508,7 +508,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::delete_attached_cluster call.
+    /// The request builder for [AttachedClusters::delete_attached_cluster][super::super::client::AttachedClusters::delete_attached_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAttachedCluster(RequestBuilder<crate::model::DeleteAttachedClusterRequest>);
 
@@ -612,7 +612,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::get_attached_server_config call.
+    /// The request builder for [AttachedClusters::get_attached_server_config][super::super::client::AttachedClusters::get_attached_server_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetAttachedServerConfig(
         RequestBuilder<crate::model::GetAttachedServerConfigRequest>,
@@ -659,7 +659,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::generate_attached_cluster_install_manifest call.
+    /// The request builder for [AttachedClusters::generate_attached_cluster_install_manifest][super::super::client::AttachedClusters::generate_attached_cluster_install_manifest] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAttachedClusterInstallManifest(
         RequestBuilder<crate::model::GenerateAttachedClusterInstallManifestRequest>,
@@ -731,7 +731,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::generate_attached_cluster_agent_token call.
+    /// The request builder for [AttachedClusters::generate_attached_cluster_agent_token][super::super::client::AttachedClusters::generate_attached_cluster_agent_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAttachedClusterAgentToken(
         RequestBuilder<crate::model::GenerateAttachedClusterAgentTokenRequest>,
@@ -826,7 +826,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::list_operations call.
+    /// The request builder for [AttachedClusters::list_operations][super::super::client::AttachedClusters::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -904,7 +904,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::get_operation call.
+    /// The request builder for [AttachedClusters::get_operation][super::super::client::AttachedClusters::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -949,7 +949,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::delete_operation call.
+    /// The request builder for [AttachedClusters::delete_operation][super::super::client::AttachedClusters::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -994,7 +994,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for a AttachedClusters::cancel_operation call.
+    /// The request builder for [AttachedClusters::cancel_operation][super::super::client::AttachedClusters::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1093,7 +1093,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::create_aws_cluster call.
+    /// The request builder for [AwsClusters::create_aws_cluster][super::super::client::AwsClusters::create_aws_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAwsCluster(RequestBuilder<crate::model::CreateAwsClusterRequest>);
 
@@ -1197,7 +1197,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::update_aws_cluster call.
+    /// The request builder for [AwsClusters::update_aws_cluster][super::super::client::AwsClusters::update_aws_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAwsCluster(RequestBuilder<crate::model::UpdateAwsClusterRequest>);
 
@@ -1298,7 +1298,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::get_aws_cluster call.
+    /// The request builder for [AwsClusters::get_aws_cluster][super::super::client::AwsClusters::get_aws_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetAwsCluster(RequestBuilder<crate::model::GetAwsClusterRequest>);
 
@@ -1340,7 +1340,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::list_aws_clusters call.
+    /// The request builder for [AwsClusters::list_aws_clusters][super::super::client::AwsClusters::list_aws_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListAwsClusters(RequestBuilder<crate::model::ListAwsClustersRequest>);
 
@@ -1409,7 +1409,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::delete_aws_cluster call.
+    /// The request builder for [AwsClusters::delete_aws_cluster][super::super::client::AwsClusters::delete_aws_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAwsCluster(RequestBuilder<crate::model::DeleteAwsClusterRequest>);
 
@@ -1513,7 +1513,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::generate_aws_cluster_agent_token call.
+    /// The request builder for [AwsClusters::generate_aws_cluster_agent_token][super::super::client::AwsClusters::generate_aws_cluster_agent_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAwsClusterAgentToken(
         RequestBuilder<crate::model::GenerateAwsClusterAgentTokenRequest>,
@@ -1614,7 +1614,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::generate_aws_access_token call.
+    /// The request builder for [AwsClusters::generate_aws_access_token][super::super::client::AwsClusters::generate_aws_access_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAwsAccessToken(RequestBuilder<crate::model::GenerateAwsAccessTokenRequest>);
 
@@ -1659,7 +1659,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::create_aws_node_pool call.
+    /// The request builder for [AwsClusters::create_aws_node_pool][super::super::client::AwsClusters::create_aws_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAwsNodePool(RequestBuilder<crate::model::CreateAwsNodePoolRequest>);
 
@@ -1763,7 +1763,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::update_aws_node_pool call.
+    /// The request builder for [AwsClusters::update_aws_node_pool][super::super::client::AwsClusters::update_aws_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAwsNodePool(RequestBuilder<crate::model::UpdateAwsNodePoolRequest>);
 
@@ -1864,7 +1864,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::rollback_aws_node_pool_update call.
+    /// The request builder for [AwsClusters::rollback_aws_node_pool_update][super::super::client::AwsClusters::rollback_aws_node_pool_update] calls.
     #[derive(Clone, Debug)]
     pub struct RollbackAwsNodePoolUpdate(
         RequestBuilder<crate::model::RollbackAwsNodePoolUpdateRequest>,
@@ -1955,7 +1955,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::get_aws_node_pool call.
+    /// The request builder for [AwsClusters::get_aws_node_pool][super::super::client::AwsClusters::get_aws_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetAwsNodePool(RequestBuilder<crate::model::GetAwsNodePoolRequest>);
 
@@ -1997,7 +1997,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::list_aws_node_pools call.
+    /// The request builder for [AwsClusters::list_aws_node_pools][super::super::client::AwsClusters::list_aws_node_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListAwsNodePools(RequestBuilder<crate::model::ListAwsNodePoolsRequest>);
 
@@ -2069,7 +2069,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::delete_aws_node_pool call.
+    /// The request builder for [AwsClusters::delete_aws_node_pool][super::super::client::AwsClusters::delete_aws_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAwsNodePool(RequestBuilder<crate::model::DeleteAwsNodePoolRequest>);
 
@@ -2173,7 +2173,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::get_aws_open_id_config call.
+    /// The request builder for [AwsClusters::get_aws_open_id_config][super::super::client::AwsClusters::get_aws_open_id_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetAwsOpenIdConfig(RequestBuilder<crate::model::GetAwsOpenIdConfigRequest>);
 
@@ -2218,7 +2218,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::get_aws_json_web_keys call.
+    /// The request builder for [AwsClusters::get_aws_json_web_keys][super::super::client::AwsClusters::get_aws_json_web_keys] calls.
     #[derive(Clone, Debug)]
     pub struct GetAwsJsonWebKeys(RequestBuilder<crate::model::GetAwsJsonWebKeysRequest>);
 
@@ -2263,7 +2263,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::get_aws_server_config call.
+    /// The request builder for [AwsClusters::get_aws_server_config][super::super::client::AwsClusters::get_aws_server_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetAwsServerConfig(RequestBuilder<crate::model::GetAwsServerConfigRequest>);
 
@@ -2308,7 +2308,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::list_operations call.
+    /// The request builder for [AwsClusters::list_operations][super::super::client::AwsClusters::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2386,7 +2386,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::get_operation call.
+    /// The request builder for [AwsClusters::get_operation][super::super::client::AwsClusters::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2431,7 +2431,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::delete_operation call.
+    /// The request builder for [AwsClusters::delete_operation][super::super::client::AwsClusters::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2476,7 +2476,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for a AwsClusters::cancel_operation call.
+    /// The request builder for [AwsClusters::cancel_operation][super::super::client::AwsClusters::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2575,7 +2575,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::create_azure_client call.
+    /// The request builder for [AzureClusters::create_azure_client][super::super::client::AzureClusters::create_azure_client] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAzureClient(RequestBuilder<crate::model::CreateAzureClientRequest>);
 
@@ -2679,7 +2679,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::get_azure_client call.
+    /// The request builder for [AzureClusters::get_azure_client][super::super::client::AzureClusters::get_azure_client] calls.
     #[derive(Clone, Debug)]
     pub struct GetAzureClient(RequestBuilder<crate::model::GetAzureClientRequest>);
 
@@ -2721,7 +2721,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::list_azure_clients call.
+    /// The request builder for [AzureClusters::list_azure_clients][super::super::client::AzureClusters::list_azure_clients] calls.
     #[derive(Clone, Debug)]
     pub struct ListAzureClients(RequestBuilder<crate::model::ListAzureClientsRequest>);
 
@@ -2793,7 +2793,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::delete_azure_client call.
+    /// The request builder for [AzureClusters::delete_azure_client][super::super::client::AzureClusters::delete_azure_client] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAzureClient(RequestBuilder<crate::model::DeleteAzureClientRequest>);
 
@@ -2885,7 +2885,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::create_azure_cluster call.
+    /// The request builder for [AzureClusters::create_azure_cluster][super::super::client::AzureClusters::create_azure_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAzureCluster(RequestBuilder<crate::model::CreateAzureClusterRequest>);
 
@@ -2989,7 +2989,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::update_azure_cluster call.
+    /// The request builder for [AzureClusters::update_azure_cluster][super::super::client::AzureClusters::update_azure_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAzureCluster(RequestBuilder<crate::model::UpdateAzureClusterRequest>);
 
@@ -3090,7 +3090,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::get_azure_cluster call.
+    /// The request builder for [AzureClusters::get_azure_cluster][super::super::client::AzureClusters::get_azure_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetAzureCluster(RequestBuilder<crate::model::GetAzureClusterRequest>);
 
@@ -3132,7 +3132,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::list_azure_clusters call.
+    /// The request builder for [AzureClusters::list_azure_clusters][super::super::client::AzureClusters::list_azure_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListAzureClusters(RequestBuilder<crate::model::ListAzureClustersRequest>);
 
@@ -3204,7 +3204,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::delete_azure_cluster call.
+    /// The request builder for [AzureClusters::delete_azure_cluster][super::super::client::AzureClusters::delete_azure_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAzureCluster(RequestBuilder<crate::model::DeleteAzureClusterRequest>);
 
@@ -3308,7 +3308,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::generate_azure_cluster_agent_token call.
+    /// The request builder for [AzureClusters::generate_azure_cluster_agent_token][super::super::client::AzureClusters::generate_azure_cluster_agent_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAzureClusterAgentToken(
         RequestBuilder<crate::model::GenerateAzureClusterAgentTokenRequest>,
@@ -3409,7 +3409,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::generate_azure_access_token call.
+    /// The request builder for [AzureClusters::generate_azure_access_token][super::super::client::AzureClusters::generate_azure_access_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAzureAccessToken(
         RequestBuilder<crate::model::GenerateAzureAccessTokenRequest>,
@@ -3456,7 +3456,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::create_azure_node_pool call.
+    /// The request builder for [AzureClusters::create_azure_node_pool][super::super::client::AzureClusters::create_azure_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAzureNodePool(RequestBuilder<crate::model::CreateAzureNodePoolRequest>);
 
@@ -3561,7 +3561,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::update_azure_node_pool call.
+    /// The request builder for [AzureClusters::update_azure_node_pool][super::super::client::AzureClusters::update_azure_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAzureNodePool(RequestBuilder<crate::model::UpdateAzureNodePoolRequest>);
 
@@ -3663,7 +3663,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::get_azure_node_pool call.
+    /// The request builder for [AzureClusters::get_azure_node_pool][super::super::client::AzureClusters::get_azure_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetAzureNodePool(RequestBuilder<crate::model::GetAzureNodePoolRequest>);
 
@@ -3708,7 +3708,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::list_azure_node_pools call.
+    /// The request builder for [AzureClusters::list_azure_node_pools][super::super::client::AzureClusters::list_azure_node_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListAzureNodePools(RequestBuilder<crate::model::ListAzureNodePoolsRequest>);
 
@@ -3780,7 +3780,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::delete_azure_node_pool call.
+    /// The request builder for [AzureClusters::delete_azure_node_pool][super::super::client::AzureClusters::delete_azure_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAzureNodePool(RequestBuilder<crate::model::DeleteAzureNodePoolRequest>);
 
@@ -3884,7 +3884,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::get_azure_open_id_config call.
+    /// The request builder for [AzureClusters::get_azure_open_id_config][super::super::client::AzureClusters::get_azure_open_id_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetAzureOpenIdConfig(RequestBuilder<crate::model::GetAzureOpenIdConfigRequest>);
 
@@ -3929,7 +3929,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::get_azure_json_web_keys call.
+    /// The request builder for [AzureClusters::get_azure_json_web_keys][super::super::client::AzureClusters::get_azure_json_web_keys] calls.
     #[derive(Clone, Debug)]
     pub struct GetAzureJsonWebKeys(RequestBuilder<crate::model::GetAzureJsonWebKeysRequest>);
 
@@ -3974,7 +3974,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::get_azure_server_config call.
+    /// The request builder for [AzureClusters::get_azure_server_config][super::super::client::AzureClusters::get_azure_server_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetAzureServerConfig(RequestBuilder<crate::model::GetAzureServerConfigRequest>);
 
@@ -4019,7 +4019,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::list_operations call.
+    /// The request builder for [AzureClusters::list_operations][super::super::client::AzureClusters::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4097,7 +4097,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::get_operation call.
+    /// The request builder for [AzureClusters::get_operation][super::super::client::AzureClusters::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4142,7 +4142,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::delete_operation call.
+    /// The request builder for [AzureClusters::delete_operation][super::super::client::AzureClusters::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4187,7 +4187,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for a AzureClusters::cancel_operation call.
+    /// The request builder for [AzureClusters::cancel_operation][super::super::client::AzureClusters::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/gsuiteaddons/v1/src/builder.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::get_authorization call.
+    /// The request builder for [GSuiteAddOns::get_authorization][super::super::client::GSuiteAddOns::get_authorization] calls.
     #[derive(Clone, Debug)]
     pub struct GetAuthorization(RequestBuilder<crate::model::GetAuthorizationRequest>);
 
@@ -112,7 +112,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::create_deployment call.
+    /// The request builder for [GSuiteAddOns::create_deployment][super::super::client::GSuiteAddOns::create_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDeployment(RequestBuilder<crate::model::CreateDeploymentRequest>);
 
@@ -172,7 +172,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::replace_deployment call.
+    /// The request builder for [GSuiteAddOns::replace_deployment][super::super::client::GSuiteAddOns::replace_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct ReplaceDeployment(RequestBuilder<crate::model::ReplaceDeploymentRequest>);
 
@@ -220,7 +220,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::get_deployment call.
+    /// The request builder for [GSuiteAddOns::get_deployment][super::super::client::GSuiteAddOns::get_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -262,7 +262,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::list_deployments call.
+    /// The request builder for [GSuiteAddOns::list_deployments][super::super::client::GSuiteAddOns::list_deployments] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -331,7 +331,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::delete_deployment call.
+    /// The request builder for [GSuiteAddOns::delete_deployment][super::super::client::GSuiteAddOns::delete_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDeployment(RequestBuilder<crate::model::DeleteDeploymentRequest>);
 
@@ -382,7 +382,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::install_deployment call.
+    /// The request builder for [GSuiteAddOns::install_deployment][super::super::client::GSuiteAddOns::install_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct InstallDeployment(RequestBuilder<crate::model::InstallDeploymentRequest>);
 
@@ -427,7 +427,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::uninstall_deployment call.
+    /// The request builder for [GSuiteAddOns::uninstall_deployment][super::super::client::GSuiteAddOns::uninstall_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct UninstallDeployment(RequestBuilder<crate::model::UninstallDeploymentRequest>);
 
@@ -472,7 +472,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for a GSuiteAddOns::get_install_status call.
+    /// The request builder for [GSuiteAddOns::get_install_status][super::super::client::GSuiteAddOns::get_install_status] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstallStatus(RequestBuilder<crate::model::GetInstallStatusRequest>);
 

--- a/src/generated/cloud/iap/v1/src/builder.rs
+++ b/src/generated/cloud/iap/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::set_iam_policy call.
+    /// The request builder for [IdentityAwareProxyAdminService::set_iam_policy][super::super::client::IdentityAwareProxyAdminService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -131,7 +131,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::get_iam_policy call.
+    /// The request builder for [IdentityAwareProxyAdminService::get_iam_policy][super::super::client::IdentityAwareProxyAdminService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -184,7 +184,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::test_iam_permissions call.
+    /// The request builder for [IdentityAwareProxyAdminService::test_iam_permissions][super::super::client::IdentityAwareProxyAdminService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -242,7 +242,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::get_iap_settings call.
+    /// The request builder for [IdentityAwareProxyAdminService::get_iap_settings][super::super::client::IdentityAwareProxyAdminService::get_iap_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetIapSettings(RequestBuilder<crate::model::GetIapSettingsRequest>);
 
@@ -286,7 +286,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::update_iap_settings call.
+    /// The request builder for [IdentityAwareProxyAdminService::update_iap_settings][super::super::client::IdentityAwareProxyAdminService::update_iap_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateIapSettings(RequestBuilder<crate::model::UpdateIapSettingsRequest>);
 
@@ -345,7 +345,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::list_tunnel_dest_groups call.
+    /// The request builder for [IdentityAwareProxyAdminService::list_tunnel_dest_groups][super::super::client::IdentityAwareProxyAdminService::list_tunnel_dest_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListTunnelDestGroups(RequestBuilder<crate::model::ListTunnelDestGroupsRequest>);
 
@@ -419,7 +419,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::create_tunnel_dest_group call.
+    /// The request builder for [IdentityAwareProxyAdminService::create_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::create_tunnel_dest_group] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTunnelDestGroup(RequestBuilder<crate::model::CreateTunnelDestGroupRequest>);
 
@@ -483,7 +483,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::get_tunnel_dest_group call.
+    /// The request builder for [IdentityAwareProxyAdminService::get_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::get_tunnel_dest_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetTunnelDestGroup(RequestBuilder<crate::model::GetTunnelDestGroupRequest>);
 
@@ -530,7 +530,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::delete_tunnel_dest_group call.
+    /// The request builder for [IdentityAwareProxyAdminService::delete_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::delete_tunnel_dest_group] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTunnelDestGroup(RequestBuilder<crate::model::DeleteTunnelDestGroupRequest>);
 
@@ -577,7 +577,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyAdminService::update_tunnel_dest_group call.
+    /// The request builder for [IdentityAwareProxyAdminService::update_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::update_tunnel_dest_group] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTunnelDestGroup(RequestBuilder<crate::model::UpdateTunnelDestGroupRequest>);
 
@@ -694,7 +694,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyOAuthService::list_brands call.
+    /// The request builder for [IdentityAwareProxyOAuthService::list_brands][super::super::client::IdentityAwareProxyOAuthService::list_brands] calls.
     #[derive(Clone, Debug)]
     pub struct ListBrands(RequestBuilder<crate::model::ListBrandsRequest>);
 
@@ -738,7 +738,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyOAuthService::create_brand call.
+    /// The request builder for [IdentityAwareProxyOAuthService::create_brand][super::super::client::IdentityAwareProxyOAuthService::create_brand] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBrand(RequestBuilder<crate::model::CreateBrandRequest>);
 
@@ -791,7 +791,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyOAuthService::get_brand call.
+    /// The request builder for [IdentityAwareProxyOAuthService::get_brand][super::super::client::IdentityAwareProxyOAuthService::get_brand] calls.
     #[derive(Clone, Debug)]
     pub struct GetBrand(RequestBuilder<crate::model::GetBrandRequest>);
 
@@ -835,7 +835,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyOAuthService::create_identity_aware_proxy_client call.
+    /// The request builder for [IdentityAwareProxyOAuthService::create_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::create_identity_aware_proxy_client] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIdentityAwareProxyClient(
         RequestBuilder<crate::model::CreateIdentityAwareProxyClientRequest>,
@@ -895,7 +895,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients call.
+    /// The request builder for [IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients][super::super::client::IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients] calls.
     #[derive(Clone, Debug)]
     pub struct ListIdentityAwareProxyClients(
         RequestBuilder<crate::model::ListIdentityAwareProxyClientsRequest>,
@@ -973,7 +973,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyOAuthService::get_identity_aware_proxy_client call.
+    /// The request builder for [IdentityAwareProxyOAuthService::get_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::get_identity_aware_proxy_client] calls.
     #[derive(Clone, Debug)]
     pub struct GetIdentityAwareProxyClient(
         RequestBuilder<crate::model::GetIdentityAwareProxyClientRequest>,
@@ -1022,7 +1022,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret call.
+    /// The request builder for [IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret][super::super::client::IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret] calls.
     #[derive(Clone, Debug)]
     pub struct ResetIdentityAwareProxyClientSecret(
         RequestBuilder<crate::model::ResetIdentityAwareProxyClientSecretRequest>,
@@ -1071,7 +1071,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for a IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client call.
+    /// The request builder for [IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIdentityAwareProxyClient(
         RequestBuilder<crate::model::DeleteIdentityAwareProxyClientRequest>,

--- a/src/generated/cloud/ids/v1/src/builder.rs
+++ b/src/generated/cloud/ids/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for a Ids::list_endpoints call.
+    /// The request builder for [Ids::list_endpoints][super::super::client::Ids::list_endpoints] calls.
     #[derive(Clone, Debug)]
     pub struct ListEndpoints(RequestBuilder<crate::model::ListEndpointsRequest>);
 
@@ -148,7 +148,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for a Ids::get_endpoint call.
+    /// The request builder for [Ids::get_endpoint][super::super::client::Ids::get_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct GetEndpoint(RequestBuilder<crate::model::GetEndpointRequest>);
 
@@ -190,7 +190,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for a Ids::create_endpoint call.
+    /// The request builder for [Ids::create_endpoint][super::super::client::Ids::create_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEndpoint(RequestBuilder<crate::model::CreateEndpointRequest>);
 
@@ -291,7 +291,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for a Ids::delete_endpoint call.
+    /// The request builder for [Ids::delete_endpoint][super::super::client::Ids::delete_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEndpoint(RequestBuilder<crate::model::DeleteEndpointRequest>);
 
@@ -374,7 +374,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for a Ids::list_operations call.
+    /// The request builder for [Ids::list_operations][super::super::client::Ids::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -452,7 +452,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for a Ids::get_operation call.
+    /// The request builder for [Ids::get_operation][super::super::client::Ids::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -497,7 +497,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for a Ids::delete_operation call.
+    /// The request builder for [Ids::delete_operation][super::super::client::Ids::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -542,7 +542,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for a Ids::cancel_operation call.
+    /// The request builder for [Ids::cancel_operation][super::super::client::Ids::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/kms/inventory/v1/src/builder.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod key_dashboard_service {
         }
     }
 
-    /// The request builder for a KeyDashboardService::list_crypto_keys call.
+    /// The request builder for [KeyDashboardService::list_crypto_keys][super::super::client::KeyDashboardService::list_crypto_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListCryptoKeys(RequestBuilder<crate::model::ListCryptoKeysRequest>);
 
@@ -190,7 +190,7 @@ pub mod key_tracking_service {
         }
     }
 
-    /// The request builder for a KeyTrackingService::get_protected_resources_summary call.
+    /// The request builder for [KeyTrackingService::get_protected_resources_summary][super::super::client::KeyTrackingService::get_protected_resources_summary] calls.
     #[derive(Clone, Debug)]
     pub struct GetProtectedResourcesSummary(
         RequestBuilder<crate::model::GetProtectedResourcesSummaryRequest>,
@@ -237,7 +237,7 @@ pub mod key_tracking_service {
         }
     }
 
-    /// The request builder for a KeyTrackingService::search_protected_resources call.
+    /// The request builder for [KeyTrackingService::search_protected_resources][super::super::client::KeyTrackingService::search_protected_resources] calls.
     #[derive(Clone, Debug)]
     pub struct SearchProtectedResources(
         RequestBuilder<crate::model::SearchProtectedResourcesRequest>,

--- a/src/generated/cloud/kms/v1/src/builder.rs
+++ b/src/generated/cloud/kms/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::create_key_handle call.
+    /// The request builder for [Autokey::create_key_handle][super::super::client::Autokey::create_key_handle] calls.
     #[derive(Clone, Debug)]
     pub struct CreateKeyHandle(RequestBuilder<crate::model::CreateKeyHandleRequest>);
 
@@ -163,7 +163,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::get_key_handle call.
+    /// The request builder for [Autokey::get_key_handle][super::super::client::Autokey::get_key_handle] calls.
     #[derive(Clone, Debug)]
     pub struct GetKeyHandle(RequestBuilder<crate::model::GetKeyHandleRequest>);
 
@@ -205,7 +205,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::list_key_handles call.
+    /// The request builder for [Autokey::list_key_handles][super::super::client::Autokey::list_key_handles] calls.
     #[derive(Clone, Debug)]
     pub struct ListKeyHandles(RequestBuilder<crate::model::ListKeyHandlesRequest>);
 
@@ -280,7 +280,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::list_locations call.
+    /// The request builder for [Autokey::list_locations][super::super::client::Autokey::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -358,7 +358,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::get_location call.
+    /// The request builder for [Autokey::get_location][super::super::client::Autokey::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -400,7 +400,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::set_iam_policy call.
+    /// The request builder for [Autokey::set_iam_policy][super::super::client::Autokey::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -460,7 +460,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::get_iam_policy call.
+    /// The request builder for [Autokey::get_iam_policy][super::super::client::Autokey::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -511,7 +511,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::test_iam_permissions call.
+    /// The request builder for [Autokey::test_iam_permissions][super::super::client::Autokey::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -567,7 +567,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for a Autokey::get_operation call.
+    /// The request builder for [Autokey::get_operation][super::super::client::Autokey::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -666,7 +666,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::update_autokey_config call.
+    /// The request builder for [AutokeyAdmin::update_autokey_config][super::super::client::AutokeyAdmin::update_autokey_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAutokeyConfig(RequestBuilder<crate::model::UpdateAutokeyConfigRequest>);
 
@@ -723,7 +723,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::get_autokey_config call.
+    /// The request builder for [AutokeyAdmin::get_autokey_config][super::super::client::AutokeyAdmin::get_autokey_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetAutokeyConfig(RequestBuilder<crate::model::GetAutokeyConfigRequest>);
 
@@ -768,7 +768,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::show_effective_autokey_config call.
+    /// The request builder for [AutokeyAdmin::show_effective_autokey_config][super::super::client::AutokeyAdmin::show_effective_autokey_config] calls.
     #[derive(Clone, Debug)]
     pub struct ShowEffectiveAutokeyConfig(
         RequestBuilder<crate::model::ShowEffectiveAutokeyConfigRequest>,
@@ -815,7 +815,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::list_locations call.
+    /// The request builder for [AutokeyAdmin::list_locations][super::super::client::AutokeyAdmin::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -893,7 +893,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::get_location call.
+    /// The request builder for [AutokeyAdmin::get_location][super::super::client::AutokeyAdmin::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -935,7 +935,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::set_iam_policy call.
+    /// The request builder for [AutokeyAdmin::set_iam_policy][super::super::client::AutokeyAdmin::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -995,7 +995,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::get_iam_policy call.
+    /// The request builder for [AutokeyAdmin::get_iam_policy][super::super::client::AutokeyAdmin::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1046,7 +1046,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::test_iam_permissions call.
+    /// The request builder for [AutokeyAdmin::test_iam_permissions][super::super::client::AutokeyAdmin::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1102,7 +1102,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for a AutokeyAdmin::get_operation call.
+    /// The request builder for [AutokeyAdmin::get_operation][super::super::client::AutokeyAdmin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1201,7 +1201,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::list_ekm_connections call.
+    /// The request builder for [EkmService::list_ekm_connections][super::super::client::EkmService::list_ekm_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListEkmConnections(RequestBuilder<crate::model::ListEkmConnectionsRequest>);
 
@@ -1285,7 +1285,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::get_ekm_connection call.
+    /// The request builder for [EkmService::get_ekm_connection][super::super::client::EkmService::get_ekm_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetEkmConnection(RequestBuilder<crate::model::GetEkmConnectionRequest>);
 
@@ -1330,7 +1330,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::create_ekm_connection call.
+    /// The request builder for [EkmService::create_ekm_connection][super::super::client::EkmService::create_ekm_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEkmConnection(RequestBuilder<crate::model::CreateEkmConnectionRequest>);
 
@@ -1390,7 +1390,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::update_ekm_connection call.
+    /// The request builder for [EkmService::update_ekm_connection][super::super::client::EkmService::update_ekm_connection] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEkmConnection(RequestBuilder<crate::model::UpdateEkmConnectionRequest>);
 
@@ -1447,7 +1447,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::get_ekm_config call.
+    /// The request builder for [EkmService::get_ekm_config][super::super::client::EkmService::get_ekm_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetEkmConfig(RequestBuilder<crate::model::GetEkmConfigRequest>);
 
@@ -1489,7 +1489,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::update_ekm_config call.
+    /// The request builder for [EkmService::update_ekm_config][super::super::client::EkmService::update_ekm_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEkmConfig(RequestBuilder<crate::model::UpdateEkmConfigRequest>);
 
@@ -1543,7 +1543,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::verify_connectivity call.
+    /// The request builder for [EkmService::verify_connectivity][super::super::client::EkmService::verify_connectivity] calls.
     #[derive(Clone, Debug)]
     pub struct VerifyConnectivity(RequestBuilder<crate::model::VerifyConnectivityRequest>);
 
@@ -1588,7 +1588,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::list_locations call.
+    /// The request builder for [EkmService::list_locations][super::super::client::EkmService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1666,7 +1666,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::get_location call.
+    /// The request builder for [EkmService::get_location][super::super::client::EkmService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1708,7 +1708,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::set_iam_policy call.
+    /// The request builder for [EkmService::set_iam_policy][super::super::client::EkmService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1768,7 +1768,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::get_iam_policy call.
+    /// The request builder for [EkmService::get_iam_policy][super::super::client::EkmService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1819,7 +1819,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::test_iam_permissions call.
+    /// The request builder for [EkmService::test_iam_permissions][super::super::client::EkmService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1875,7 +1875,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for a EkmService::get_operation call.
+    /// The request builder for [EkmService::get_operation][super::super::client::EkmService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1976,7 +1976,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::list_key_rings call.
+    /// The request builder for [KeyManagementService::list_key_rings][super::super::client::KeyManagementService::list_key_rings] calls.
     #[derive(Clone, Debug)]
     pub struct ListKeyRings(RequestBuilder<crate::model::ListKeyRingsRequest>);
 
@@ -2059,7 +2059,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::list_crypto_keys call.
+    /// The request builder for [KeyManagementService::list_crypto_keys][super::super::client::KeyManagementService::list_crypto_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListCryptoKeys(RequestBuilder<crate::model::ListCryptoKeysRequest>);
 
@@ -2151,7 +2151,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::list_crypto_key_versions call.
+    /// The request builder for [KeyManagementService::list_crypto_key_versions][super::super::client::KeyManagementService::list_crypto_key_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListCryptoKeyVersions(RequestBuilder<crate::model::ListCryptoKeyVersionsRequest>);
 
@@ -2246,7 +2246,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::list_import_jobs call.
+    /// The request builder for [KeyManagementService::list_import_jobs][super::super::client::KeyManagementService::list_import_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListImportJobs(RequestBuilder<crate::model::ListImportJobsRequest>);
 
@@ -2329,7 +2329,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::get_key_ring call.
+    /// The request builder for [KeyManagementService::get_key_ring][super::super::client::KeyManagementService::get_key_ring] calls.
     #[derive(Clone, Debug)]
     pub struct GetKeyRing(RequestBuilder<crate::model::GetKeyRingRequest>);
 
@@ -2373,7 +2373,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::get_crypto_key call.
+    /// The request builder for [KeyManagementService::get_crypto_key][super::super::client::KeyManagementService::get_crypto_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetCryptoKey(RequestBuilder<crate::model::GetCryptoKeyRequest>);
 
@@ -2417,7 +2417,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::get_crypto_key_version call.
+    /// The request builder for [KeyManagementService::get_crypto_key_version][super::super::client::KeyManagementService::get_crypto_key_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetCryptoKeyVersion(RequestBuilder<crate::model::GetCryptoKeyVersionRequest>);
 
@@ -2464,7 +2464,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::get_public_key call.
+    /// The request builder for [KeyManagementService::get_public_key][super::super::client::KeyManagementService::get_public_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetPublicKey(RequestBuilder<crate::model::GetPublicKeyRequest>);
 
@@ -2517,7 +2517,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::get_import_job call.
+    /// The request builder for [KeyManagementService::get_import_job][super::super::client::KeyManagementService::get_import_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetImportJob(RequestBuilder<crate::model::GetImportJobRequest>);
 
@@ -2561,7 +2561,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::create_key_ring call.
+    /// The request builder for [KeyManagementService::create_key_ring][super::super::client::KeyManagementService::create_key_ring] calls.
     #[derive(Clone, Debug)]
     pub struct CreateKeyRing(RequestBuilder<crate::model::CreateKeyRingRequest>);
 
@@ -2620,7 +2620,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::create_crypto_key call.
+    /// The request builder for [KeyManagementService::create_crypto_key][super::super::client::KeyManagementService::create_crypto_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCryptoKey(RequestBuilder<crate::model::CreateCryptoKeyRequest>);
 
@@ -2685,7 +2685,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::create_crypto_key_version call.
+    /// The request builder for [KeyManagementService::create_crypto_key_version][super::super::client::KeyManagementService::create_crypto_key_version] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCryptoKeyVersion(RequestBuilder<crate::model::CreateCryptoKeyVersionRequest>);
 
@@ -2743,7 +2743,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::import_crypto_key_version call.
+    /// The request builder for [KeyManagementService::import_crypto_key_version][super::super::client::KeyManagementService::import_crypto_key_version] calls.
     #[derive(Clone, Debug)]
     pub struct ImportCryptoKeyVersion(RequestBuilder<crate::model::ImportCryptoKeyVersionRequest>);
 
@@ -2830,7 +2830,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::create_import_job call.
+    /// The request builder for [KeyManagementService::create_import_job][super::super::client::KeyManagementService::create_import_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateImportJob(RequestBuilder<crate::model::CreateImportJobRequest>);
 
@@ -2889,7 +2889,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::update_crypto_key call.
+    /// The request builder for [KeyManagementService::update_crypto_key][super::super::client::KeyManagementService::update_crypto_key] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCryptoKey(RequestBuilder<crate::model::UpdateCryptoKeyRequest>);
 
@@ -2945,7 +2945,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::update_crypto_key_version call.
+    /// The request builder for [KeyManagementService::update_crypto_key_version][super::super::client::KeyManagementService::update_crypto_key_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCryptoKeyVersion(RequestBuilder<crate::model::UpdateCryptoKeyVersionRequest>);
 
@@ -3006,7 +3006,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::update_crypto_key_primary_version call.
+    /// The request builder for [KeyManagementService::update_crypto_key_primary_version][super::super::client::KeyManagementService::update_crypto_key_primary_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCryptoKeyPrimaryVersion(
         RequestBuilder<crate::model::UpdateCryptoKeyPrimaryVersionRequest>,
@@ -3061,7 +3061,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::destroy_crypto_key_version call.
+    /// The request builder for [KeyManagementService::destroy_crypto_key_version][super::super::client::KeyManagementService::destroy_crypto_key_version] calls.
     #[derive(Clone, Debug)]
     pub struct DestroyCryptoKeyVersion(
         RequestBuilder<crate::model::DestroyCryptoKeyVersionRequest>,
@@ -3110,7 +3110,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::restore_crypto_key_version call.
+    /// The request builder for [KeyManagementService::restore_crypto_key_version][super::super::client::KeyManagementService::restore_crypto_key_version] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreCryptoKeyVersion(
         RequestBuilder<crate::model::RestoreCryptoKeyVersionRequest>,
@@ -3159,7 +3159,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::encrypt call.
+    /// The request builder for [KeyManagementService::encrypt][super::super::client::KeyManagementService::encrypt] calls.
     #[derive(Clone, Debug)]
     pub struct Encrypt(RequestBuilder<crate::model::EncryptRequest>);
 
@@ -3233,7 +3233,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::decrypt call.
+    /// The request builder for [KeyManagementService::decrypt][super::super::client::KeyManagementService::decrypt] calls.
     #[derive(Clone, Debug)]
     pub struct Decrypt(RequestBuilder<crate::model::DecryptRequest>);
 
@@ -3307,7 +3307,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::raw_encrypt call.
+    /// The request builder for [KeyManagementService::raw_encrypt][super::super::client::KeyManagementService::raw_encrypt] calls.
     #[derive(Clone, Debug)]
     pub struct RawEncrypt(RequestBuilder<crate::model::RawEncryptRequest>);
 
@@ -3398,7 +3398,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::raw_decrypt call.
+    /// The request builder for [KeyManagementService::raw_decrypt][super::super::client::KeyManagementService::raw_decrypt] calls.
     #[derive(Clone, Debug)]
     pub struct RawDecrypt(RequestBuilder<crate::model::RawDecryptRequest>);
 
@@ -3495,7 +3495,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::asymmetric_sign call.
+    /// The request builder for [KeyManagementService::asymmetric_sign][super::super::client::KeyManagementService::asymmetric_sign] calls.
     #[derive(Clone, Debug)]
     pub struct AsymmetricSign(RequestBuilder<crate::model::AsymmetricSignRequest>);
 
@@ -3572,7 +3572,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::asymmetric_decrypt call.
+    /// The request builder for [KeyManagementService::asymmetric_decrypt][super::super::client::KeyManagementService::asymmetric_decrypt] calls.
     #[derive(Clone, Debug)]
     pub struct AsymmetricDecrypt(RequestBuilder<crate::model::AsymmetricDecryptRequest>);
 
@@ -3634,7 +3634,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::mac_sign call.
+    /// The request builder for [KeyManagementService::mac_sign][super::super::client::KeyManagementService::mac_sign] calls.
     #[derive(Clone, Debug)]
     pub struct MacSign(RequestBuilder<crate::model::MacSignRequest>);
 
@@ -3693,7 +3693,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::mac_verify call.
+    /// The request builder for [KeyManagementService::mac_verify][super::super::client::KeyManagementService::mac_verify] calls.
     #[derive(Clone, Debug)]
     pub struct MacVerify(RequestBuilder<crate::model::MacVerifyRequest>);
 
@@ -3767,7 +3767,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::generate_random_bytes call.
+    /// The request builder for [KeyManagementService::generate_random_bytes][super::super::client::KeyManagementService::generate_random_bytes] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateRandomBytes(RequestBuilder<crate::model::GenerateRandomBytesRequest>);
 
@@ -3829,7 +3829,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::list_locations call.
+    /// The request builder for [KeyManagementService::list_locations][super::super::client::KeyManagementService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3909,7 +3909,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::get_location call.
+    /// The request builder for [KeyManagementService::get_location][super::super::client::KeyManagementService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3953,7 +3953,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::set_iam_policy call.
+    /// The request builder for [KeyManagementService::set_iam_policy][super::super::client::KeyManagementService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4015,7 +4015,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::get_iam_policy call.
+    /// The request builder for [KeyManagementService::get_iam_policy][super::super::client::KeyManagementService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4068,7 +4068,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::test_iam_permissions call.
+    /// The request builder for [KeyManagementService::test_iam_permissions][super::super::client::KeyManagementService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4126,7 +4126,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for a KeyManagementService::get_operation call.
+    /// The request builder for [KeyManagementService::get_operation][super::super::client::KeyManagementService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/language/v2/src/builder.rs
+++ b/src/generated/cloud/language/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for a LanguageService::analyze_sentiment call.
+    /// The request builder for [LanguageService::analyze_sentiment][super::super::client::LanguageService::analyze_sentiment] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeSentiment(RequestBuilder<crate::model::AnalyzeSentimentRequest>);
 
@@ -121,7 +121,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for a LanguageService::analyze_entities call.
+    /// The request builder for [LanguageService::analyze_entities][super::super::client::LanguageService::analyze_entities] calls.
     #[derive(Clone, Debug)]
     pub struct AnalyzeEntities(RequestBuilder<crate::model::AnalyzeEntitiesRequest>);
 
@@ -172,7 +172,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for a LanguageService::classify_text call.
+    /// The request builder for [LanguageService::classify_text][super::super::client::LanguageService::classify_text] calls.
     #[derive(Clone, Debug)]
     pub struct ClassifyText(RequestBuilder<crate::model::ClassifyTextRequest>);
 
@@ -217,7 +217,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for a LanguageService::moderate_text call.
+    /// The request builder for [LanguageService::moderate_text][super::super::client::LanguageService::moderate_text] calls.
     #[derive(Clone, Debug)]
     pub struct ModerateText(RequestBuilder<crate::model::ModerateTextRequest>);
 
@@ -271,7 +271,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for a LanguageService::annotate_text call.
+    /// The request builder for [LanguageService::annotate_text][super::super::client::LanguageService::annotate_text] calls.
     #[derive(Clone, Debug)]
     pub struct AnnotateText(RequestBuilder<crate::model::AnnotateTextRequest>);
 

--- a/src/generated/cloud/location/src/builder.rs
+++ b/src/generated/cloud/location/src/builder.rs
@@ -67,7 +67,7 @@ pub mod locations {
         }
     }
 
-    /// The request builder for a Locations::list_locations call.
+    /// The request builder for [Locations::list_locations][super::super::client::Locations::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<crate::model::ListLocationsRequest>);
 
@@ -142,7 +142,7 @@ pub mod locations {
         }
     }
 
-    /// The request builder for a Locations::get_location call.
+    /// The request builder for [Locations::get_location][super::super::client::Locations::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<crate::model::GetLocationRequest>);
 

--- a/src/generated/cloud/managedidentities/v1/src/builder.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::create_microsoft_ad_domain call.
+    /// The request builder for [ManagedIdentitiesService::create_microsoft_ad_domain][super::super::client::ManagedIdentitiesService::create_microsoft_ad_domain] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMicrosoftAdDomain(
         RequestBuilder<crate::model::CreateMicrosoftAdDomainRequest>,
@@ -168,7 +168,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::reset_admin_password call.
+    /// The request builder for [ManagedIdentitiesService::reset_admin_password][super::super::client::ManagedIdentitiesService::reset_admin_password] calls.
     #[derive(Clone, Debug)]
     pub struct ResetAdminPassword(RequestBuilder<crate::model::ResetAdminPasswordRequest>);
 
@@ -215,7 +215,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::list_domains call.
+    /// The request builder for [ManagedIdentitiesService::list_domains][super::super::client::ManagedIdentitiesService::list_domains] calls.
     #[derive(Clone, Debug)]
     pub struct ListDomains(RequestBuilder<crate::model::ListDomainsRequest>);
 
@@ -298,7 +298,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::get_domain call.
+    /// The request builder for [ManagedIdentitiesService::get_domain][super::super::client::ManagedIdentitiesService::get_domain] calls.
     #[derive(Clone, Debug)]
     pub struct GetDomain(RequestBuilder<crate::model::GetDomainRequest>);
 
@@ -342,7 +342,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::update_domain call.
+    /// The request builder for [ManagedIdentitiesService::update_domain][super::super::client::ManagedIdentitiesService::update_domain] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDomain(RequestBuilder<crate::model::UpdateDomainRequest>);
 
@@ -433,7 +433,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::delete_domain call.
+    /// The request builder for [ManagedIdentitiesService::delete_domain][super::super::client::ManagedIdentitiesService::delete_domain] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDomain(RequestBuilder<crate::model::DeleteDomainRequest>);
 
@@ -512,7 +512,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::attach_trust call.
+    /// The request builder for [ManagedIdentitiesService::attach_trust][super::super::client::ManagedIdentitiesService::attach_trust] calls.
     #[derive(Clone, Debug)]
     pub struct AttachTrust(RequestBuilder<crate::model::AttachTrustRequest>);
 
@@ -600,7 +600,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::reconfigure_trust call.
+    /// The request builder for [ManagedIdentitiesService::reconfigure_trust][super::super::client::ManagedIdentitiesService::reconfigure_trust] calls.
     #[derive(Clone, Debug)]
     pub struct ReconfigureTrust(RequestBuilder<crate::model::ReconfigureTrustRequest>);
 
@@ -699,7 +699,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::detach_trust call.
+    /// The request builder for [ManagedIdentitiesService::detach_trust][super::super::client::ManagedIdentitiesService::detach_trust] calls.
     #[derive(Clone, Debug)]
     pub struct DetachTrust(RequestBuilder<crate::model::DetachTrustRequest>);
 
@@ -787,7 +787,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::validate_trust call.
+    /// The request builder for [ManagedIdentitiesService::validate_trust][super::super::client::ManagedIdentitiesService::validate_trust] calls.
     #[derive(Clone, Debug)]
     pub struct ValidateTrust(RequestBuilder<crate::model::ValidateTrustRequest>);
 
@@ -875,7 +875,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::list_operations call.
+    /// The request builder for [ManagedIdentitiesService::list_operations][super::super::client::ManagedIdentitiesService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -955,7 +955,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::get_operation call.
+    /// The request builder for [ManagedIdentitiesService::get_operation][super::super::client::ManagedIdentitiesService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1002,7 +1002,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::delete_operation call.
+    /// The request builder for [ManagedIdentitiesService::delete_operation][super::super::client::ManagedIdentitiesService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1049,7 +1049,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for a ManagedIdentitiesService::cancel_operation call.
+    /// The request builder for [ManagedIdentitiesService::cancel_operation][super::super::client::ManagedIdentitiesService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/memcache/v1/src/builder.rs
+++ b/src/generated/cloud/memcache/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::list_instances call.
+    /// The request builder for [CloudMemcache::list_instances][super::super::client::CloudMemcache::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -148,7 +148,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::get_instance call.
+    /// The request builder for [CloudMemcache::get_instance][super::super::client::CloudMemcache::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -190,7 +190,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::create_instance call.
+    /// The request builder for [CloudMemcache::create_instance][super::super::client::CloudMemcache::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -285,7 +285,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::update_instance call.
+    /// The request builder for [CloudMemcache::update_instance][super::super::client::CloudMemcache::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -377,7 +377,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::update_parameters call.
+    /// The request builder for [CloudMemcache::update_parameters][super::super::client::CloudMemcache::update_parameters] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateParameters(RequestBuilder<crate::model::UpdateParametersRequest>);
 
@@ -478,7 +478,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::delete_instance call.
+    /// The request builder for [CloudMemcache::delete_instance][super::super::client::CloudMemcache::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -555,7 +555,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::apply_parameters call.
+    /// The request builder for [CloudMemcache::apply_parameters][super::super::client::CloudMemcache::apply_parameters] calls.
     #[derive(Clone, Debug)]
     pub struct ApplyParameters(RequestBuilder<crate::model::ApplyParametersRequest>);
 
@@ -652,7 +652,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::reschedule_maintenance call.
+    /// The request builder for [CloudMemcache::reschedule_maintenance][super::super::client::CloudMemcache::reschedule_maintenance] calls.
     #[derive(Clone, Debug)]
     pub struct RescheduleMaintenance(RequestBuilder<crate::model::RescheduleMaintenanceRequest>);
 
@@ -755,7 +755,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::list_locations call.
+    /// The request builder for [CloudMemcache::list_locations][super::super::client::CloudMemcache::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -833,7 +833,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::get_location call.
+    /// The request builder for [CloudMemcache::get_location][super::super::client::CloudMemcache::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -875,7 +875,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::list_operations call.
+    /// The request builder for [CloudMemcache::list_operations][super::super::client::CloudMemcache::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -953,7 +953,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::get_operation call.
+    /// The request builder for [CloudMemcache::get_operation][super::super::client::CloudMemcache::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -998,7 +998,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::delete_operation call.
+    /// The request builder for [CloudMemcache::delete_operation][super::super::client::CloudMemcache::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1043,7 +1043,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for a CloudMemcache::cancel_operation call.
+    /// The request builder for [CloudMemcache::cancel_operation][super::super::client::CloudMemcache::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/memorystore/v1/src/builder.rs
+++ b/src/generated/cloud/memorystore/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::list_instances call.
+    /// The request builder for [Memorystore::list_instances][super::super::client::Memorystore::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -148,7 +148,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::get_instance call.
+    /// The request builder for [Memorystore::get_instance][super::super::client::Memorystore::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -190,7 +190,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::create_instance call.
+    /// The request builder for [Memorystore::create_instance][super::super::client::Memorystore::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -291,7 +291,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::update_instance call.
+    /// The request builder for [Memorystore::update_instance][super::super::client::Memorystore::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -389,7 +389,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::delete_instance call.
+    /// The request builder for [Memorystore::delete_instance][super::super::client::Memorystore::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -472,7 +472,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::get_certificate_authority call.
+    /// The request builder for [Memorystore::get_certificate_authority][super::super::client::Memorystore::get_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificateAuthority(
         RequestBuilder<crate::model::GetCertificateAuthorityRequest>,
@@ -519,7 +519,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::list_locations call.
+    /// The request builder for [Memorystore::list_locations][super::super::client::Memorystore::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -597,7 +597,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::get_location call.
+    /// The request builder for [Memorystore::get_location][super::super::client::Memorystore::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -639,7 +639,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::list_operations call.
+    /// The request builder for [Memorystore::list_operations][super::super::client::Memorystore::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -717,7 +717,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::get_operation call.
+    /// The request builder for [Memorystore::get_operation][super::super::client::Memorystore::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -762,7 +762,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::delete_operation call.
+    /// The request builder for [Memorystore::delete_operation][super::super::client::Memorystore::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -807,7 +807,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for a Memorystore::cancel_operation call.
+    /// The request builder for [Memorystore::cancel_operation][super::super::client::Memorystore::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/metastore/v1/src/builder.rs
+++ b/src/generated/cloud/metastore/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::list_services call.
+    /// The request builder for [DataprocMetastore::list_services][super::super::client::DataprocMetastore::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -148,7 +148,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::get_service call.
+    /// The request builder for [DataprocMetastore::get_service][super::super::client::DataprocMetastore::get_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -190,7 +190,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::create_service call.
+    /// The request builder for [DataprocMetastore::create_service][super::super::client::DataprocMetastore::create_service] calls.
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -290,7 +290,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::update_service call.
+    /// The request builder for [DataprocMetastore::update_service][super::super::client::DataprocMetastore::update_service] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -387,7 +387,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::delete_service call.
+    /// The request builder for [DataprocMetastore::delete_service][super::super::client::DataprocMetastore::delete_service] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -470,7 +470,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::list_metadata_imports call.
+    /// The request builder for [DataprocMetastore::list_metadata_imports][super::super::client::DataprocMetastore::list_metadata_imports] calls.
     #[derive(Clone, Debug)]
     pub struct ListMetadataImports(RequestBuilder<crate::model::ListMetadataImportsRequest>);
 
@@ -554,7 +554,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::get_metadata_import call.
+    /// The request builder for [DataprocMetastore::get_metadata_import][super::super::client::DataprocMetastore::get_metadata_import] calls.
     #[derive(Clone, Debug)]
     pub struct GetMetadataImport(RequestBuilder<crate::model::GetMetadataImportRequest>);
 
@@ -599,7 +599,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::create_metadata_import call.
+    /// The request builder for [DataprocMetastore::create_metadata_import][super::super::client::DataprocMetastore::create_metadata_import] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMetadataImport(RequestBuilder<crate::model::CreateMetadataImportRequest>);
 
@@ -704,7 +704,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::update_metadata_import call.
+    /// The request builder for [DataprocMetastore::update_metadata_import][super::super::client::DataprocMetastore::update_metadata_import] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMetadataImport(RequestBuilder<crate::model::UpdateMetadataImportRequest>);
 
@@ -806,7 +806,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::export_metadata call.
+    /// The request builder for [DataprocMetastore::export_metadata][super::super::client::DataprocMetastore::export_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct ExportMetadata(RequestBuilder<crate::model::ExportMetadataRequest>);
 
@@ -913,7 +913,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::restore_service call.
+    /// The request builder for [DataprocMetastore::restore_service][super::super::client::DataprocMetastore::restore_service] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreService(RequestBuilder<crate::model::RestoreServiceRequest>);
 
@@ -1013,7 +1013,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::list_backups call.
+    /// The request builder for [DataprocMetastore::list_backups][super::super::client::DataprocMetastore::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1094,7 +1094,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::get_backup call.
+    /// The request builder for [DataprocMetastore::get_backup][super::super::client::DataprocMetastore::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1136,7 +1136,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::create_backup call.
+    /// The request builder for [DataprocMetastore::create_backup][super::super::client::DataprocMetastore::create_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -1236,7 +1236,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::delete_backup call.
+    /// The request builder for [DataprocMetastore::delete_backup][super::super::client::DataprocMetastore::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1319,7 +1319,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::query_metadata call.
+    /// The request builder for [DataprocMetastore::query_metadata][super::super::client::DataprocMetastore::query_metadata] calls.
     #[derive(Clone, Debug)]
     pub struct QueryMetadata(RequestBuilder<crate::model::QueryMetadataRequest>);
 
@@ -1408,7 +1408,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::move_table_to_database call.
+    /// The request builder for [DataprocMetastore::move_table_to_database][super::super::client::DataprocMetastore::move_table_to_database] calls.
     #[derive(Clone, Debug)]
     pub struct MoveTableToDatabase(RequestBuilder<crate::model::MoveTableToDatabaseRequest>);
 
@@ -1512,7 +1512,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::alter_metadata_resource_location call.
+    /// The request builder for [DataprocMetastore::alter_metadata_resource_location][super::super::client::DataprocMetastore::alter_metadata_resource_location] calls.
     #[derive(Clone, Debug)]
     pub struct AlterMetadataResourceLocation(
         RequestBuilder<crate::model::AlterMetadataResourceLocationRequest>,
@@ -1614,7 +1614,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::list_locations call.
+    /// The request builder for [DataprocMetastore::list_locations][super::super::client::DataprocMetastore::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1692,7 +1692,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::get_location call.
+    /// The request builder for [DataprocMetastore::get_location][super::super::client::DataprocMetastore::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1734,7 +1734,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::set_iam_policy call.
+    /// The request builder for [DataprocMetastore::set_iam_policy][super::super::client::DataprocMetastore::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1794,7 +1794,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::get_iam_policy call.
+    /// The request builder for [DataprocMetastore::get_iam_policy][super::super::client::DataprocMetastore::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1845,7 +1845,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::test_iam_permissions call.
+    /// The request builder for [DataprocMetastore::test_iam_permissions][super::super::client::DataprocMetastore::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1901,7 +1901,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::list_operations call.
+    /// The request builder for [DataprocMetastore::list_operations][super::super::client::DataprocMetastore::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1979,7 +1979,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::get_operation call.
+    /// The request builder for [DataprocMetastore::get_operation][super::super::client::DataprocMetastore::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2024,7 +2024,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::delete_operation call.
+    /// The request builder for [DataprocMetastore::delete_operation][super::super::client::DataprocMetastore::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2069,7 +2069,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for a DataprocMetastore::cancel_operation call.
+    /// The request builder for [DataprocMetastore::cancel_operation][super::super::client::DataprocMetastore::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2170,7 +2170,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::list_federations call.
+    /// The request builder for [DataprocMetastoreFederation::list_federations][super::super::client::DataprocMetastoreFederation::list_federations] calls.
     #[derive(Clone, Debug)]
     pub struct ListFederations(RequestBuilder<crate::model::ListFederationsRequest>);
 
@@ -2253,7 +2253,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::get_federation call.
+    /// The request builder for [DataprocMetastoreFederation::get_federation][super::super::client::DataprocMetastoreFederation::get_federation] calls.
     #[derive(Clone, Debug)]
     pub struct GetFederation(RequestBuilder<crate::model::GetFederationRequest>);
 
@@ -2297,7 +2297,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::create_federation call.
+    /// The request builder for [DataprocMetastoreFederation::create_federation][super::super::client::DataprocMetastoreFederation::create_federation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFederation(RequestBuilder<crate::model::CreateFederationRequest>);
 
@@ -2403,7 +2403,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::update_federation call.
+    /// The request builder for [DataprocMetastoreFederation::update_federation][super::super::client::DataprocMetastoreFederation::update_federation] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFederation(RequestBuilder<crate::model::UpdateFederationRequest>);
 
@@ -2506,7 +2506,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::delete_federation call.
+    /// The request builder for [DataprocMetastoreFederation::delete_federation][super::super::client::DataprocMetastoreFederation::delete_federation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFederation(RequestBuilder<crate::model::DeleteFederationRequest>);
 
@@ -2594,7 +2594,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::list_locations call.
+    /// The request builder for [DataprocMetastoreFederation::list_locations][super::super::client::DataprocMetastoreFederation::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2674,7 +2674,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::get_location call.
+    /// The request builder for [DataprocMetastoreFederation::get_location][super::super::client::DataprocMetastoreFederation::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2718,7 +2718,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::set_iam_policy call.
+    /// The request builder for [DataprocMetastoreFederation::set_iam_policy][super::super::client::DataprocMetastoreFederation::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2780,7 +2780,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::get_iam_policy call.
+    /// The request builder for [DataprocMetastoreFederation::get_iam_policy][super::super::client::DataprocMetastoreFederation::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2833,7 +2833,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::test_iam_permissions call.
+    /// The request builder for [DataprocMetastoreFederation::test_iam_permissions][super::super::client::DataprocMetastoreFederation::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2891,7 +2891,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::list_operations call.
+    /// The request builder for [DataprocMetastoreFederation::list_operations][super::super::client::DataprocMetastoreFederation::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2971,7 +2971,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::get_operation call.
+    /// The request builder for [DataprocMetastoreFederation::get_operation][super::super::client::DataprocMetastoreFederation::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3018,7 +3018,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::delete_operation call.
+    /// The request builder for [DataprocMetastoreFederation::delete_operation][super::super::client::DataprocMetastoreFederation::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3065,7 +3065,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for a DataprocMetastoreFederation::cancel_operation call.
+    /// The request builder for [DataprocMetastoreFederation::cancel_operation][super::super::client::DataprocMetastoreFederation::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/migrationcenter/v1/src/builder.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_assets call.
+    /// The request builder for [MigrationCenter::list_assets][super::super::client::MigrationCenter::list_assets] calls.
     #[derive(Clone, Debug)]
     pub struct ListAssets(RequestBuilder<crate::model::ListAssetsRequest>);
 
@@ -154,7 +154,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_asset call.
+    /// The request builder for [MigrationCenter::get_asset][super::super::client::MigrationCenter::get_asset] calls.
     #[derive(Clone, Debug)]
     pub struct GetAsset(RequestBuilder<crate::model::GetAssetRequest>);
 
@@ -202,7 +202,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::update_asset call.
+    /// The request builder for [MigrationCenter::update_asset][super::super::client::MigrationCenter::update_asset] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAsset(RequestBuilder<crate::model::UpdateAssetRequest>);
 
@@ -262,7 +262,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::batch_update_assets call.
+    /// The request builder for [MigrationCenter::batch_update_assets][super::super::client::MigrationCenter::batch_update_assets] calls.
     #[derive(Clone, Debug)]
     pub struct BatchUpdateAssets(RequestBuilder<crate::model::BatchUpdateAssetsRequest>);
 
@@ -318,7 +318,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_asset call.
+    /// The request builder for [MigrationCenter::delete_asset][super::super::client::MigrationCenter::delete_asset] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAsset(RequestBuilder<crate::model::DeleteAssetRequest>);
 
@@ -366,7 +366,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::batch_delete_assets call.
+    /// The request builder for [MigrationCenter::batch_delete_assets][super::super::client::MigrationCenter::batch_delete_assets] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeleteAssets(RequestBuilder<crate::model::BatchDeleteAssetsRequest>);
 
@@ -428,7 +428,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::report_asset_frames call.
+    /// The request builder for [MigrationCenter::report_asset_frames][super::super::client::MigrationCenter::report_asset_frames] calls.
     #[derive(Clone, Debug)]
     pub struct ReportAssetFrames(RequestBuilder<crate::model::ReportAssetFramesRequest>);
 
@@ -488,7 +488,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::aggregate_assets_values call.
+    /// The request builder for [MigrationCenter::aggregate_assets_values][super::super::client::MigrationCenter::aggregate_assets_values] calls.
     #[derive(Clone, Debug)]
     pub struct AggregateAssetsValues(RequestBuilder<crate::model::AggregateAssetsValuesRequest>);
 
@@ -550,7 +550,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::create_import_job call.
+    /// The request builder for [MigrationCenter::create_import_job][super::super::client::MigrationCenter::create_import_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateImportJob(RequestBuilder<crate::model::CreateImportJobRequest>);
 
@@ -651,7 +651,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_import_jobs call.
+    /// The request builder for [MigrationCenter::list_import_jobs][super::super::client::MigrationCenter::list_import_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListImportJobs(RequestBuilder<crate::model::ListImportJobsRequest>);
 
@@ -738,7 +738,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_import_job call.
+    /// The request builder for [MigrationCenter::get_import_job][super::super::client::MigrationCenter::get_import_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetImportJob(RequestBuilder<crate::model::GetImportJobRequest>);
 
@@ -786,7 +786,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_import_job call.
+    /// The request builder for [MigrationCenter::delete_import_job][super::super::client::MigrationCenter::delete_import_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteImportJob(RequestBuilder<crate::model::DeleteImportJobRequest>);
 
@@ -875,7 +875,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::update_import_job call.
+    /// The request builder for [MigrationCenter::update_import_job][super::super::client::MigrationCenter::update_import_job] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateImportJob(RequestBuilder<crate::model::UpdateImportJobRequest>);
 
@@ -973,7 +973,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::validate_import_job call.
+    /// The request builder for [MigrationCenter::validate_import_job][super::super::client::MigrationCenter::validate_import_job] calls.
     #[derive(Clone, Debug)]
     pub struct ValidateImportJob(RequestBuilder<crate::model::ValidateImportJobRequest>);
 
@@ -1059,7 +1059,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::run_import_job call.
+    /// The request builder for [MigrationCenter::run_import_job][super::super::client::MigrationCenter::run_import_job] calls.
     #[derive(Clone, Debug)]
     pub struct RunImportJob(RequestBuilder<crate::model::RunImportJobRequest>);
 
@@ -1142,7 +1142,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_import_data_file call.
+    /// The request builder for [MigrationCenter::get_import_data_file][super::super::client::MigrationCenter::get_import_data_file] calls.
     #[derive(Clone, Debug)]
     pub struct GetImportDataFile(RequestBuilder<crate::model::GetImportDataFileRequest>);
 
@@ -1187,7 +1187,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_import_data_files call.
+    /// The request builder for [MigrationCenter::list_import_data_files][super::super::client::MigrationCenter::list_import_data_files] calls.
     #[derive(Clone, Debug)]
     pub struct ListImportDataFiles(RequestBuilder<crate::model::ListImportDataFilesRequest>);
 
@@ -1271,7 +1271,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::create_import_data_file call.
+    /// The request builder for [MigrationCenter::create_import_data_file][super::super::client::MigrationCenter::create_import_data_file] calls.
     #[derive(Clone, Debug)]
     pub struct CreateImportDataFile(RequestBuilder<crate::model::CreateImportDataFileRequest>);
 
@@ -1376,7 +1376,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_import_data_file call.
+    /// The request builder for [MigrationCenter::delete_import_data_file][super::super::client::MigrationCenter::delete_import_data_file] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteImportDataFile(RequestBuilder<crate::model::DeleteImportDataFileRequest>);
 
@@ -1462,7 +1462,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_groups call.
+    /// The request builder for [MigrationCenter::list_groups][super::super::client::MigrationCenter::list_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListGroups(RequestBuilder<crate::model::ListGroupsRequest>);
 
@@ -1543,7 +1543,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_group call.
+    /// The request builder for [MigrationCenter::get_group][super::super::client::MigrationCenter::get_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetGroup(RequestBuilder<crate::model::GetGroupRequest>);
 
@@ -1585,7 +1585,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::create_group call.
+    /// The request builder for [MigrationCenter::create_group][super::super::client::MigrationCenter::create_group] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGroup(RequestBuilder<crate::model::CreateGroupRequest>);
 
@@ -1685,7 +1685,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::update_group call.
+    /// The request builder for [MigrationCenter::update_group][super::super::client::MigrationCenter::update_group] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGroup(RequestBuilder<crate::model::UpdateGroupRequest>);
 
@@ -1782,7 +1782,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_group call.
+    /// The request builder for [MigrationCenter::delete_group][super::super::client::MigrationCenter::delete_group] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGroup(RequestBuilder<crate::model::DeleteGroupRequest>);
 
@@ -1865,7 +1865,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::add_assets_to_group call.
+    /// The request builder for [MigrationCenter::add_assets_to_group][super::super::client::MigrationCenter::add_assets_to_group] calls.
     #[derive(Clone, Debug)]
     pub struct AddAssetsToGroup(RequestBuilder<crate::model::AddAssetsToGroupRequest>);
 
@@ -1968,7 +1968,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::remove_assets_from_group call.
+    /// The request builder for [MigrationCenter::remove_assets_from_group][super::super::client::MigrationCenter::remove_assets_from_group] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveAssetsFromGroup(RequestBuilder<crate::model::RemoveAssetsFromGroupRequest>);
 
@@ -2071,7 +2071,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_error_frames call.
+    /// The request builder for [MigrationCenter::list_error_frames][super::super::client::MigrationCenter::list_error_frames] calls.
     #[derive(Clone, Debug)]
     pub struct ListErrorFrames(RequestBuilder<crate::model::ListErrorFramesRequest>);
 
@@ -2146,7 +2146,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_error_frame call.
+    /// The request builder for [MigrationCenter::get_error_frame][super::super::client::MigrationCenter::get_error_frame] calls.
     #[derive(Clone, Debug)]
     pub struct GetErrorFrame(RequestBuilder<crate::model::GetErrorFrameRequest>);
 
@@ -2194,7 +2194,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_sources call.
+    /// The request builder for [MigrationCenter::list_sources][super::super::client::MigrationCenter::list_sources] calls.
     #[derive(Clone, Debug)]
     pub struct ListSources(RequestBuilder<crate::model::ListSourcesRequest>);
 
@@ -2275,7 +2275,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_source call.
+    /// The request builder for [MigrationCenter::get_source][super::super::client::MigrationCenter::get_source] calls.
     #[derive(Clone, Debug)]
     pub struct GetSource(RequestBuilder<crate::model::GetSourceRequest>);
 
@@ -2317,7 +2317,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::create_source call.
+    /// The request builder for [MigrationCenter::create_source][super::super::client::MigrationCenter::create_source] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSource(RequestBuilder<crate::model::CreateSourceRequest>);
 
@@ -2417,7 +2417,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::update_source call.
+    /// The request builder for [MigrationCenter::update_source][super::super::client::MigrationCenter::update_source] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSource(RequestBuilder<crate::model::UpdateSourceRequest>);
 
@@ -2514,7 +2514,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_source call.
+    /// The request builder for [MigrationCenter::delete_source][super::super::client::MigrationCenter::delete_source] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSource(RequestBuilder<crate::model::DeleteSourceRequest>);
 
@@ -2597,7 +2597,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_preference_sets call.
+    /// The request builder for [MigrationCenter::list_preference_sets][super::super::client::MigrationCenter::list_preference_sets] calls.
     #[derive(Clone, Debug)]
     pub struct ListPreferenceSets(RequestBuilder<crate::model::ListPreferenceSetsRequest>);
 
@@ -2675,7 +2675,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_preference_set call.
+    /// The request builder for [MigrationCenter::get_preference_set][super::super::client::MigrationCenter::get_preference_set] calls.
     #[derive(Clone, Debug)]
     pub struct GetPreferenceSet(RequestBuilder<crate::model::GetPreferenceSetRequest>);
 
@@ -2720,7 +2720,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::create_preference_set call.
+    /// The request builder for [MigrationCenter::create_preference_set][super::super::client::MigrationCenter::create_preference_set] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePreferenceSet(RequestBuilder<crate::model::CreatePreferenceSetRequest>);
 
@@ -2825,7 +2825,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::update_preference_set call.
+    /// The request builder for [MigrationCenter::update_preference_set][super::super::client::MigrationCenter::update_preference_set] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePreferenceSet(RequestBuilder<crate::model::UpdatePreferenceSetRequest>);
 
@@ -2927,7 +2927,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_preference_set call.
+    /// The request builder for [MigrationCenter::delete_preference_set][super::super::client::MigrationCenter::delete_preference_set] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePreferenceSet(RequestBuilder<crate::model::DeletePreferenceSetRequest>);
 
@@ -3013,7 +3013,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_settings call.
+    /// The request builder for [MigrationCenter::get_settings][super::super::client::MigrationCenter::get_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetSettings(RequestBuilder<crate::model::GetSettingsRequest>);
 
@@ -3055,7 +3055,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::update_settings call.
+    /// The request builder for [MigrationCenter::update_settings][super::super::client::MigrationCenter::update_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSettings(RequestBuilder<crate::model::UpdateSettingsRequest>);
 
@@ -3153,7 +3153,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::create_report_config call.
+    /// The request builder for [MigrationCenter::create_report_config][super::super::client::MigrationCenter::create_report_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateReportConfig(RequestBuilder<crate::model::CreateReportConfigRequest>);
 
@@ -3257,7 +3257,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_report_config call.
+    /// The request builder for [MigrationCenter::get_report_config][super::super::client::MigrationCenter::get_report_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetReportConfig(RequestBuilder<crate::model::GetReportConfigRequest>);
 
@@ -3299,7 +3299,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_report_configs call.
+    /// The request builder for [MigrationCenter::list_report_configs][super::super::client::MigrationCenter::list_report_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListReportConfigs(RequestBuilder<crate::model::ListReportConfigsRequest>);
 
@@ -3383,7 +3383,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_report_config call.
+    /// The request builder for [MigrationCenter::delete_report_config][super::super::client::MigrationCenter::delete_report_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteReportConfig(RequestBuilder<crate::model::DeleteReportConfigRequest>);
 
@@ -3475,7 +3475,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::create_report call.
+    /// The request builder for [MigrationCenter::create_report][super::super::client::MigrationCenter::create_report] calls.
     #[derive(Clone, Debug)]
     pub struct CreateReport(RequestBuilder<crate::model::CreateReportRequest>);
 
@@ -3575,7 +3575,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_report call.
+    /// The request builder for [MigrationCenter::get_report][super::super::client::MigrationCenter::get_report] calls.
     #[derive(Clone, Debug)]
     pub struct GetReport(RequestBuilder<crate::model::GetReportRequest>);
 
@@ -3623,7 +3623,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_reports call.
+    /// The request builder for [MigrationCenter::list_reports][super::super::client::MigrationCenter::list_reports] calls.
     #[derive(Clone, Debug)]
     pub struct ListReports(RequestBuilder<crate::model::ListReportsRequest>);
 
@@ -3710,7 +3710,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_report call.
+    /// The request builder for [MigrationCenter::delete_report][super::super::client::MigrationCenter::delete_report] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteReport(RequestBuilder<crate::model::DeleteReportRequest>);
 
@@ -3793,7 +3793,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_locations call.
+    /// The request builder for [MigrationCenter::list_locations][super::super::client::MigrationCenter::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3871,7 +3871,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_location call.
+    /// The request builder for [MigrationCenter::get_location][super::super::client::MigrationCenter::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3913,7 +3913,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::list_operations call.
+    /// The request builder for [MigrationCenter::list_operations][super::super::client::MigrationCenter::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3991,7 +3991,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::get_operation call.
+    /// The request builder for [MigrationCenter::get_operation][super::super::client::MigrationCenter::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4036,7 +4036,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::delete_operation call.
+    /// The request builder for [MigrationCenter::delete_operation][super::super::client::MigrationCenter::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4081,7 +4081,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for a MigrationCenter::cancel_operation call.
+    /// The request builder for [MigrationCenter::cancel_operation][super::super::client::MigrationCenter::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/modelarmor/v1/src/builder.rs
+++ b/src/generated/cloud/modelarmor/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::list_templates call.
+    /// The request builder for [ModelArmor::list_templates][super::super::client::ModelArmor::list_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListTemplates(RequestBuilder<crate::model::ListTemplatesRequest>);
 
@@ -148,7 +148,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::get_template call.
+    /// The request builder for [ModelArmor::get_template][super::super::client::ModelArmor::get_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetTemplate(RequestBuilder<crate::model::GetTemplateRequest>);
 
@@ -190,7 +190,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::create_template call.
+    /// The request builder for [ModelArmor::create_template][super::super::client::ModelArmor::create_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTemplate(RequestBuilder<crate::model::CreateTemplateRequest>);
 
@@ -253,7 +253,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::update_template call.
+    /// The request builder for [ModelArmor::update_template][super::super::client::ModelArmor::update_template] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTemplate(RequestBuilder<crate::model::UpdateTemplateRequest>);
 
@@ -313,7 +313,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::delete_template call.
+    /// The request builder for [ModelArmor::delete_template][super::super::client::ModelArmor::delete_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTemplate(RequestBuilder<crate::model::DeleteTemplateRequest>);
 
@@ -361,7 +361,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::get_floor_setting call.
+    /// The request builder for [ModelArmor::get_floor_setting][super::super::client::ModelArmor::get_floor_setting] calls.
     #[derive(Clone, Debug)]
     pub struct GetFloorSetting(RequestBuilder<crate::model::GetFloorSettingRequest>);
 
@@ -403,7 +403,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::update_floor_setting call.
+    /// The request builder for [ModelArmor::update_floor_setting][super::super::client::ModelArmor::update_floor_setting] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFloorSetting(RequestBuilder<crate::model::UpdateFloorSettingRequest>);
 
@@ -460,7 +460,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::sanitize_user_prompt call.
+    /// The request builder for [ModelArmor::sanitize_user_prompt][super::super::client::ModelArmor::sanitize_user_prompt] calls.
     #[derive(Clone, Debug)]
     pub struct SanitizeUserPrompt(RequestBuilder<crate::model::SanitizeUserPromptRequest>);
 
@@ -514,7 +514,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::sanitize_model_response call.
+    /// The request builder for [ModelArmor::sanitize_model_response][super::super::client::ModelArmor::sanitize_model_response] calls.
     #[derive(Clone, Debug)]
     pub struct SanitizeModelResponse(RequestBuilder<crate::model::SanitizeModelResponseRequest>);
 
@@ -574,7 +574,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::list_locations call.
+    /// The request builder for [ModelArmor::list_locations][super::super::client::ModelArmor::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -652,7 +652,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for a ModelArmor::get_location call.
+    /// The request builder for [ModelArmor::get_location][super::super::client::ModelArmor::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/netapp/v1/src/builder.rs
+++ b/src/generated/cloud/netapp/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_storage_pools call.
+    /// The request builder for [NetApp::list_storage_pools][super::super::client::NetApp::list_storage_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListStoragePools(RequestBuilder<crate::model::ListStoragePoolsRequest>);
 
@@ -151,7 +151,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_storage_pool call.
+    /// The request builder for [NetApp::create_storage_pool][super::super::client::NetApp::create_storage_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateStoragePool(RequestBuilder<crate::model::CreateStoragePoolRequest>);
 
@@ -249,7 +249,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_storage_pool call.
+    /// The request builder for [NetApp::get_storage_pool][super::super::client::NetApp::get_storage_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetStoragePool(RequestBuilder<crate::model::GetStoragePoolRequest>);
 
@@ -291,7 +291,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_storage_pool call.
+    /// The request builder for [NetApp::update_storage_pool][super::super::client::NetApp::update_storage_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateStoragePool(RequestBuilder<crate::model::UpdateStoragePoolRequest>);
 
@@ -386,7 +386,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_storage_pool call.
+    /// The request builder for [NetApp::delete_storage_pool][super::super::client::NetApp::delete_storage_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteStoragePool(RequestBuilder<crate::model::DeleteStoragePoolRequest>);
 
@@ -466,7 +466,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::validate_directory_service call.
+    /// The request builder for [NetApp::validate_directory_service][super::super::client::NetApp::validate_directory_service] calls.
     #[derive(Clone, Debug)]
     pub struct ValidateDirectoryService(
         RequestBuilder<crate::model::ValidateDirectoryServiceRequest>,
@@ -557,7 +557,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::switch_active_replica_zone call.
+    /// The request builder for [NetApp::switch_active_replica_zone][super::super::client::NetApp::switch_active_replica_zone] calls.
     #[derive(Clone, Debug)]
     pub struct SwitchActiveReplicaZone(
         RequestBuilder<crate::model::SwitchActiveReplicaZoneRequest>,
@@ -642,7 +642,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_volumes call.
+    /// The request builder for [NetApp::list_volumes][super::super::client::NetApp::list_volumes] calls.
     #[derive(Clone, Debug)]
     pub struct ListVolumes(RequestBuilder<crate::model::ListVolumesRequest>);
 
@@ -723,7 +723,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_volume call.
+    /// The request builder for [NetApp::get_volume][super::super::client::NetApp::get_volume] calls.
     #[derive(Clone, Debug)]
     pub struct GetVolume(RequestBuilder<crate::model::GetVolumeRequest>);
 
@@ -765,7 +765,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_volume call.
+    /// The request builder for [NetApp::create_volume][super::super::client::NetApp::create_volume] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVolume(RequestBuilder<crate::model::CreateVolumeRequest>);
 
@@ -859,7 +859,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_volume call.
+    /// The request builder for [NetApp::update_volume][super::super::client::NetApp::update_volume] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVolume(RequestBuilder<crate::model::UpdateVolumeRequest>);
 
@@ -950,7 +950,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_volume call.
+    /// The request builder for [NetApp::delete_volume][super::super::client::NetApp::delete_volume] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVolume(RequestBuilder<crate::model::DeleteVolumeRequest>);
 
@@ -1033,7 +1033,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::revert_volume call.
+    /// The request builder for [NetApp::revert_volume][super::super::client::NetApp::revert_volume] calls.
     #[derive(Clone, Debug)]
     pub struct RevertVolume(RequestBuilder<crate::model::RevertVolumeRequest>);
 
@@ -1118,7 +1118,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_snapshots call.
+    /// The request builder for [NetApp::list_snapshots][super::super::client::NetApp::list_snapshots] calls.
     #[derive(Clone, Debug)]
     pub struct ListSnapshots(RequestBuilder<crate::model::ListSnapshotsRequest>);
 
@@ -1199,7 +1199,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_snapshot call.
+    /// The request builder for [NetApp::get_snapshot][super::super::client::NetApp::get_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct GetSnapshot(RequestBuilder<crate::model::GetSnapshotRequest>);
 
@@ -1241,7 +1241,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_snapshot call.
+    /// The request builder for [NetApp::create_snapshot][super::super::client::NetApp::create_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSnapshot(RequestBuilder<crate::model::CreateSnapshotRequest>);
 
@@ -1336,7 +1336,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_snapshot call.
+    /// The request builder for [NetApp::delete_snapshot][super::super::client::NetApp::delete_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSnapshot(RequestBuilder<crate::model::DeleteSnapshotRequest>);
 
@@ -1413,7 +1413,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_snapshot call.
+    /// The request builder for [NetApp::update_snapshot][super::super::client::NetApp::update_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSnapshot(RequestBuilder<crate::model::UpdateSnapshotRequest>);
 
@@ -1505,7 +1505,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_active_directories call.
+    /// The request builder for [NetApp::list_active_directories][super::super::client::NetApp::list_active_directories] calls.
     #[derive(Clone, Debug)]
     pub struct ListActiveDirectories(RequestBuilder<crate::model::ListActiveDirectoriesRequest>);
 
@@ -1589,7 +1589,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_active_directory call.
+    /// The request builder for [NetApp::get_active_directory][super::super::client::NetApp::get_active_directory] calls.
     #[derive(Clone, Debug)]
     pub struct GetActiveDirectory(RequestBuilder<crate::model::GetActiveDirectoryRequest>);
 
@@ -1634,7 +1634,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_active_directory call.
+    /// The request builder for [NetApp::create_active_directory][super::super::client::NetApp::create_active_directory] calls.
     #[derive(Clone, Debug)]
     pub struct CreateActiveDirectory(RequestBuilder<crate::model::CreateActiveDirectoryRequest>);
 
@@ -1733,7 +1733,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_active_directory call.
+    /// The request builder for [NetApp::update_active_directory][super::super::client::NetApp::update_active_directory] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateActiveDirectory(RequestBuilder<crate::model::UpdateActiveDirectoryRequest>);
 
@@ -1829,7 +1829,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_active_directory call.
+    /// The request builder for [NetApp::delete_active_directory][super::super::client::NetApp::delete_active_directory] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteActiveDirectory(RequestBuilder<crate::model::DeleteActiveDirectoryRequest>);
 
@@ -1909,7 +1909,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_kms_configs call.
+    /// The request builder for [NetApp::list_kms_configs][super::super::client::NetApp::list_kms_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListKmsConfigs(RequestBuilder<crate::model::ListKmsConfigsRequest>);
 
@@ -1990,7 +1990,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_kms_config call.
+    /// The request builder for [NetApp::create_kms_config][super::super::client::NetApp::create_kms_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateKmsConfig(RequestBuilder<crate::model::CreateKmsConfigRequest>);
 
@@ -2085,7 +2085,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_kms_config call.
+    /// The request builder for [NetApp::get_kms_config][super::super::client::NetApp::get_kms_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetKmsConfig(RequestBuilder<crate::model::GetKmsConfigRequest>);
 
@@ -2127,7 +2127,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_kms_config call.
+    /// The request builder for [NetApp::update_kms_config][super::super::client::NetApp::update_kms_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateKmsConfig(RequestBuilder<crate::model::UpdateKmsConfigRequest>);
 
@@ -2219,7 +2219,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::encrypt_volumes call.
+    /// The request builder for [NetApp::encrypt_volumes][super::super::client::NetApp::encrypt_volumes] calls.
     #[derive(Clone, Debug)]
     pub struct EncryptVolumes(RequestBuilder<crate::model::EncryptVolumesRequest>);
 
@@ -2299,7 +2299,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::verify_kms_config call.
+    /// The request builder for [NetApp::verify_kms_config][super::super::client::NetApp::verify_kms_config] calls.
     #[derive(Clone, Debug)]
     pub struct VerifyKmsConfig(RequestBuilder<crate::model::VerifyKmsConfigRequest>);
 
@@ -2341,7 +2341,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_kms_config call.
+    /// The request builder for [NetApp::delete_kms_config][super::super::client::NetApp::delete_kms_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteKmsConfig(RequestBuilder<crate::model::DeleteKmsConfigRequest>);
 
@@ -2418,7 +2418,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_replications call.
+    /// The request builder for [NetApp::list_replications][super::super::client::NetApp::list_replications] calls.
     #[derive(Clone, Debug)]
     pub struct ListReplications(RequestBuilder<crate::model::ListReplicationsRequest>);
 
@@ -2502,7 +2502,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_replication call.
+    /// The request builder for [NetApp::get_replication][super::super::client::NetApp::get_replication] calls.
     #[derive(Clone, Debug)]
     pub struct GetReplication(RequestBuilder<crate::model::GetReplicationRequest>);
 
@@ -2544,7 +2544,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_replication call.
+    /// The request builder for [NetApp::create_replication][super::super::client::NetApp::create_replication] calls.
     #[derive(Clone, Debug)]
     pub struct CreateReplication(RequestBuilder<crate::model::CreateReplicationRequest>);
 
@@ -2642,7 +2642,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_replication call.
+    /// The request builder for [NetApp::delete_replication][super::super::client::NetApp::delete_replication] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteReplication(RequestBuilder<crate::model::DeleteReplicationRequest>);
 
@@ -2722,7 +2722,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_replication call.
+    /// The request builder for [NetApp::update_replication][super::super::client::NetApp::update_replication] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateReplication(RequestBuilder<crate::model::UpdateReplicationRequest>);
 
@@ -2817,7 +2817,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::stop_replication call.
+    /// The request builder for [NetApp::stop_replication][super::super::client::NetApp::stop_replication] calls.
     #[derive(Clone, Debug)]
     pub struct StopReplication(RequestBuilder<crate::model::StopReplicationRequest>);
 
@@ -2903,7 +2903,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::resume_replication call.
+    /// The request builder for [NetApp::resume_replication][super::super::client::NetApp::resume_replication] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeReplication(RequestBuilder<crate::model::ResumeReplicationRequest>);
 
@@ -2986,7 +2986,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::reverse_replication_direction call.
+    /// The request builder for [NetApp::reverse_replication_direction][super::super::client::NetApp::reverse_replication_direction] calls.
     #[derive(Clone, Debug)]
     pub struct ReverseReplicationDirection(
         RequestBuilder<crate::model::ReverseReplicationDirectionRequest>,
@@ -3071,7 +3071,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::establish_peering call.
+    /// The request builder for [NetApp::establish_peering][super::super::client::NetApp::establish_peering] calls.
     #[derive(Clone, Debug)]
     pub struct EstablishPeering(RequestBuilder<crate::model::EstablishPeeringRequest>);
 
@@ -3183,7 +3183,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::sync_replication call.
+    /// The request builder for [NetApp::sync_replication][super::super::client::NetApp::sync_replication] calls.
     #[derive(Clone, Debug)]
     pub struct SyncReplication(RequestBuilder<crate::model::SyncReplicationRequest>);
 
@@ -3263,7 +3263,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_backup_vault call.
+    /// The request builder for [NetApp::create_backup_vault][super::super::client::NetApp::create_backup_vault] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackupVault(RequestBuilder<crate::model::CreateBackupVaultRequest>);
 
@@ -3361,7 +3361,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_backup_vault call.
+    /// The request builder for [NetApp::get_backup_vault][super::super::client::NetApp::get_backup_vault] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupVault(RequestBuilder<crate::model::GetBackupVaultRequest>);
 
@@ -3403,7 +3403,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_backup_vaults call.
+    /// The request builder for [NetApp::list_backup_vaults][super::super::client::NetApp::list_backup_vaults] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupVaults(RequestBuilder<crate::model::ListBackupVaultsRequest>);
 
@@ -3487,7 +3487,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_backup_vault call.
+    /// The request builder for [NetApp::update_backup_vault][super::super::client::NetApp::update_backup_vault] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackupVault(RequestBuilder<crate::model::UpdateBackupVaultRequest>);
 
@@ -3582,7 +3582,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_backup_vault call.
+    /// The request builder for [NetApp::delete_backup_vault][super::super::client::NetApp::delete_backup_vault] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackupVault(RequestBuilder<crate::model::DeleteBackupVaultRequest>);
 
@@ -3662,7 +3662,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_backup call.
+    /// The request builder for [NetApp::create_backup][super::super::client::NetApp::create_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -3756,7 +3756,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_backup call.
+    /// The request builder for [NetApp::get_backup][super::super::client::NetApp::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -3798,7 +3798,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_backups call.
+    /// The request builder for [NetApp::list_backups][super::super::client::NetApp::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -3879,7 +3879,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_backup call.
+    /// The request builder for [NetApp::delete_backup][super::super::client::NetApp::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -3956,7 +3956,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_backup call.
+    /// The request builder for [NetApp::update_backup][super::super::client::NetApp::update_backup] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -4047,7 +4047,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_backup_policy call.
+    /// The request builder for [NetApp::create_backup_policy][super::super::client::NetApp::create_backup_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackupPolicy(RequestBuilder<crate::model::CreateBackupPolicyRequest>);
 
@@ -4145,7 +4145,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_backup_policy call.
+    /// The request builder for [NetApp::get_backup_policy][super::super::client::NetApp::get_backup_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupPolicy(RequestBuilder<crate::model::GetBackupPolicyRequest>);
 
@@ -4187,7 +4187,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_backup_policies call.
+    /// The request builder for [NetApp::list_backup_policies][super::super::client::NetApp::list_backup_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupPolicies(RequestBuilder<crate::model::ListBackupPoliciesRequest>);
 
@@ -4271,7 +4271,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_backup_policy call.
+    /// The request builder for [NetApp::update_backup_policy][super::super::client::NetApp::update_backup_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackupPolicy(RequestBuilder<crate::model::UpdateBackupPolicyRequest>);
 
@@ -4366,7 +4366,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_backup_policy call.
+    /// The request builder for [NetApp::delete_backup_policy][super::super::client::NetApp::delete_backup_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackupPolicy(RequestBuilder<crate::model::DeleteBackupPolicyRequest>);
 
@@ -4446,7 +4446,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_quota_rules call.
+    /// The request builder for [NetApp::list_quota_rules][super::super::client::NetApp::list_quota_rules] calls.
     #[derive(Clone, Debug)]
     pub struct ListQuotaRules(RequestBuilder<crate::model::ListQuotaRulesRequest>);
 
@@ -4527,7 +4527,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_quota_rule call.
+    /// The request builder for [NetApp::get_quota_rule][super::super::client::NetApp::get_quota_rule] calls.
     #[derive(Clone, Debug)]
     pub struct GetQuotaRule(RequestBuilder<crate::model::GetQuotaRuleRequest>);
 
@@ -4569,7 +4569,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::create_quota_rule call.
+    /// The request builder for [NetApp::create_quota_rule][super::super::client::NetApp::create_quota_rule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateQuotaRule(RequestBuilder<crate::model::CreateQuotaRuleRequest>);
 
@@ -4664,7 +4664,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::update_quota_rule call.
+    /// The request builder for [NetApp::update_quota_rule][super::super::client::NetApp::update_quota_rule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateQuotaRule(RequestBuilder<crate::model::UpdateQuotaRuleRequest>);
 
@@ -4756,7 +4756,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_quota_rule call.
+    /// The request builder for [NetApp::delete_quota_rule][super::super::client::NetApp::delete_quota_rule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteQuotaRule(RequestBuilder<crate::model::DeleteQuotaRuleRequest>);
 
@@ -4833,7 +4833,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_locations call.
+    /// The request builder for [NetApp::list_locations][super::super::client::NetApp::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4911,7 +4911,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_location call.
+    /// The request builder for [NetApp::get_location][super::super::client::NetApp::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4953,7 +4953,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::list_operations call.
+    /// The request builder for [NetApp::list_operations][super::super::client::NetApp::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5031,7 +5031,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::get_operation call.
+    /// The request builder for [NetApp::get_operation][super::super::client::NetApp::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5076,7 +5076,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::delete_operation call.
+    /// The request builder for [NetApp::delete_operation][super::super::client::NetApp::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5121,7 +5121,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for a NetApp::cancel_operation call.
+    /// The request builder for [NetApp::cancel_operation][super::super::client::NetApp::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/networkconnectivity/v1/src/builder.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::list_service_connection_maps call.
+    /// The request builder for [CrossNetworkAutomationService::list_service_connection_maps][super::super::client::CrossNetworkAutomationService::list_service_connection_maps] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceConnectionMaps(
         RequestBuilder<crate::model::ListServiceConnectionMapsRequest>,
@@ -159,7 +159,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::get_service_connection_map call.
+    /// The request builder for [CrossNetworkAutomationService::get_service_connection_map][super::super::client::CrossNetworkAutomationService::get_service_connection_map] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceConnectionMap(
         RequestBuilder<crate::model::GetServiceConnectionMapRequest>,
@@ -208,7 +208,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::create_service_connection_map call.
+    /// The request builder for [CrossNetworkAutomationService::create_service_connection_map][super::super::client::CrossNetworkAutomationService::create_service_connection_map] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceConnectionMap(
         RequestBuilder<crate::model::CreateServiceConnectionMapRequest>,
@@ -319,7 +319,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::update_service_connection_map call.
+    /// The request builder for [CrossNetworkAutomationService::update_service_connection_map][super::super::client::CrossNetworkAutomationService::update_service_connection_map] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServiceConnectionMap(
         RequestBuilder<crate::model::UpdateServiceConnectionMapRequest>,
@@ -427,7 +427,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::delete_service_connection_map call.
+    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_map][super::super::client::CrossNetworkAutomationService::delete_service_connection_map] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceConnectionMap(
         RequestBuilder<crate::model::DeleteServiceConnectionMapRequest>,
@@ -523,7 +523,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::list_service_connection_policies call.
+    /// The request builder for [CrossNetworkAutomationService::list_service_connection_policies][super::super::client::CrossNetworkAutomationService::list_service_connection_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceConnectionPolicies(
         RequestBuilder<crate::model::ListServiceConnectionPoliciesRequest>,
@@ -613,7 +613,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::get_service_connection_policy call.
+    /// The request builder for [CrossNetworkAutomationService::get_service_connection_policy][super::super::client::CrossNetworkAutomationService::get_service_connection_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceConnectionPolicy(
         RequestBuilder<crate::model::GetServiceConnectionPolicyRequest>,
@@ -662,7 +662,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::create_service_connection_policy call.
+    /// The request builder for [CrossNetworkAutomationService::create_service_connection_policy][super::super::client::CrossNetworkAutomationService::create_service_connection_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceConnectionPolicy(
         RequestBuilder<crate::model::CreateServiceConnectionPolicyRequest>,
@@ -778,7 +778,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::update_service_connection_policy call.
+    /// The request builder for [CrossNetworkAutomationService::update_service_connection_policy][super::super::client::CrossNetworkAutomationService::update_service_connection_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServiceConnectionPolicy(
         RequestBuilder<crate::model::UpdateServiceConnectionPolicyRequest>,
@@ -888,7 +888,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::delete_service_connection_policy call.
+    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_policy][super::super::client::CrossNetworkAutomationService::delete_service_connection_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceConnectionPolicy(
         RequestBuilder<crate::model::DeleteServiceConnectionPolicyRequest>,
@@ -984,7 +984,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::list_service_classes call.
+    /// The request builder for [CrossNetworkAutomationService::list_service_classes][super::super::client::CrossNetworkAutomationService::list_service_classes] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceClasses(RequestBuilder<crate::model::ListServiceClassesRequest>);
 
@@ -1070,7 +1070,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::get_service_class call.
+    /// The request builder for [CrossNetworkAutomationService::get_service_class][super::super::client::CrossNetworkAutomationService::get_service_class] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceClass(RequestBuilder<crate::model::GetServiceClassRequest>);
 
@@ -1114,7 +1114,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::update_service_class call.
+    /// The request builder for [CrossNetworkAutomationService::update_service_class][super::super::client::CrossNetworkAutomationService::update_service_class] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServiceClass(RequestBuilder<crate::model::UpdateServiceClassRequest>);
 
@@ -1217,7 +1217,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::delete_service_class call.
+    /// The request builder for [CrossNetworkAutomationService::delete_service_class][super::super::client::CrossNetworkAutomationService::delete_service_class] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceClass(RequestBuilder<crate::model::DeleteServiceClassRequest>);
 
@@ -1311,7 +1311,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::get_service_connection_token call.
+    /// The request builder for [CrossNetworkAutomationService::get_service_connection_token][super::super::client::CrossNetworkAutomationService::get_service_connection_token] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceConnectionToken(
         RequestBuilder<crate::model::GetServiceConnectionTokenRequest>,
@@ -1360,7 +1360,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::list_service_connection_tokens call.
+    /// The request builder for [CrossNetworkAutomationService::list_service_connection_tokens][super::super::client::CrossNetworkAutomationService::list_service_connection_tokens] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceConnectionTokens(
         RequestBuilder<crate::model::ListServiceConnectionTokensRequest>,
@@ -1450,7 +1450,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::create_service_connection_token call.
+    /// The request builder for [CrossNetworkAutomationService::create_service_connection_token][super::super::client::CrossNetworkAutomationService::create_service_connection_token] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceConnectionToken(
         RequestBuilder<crate::model::CreateServiceConnectionTokenRequest>,
@@ -1566,7 +1566,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::delete_service_connection_token call.
+    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_token][super::super::client::CrossNetworkAutomationService::delete_service_connection_token] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceConnectionToken(
         RequestBuilder<crate::model::DeleteServiceConnectionTokenRequest>,
@@ -1662,7 +1662,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::list_locations call.
+    /// The request builder for [CrossNetworkAutomationService::list_locations][super::super::client::CrossNetworkAutomationService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1742,7 +1742,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::get_location call.
+    /// The request builder for [CrossNetworkAutomationService::get_location][super::super::client::CrossNetworkAutomationService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1786,7 +1786,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::set_iam_policy call.
+    /// The request builder for [CrossNetworkAutomationService::set_iam_policy][super::super::client::CrossNetworkAutomationService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1848,7 +1848,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::get_iam_policy call.
+    /// The request builder for [CrossNetworkAutomationService::get_iam_policy][super::super::client::CrossNetworkAutomationService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1901,7 +1901,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::test_iam_permissions call.
+    /// The request builder for [CrossNetworkAutomationService::test_iam_permissions][super::super::client::CrossNetworkAutomationService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1959,7 +1959,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::list_operations call.
+    /// The request builder for [CrossNetworkAutomationService::list_operations][super::super::client::CrossNetworkAutomationService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2039,7 +2039,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::get_operation call.
+    /// The request builder for [CrossNetworkAutomationService::get_operation][super::super::client::CrossNetworkAutomationService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2086,7 +2086,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::delete_operation call.
+    /// The request builder for [CrossNetworkAutomationService::delete_operation][super::super::client::CrossNetworkAutomationService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2133,7 +2133,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for a CrossNetworkAutomationService::cancel_operation call.
+    /// The request builder for [CrossNetworkAutomationService::cancel_operation][super::super::client::CrossNetworkAutomationService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2234,7 +2234,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::list_hubs call.
+    /// The request builder for [HubService::list_hubs][super::super::client::HubService::list_hubs] calls.
     #[derive(Clone, Debug)]
     pub struct ListHubs(RequestBuilder<crate::model::ListHubsRequest>);
 
@@ -2314,7 +2314,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::get_hub call.
+    /// The request builder for [HubService::get_hub][super::super::client::HubService::get_hub] calls.
     #[derive(Clone, Debug)]
     pub struct GetHub(RequestBuilder<crate::model::GetHubRequest>);
 
@@ -2354,7 +2354,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::create_hub call.
+    /// The request builder for [HubService::create_hub][super::super::client::HubService::create_hub] calls.
     #[derive(Clone, Debug)]
     pub struct CreateHub(RequestBuilder<crate::model::CreateHubRequest>);
 
@@ -2451,7 +2451,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::update_hub call.
+    /// The request builder for [HubService::update_hub][super::super::client::HubService::update_hub] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateHub(RequestBuilder<crate::model::UpdateHubRequest>);
 
@@ -2545,7 +2545,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::delete_hub call.
+    /// The request builder for [HubService::delete_hub][super::super::client::HubService::delete_hub] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteHub(RequestBuilder<crate::model::DeleteHubRequest>);
 
@@ -2628,7 +2628,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::list_hub_spokes call.
+    /// The request builder for [HubService::list_hub_spokes][super::super::client::HubService::list_hub_spokes] calls.
     #[derive(Clone, Debug)]
     pub struct ListHubSpokes(RequestBuilder<crate::model::ListHubSpokesRequest>);
 
@@ -2729,7 +2729,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::query_hub_status call.
+    /// The request builder for [HubService::query_hub_status][super::super::client::HubService::query_hub_status] calls.
     #[derive(Clone, Debug)]
     pub struct QueryHubStatus(RequestBuilder<crate::model::QueryHubStatusRequest>);
 
@@ -2816,7 +2816,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::list_spokes call.
+    /// The request builder for [HubService::list_spokes][super::super::client::HubService::list_spokes] calls.
     #[derive(Clone, Debug)]
     pub struct ListSpokes(RequestBuilder<crate::model::ListSpokesRequest>);
 
@@ -2897,7 +2897,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::get_spoke call.
+    /// The request builder for [HubService::get_spoke][super::super::client::HubService::get_spoke] calls.
     #[derive(Clone, Debug)]
     pub struct GetSpoke(RequestBuilder<crate::model::GetSpokeRequest>);
 
@@ -2939,7 +2939,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::create_spoke call.
+    /// The request builder for [HubService::create_spoke][super::super::client::HubService::create_spoke] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSpoke(RequestBuilder<crate::model::CreateSpokeRequest>);
 
@@ -3039,7 +3039,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::update_spoke call.
+    /// The request builder for [HubService::update_spoke][super::super::client::HubService::update_spoke] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSpoke(RequestBuilder<crate::model::UpdateSpokeRequest>);
 
@@ -3136,7 +3136,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::reject_hub_spoke call.
+    /// The request builder for [HubService::reject_hub_spoke][super::super::client::HubService::reject_hub_spoke] calls.
     #[derive(Clone, Debug)]
     pub struct RejectHubSpoke(RequestBuilder<crate::model::RejectHubSpokeRequest>);
 
@@ -3237,7 +3237,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::accept_hub_spoke call.
+    /// The request builder for [HubService::accept_hub_spoke][super::super::client::HubService::accept_hub_spoke] calls.
     #[derive(Clone, Debug)]
     pub struct AcceptHubSpoke(RequestBuilder<crate::model::AcceptHubSpokeRequest>);
 
@@ -3332,7 +3332,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::accept_spoke_update call.
+    /// The request builder for [HubService::accept_spoke_update][super::super::client::HubService::accept_spoke_update] calls.
     #[derive(Clone, Debug)]
     pub struct AcceptSpokeUpdate(RequestBuilder<crate::model::AcceptSpokeUpdateRequest>);
 
@@ -3436,7 +3436,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::reject_spoke_update call.
+    /// The request builder for [HubService::reject_spoke_update][super::super::client::HubService::reject_spoke_update] calls.
     #[derive(Clone, Debug)]
     pub struct RejectSpokeUpdate(RequestBuilder<crate::model::RejectSpokeUpdateRequest>);
 
@@ -3546,7 +3546,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::delete_spoke call.
+    /// The request builder for [HubService::delete_spoke][super::super::client::HubService::delete_spoke] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSpoke(RequestBuilder<crate::model::DeleteSpokeRequest>);
 
@@ -3629,7 +3629,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::get_route_table call.
+    /// The request builder for [HubService::get_route_table][super::super::client::HubService::get_route_table] calls.
     #[derive(Clone, Debug)]
     pub struct GetRouteTable(RequestBuilder<crate::model::GetRouteTableRequest>);
 
@@ -3671,7 +3671,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::get_route call.
+    /// The request builder for [HubService::get_route][super::super::client::HubService::get_route] calls.
     #[derive(Clone, Debug)]
     pub struct GetRoute(RequestBuilder<crate::model::GetRouteRequest>);
 
@@ -3713,7 +3713,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::list_routes call.
+    /// The request builder for [HubService::list_routes][super::super::client::HubService::list_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListRoutes(RequestBuilder<crate::model::ListRoutesRequest>);
 
@@ -3794,7 +3794,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::list_route_tables call.
+    /// The request builder for [HubService::list_route_tables][super::super::client::HubService::list_route_tables] calls.
     #[derive(Clone, Debug)]
     pub struct ListRouteTables(RequestBuilder<crate::model::ListRouteTablesRequest>);
 
@@ -3875,7 +3875,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::get_group call.
+    /// The request builder for [HubService::get_group][super::super::client::HubService::get_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetGroup(RequestBuilder<crate::model::GetGroupRequest>);
 
@@ -3917,7 +3917,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::list_groups call.
+    /// The request builder for [HubService::list_groups][super::super::client::HubService::list_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListGroups(RequestBuilder<crate::model::ListGroupsRequest>);
 
@@ -3998,7 +3998,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::update_group call.
+    /// The request builder for [HubService::update_group][super::super::client::HubService::update_group] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGroup(RequestBuilder<crate::model::UpdateGroupRequest>);
 
@@ -4095,7 +4095,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::list_locations call.
+    /// The request builder for [HubService::list_locations][super::super::client::HubService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4173,7 +4173,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::get_location call.
+    /// The request builder for [HubService::get_location][super::super::client::HubService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4215,7 +4215,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::set_iam_policy call.
+    /// The request builder for [HubService::set_iam_policy][super::super::client::HubService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4275,7 +4275,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::get_iam_policy call.
+    /// The request builder for [HubService::get_iam_policy][super::super::client::HubService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4326,7 +4326,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::test_iam_permissions call.
+    /// The request builder for [HubService::test_iam_permissions][super::super::client::HubService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4382,7 +4382,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::list_operations call.
+    /// The request builder for [HubService::list_operations][super::super::client::HubService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4460,7 +4460,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::get_operation call.
+    /// The request builder for [HubService::get_operation][super::super::client::HubService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4505,7 +4505,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::delete_operation call.
+    /// The request builder for [HubService::delete_operation][super::super::client::HubService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4550,7 +4550,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for a HubService::cancel_operation call.
+    /// The request builder for [HubService::cancel_operation][super::super::client::HubService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4651,7 +4651,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::list_policy_based_routes call.
+    /// The request builder for [PolicyBasedRoutingService::list_policy_based_routes][super::super::client::PolicyBasedRoutingService::list_policy_based_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListPolicyBasedRoutes(RequestBuilder<crate::model::ListPolicyBasedRoutesRequest>);
 
@@ -4737,7 +4737,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::get_policy_based_route call.
+    /// The request builder for [PolicyBasedRoutingService::get_policy_based_route][super::super::client::PolicyBasedRoutingService::get_policy_based_route] calls.
     #[derive(Clone, Debug)]
     pub struct GetPolicyBasedRoute(RequestBuilder<crate::model::GetPolicyBasedRouteRequest>);
 
@@ -4784,7 +4784,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::create_policy_based_route call.
+    /// The request builder for [PolicyBasedRoutingService::create_policy_based_route][super::super::client::PolicyBasedRoutingService::create_policy_based_route] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePolicyBasedRoute(RequestBuilder<crate::model::CreatePolicyBasedRouteRequest>);
 
@@ -4893,7 +4893,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::delete_policy_based_route call.
+    /// The request builder for [PolicyBasedRoutingService::delete_policy_based_route][super::super::client::PolicyBasedRoutingService::delete_policy_based_route] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePolicyBasedRoute(RequestBuilder<crate::model::DeletePolicyBasedRouteRequest>);
 
@@ -4981,7 +4981,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::list_locations call.
+    /// The request builder for [PolicyBasedRoutingService::list_locations][super::super::client::PolicyBasedRoutingService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5061,7 +5061,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::get_location call.
+    /// The request builder for [PolicyBasedRoutingService::get_location][super::super::client::PolicyBasedRoutingService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5105,7 +5105,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::set_iam_policy call.
+    /// The request builder for [PolicyBasedRoutingService::set_iam_policy][super::super::client::PolicyBasedRoutingService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -5167,7 +5167,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::get_iam_policy call.
+    /// The request builder for [PolicyBasedRoutingService::get_iam_policy][super::super::client::PolicyBasedRoutingService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -5220,7 +5220,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::test_iam_permissions call.
+    /// The request builder for [PolicyBasedRoutingService::test_iam_permissions][super::super::client::PolicyBasedRoutingService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5278,7 +5278,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::list_operations call.
+    /// The request builder for [PolicyBasedRoutingService::list_operations][super::super::client::PolicyBasedRoutingService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5358,7 +5358,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::get_operation call.
+    /// The request builder for [PolicyBasedRoutingService::get_operation][super::super::client::PolicyBasedRoutingService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5405,7 +5405,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::delete_operation call.
+    /// The request builder for [PolicyBasedRoutingService::delete_operation][super::super::client::PolicyBasedRoutingService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5452,7 +5452,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for a PolicyBasedRoutingService::cancel_operation call.
+    /// The request builder for [PolicyBasedRoutingService::cancel_operation][super::super::client::PolicyBasedRoutingService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/networkmanagement/v1/src/builder.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::list_connectivity_tests call.
+    /// The request builder for [ReachabilityService::list_connectivity_tests][super::super::client::ReachabilityService::list_connectivity_tests] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnectivityTests(RequestBuilder<crate::model::ListConnectivityTestsRequest>);
 
@@ -151,7 +151,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::get_connectivity_test call.
+    /// The request builder for [ReachabilityService::get_connectivity_test][super::super::client::ReachabilityService::get_connectivity_test] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnectivityTest(RequestBuilder<crate::model::GetConnectivityTestRequest>);
 
@@ -196,7 +196,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::create_connectivity_test call.
+    /// The request builder for [ReachabilityService::create_connectivity_test][super::super::client::ReachabilityService::create_connectivity_test] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnectivityTest(RequestBuilder<crate::model::CreateConnectivityTestRequest>);
 
@@ -295,7 +295,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::update_connectivity_test call.
+    /// The request builder for [ReachabilityService::update_connectivity_test][super::super::client::ReachabilityService::update_connectivity_test] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConnectivityTest(RequestBuilder<crate::model::UpdateConnectivityTestRequest>);
 
@@ -391,7 +391,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::rerun_connectivity_test call.
+    /// The request builder for [ReachabilityService::rerun_connectivity_test][super::super::client::ReachabilityService::rerun_connectivity_test] calls.
     #[derive(Clone, Debug)]
     pub struct RerunConnectivityTest(RequestBuilder<crate::model::RerunConnectivityTestRequest>);
 
@@ -475,7 +475,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::delete_connectivity_test call.
+    /// The request builder for [ReachabilityService::delete_connectivity_test][super::super::client::ReachabilityService::delete_connectivity_test] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnectivityTest(RequestBuilder<crate::model::DeleteConnectivityTestRequest>);
 
@@ -555,7 +555,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::list_locations call.
+    /// The request builder for [ReachabilityService::list_locations][super::super::client::ReachabilityService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -633,7 +633,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::get_location call.
+    /// The request builder for [ReachabilityService::get_location][super::super::client::ReachabilityService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -675,7 +675,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::set_iam_policy call.
+    /// The request builder for [ReachabilityService::set_iam_policy][super::super::client::ReachabilityService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -735,7 +735,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::get_iam_policy call.
+    /// The request builder for [ReachabilityService::get_iam_policy][super::super::client::ReachabilityService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -786,7 +786,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::test_iam_permissions call.
+    /// The request builder for [ReachabilityService::test_iam_permissions][super::super::client::ReachabilityService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -842,7 +842,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::list_operations call.
+    /// The request builder for [ReachabilityService::list_operations][super::super::client::ReachabilityService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -920,7 +920,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::get_operation call.
+    /// The request builder for [ReachabilityService::get_operation][super::super::client::ReachabilityService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -965,7 +965,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::delete_operation call.
+    /// The request builder for [ReachabilityService::delete_operation][super::super::client::ReachabilityService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1010,7 +1010,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for a ReachabilityService::cancel_operation call.
+    /// The request builder for [ReachabilityService::cancel_operation][super::super::client::ReachabilityService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1109,7 +1109,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::list_vpc_flow_logs_configs call.
+    /// The request builder for [VpcFlowLogsService::list_vpc_flow_logs_configs][super::super::client::VpcFlowLogsService::list_vpc_flow_logs_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListVpcFlowLogsConfigs(RequestBuilder<crate::model::ListVpcFlowLogsConfigsRequest>);
 
@@ -1195,7 +1195,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::get_vpc_flow_logs_config call.
+    /// The request builder for [VpcFlowLogsService::get_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::get_vpc_flow_logs_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetVpcFlowLogsConfig(RequestBuilder<crate::model::GetVpcFlowLogsConfigRequest>);
 
@@ -1240,7 +1240,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::create_vpc_flow_logs_config call.
+    /// The request builder for [VpcFlowLogsService::create_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::create_vpc_flow_logs_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVpcFlowLogsConfig(
         RequestBuilder<crate::model::CreateVpcFlowLogsConfigRequest>,
@@ -1343,7 +1343,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::update_vpc_flow_logs_config call.
+    /// The request builder for [VpcFlowLogsService::update_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::update_vpc_flow_logs_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVpcFlowLogsConfig(
         RequestBuilder<crate::model::UpdateVpcFlowLogsConfigRequest>,
@@ -1443,7 +1443,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::delete_vpc_flow_logs_config call.
+    /// The request builder for [VpcFlowLogsService::delete_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::delete_vpc_flow_logs_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVpcFlowLogsConfig(
         RequestBuilder<crate::model::DeleteVpcFlowLogsConfigRequest>,
@@ -1525,7 +1525,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::list_locations call.
+    /// The request builder for [VpcFlowLogsService::list_locations][super::super::client::VpcFlowLogsService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1603,7 +1603,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::get_location call.
+    /// The request builder for [VpcFlowLogsService::get_location][super::super::client::VpcFlowLogsService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1645,7 +1645,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::set_iam_policy call.
+    /// The request builder for [VpcFlowLogsService::set_iam_policy][super::super::client::VpcFlowLogsService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1705,7 +1705,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::get_iam_policy call.
+    /// The request builder for [VpcFlowLogsService::get_iam_policy][super::super::client::VpcFlowLogsService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1756,7 +1756,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::test_iam_permissions call.
+    /// The request builder for [VpcFlowLogsService::test_iam_permissions][super::super::client::VpcFlowLogsService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1812,7 +1812,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::list_operations call.
+    /// The request builder for [VpcFlowLogsService::list_operations][super::super::client::VpcFlowLogsService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1890,7 +1890,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::get_operation call.
+    /// The request builder for [VpcFlowLogsService::get_operation][super::super::client::VpcFlowLogsService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1935,7 +1935,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::delete_operation call.
+    /// The request builder for [VpcFlowLogsService::delete_operation][super::super::client::VpcFlowLogsService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1980,7 +1980,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for a VpcFlowLogsService::cancel_operation call.
+    /// The request builder for [VpcFlowLogsService::cancel_operation][super::super::client::VpcFlowLogsService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/networksecurity/v1/src/builder.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::list_authorization_policies call.
+    /// The request builder for [NetworkSecurity::list_authorization_policies][super::super::client::NetworkSecurity::list_authorization_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListAuthorizationPolicies(
         RequestBuilder<crate::model::ListAuthorizationPoliciesRequest>,
@@ -143,7 +143,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::get_authorization_policy call.
+    /// The request builder for [NetworkSecurity::get_authorization_policy][super::super::client::NetworkSecurity::get_authorization_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetAuthorizationPolicy(RequestBuilder<crate::model::GetAuthorizationPolicyRequest>);
 
@@ -188,7 +188,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::create_authorization_policy call.
+    /// The request builder for [NetworkSecurity::create_authorization_policy][super::super::client::NetworkSecurity::create_authorization_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAuthorizationPolicy(
         RequestBuilder<crate::model::CreateAuthorizationPolicyRequest>,
@@ -291,7 +291,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::update_authorization_policy call.
+    /// The request builder for [NetworkSecurity::update_authorization_policy][super::super::client::NetworkSecurity::update_authorization_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAuthorizationPolicy(
         RequestBuilder<crate::model::UpdateAuthorizationPolicyRequest>,
@@ -391,7 +391,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::delete_authorization_policy call.
+    /// The request builder for [NetworkSecurity::delete_authorization_policy][super::super::client::NetworkSecurity::delete_authorization_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAuthorizationPolicy(
         RequestBuilder<crate::model::DeleteAuthorizationPolicyRequest>,
@@ -473,7 +473,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::list_server_tls_policies call.
+    /// The request builder for [NetworkSecurity::list_server_tls_policies][super::super::client::NetworkSecurity::list_server_tls_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListServerTlsPolicies(RequestBuilder<crate::model::ListServerTlsPoliciesRequest>);
 
@@ -545,7 +545,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::get_server_tls_policy call.
+    /// The request builder for [NetworkSecurity::get_server_tls_policy][super::super::client::NetworkSecurity::get_server_tls_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetServerTlsPolicy(RequestBuilder<crate::model::GetServerTlsPolicyRequest>);
 
@@ -590,7 +590,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::create_server_tls_policy call.
+    /// The request builder for [NetworkSecurity::create_server_tls_policy][super::super::client::NetworkSecurity::create_server_tls_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServerTlsPolicy(RequestBuilder<crate::model::CreateServerTlsPolicyRequest>);
 
@@ -691,7 +691,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::update_server_tls_policy call.
+    /// The request builder for [NetworkSecurity::update_server_tls_policy][super::super::client::NetworkSecurity::update_server_tls_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServerTlsPolicy(RequestBuilder<crate::model::UpdateServerTlsPolicyRequest>);
 
@@ -789,7 +789,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::delete_server_tls_policy call.
+    /// The request builder for [NetworkSecurity::delete_server_tls_policy][super::super::client::NetworkSecurity::delete_server_tls_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServerTlsPolicy(RequestBuilder<crate::model::DeleteServerTlsPolicyRequest>);
 
@@ -869,7 +869,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::list_client_tls_policies call.
+    /// The request builder for [NetworkSecurity::list_client_tls_policies][super::super::client::NetworkSecurity::list_client_tls_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListClientTlsPolicies(RequestBuilder<crate::model::ListClientTlsPoliciesRequest>);
 
@@ -941,7 +941,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::get_client_tls_policy call.
+    /// The request builder for [NetworkSecurity::get_client_tls_policy][super::super::client::NetworkSecurity::get_client_tls_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetClientTlsPolicy(RequestBuilder<crate::model::GetClientTlsPolicyRequest>);
 
@@ -986,7 +986,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::create_client_tls_policy call.
+    /// The request builder for [NetworkSecurity::create_client_tls_policy][super::super::client::NetworkSecurity::create_client_tls_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateClientTlsPolicy(RequestBuilder<crate::model::CreateClientTlsPolicyRequest>);
 
@@ -1087,7 +1087,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::update_client_tls_policy call.
+    /// The request builder for [NetworkSecurity::update_client_tls_policy][super::super::client::NetworkSecurity::update_client_tls_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateClientTlsPolicy(RequestBuilder<crate::model::UpdateClientTlsPolicyRequest>);
 
@@ -1185,7 +1185,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::delete_client_tls_policy call.
+    /// The request builder for [NetworkSecurity::delete_client_tls_policy][super::super::client::NetworkSecurity::delete_client_tls_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteClientTlsPolicy(RequestBuilder<crate::model::DeleteClientTlsPolicyRequest>);
 
@@ -1265,7 +1265,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::list_locations call.
+    /// The request builder for [NetworkSecurity::list_locations][super::super::client::NetworkSecurity::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1343,7 +1343,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::get_location call.
+    /// The request builder for [NetworkSecurity::get_location][super::super::client::NetworkSecurity::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1385,7 +1385,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::set_iam_policy call.
+    /// The request builder for [NetworkSecurity::set_iam_policy][super::super::client::NetworkSecurity::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1445,7 +1445,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::get_iam_policy call.
+    /// The request builder for [NetworkSecurity::get_iam_policy][super::super::client::NetworkSecurity::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1496,7 +1496,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::test_iam_permissions call.
+    /// The request builder for [NetworkSecurity::test_iam_permissions][super::super::client::NetworkSecurity::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1552,7 +1552,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::list_operations call.
+    /// The request builder for [NetworkSecurity::list_operations][super::super::client::NetworkSecurity::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1630,7 +1630,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::get_operation call.
+    /// The request builder for [NetworkSecurity::get_operation][super::super::client::NetworkSecurity::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1675,7 +1675,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::delete_operation call.
+    /// The request builder for [NetworkSecurity::delete_operation][super::super::client::NetworkSecurity::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1720,7 +1720,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for a NetworkSecurity::cancel_operation call.
+    /// The request builder for [NetworkSecurity::cancel_operation][super::super::client::NetworkSecurity::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/networkservices/v1/src/builder.rs
+++ b/src/generated/cloud/networkservices/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::list_lb_traffic_extensions call.
+    /// The request builder for [DepService::list_lb_traffic_extensions][super::super::client::DepService::list_lb_traffic_extensions] calls.
     #[derive(Clone, Debug)]
     pub struct ListLbTrafficExtensions(
         RequestBuilder<crate::model::ListLbTrafficExtensionsRequest>,
@@ -155,7 +155,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::get_lb_traffic_extension call.
+    /// The request builder for [DepService::get_lb_traffic_extension][super::super::client::DepService::get_lb_traffic_extension] calls.
     #[derive(Clone, Debug)]
     pub struct GetLbTrafficExtension(RequestBuilder<crate::model::GetLbTrafficExtensionRequest>);
 
@@ -200,7 +200,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::create_lb_traffic_extension call.
+    /// The request builder for [DepService::create_lb_traffic_extension][super::super::client::DepService::create_lb_traffic_extension] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLbTrafficExtension(
         RequestBuilder<crate::model::CreateLbTrafficExtensionRequest>,
@@ -309,7 +309,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::update_lb_traffic_extension call.
+    /// The request builder for [DepService::update_lb_traffic_extension][super::super::client::DepService::update_lb_traffic_extension] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateLbTrafficExtension(
         RequestBuilder<crate::model::UpdateLbTrafficExtensionRequest>,
@@ -415,7 +415,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::delete_lb_traffic_extension call.
+    /// The request builder for [DepService::delete_lb_traffic_extension][super::super::client::DepService::delete_lb_traffic_extension] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLbTrafficExtension(
         RequestBuilder<crate::model::DeleteLbTrafficExtensionRequest>,
@@ -503,7 +503,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::list_lb_route_extensions call.
+    /// The request builder for [DepService::list_lb_route_extensions][super::super::client::DepService::list_lb_route_extensions] calls.
     #[derive(Clone, Debug)]
     pub struct ListLbRouteExtensions(RequestBuilder<crate::model::ListLbRouteExtensionsRequest>);
 
@@ -587,7 +587,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::get_lb_route_extension call.
+    /// The request builder for [DepService::get_lb_route_extension][super::super::client::DepService::get_lb_route_extension] calls.
     #[derive(Clone, Debug)]
     pub struct GetLbRouteExtension(RequestBuilder<crate::model::GetLbRouteExtensionRequest>);
 
@@ -632,7 +632,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::create_lb_route_extension call.
+    /// The request builder for [DepService::create_lb_route_extension][super::super::client::DepService::create_lb_route_extension] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLbRouteExtension(RequestBuilder<crate::model::CreateLbRouteExtensionRequest>);
 
@@ -739,7 +739,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::update_lb_route_extension call.
+    /// The request builder for [DepService::update_lb_route_extension][super::super::client::DepService::update_lb_route_extension] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateLbRouteExtension(RequestBuilder<crate::model::UpdateLbRouteExtensionRequest>);
 
@@ -843,7 +843,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::delete_lb_route_extension call.
+    /// The request builder for [DepService::delete_lb_route_extension][super::super::client::DepService::delete_lb_route_extension] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLbRouteExtension(RequestBuilder<crate::model::DeleteLbRouteExtensionRequest>);
 
@@ -929,7 +929,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::list_locations call.
+    /// The request builder for [DepService::list_locations][super::super::client::DepService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1007,7 +1007,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::get_location call.
+    /// The request builder for [DepService::get_location][super::super::client::DepService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1049,7 +1049,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::set_iam_policy call.
+    /// The request builder for [DepService::set_iam_policy][super::super::client::DepService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1109,7 +1109,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::get_iam_policy call.
+    /// The request builder for [DepService::get_iam_policy][super::super::client::DepService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1160,7 +1160,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::test_iam_permissions call.
+    /// The request builder for [DepService::test_iam_permissions][super::super::client::DepService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1216,7 +1216,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::list_operations call.
+    /// The request builder for [DepService::list_operations][super::super::client::DepService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1294,7 +1294,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::get_operation call.
+    /// The request builder for [DepService::get_operation][super::super::client::DepService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1339,7 +1339,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::delete_operation call.
+    /// The request builder for [DepService::delete_operation][super::super::client::DepService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1384,7 +1384,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for a DepService::cancel_operation call.
+    /// The request builder for [DepService::cancel_operation][super::super::client::DepService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1483,7 +1483,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_endpoint_policies call.
+    /// The request builder for [NetworkServices::list_endpoint_policies][super::super::client::NetworkServices::list_endpoint_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListEndpointPolicies(RequestBuilder<crate::model::ListEndpointPoliciesRequest>);
 
@@ -1555,7 +1555,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_endpoint_policy call.
+    /// The request builder for [NetworkServices::get_endpoint_policy][super::super::client::NetworkServices::get_endpoint_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetEndpointPolicy(RequestBuilder<crate::model::GetEndpointPolicyRequest>);
 
@@ -1600,7 +1600,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::create_endpoint_policy call.
+    /// The request builder for [NetworkServices::create_endpoint_policy][super::super::client::NetworkServices::create_endpoint_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEndpointPolicy(RequestBuilder<crate::model::CreateEndpointPolicyRequest>);
 
@@ -1699,7 +1699,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::update_endpoint_policy call.
+    /// The request builder for [NetworkServices::update_endpoint_policy][super::super::client::NetworkServices::update_endpoint_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEndpointPolicy(RequestBuilder<crate::model::UpdateEndpointPolicyRequest>);
 
@@ -1795,7 +1795,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_endpoint_policy call.
+    /// The request builder for [NetworkServices::delete_endpoint_policy][super::super::client::NetworkServices::delete_endpoint_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEndpointPolicy(RequestBuilder<crate::model::DeleteEndpointPolicyRequest>);
 
@@ -1875,7 +1875,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_gateways call.
+    /// The request builder for [NetworkServices::list_gateways][super::super::client::NetworkServices::list_gateways] calls.
     #[derive(Clone, Debug)]
     pub struct ListGateways(RequestBuilder<crate::model::ListGatewaysRequest>);
 
@@ -1944,7 +1944,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_gateway call.
+    /// The request builder for [NetworkServices::get_gateway][super::super::client::NetworkServices::get_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct GetGateway(RequestBuilder<crate::model::GetGatewayRequest>);
 
@@ -1986,7 +1986,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::create_gateway call.
+    /// The request builder for [NetworkServices::create_gateway][super::super::client::NetworkServices::create_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGateway(RequestBuilder<crate::model::CreateGatewayRequest>);
 
@@ -2080,7 +2080,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::update_gateway call.
+    /// The request builder for [NetworkServices::update_gateway][super::super::client::NetworkServices::update_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGateway(RequestBuilder<crate::model::UpdateGatewayRequest>);
 
@@ -2171,7 +2171,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_gateway call.
+    /// The request builder for [NetworkServices::delete_gateway][super::super::client::NetworkServices::delete_gateway] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGateway(RequestBuilder<crate::model::DeleteGatewayRequest>);
 
@@ -2248,7 +2248,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_grpc_routes call.
+    /// The request builder for [NetworkServices::list_grpc_routes][super::super::client::NetworkServices::list_grpc_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListGrpcRoutes(RequestBuilder<crate::model::ListGrpcRoutesRequest>);
 
@@ -2317,7 +2317,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_grpc_route call.
+    /// The request builder for [NetworkServices::get_grpc_route][super::super::client::NetworkServices::get_grpc_route] calls.
     #[derive(Clone, Debug)]
     pub struct GetGrpcRoute(RequestBuilder<crate::model::GetGrpcRouteRequest>);
 
@@ -2359,7 +2359,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::create_grpc_route call.
+    /// The request builder for [NetworkServices::create_grpc_route][super::super::client::NetworkServices::create_grpc_route] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGrpcRoute(RequestBuilder<crate::model::CreateGrpcRouteRequest>);
 
@@ -2454,7 +2454,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::update_grpc_route call.
+    /// The request builder for [NetworkServices::update_grpc_route][super::super::client::NetworkServices::update_grpc_route] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGrpcRoute(RequestBuilder<crate::model::UpdateGrpcRouteRequest>);
 
@@ -2546,7 +2546,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_grpc_route call.
+    /// The request builder for [NetworkServices::delete_grpc_route][super::super::client::NetworkServices::delete_grpc_route] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGrpcRoute(RequestBuilder<crate::model::DeleteGrpcRouteRequest>);
 
@@ -2623,7 +2623,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_http_routes call.
+    /// The request builder for [NetworkServices::list_http_routes][super::super::client::NetworkServices::list_http_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListHttpRoutes(RequestBuilder<crate::model::ListHttpRoutesRequest>);
 
@@ -2692,7 +2692,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_http_route call.
+    /// The request builder for [NetworkServices::get_http_route][super::super::client::NetworkServices::get_http_route] calls.
     #[derive(Clone, Debug)]
     pub struct GetHttpRoute(RequestBuilder<crate::model::GetHttpRouteRequest>);
 
@@ -2734,7 +2734,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::create_http_route call.
+    /// The request builder for [NetworkServices::create_http_route][super::super::client::NetworkServices::create_http_route] calls.
     #[derive(Clone, Debug)]
     pub struct CreateHttpRoute(RequestBuilder<crate::model::CreateHttpRouteRequest>);
 
@@ -2829,7 +2829,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::update_http_route call.
+    /// The request builder for [NetworkServices::update_http_route][super::super::client::NetworkServices::update_http_route] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateHttpRoute(RequestBuilder<crate::model::UpdateHttpRouteRequest>);
 
@@ -2921,7 +2921,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_http_route call.
+    /// The request builder for [NetworkServices::delete_http_route][super::super::client::NetworkServices::delete_http_route] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteHttpRoute(RequestBuilder<crate::model::DeleteHttpRouteRequest>);
 
@@ -2998,7 +2998,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_tcp_routes call.
+    /// The request builder for [NetworkServices::list_tcp_routes][super::super::client::NetworkServices::list_tcp_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListTcpRoutes(RequestBuilder<crate::model::ListTcpRoutesRequest>);
 
@@ -3067,7 +3067,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_tcp_route call.
+    /// The request builder for [NetworkServices::get_tcp_route][super::super::client::NetworkServices::get_tcp_route] calls.
     #[derive(Clone, Debug)]
     pub struct GetTcpRoute(RequestBuilder<crate::model::GetTcpRouteRequest>);
 
@@ -3109,7 +3109,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::create_tcp_route call.
+    /// The request builder for [NetworkServices::create_tcp_route][super::super::client::NetworkServices::create_tcp_route] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTcpRoute(RequestBuilder<crate::model::CreateTcpRouteRequest>);
 
@@ -3204,7 +3204,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::update_tcp_route call.
+    /// The request builder for [NetworkServices::update_tcp_route][super::super::client::NetworkServices::update_tcp_route] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTcpRoute(RequestBuilder<crate::model::UpdateTcpRouteRequest>);
 
@@ -3296,7 +3296,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_tcp_route call.
+    /// The request builder for [NetworkServices::delete_tcp_route][super::super::client::NetworkServices::delete_tcp_route] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTcpRoute(RequestBuilder<crate::model::DeleteTcpRouteRequest>);
 
@@ -3373,7 +3373,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_tls_routes call.
+    /// The request builder for [NetworkServices::list_tls_routes][super::super::client::NetworkServices::list_tls_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListTlsRoutes(RequestBuilder<crate::model::ListTlsRoutesRequest>);
 
@@ -3442,7 +3442,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_tls_route call.
+    /// The request builder for [NetworkServices::get_tls_route][super::super::client::NetworkServices::get_tls_route] calls.
     #[derive(Clone, Debug)]
     pub struct GetTlsRoute(RequestBuilder<crate::model::GetTlsRouteRequest>);
 
@@ -3484,7 +3484,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::create_tls_route call.
+    /// The request builder for [NetworkServices::create_tls_route][super::super::client::NetworkServices::create_tls_route] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTlsRoute(RequestBuilder<crate::model::CreateTlsRouteRequest>);
 
@@ -3579,7 +3579,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::update_tls_route call.
+    /// The request builder for [NetworkServices::update_tls_route][super::super::client::NetworkServices::update_tls_route] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTlsRoute(RequestBuilder<crate::model::UpdateTlsRouteRequest>);
 
@@ -3671,7 +3671,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_tls_route call.
+    /// The request builder for [NetworkServices::delete_tls_route][super::super::client::NetworkServices::delete_tls_route] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTlsRoute(RequestBuilder<crate::model::DeleteTlsRouteRequest>);
 
@@ -3748,7 +3748,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_service_bindings call.
+    /// The request builder for [NetworkServices::list_service_bindings][super::super::client::NetworkServices::list_service_bindings] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceBindings(RequestBuilder<crate::model::ListServiceBindingsRequest>);
 
@@ -3820,7 +3820,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_service_binding call.
+    /// The request builder for [NetworkServices::get_service_binding][super::super::client::NetworkServices::get_service_binding] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceBinding(RequestBuilder<crate::model::GetServiceBindingRequest>);
 
@@ -3865,7 +3865,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::create_service_binding call.
+    /// The request builder for [NetworkServices::create_service_binding][super::super::client::NetworkServices::create_service_binding] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceBinding(RequestBuilder<crate::model::CreateServiceBindingRequest>);
 
@@ -3964,7 +3964,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_service_binding call.
+    /// The request builder for [NetworkServices::delete_service_binding][super::super::client::NetworkServices::delete_service_binding] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceBinding(RequestBuilder<crate::model::DeleteServiceBindingRequest>);
 
@@ -4044,7 +4044,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_meshes call.
+    /// The request builder for [NetworkServices::list_meshes][super::super::client::NetworkServices::list_meshes] calls.
     #[derive(Clone, Debug)]
     pub struct ListMeshes(RequestBuilder<crate::model::ListMeshesRequest>);
 
@@ -4113,7 +4113,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_mesh call.
+    /// The request builder for [NetworkServices::get_mesh][super::super::client::NetworkServices::get_mesh] calls.
     #[derive(Clone, Debug)]
     pub struct GetMesh(RequestBuilder<crate::model::GetMeshRequest>);
 
@@ -4155,7 +4155,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::create_mesh call.
+    /// The request builder for [NetworkServices::create_mesh][super::super::client::NetworkServices::create_mesh] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMesh(RequestBuilder<crate::model::CreateMeshRequest>);
 
@@ -4246,7 +4246,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::update_mesh call.
+    /// The request builder for [NetworkServices::update_mesh][super::super::client::NetworkServices::update_mesh] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMesh(RequestBuilder<crate::model::UpdateMeshRequest>);
 
@@ -4334,7 +4334,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_mesh call.
+    /// The request builder for [NetworkServices::delete_mesh][super::super::client::NetworkServices::delete_mesh] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMesh(RequestBuilder<crate::model::DeleteMeshRequest>);
 
@@ -4411,7 +4411,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_locations call.
+    /// The request builder for [NetworkServices::list_locations][super::super::client::NetworkServices::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4489,7 +4489,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_location call.
+    /// The request builder for [NetworkServices::get_location][super::super::client::NetworkServices::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4531,7 +4531,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::set_iam_policy call.
+    /// The request builder for [NetworkServices::set_iam_policy][super::super::client::NetworkServices::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4591,7 +4591,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_iam_policy call.
+    /// The request builder for [NetworkServices::get_iam_policy][super::super::client::NetworkServices::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4642,7 +4642,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::test_iam_permissions call.
+    /// The request builder for [NetworkServices::test_iam_permissions][super::super::client::NetworkServices::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4698,7 +4698,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::list_operations call.
+    /// The request builder for [NetworkServices::list_operations][super::super::client::NetworkServices::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4776,7 +4776,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::get_operation call.
+    /// The request builder for [NetworkServices::get_operation][super::super::client::NetworkServices::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4821,7 +4821,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::delete_operation call.
+    /// The request builder for [NetworkServices::delete_operation][super::super::client::NetworkServices::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4866,7 +4866,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for a NetworkServices::cancel_operation call.
+    /// The request builder for [NetworkServices::cancel_operation][super::super::client::NetworkServices::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/notebooks/v2/src/builder.rs
+++ b/src/generated/cloud/notebooks/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::list_instances call.
+    /// The request builder for [NotebookService::list_instances][super::super::client::NotebookService::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -148,7 +148,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_instance call.
+    /// The request builder for [NotebookService::get_instance][super::super::client::NotebookService::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -190,7 +190,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::create_instance call.
+    /// The request builder for [NotebookService::create_instance][super::super::client::NotebookService::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -291,7 +291,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::update_instance call.
+    /// The request builder for [NotebookService::update_instance][super::super::client::NotebookService::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -389,7 +389,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::delete_instance call.
+    /// The request builder for [NotebookService::delete_instance][super::super::client::NotebookService::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -472,7 +472,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::start_instance call.
+    /// The request builder for [NotebookService::start_instance][super::super::client::NotebookService::start_instance] calls.
     #[derive(Clone, Debug)]
     pub struct StartInstance(RequestBuilder<crate::model::StartInstanceRequest>);
 
@@ -552,7 +552,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::stop_instance call.
+    /// The request builder for [NotebookService::stop_instance][super::super::client::NotebookService::stop_instance] calls.
     #[derive(Clone, Debug)]
     pub struct StopInstance(RequestBuilder<crate::model::StopInstanceRequest>);
 
@@ -632,7 +632,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::reset_instance call.
+    /// The request builder for [NotebookService::reset_instance][super::super::client::NotebookService::reset_instance] calls.
     #[derive(Clone, Debug)]
     pub struct ResetInstance(RequestBuilder<crate::model::ResetInstanceRequest>);
 
@@ -712,7 +712,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::check_instance_upgradability call.
+    /// The request builder for [NotebookService::check_instance_upgradability][super::super::client::NotebookService::check_instance_upgradability] calls.
     #[derive(Clone, Debug)]
     pub struct CheckInstanceUpgradability(
         RequestBuilder<crate::model::CheckInstanceUpgradabilityRequest>,
@@ -759,7 +759,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::upgrade_instance call.
+    /// The request builder for [NotebookService::upgrade_instance][super::super::client::NotebookService::upgrade_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpgradeInstance(RequestBuilder<crate::model::UpgradeInstanceRequest>);
 
@@ -839,7 +839,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::rollback_instance call.
+    /// The request builder for [NotebookService::rollback_instance][super::super::client::NotebookService::rollback_instance] calls.
     #[derive(Clone, Debug)]
     pub struct RollbackInstance(RequestBuilder<crate::model::RollbackInstanceRequest>);
 
@@ -934,7 +934,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::diagnose_instance call.
+    /// The request builder for [NotebookService::diagnose_instance][super::super::client::NotebookService::diagnose_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DiagnoseInstance(RequestBuilder<crate::model::DiagnoseInstanceRequest>);
 
@@ -1034,7 +1034,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::list_locations call.
+    /// The request builder for [NotebookService::list_locations][super::super::client::NotebookService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1112,7 +1112,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_location call.
+    /// The request builder for [NotebookService::get_location][super::super::client::NotebookService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1154,7 +1154,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::set_iam_policy call.
+    /// The request builder for [NotebookService::set_iam_policy][super::super::client::NotebookService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1214,7 +1214,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_iam_policy call.
+    /// The request builder for [NotebookService::get_iam_policy][super::super::client::NotebookService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1265,7 +1265,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::test_iam_permissions call.
+    /// The request builder for [NotebookService::test_iam_permissions][super::super::client::NotebookService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1321,7 +1321,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::list_operations call.
+    /// The request builder for [NotebookService::list_operations][super::super::client::NotebookService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1399,7 +1399,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::get_operation call.
+    /// The request builder for [NotebookService::get_operation][super::super::client::NotebookService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1444,7 +1444,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::delete_operation call.
+    /// The request builder for [NotebookService::delete_operation][super::super::client::NotebookService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1489,7 +1489,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for a NotebookService::cancel_operation call.
+    /// The request builder for [NotebookService::cancel_operation][super::super::client::NotebookService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/optimization/v1/src/builder.rs
+++ b/src/generated/cloud/optimization/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod fleet_routing {
         }
     }
 
-    /// The request builder for a FleetRouting::optimize_tours call.
+    /// The request builder for [FleetRouting::optimize_tours][super::super::client::FleetRouting::optimize_tours] calls.
     #[derive(Clone, Debug)]
     pub struct OptimizeTours(RequestBuilder<crate::model::OptimizeToursRequest>);
 
@@ -250,7 +250,7 @@ pub mod fleet_routing {
         }
     }
 
-    /// The request builder for a FleetRouting::batch_optimize_tours call.
+    /// The request builder for [FleetRouting::batch_optimize_tours][super::super::client::FleetRouting::batch_optimize_tours] calls.
     #[derive(Clone, Debug)]
     pub struct BatchOptimizeTours(RequestBuilder<crate::model::BatchOptimizeToursRequest>);
 
@@ -347,7 +347,7 @@ pub mod fleet_routing {
         }
     }
 
-    /// The request builder for a FleetRouting::get_operation call.
+    /// The request builder for [FleetRouting::get_operation][super::super::client::FleetRouting::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/oracledatabase/v1/src/builder.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_cloud_exadata_infrastructures call.
+    /// The request builder for [OracleDatabase::list_cloud_exadata_infrastructures][super::super::client::OracleDatabase::list_cloud_exadata_infrastructures] calls.
     #[derive(Clone, Debug)]
     pub struct ListCloudExadataInfrastructures(
         RequestBuilder<crate::model::ListCloudExadataInfrastructuresRequest>,
@@ -143,7 +143,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::get_cloud_exadata_infrastructure call.
+    /// The request builder for [OracleDatabase::get_cloud_exadata_infrastructure][super::super::client::OracleDatabase::get_cloud_exadata_infrastructure] calls.
     #[derive(Clone, Debug)]
     pub struct GetCloudExadataInfrastructure(
         RequestBuilder<crate::model::GetCloudExadataInfrastructureRequest>,
@@ -190,7 +190,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::create_cloud_exadata_infrastructure call.
+    /// The request builder for [OracleDatabase::create_cloud_exadata_infrastructure][super::super::client::OracleDatabase::create_cloud_exadata_infrastructure] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCloudExadataInfrastructure(
         RequestBuilder<crate::model::CreateCloudExadataInfrastructureRequest>,
@@ -304,7 +304,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::delete_cloud_exadata_infrastructure call.
+    /// The request builder for [OracleDatabase::delete_cloud_exadata_infrastructure][super::super::client::OracleDatabase::delete_cloud_exadata_infrastructure] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCloudExadataInfrastructure(
         RequestBuilder<crate::model::DeleteCloudExadataInfrastructureRequest>,
@@ -398,7 +398,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_cloud_vm_clusters call.
+    /// The request builder for [OracleDatabase::list_cloud_vm_clusters][super::super::client::OracleDatabase::list_cloud_vm_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListCloudVmClusters(RequestBuilder<crate::model::ListCloudVmClustersRequest>);
 
@@ -476,7 +476,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::get_cloud_vm_cluster call.
+    /// The request builder for [OracleDatabase::get_cloud_vm_cluster][super::super::client::OracleDatabase::get_cloud_vm_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetCloudVmCluster(RequestBuilder<crate::model::GetCloudVmClusterRequest>);
 
@@ -521,7 +521,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::create_cloud_vm_cluster call.
+    /// The request builder for [OracleDatabase::create_cloud_vm_cluster][super::super::client::OracleDatabase::create_cloud_vm_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCloudVmCluster(RequestBuilder<crate::model::CreateCloudVmClusterRequest>);
 
@@ -626,7 +626,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::delete_cloud_vm_cluster call.
+    /// The request builder for [OracleDatabase::delete_cloud_vm_cluster][super::super::client::OracleDatabase::delete_cloud_vm_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCloudVmCluster(RequestBuilder<crate::model::DeleteCloudVmClusterRequest>);
 
@@ -718,7 +718,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_entitlements call.
+    /// The request builder for [OracleDatabase::list_entitlements][super::super::client::OracleDatabase::list_entitlements] calls.
     #[derive(Clone, Debug)]
     pub struct ListEntitlements(RequestBuilder<crate::model::ListEntitlementsRequest>);
 
@@ -790,7 +790,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_db_servers call.
+    /// The request builder for [OracleDatabase::list_db_servers][super::super::client::OracleDatabase::list_db_servers] calls.
     #[derive(Clone, Debug)]
     pub struct ListDbServers(RequestBuilder<crate::model::ListDbServersRequest>);
 
@@ -859,7 +859,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_db_nodes call.
+    /// The request builder for [OracleDatabase::list_db_nodes][super::super::client::OracleDatabase::list_db_nodes] calls.
     #[derive(Clone, Debug)]
     pub struct ListDbNodes(RequestBuilder<crate::model::ListDbNodesRequest>);
 
@@ -928,7 +928,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_gi_versions call.
+    /// The request builder for [OracleDatabase::list_gi_versions][super::super::client::OracleDatabase::list_gi_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListGiVersions(RequestBuilder<crate::model::ListGiVersionsRequest>);
 
@@ -997,7 +997,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_db_system_shapes call.
+    /// The request builder for [OracleDatabase::list_db_system_shapes][super::super::client::OracleDatabase::list_db_system_shapes] calls.
     #[derive(Clone, Debug)]
     pub struct ListDbSystemShapes(RequestBuilder<crate::model::ListDbSystemShapesRequest>);
 
@@ -1069,7 +1069,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_autonomous_databases call.
+    /// The request builder for [OracleDatabase::list_autonomous_databases][super::super::client::OracleDatabase::list_autonomous_databases] calls.
     #[derive(Clone, Debug)]
     pub struct ListAutonomousDatabases(
         RequestBuilder<crate::model::ListAutonomousDatabasesRequest>,
@@ -1157,7 +1157,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::get_autonomous_database call.
+    /// The request builder for [OracleDatabase::get_autonomous_database][super::super::client::OracleDatabase::get_autonomous_database] calls.
     #[derive(Clone, Debug)]
     pub struct GetAutonomousDatabase(RequestBuilder<crate::model::GetAutonomousDatabaseRequest>);
 
@@ -1202,7 +1202,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::create_autonomous_database call.
+    /// The request builder for [OracleDatabase::create_autonomous_database][super::super::client::OracleDatabase::create_autonomous_database] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAutonomousDatabase(
         RequestBuilder<crate::model::CreateAutonomousDatabaseRequest>,
@@ -1311,7 +1311,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::delete_autonomous_database call.
+    /// The request builder for [OracleDatabase::delete_autonomous_database][super::super::client::OracleDatabase::delete_autonomous_database] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAutonomousDatabase(
         RequestBuilder<crate::model::DeleteAutonomousDatabaseRequest>,
@@ -1399,7 +1399,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::restore_autonomous_database call.
+    /// The request builder for [OracleDatabase::restore_autonomous_database][super::super::client::OracleDatabase::restore_autonomous_database] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreAutonomousDatabase(
         RequestBuilder<crate::model::RestoreAutonomousDatabaseRequest>,
@@ -1494,7 +1494,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::generate_autonomous_database_wallet call.
+    /// The request builder for [OracleDatabase::generate_autonomous_database_wallet][super::super::client::OracleDatabase::generate_autonomous_database_wallet] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAutonomousDatabaseWallet(
         RequestBuilder<crate::model::GenerateAutonomousDatabaseWalletRequest>,
@@ -1559,7 +1559,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_autonomous_db_versions call.
+    /// The request builder for [OracleDatabase::list_autonomous_db_versions][super::super::client::OracleDatabase::list_autonomous_db_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListAutonomousDbVersions(
         RequestBuilder<crate::model::ListAutonomousDbVersionsRequest>,
@@ -1635,7 +1635,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_autonomous_database_character_sets call.
+    /// The request builder for [OracleDatabase::list_autonomous_database_character_sets][super::super::client::OracleDatabase::list_autonomous_database_character_sets] calls.
     #[derive(Clone, Debug)]
     pub struct ListAutonomousDatabaseCharacterSets(
         RequestBuilder<crate::model::ListAutonomousDatabaseCharacterSetsRequest>,
@@ -1719,7 +1719,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_autonomous_database_backups call.
+    /// The request builder for [OracleDatabase::list_autonomous_database_backups][super::super::client::OracleDatabase::list_autonomous_database_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListAutonomousDatabaseBackups(
         RequestBuilder<crate::model::ListAutonomousDatabaseBackupsRequest>,
@@ -1801,7 +1801,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_locations call.
+    /// The request builder for [OracleDatabase::list_locations][super::super::client::OracleDatabase::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1879,7 +1879,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::get_location call.
+    /// The request builder for [OracleDatabase::get_location][super::super::client::OracleDatabase::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1921,7 +1921,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::list_operations call.
+    /// The request builder for [OracleDatabase::list_operations][super::super::client::OracleDatabase::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1999,7 +1999,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::get_operation call.
+    /// The request builder for [OracleDatabase::get_operation][super::super::client::OracleDatabase::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2044,7 +2044,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::delete_operation call.
+    /// The request builder for [OracleDatabase::delete_operation][super::super::client::OracleDatabase::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2089,7 +2089,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for a OracleDatabase::cancel_operation call.
+    /// The request builder for [OracleDatabase::cancel_operation][super::super::client::OracleDatabase::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::create_environment call.
+    /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEnvironment(RequestBuilder<crate::model::CreateEnvironmentRequest>);
 
@@ -159,7 +159,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_environment call.
+    /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -201,7 +201,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_environments call.
+    /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
     #[derive(Clone, Debug)]
     pub struct ListEnvironments(RequestBuilder<crate::model::ListEnvironmentsRequest>);
 
@@ -273,7 +273,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::update_environment call.
+    /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEnvironment(RequestBuilder<crate::model::UpdateEnvironmentRequest>);
 
@@ -374,7 +374,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::delete_environment call.
+    /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEnvironment(RequestBuilder<crate::model::DeleteEnvironmentRequest>);
 
@@ -454,7 +454,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::execute_airflow_command call.
+    /// The request builder for [Environments::execute_airflow_command][super::super::client::Environments::execute_airflow_command] calls.
     #[derive(Clone, Debug)]
     pub struct ExecuteAirflowCommand(RequestBuilder<crate::model::ExecuteAirflowCommandRequest>);
 
@@ -522,7 +522,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::stop_airflow_command call.
+    /// The request builder for [Environments::stop_airflow_command][super::super::client::Environments::stop_airflow_command] calls.
     #[derive(Clone, Debug)]
     pub struct StopAirflowCommand(RequestBuilder<crate::model::StopAirflowCommandRequest>);
 
@@ -591,7 +591,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::poll_airflow_command call.
+    /// The request builder for [Environments::poll_airflow_command][super::super::client::Environments::poll_airflow_command] calls.
     #[derive(Clone, Debug)]
     pub struct PollAirflowCommand(RequestBuilder<crate::model::PollAirflowCommandRequest>);
 
@@ -660,7 +660,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_workloads call.
+    /// The request builder for [Environments::list_workloads][super::super::client::Environments::list_workloads] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkloads(RequestBuilder<crate::model::ListWorkloadsRequest>);
 
@@ -735,7 +735,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::check_upgrade call.
+    /// The request builder for [Environments::check_upgrade][super::super::client::Environments::check_upgrade] calls.
     #[derive(Clone, Debug)]
     pub struct CheckUpgrade(RequestBuilder<crate::model::CheckUpgradeRequest>);
 
@@ -822,7 +822,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::create_user_workloads_secret call.
+    /// The request builder for [Environments::create_user_workloads_secret][super::super::client::Environments::create_user_workloads_secret] calls.
     #[derive(Clone, Debug)]
     pub struct CreateUserWorkloadsSecret(
         RequestBuilder<crate::model::CreateUserWorkloadsSecretRequest>,
@@ -880,7 +880,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_user_workloads_secret call.
+    /// The request builder for [Environments::get_user_workloads_secret][super::super::client::Environments::get_user_workloads_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetUserWorkloadsSecret(RequestBuilder<crate::model::GetUserWorkloadsSecretRequest>);
 
@@ -925,7 +925,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_user_workloads_secrets call.
+    /// The request builder for [Environments::list_user_workloads_secrets][super::super::client::Environments::list_user_workloads_secrets] calls.
     #[derive(Clone, Debug)]
     pub struct ListUserWorkloadsSecrets(
         RequestBuilder<crate::model::ListUserWorkloadsSecretsRequest>,
@@ -1001,7 +1001,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::update_user_workloads_secret call.
+    /// The request builder for [Environments::update_user_workloads_secret][super::super::client::Environments::update_user_workloads_secret] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateUserWorkloadsSecret(
         RequestBuilder<crate::model::UpdateUserWorkloadsSecretRequest>,
@@ -1053,7 +1053,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::delete_user_workloads_secret call.
+    /// The request builder for [Environments::delete_user_workloads_secret][super::super::client::Environments::delete_user_workloads_secret] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteUserWorkloadsSecret(
         RequestBuilder<crate::model::DeleteUserWorkloadsSecretRequest>,
@@ -1100,7 +1100,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::create_user_workloads_config_map call.
+    /// The request builder for [Environments::create_user_workloads_config_map][super::super::client::Environments::create_user_workloads_config_map] calls.
     #[derive(Clone, Debug)]
     pub struct CreateUserWorkloadsConfigMap(
         RequestBuilder<crate::model::CreateUserWorkloadsConfigMapRequest>,
@@ -1158,7 +1158,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_user_workloads_config_map call.
+    /// The request builder for [Environments::get_user_workloads_config_map][super::super::client::Environments::get_user_workloads_config_map] calls.
     #[derive(Clone, Debug)]
     pub struct GetUserWorkloadsConfigMap(
         RequestBuilder<crate::model::GetUserWorkloadsConfigMapRequest>,
@@ -1205,7 +1205,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_user_workloads_config_maps call.
+    /// The request builder for [Environments::list_user_workloads_config_maps][super::super::client::Environments::list_user_workloads_config_maps] calls.
     #[derive(Clone, Debug)]
     pub struct ListUserWorkloadsConfigMaps(
         RequestBuilder<crate::model::ListUserWorkloadsConfigMapsRequest>,
@@ -1281,7 +1281,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::update_user_workloads_config_map call.
+    /// The request builder for [Environments::update_user_workloads_config_map][super::super::client::Environments::update_user_workloads_config_map] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateUserWorkloadsConfigMap(
         RequestBuilder<crate::model::UpdateUserWorkloadsConfigMapRequest>,
@@ -1333,7 +1333,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::delete_user_workloads_config_map call.
+    /// The request builder for [Environments::delete_user_workloads_config_map][super::super::client::Environments::delete_user_workloads_config_map] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteUserWorkloadsConfigMap(
         RequestBuilder<crate::model::DeleteUserWorkloadsConfigMapRequest>,
@@ -1380,7 +1380,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::save_snapshot call.
+    /// The request builder for [Environments::save_snapshot][super::super::client::Environments::save_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct SaveSnapshot(RequestBuilder<crate::model::SaveSnapshotRequest>);
 
@@ -1467,7 +1467,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::load_snapshot call.
+    /// The request builder for [Environments::load_snapshot][super::super::client::Environments::load_snapshot] calls.
     #[derive(Clone, Debug)]
     pub struct LoadSnapshot(RequestBuilder<crate::model::LoadSnapshotRequest>);
 
@@ -1578,7 +1578,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::database_failover call.
+    /// The request builder for [Environments::database_failover][super::super::client::Environments::database_failover] calls.
     #[derive(Clone, Debug)]
     pub struct DatabaseFailover(RequestBuilder<crate::model::DatabaseFailoverRequest>);
 
@@ -1664,7 +1664,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::fetch_database_properties call.
+    /// The request builder for [Environments::fetch_database_properties][super::super::client::Environments::fetch_database_properties] calls.
     #[derive(Clone, Debug)]
     pub struct FetchDatabaseProperties(
         RequestBuilder<crate::model::FetchDatabasePropertiesRequest>,
@@ -1711,7 +1711,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::list_operations call.
+    /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1789,7 +1789,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::get_operation call.
+    /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1834,7 +1834,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for a Environments::delete_operation call.
+    /// The request builder for [Environments::delete_operation][super::super::client::Environments::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1933,7 +1933,7 @@ pub mod image_versions {
         }
     }
 
-    /// The request builder for a ImageVersions::list_image_versions call.
+    /// The request builder for [ImageVersions::list_image_versions][super::super::client::ImageVersions::list_image_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListImageVersions(RequestBuilder<crate::model::ListImageVersionsRequest>);
 
@@ -2011,7 +2011,7 @@ pub mod image_versions {
         }
     }
 
-    /// The request builder for a ImageVersions::list_operations call.
+    /// The request builder for [ImageVersions::list_operations][super::super::client::ImageVersions::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2089,7 +2089,7 @@ pub mod image_versions {
         }
     }
 
-    /// The request builder for a ImageVersions::get_operation call.
+    /// The request builder for [ImageVersions::get_operation][super::super::client::ImageVersions::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2134,7 +2134,7 @@ pub mod image_versions {
         }
     }
 
-    /// The request builder for a ImageVersions::delete_operation call.
+    /// The request builder for [ImageVersions::delete_operation][super::super::client::ImageVersions::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 

--- a/src/generated/cloud/orgpolicy/v2/src/builder.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::list_constraints call.
+    /// The request builder for [OrgPolicy::list_constraints][super::super::client::OrgPolicy::list_constraints] calls.
     #[derive(Clone, Debug)]
     pub struct ListConstraints(RequestBuilder<crate::model::ListConstraintsRequest>);
 
@@ -136,7 +136,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::list_policies call.
+    /// The request builder for [OrgPolicy::list_policies][super::super::client::OrgPolicy::list_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListPolicies(RequestBuilder<crate::model::ListPoliciesRequest>);
 
@@ -205,7 +205,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::get_policy call.
+    /// The request builder for [OrgPolicy::get_policy][super::super::client::OrgPolicy::get_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetPolicy(RequestBuilder<crate::model::GetPolicyRequest>);
 
@@ -247,7 +247,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::get_effective_policy call.
+    /// The request builder for [OrgPolicy::get_effective_policy][super::super::client::OrgPolicy::get_effective_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetEffectivePolicy(RequestBuilder<crate::model::GetEffectivePolicyRequest>);
 
@@ -292,7 +292,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::create_policy call.
+    /// The request builder for [OrgPolicy::create_policy][super::super::client::OrgPolicy::create_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePolicy(RequestBuilder<crate::model::CreatePolicyRequest>);
 
@@ -343,7 +343,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::update_policy call.
+    /// The request builder for [OrgPolicy::update_policy][super::super::client::OrgPolicy::update_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePolicy(RequestBuilder<crate::model::UpdatePolicyRequest>);
 
@@ -397,7 +397,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::delete_policy call.
+    /// The request builder for [OrgPolicy::delete_policy][super::super::client::OrgPolicy::delete_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePolicy(RequestBuilder<crate::model::DeletePolicyRequest>);
 
@@ -445,7 +445,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::create_custom_constraint call.
+    /// The request builder for [OrgPolicy::create_custom_constraint][super::super::client::OrgPolicy::create_custom_constraint] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCustomConstraint(RequestBuilder<crate::model::CreateCustomConstraintRequest>);
 
@@ -501,7 +501,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::update_custom_constraint call.
+    /// The request builder for [OrgPolicy::update_custom_constraint][super::super::client::OrgPolicy::update_custom_constraint] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCustomConstraint(RequestBuilder<crate::model::UpdateCustomConstraintRequest>);
 
@@ -551,7 +551,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::get_custom_constraint call.
+    /// The request builder for [OrgPolicy::get_custom_constraint][super::super::client::OrgPolicy::get_custom_constraint] calls.
     #[derive(Clone, Debug)]
     pub struct GetCustomConstraint(RequestBuilder<crate::model::GetCustomConstraintRequest>);
 
@@ -596,7 +596,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::list_custom_constraints call.
+    /// The request builder for [OrgPolicy::list_custom_constraints][super::super::client::OrgPolicy::list_custom_constraints] calls.
     #[derive(Clone, Debug)]
     pub struct ListCustomConstraints(RequestBuilder<crate::model::ListCustomConstraintsRequest>);
 
@@ -668,7 +668,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for a OrgPolicy::delete_custom_constraint call.
+    /// The request builder for [OrgPolicy::delete_custom_constraint][super::super::client::OrgPolicy::delete_custom_constraint] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCustomConstraint(RequestBuilder<crate::model::DeleteCustomConstraintRequest>);
 

--- a/src/generated/cloud/osconfig/v1/src/builder.rs
+++ b/src/generated/cloud/osconfig/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::execute_patch_job call.
+    /// The request builder for [OsConfigService::execute_patch_job][super::super::client::OsConfigService::execute_patch_job] calls.
     #[derive(Clone, Debug)]
     pub struct ExecutePatchJob(RequestBuilder<crate::model::ExecutePatchJobRequest>);
 
@@ -162,7 +162,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::get_patch_job call.
+    /// The request builder for [OsConfigService::get_patch_job][super::super::client::OsConfigService::get_patch_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetPatchJob(RequestBuilder<crate::model::GetPatchJobRequest>);
 
@@ -204,7 +204,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::cancel_patch_job call.
+    /// The request builder for [OsConfigService::cancel_patch_job][super::super::client::OsConfigService::cancel_patch_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelPatchJob(RequestBuilder<crate::model::CancelPatchJobRequest>);
 
@@ -246,7 +246,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::list_patch_jobs call.
+    /// The request builder for [OsConfigService::list_patch_jobs][super::super::client::OsConfigService::list_patch_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListPatchJobs(RequestBuilder<crate::model::ListPatchJobsRequest>);
 
@@ -321,7 +321,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::list_patch_job_instance_details call.
+    /// The request builder for [OsConfigService::list_patch_job_instance_details][super::super::client::OsConfigService::list_patch_job_instance_details] calls.
     #[derive(Clone, Debug)]
     pub struct ListPatchJobInstanceDetails(
         RequestBuilder<crate::model::ListPatchJobInstanceDetailsRequest>,
@@ -403,7 +403,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::create_patch_deployment call.
+    /// The request builder for [OsConfigService::create_patch_deployment][super::super::client::OsConfigService::create_patch_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePatchDeployment(RequestBuilder<crate::model::CreatePatchDeploymentRequest>);
 
@@ -463,7 +463,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::get_patch_deployment call.
+    /// The request builder for [OsConfigService::get_patch_deployment][super::super::client::OsConfigService::get_patch_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct GetPatchDeployment(RequestBuilder<crate::model::GetPatchDeploymentRequest>);
 
@@ -508,7 +508,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::list_patch_deployments call.
+    /// The request builder for [OsConfigService::list_patch_deployments][super::super::client::OsConfigService::list_patch_deployments] calls.
     #[derive(Clone, Debug)]
     pub struct ListPatchDeployments(RequestBuilder<crate::model::ListPatchDeploymentsRequest>);
 
@@ -580,7 +580,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::delete_patch_deployment call.
+    /// The request builder for [OsConfigService::delete_patch_deployment][super::super::client::OsConfigService::delete_patch_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePatchDeployment(RequestBuilder<crate::model::DeletePatchDeploymentRequest>);
 
@@ -625,7 +625,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::update_patch_deployment call.
+    /// The request builder for [OsConfigService::update_patch_deployment][super::super::client::OsConfigService::update_patch_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePatchDeployment(RequestBuilder<crate::model::UpdatePatchDeploymentRequest>);
 
@@ -682,7 +682,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::pause_patch_deployment call.
+    /// The request builder for [OsConfigService::pause_patch_deployment][super::super::client::OsConfigService::pause_patch_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct PausePatchDeployment(RequestBuilder<crate::model::PausePatchDeploymentRequest>);
 
@@ -727,7 +727,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::resume_patch_deployment call.
+    /// The request builder for [OsConfigService::resume_patch_deployment][super::super::client::OsConfigService::resume_patch_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct ResumePatchDeployment(RequestBuilder<crate::model::ResumePatchDeploymentRequest>);
 
@@ -772,7 +772,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::get_operation call.
+    /// The request builder for [OsConfigService::get_operation][super::super::client::OsConfigService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -817,7 +817,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for a OsConfigService::cancel_operation call.
+    /// The request builder for [OsConfigService::cancel_operation][super::super::client::OsConfigService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -918,7 +918,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::create_os_policy_assignment call.
+    /// The request builder for [OsConfigZonalService::create_os_policy_assignment][super::super::client::OsConfigZonalService::create_os_policy_assignment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateOSPolicyAssignment(
         RequestBuilder<crate::model::CreateOSPolicyAssignmentRequest>,
@@ -1027,7 +1027,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::update_os_policy_assignment call.
+    /// The request builder for [OsConfigZonalService::update_os_policy_assignment][super::super::client::OsConfigZonalService::update_os_policy_assignment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateOSPolicyAssignment(
         RequestBuilder<crate::model::UpdateOSPolicyAssignmentRequest>,
@@ -1133,7 +1133,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::get_os_policy_assignment call.
+    /// The request builder for [OsConfigZonalService::get_os_policy_assignment][super::super::client::OsConfigZonalService::get_os_policy_assignment] calls.
     #[derive(Clone, Debug)]
     pub struct GetOSPolicyAssignment(RequestBuilder<crate::model::GetOSPolicyAssignmentRequest>);
 
@@ -1180,7 +1180,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::list_os_policy_assignments call.
+    /// The request builder for [OsConfigZonalService::list_os_policy_assignments][super::super::client::OsConfigZonalService::list_os_policy_assignments] calls.
     #[derive(Clone, Debug)]
     pub struct ListOSPolicyAssignments(
         RequestBuilder<crate::model::ListOSPolicyAssignmentsRequest>,
@@ -1258,7 +1258,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::list_os_policy_assignment_revisions call.
+    /// The request builder for [OsConfigZonalService::list_os_policy_assignment_revisions][super::super::client::OsConfigZonalService::list_os_policy_assignment_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct ListOSPolicyAssignmentRevisions(
         RequestBuilder<crate::model::ListOSPolicyAssignmentRevisionsRequest>,
@@ -1336,7 +1336,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::delete_os_policy_assignment call.
+    /// The request builder for [OsConfigZonalService::delete_os_policy_assignment][super::super::client::OsConfigZonalService::delete_os_policy_assignment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOSPolicyAssignment(
         RequestBuilder<crate::model::DeleteOSPolicyAssignmentRequest>,
@@ -1424,7 +1424,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::get_os_policy_assignment_report call.
+    /// The request builder for [OsConfigZonalService::get_os_policy_assignment_report][super::super::client::OsConfigZonalService::get_os_policy_assignment_report] calls.
     #[derive(Clone, Debug)]
     pub struct GetOSPolicyAssignmentReport(
         RequestBuilder<crate::model::GetOSPolicyAssignmentReportRequest>,
@@ -1473,7 +1473,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::list_os_policy_assignment_reports call.
+    /// The request builder for [OsConfigZonalService::list_os_policy_assignment_reports][super::super::client::OsConfigZonalService::list_os_policy_assignment_reports] calls.
     #[derive(Clone, Debug)]
     pub struct ListOSPolicyAssignmentReports(
         RequestBuilder<crate::model::ListOSPolicyAssignmentReportsRequest>,
@@ -1557,7 +1557,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::get_inventory call.
+    /// The request builder for [OsConfigZonalService::get_inventory][super::super::client::OsConfigZonalService::get_inventory] calls.
     #[derive(Clone, Debug)]
     pub struct GetInventory(RequestBuilder<crate::model::GetInventoryRequest>);
 
@@ -1607,7 +1607,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::list_inventories call.
+    /// The request builder for [OsConfigZonalService::list_inventories][super::super::client::OsConfigZonalService::list_inventories] calls.
     #[derive(Clone, Debug)]
     pub struct ListInventories(RequestBuilder<crate::model::ListInventoriesRequest>);
 
@@ -1690,7 +1690,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::get_vulnerability_report call.
+    /// The request builder for [OsConfigZonalService::get_vulnerability_report][super::super::client::OsConfigZonalService::get_vulnerability_report] calls.
     #[derive(Clone, Debug)]
     pub struct GetVulnerabilityReport(RequestBuilder<crate::model::GetVulnerabilityReportRequest>);
 
@@ -1737,7 +1737,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::list_vulnerability_reports call.
+    /// The request builder for [OsConfigZonalService::list_vulnerability_reports][super::super::client::OsConfigZonalService::list_vulnerability_reports] calls.
     #[derive(Clone, Debug)]
     pub struct ListVulnerabilityReports(
         RequestBuilder<crate::model::ListVulnerabilityReportsRequest>,
@@ -1821,7 +1821,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::get_operation call.
+    /// The request builder for [OsConfigZonalService::get_operation][super::super::client::OsConfigZonalService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1868,7 +1868,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for a OsConfigZonalService::cancel_operation call.
+    /// The request builder for [OsConfigZonalService::cancel_operation][super::super::client::OsConfigZonalService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/oslogin/v1/src/builder.rs
+++ b/src/generated/cloud/oslogin/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for a OsLoginService::create_ssh_public_key call.
+    /// The request builder for [OsLoginService::create_ssh_public_key][super::super::client::OsLoginService::create_ssh_public_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSshPublicKey(RequestBuilder<crate::model::CreateSshPublicKeyRequest>);
 
@@ -123,7 +123,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for a OsLoginService::delete_posix_account call.
+    /// The request builder for [OsLoginService::delete_posix_account][super::super::client::OsLoginService::delete_posix_account] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePosixAccount(RequestBuilder<crate::model::DeletePosixAccountRequest>);
 
@@ -168,7 +168,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for a OsLoginService::delete_ssh_public_key call.
+    /// The request builder for [OsLoginService::delete_ssh_public_key][super::super::client::OsLoginService::delete_ssh_public_key] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSshPublicKey(RequestBuilder<crate::model::DeleteSshPublicKeyRequest>);
 
@@ -213,7 +213,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for a OsLoginService::get_login_profile call.
+    /// The request builder for [OsLoginService::get_login_profile][super::super::client::OsLoginService::get_login_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetLoginProfile(RequestBuilder<crate::model::GetLoginProfileRequest>);
 
@@ -267,7 +267,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for a OsLoginService::get_ssh_public_key call.
+    /// The request builder for [OsLoginService::get_ssh_public_key][super::super::client::OsLoginService::get_ssh_public_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetSshPublicKey(RequestBuilder<crate::model::GetSshPublicKeyRequest>);
 
@@ -309,7 +309,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for a OsLoginService::import_ssh_public_key call.
+    /// The request builder for [OsLoginService::import_ssh_public_key][super::super::client::OsLoginService::import_ssh_public_key] calls.
     #[derive(Clone, Debug)]
     pub struct ImportSshPublicKey(RequestBuilder<crate::model::ImportSshPublicKeyRequest>);
 
@@ -382,7 +382,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for a OsLoginService::update_ssh_public_key call.
+    /// The request builder for [OsLoginService::update_ssh_public_key][super::super::client::OsLoginService::update_ssh_public_key] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSshPublicKey(RequestBuilder<crate::model::UpdateSshPublicKeyRequest>);
 

--- a/src/generated/cloud/parallelstore/v1/src/builder.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::list_instances call.
+    /// The request builder for [Parallelstore::list_instances][super::super::client::Parallelstore::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -148,7 +148,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::get_instance call.
+    /// The request builder for [Parallelstore::get_instance][super::super::client::Parallelstore::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -190,7 +190,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::create_instance call.
+    /// The request builder for [Parallelstore::create_instance][super::super::client::Parallelstore::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -291,7 +291,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::update_instance call.
+    /// The request builder for [Parallelstore::update_instance][super::super::client::Parallelstore::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -389,7 +389,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::delete_instance call.
+    /// The request builder for [Parallelstore::delete_instance][super::super::client::Parallelstore::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -472,7 +472,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::import_data call.
+    /// The request builder for [Parallelstore::import_data][super::super::client::Parallelstore::import_data] calls.
     #[derive(Clone, Debug)]
     pub struct ImportData(RequestBuilder<crate::model::ImportDataRequest>);
 
@@ -583,7 +583,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::export_data call.
+    /// The request builder for [Parallelstore::export_data][super::super::client::Parallelstore::export_data] calls.
     #[derive(Clone, Debug)]
     pub struct ExportData(RequestBuilder<crate::model::ExportDataRequest>);
 
@@ -694,7 +694,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::list_locations call.
+    /// The request builder for [Parallelstore::list_locations][super::super::client::Parallelstore::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -772,7 +772,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::get_location call.
+    /// The request builder for [Parallelstore::get_location][super::super::client::Parallelstore::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -814,7 +814,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::list_operations call.
+    /// The request builder for [Parallelstore::list_operations][super::super::client::Parallelstore::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -892,7 +892,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::get_operation call.
+    /// The request builder for [Parallelstore::get_operation][super::super::client::Parallelstore::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -937,7 +937,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::delete_operation call.
+    /// The request builder for [Parallelstore::delete_operation][super::super::client::Parallelstore::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -982,7 +982,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for a Parallelstore::cancel_operation call.
+    /// The request builder for [Parallelstore::cancel_operation][super::super::client::Parallelstore::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/parametermanager/v1/src/builder.rs
+++ b/src/generated/cloud/parametermanager/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::list_parameters call.
+    /// The request builder for [ParameterManager::list_parameters][super::super::client::ParameterManager::list_parameters] calls.
     #[derive(Clone, Debug)]
     pub struct ListParameters(RequestBuilder<crate::model::ListParametersRequest>);
 
@@ -148,7 +148,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::get_parameter call.
+    /// The request builder for [ParameterManager::get_parameter][super::super::client::ParameterManager::get_parameter] calls.
     #[derive(Clone, Debug)]
     pub struct GetParameter(RequestBuilder<crate::model::GetParameterRequest>);
 
@@ -190,7 +190,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::create_parameter call.
+    /// The request builder for [ParameterManager::create_parameter][super::super::client::ParameterManager::create_parameter] calls.
     #[derive(Clone, Debug)]
     pub struct CreateParameter(RequestBuilder<crate::model::CreateParameterRequest>);
 
@@ -253,7 +253,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::update_parameter call.
+    /// The request builder for [ParameterManager::update_parameter][super::super::client::ParameterManager::update_parameter] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateParameter(RequestBuilder<crate::model::UpdateParameterRequest>);
 
@@ -313,7 +313,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::delete_parameter call.
+    /// The request builder for [ParameterManager::delete_parameter][super::super::client::ParameterManager::delete_parameter] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteParameter(RequestBuilder<crate::model::DeleteParameterRequest>);
 
@@ -361,7 +361,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::list_parameter_versions call.
+    /// The request builder for [ParameterManager::list_parameter_versions][super::super::client::ParameterManager::list_parameter_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListParameterVersions(RequestBuilder<crate::model::ListParameterVersionsRequest>);
 
@@ -445,7 +445,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::get_parameter_version call.
+    /// The request builder for [ParameterManager::get_parameter_version][super::super::client::ParameterManager::get_parameter_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetParameterVersion(RequestBuilder<crate::model::GetParameterVersionRequest>);
 
@@ -496,7 +496,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::render_parameter_version call.
+    /// The request builder for [ParameterManager::render_parameter_version][super::super::client::ParameterManager::render_parameter_version] calls.
     #[derive(Clone, Debug)]
     pub struct RenderParameterVersion(RequestBuilder<crate::model::RenderParameterVersionRequest>);
 
@@ -541,7 +541,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::create_parameter_version call.
+    /// The request builder for [ParameterManager::create_parameter_version][super::super::client::ParameterManager::create_parameter_version] calls.
     #[derive(Clone, Debug)]
     pub struct CreateParameterVersion(RequestBuilder<crate::model::CreateParameterVersionRequest>);
 
@@ -609,7 +609,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::update_parameter_version call.
+    /// The request builder for [ParameterManager::update_parameter_version][super::super::client::ParameterManager::update_parameter_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateParameterVersion(RequestBuilder<crate::model::UpdateParameterVersionRequest>);
 
@@ -674,7 +674,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::delete_parameter_version call.
+    /// The request builder for [ParameterManager::delete_parameter_version][super::super::client::ParameterManager::delete_parameter_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteParameterVersion(RequestBuilder<crate::model::DeleteParameterVersionRequest>);
 
@@ -725,7 +725,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::list_locations call.
+    /// The request builder for [ParameterManager::list_locations][super::super::client::ParameterManager::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -803,7 +803,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for a ParameterManager::get_location call.
+    /// The request builder for [ParameterManager::get_location][super::super::client::ParameterManager::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/policysimulator/v1/src/builder.rs
+++ b/src/generated/cloud/policysimulator/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for a Simulator::get_replay call.
+    /// The request builder for [Simulator::get_replay][super::super::client::Simulator::get_replay] calls.
     #[derive(Clone, Debug)]
     pub struct GetReplay(RequestBuilder<crate::model::GetReplayRequest>);
 
@@ -109,7 +109,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for a Simulator::create_replay call.
+    /// The request builder for [Simulator::create_replay][super::super::client::Simulator::create_replay] calls.
     #[derive(Clone, Debug)]
     pub struct CreateReplay(RequestBuilder<crate::model::CreateReplayRequest>);
 
@@ -198,7 +198,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for a Simulator::list_replay_results call.
+    /// The request builder for [Simulator::list_replay_results][super::super::client::Simulator::list_replay_results] calls.
     #[derive(Clone, Debug)]
     pub struct ListReplayResults(RequestBuilder<crate::model::ListReplayResultsRequest>);
 
@@ -270,7 +270,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for a Simulator::list_operations call.
+    /// The request builder for [Simulator::list_operations][super::super::client::Simulator::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -348,7 +348,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for a Simulator::get_operation call.
+    /// The request builder for [Simulator::get_operation][super::super::client::Simulator::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/builder.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/builder.rs
@@ -69,7 +69,7 @@ pub mod policy_troubleshooter {
         }
     }
 
-    /// The request builder for a PolicyTroubleshooter::troubleshoot_iam_policy call.
+    /// The request builder for [PolicyTroubleshooter::troubleshoot_iam_policy][super::super::client::PolicyTroubleshooter::troubleshoot_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct TroubleshootIamPolicy(RequestBuilder<crate::model::TroubleshootIamPolicyRequest>);
 

--- a/src/generated/cloud/policytroubleshooter/v1/src/builder.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod iam_checker {
         }
     }
 
-    /// The request builder for a IamChecker::troubleshoot_iam_policy call.
+    /// The request builder for [IamChecker::troubleshoot_iam_policy][super::super::client::IamChecker::troubleshoot_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct TroubleshootIamPolicy(RequestBuilder<crate::model::TroubleshootIamPolicyRequest>);
 

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/builder.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::check_onboarding_status call.
+    /// The request builder for [PrivilegedAccessManager::check_onboarding_status][super::super::client::PrivilegedAccessManager::check_onboarding_status] calls.
     #[derive(Clone, Debug)]
     pub struct CheckOnboardingStatus(RequestBuilder<crate::model::CheckOnboardingStatusRequest>);
 
@@ -116,7 +116,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::list_entitlements call.
+    /// The request builder for [PrivilegedAccessManager::list_entitlements][super::super::client::PrivilegedAccessManager::list_entitlements] calls.
     #[derive(Clone, Debug)]
     pub struct ListEntitlements(RequestBuilder<crate::model::ListEntitlementsRequest>);
 
@@ -202,7 +202,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::search_entitlements call.
+    /// The request builder for [PrivilegedAccessManager::search_entitlements][super::super::client::PrivilegedAccessManager::search_entitlements] calls.
     #[derive(Clone, Debug)]
     pub struct SearchEntitlements(RequestBuilder<crate::model::SearchEntitlementsRequest>);
 
@@ -293,7 +293,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::get_entitlement call.
+    /// The request builder for [PrivilegedAccessManager::get_entitlement][super::super::client::PrivilegedAccessManager::get_entitlement] calls.
     #[derive(Clone, Debug)]
     pub struct GetEntitlement(RequestBuilder<crate::model::GetEntitlementRequest>);
 
@@ -337,7 +337,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::create_entitlement call.
+    /// The request builder for [PrivilegedAccessManager::create_entitlement][super::super::client::PrivilegedAccessManager::create_entitlement] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEntitlement(RequestBuilder<crate::model::CreateEntitlementRequest>);
 
@@ -443,7 +443,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::delete_entitlement call.
+    /// The request builder for [PrivilegedAccessManager::delete_entitlement][super::super::client::PrivilegedAccessManager::delete_entitlement] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEntitlement(RequestBuilder<crate::model::DeleteEntitlementRequest>);
 
@@ -540,7 +540,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::update_entitlement call.
+    /// The request builder for [PrivilegedAccessManager::update_entitlement][super::super::client::PrivilegedAccessManager::update_entitlement] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEntitlement(RequestBuilder<crate::model::UpdateEntitlementRequest>);
 
@@ -637,7 +637,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::list_grants call.
+    /// The request builder for [PrivilegedAccessManager::list_grants][super::super::client::PrivilegedAccessManager::list_grants] calls.
     #[derive(Clone, Debug)]
     pub struct ListGrants(RequestBuilder<crate::model::ListGrantsRequest>);
 
@@ -720,7 +720,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::search_grants call.
+    /// The request builder for [PrivilegedAccessManager::search_grants][super::super::client::PrivilegedAccessManager::search_grants] calls.
     #[derive(Clone, Debug)]
     pub struct SearchGrants(RequestBuilder<crate::model::SearchGrantsRequest>);
 
@@ -808,7 +808,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::get_grant call.
+    /// The request builder for [PrivilegedAccessManager::get_grant][super::super::client::PrivilegedAccessManager::get_grant] calls.
     #[derive(Clone, Debug)]
     pub struct GetGrant(RequestBuilder<crate::model::GetGrantRequest>);
 
@@ -852,7 +852,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::create_grant call.
+    /// The request builder for [PrivilegedAccessManager::create_grant][super::super::client::PrivilegedAccessManager::create_grant] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGrant(RequestBuilder<crate::model::CreateGrantRequest>);
 
@@ -911,7 +911,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::approve_grant call.
+    /// The request builder for [PrivilegedAccessManager::approve_grant][super::super::client::PrivilegedAccessManager::approve_grant] calls.
     #[derive(Clone, Debug)]
     pub struct ApproveGrant(RequestBuilder<crate::model::ApproveGrantRequest>);
 
@@ -961,7 +961,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::deny_grant call.
+    /// The request builder for [PrivilegedAccessManager::deny_grant][super::super::client::PrivilegedAccessManager::deny_grant] calls.
     #[derive(Clone, Debug)]
     pub struct DenyGrant(RequestBuilder<crate::model::DenyGrantRequest>);
 
@@ -1011,7 +1011,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::revoke_grant call.
+    /// The request builder for [PrivilegedAccessManager::revoke_grant][super::super::client::PrivilegedAccessManager::revoke_grant] calls.
     #[derive(Clone, Debug)]
     pub struct RevokeGrant(RequestBuilder<crate::model::RevokeGrantRequest>);
 
@@ -1098,7 +1098,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::list_locations call.
+    /// The request builder for [PrivilegedAccessManager::list_locations][super::super::client::PrivilegedAccessManager::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1178,7 +1178,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::get_location call.
+    /// The request builder for [PrivilegedAccessManager::get_location][super::super::client::PrivilegedAccessManager::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1222,7 +1222,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::list_operations call.
+    /// The request builder for [PrivilegedAccessManager::list_operations][super::super::client::PrivilegedAccessManager::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1302,7 +1302,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::get_operation call.
+    /// The request builder for [PrivilegedAccessManager::get_operation][super::super::client::PrivilegedAccessManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1349,7 +1349,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for a PrivilegedAccessManager::delete_operation call.
+    /// The request builder for [PrivilegedAccessManager::delete_operation][super::super::client::PrivilegedAccessManager::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/builder.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::create_collector call.
+    /// The request builder for [RapidMigrationAssessment::create_collector][super::super::client::RapidMigrationAssessment::create_collector] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCollector(RequestBuilder<crate::model::CreateCollectorRequest>);
 
@@ -172,7 +172,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::create_annotation call.
+    /// The request builder for [RapidMigrationAssessment::create_annotation][super::super::client::RapidMigrationAssessment::create_annotation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAnnotation(RequestBuilder<crate::model::CreateAnnotationRequest>);
 
@@ -272,7 +272,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::get_annotation call.
+    /// The request builder for [RapidMigrationAssessment::get_annotation][super::super::client::RapidMigrationAssessment::get_annotation] calls.
     #[derive(Clone, Debug)]
     pub struct GetAnnotation(RequestBuilder<crate::model::GetAnnotationRequest>);
 
@@ -316,7 +316,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::list_collectors call.
+    /// The request builder for [RapidMigrationAssessment::list_collectors][super::super::client::RapidMigrationAssessment::list_collectors] calls.
     #[derive(Clone, Debug)]
     pub struct ListCollectors(RequestBuilder<crate::model::ListCollectorsRequest>);
 
@@ -399,7 +399,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::get_collector call.
+    /// The request builder for [RapidMigrationAssessment::get_collector][super::super::client::RapidMigrationAssessment::get_collector] calls.
     #[derive(Clone, Debug)]
     pub struct GetCollector(RequestBuilder<crate::model::GetCollectorRequest>);
 
@@ -443,7 +443,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::update_collector call.
+    /// The request builder for [RapidMigrationAssessment::update_collector][super::super::client::RapidMigrationAssessment::update_collector] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCollector(RequestBuilder<crate::model::UpdateCollectorRequest>);
 
@@ -543,7 +543,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::delete_collector call.
+    /// The request builder for [RapidMigrationAssessment::delete_collector][super::super::client::RapidMigrationAssessment::delete_collector] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCollector(RequestBuilder<crate::model::DeleteCollectorRequest>);
 
@@ -631,7 +631,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::resume_collector call.
+    /// The request builder for [RapidMigrationAssessment::resume_collector][super::super::client::RapidMigrationAssessment::resume_collector] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeCollector(RequestBuilder<crate::model::ResumeCollectorRequest>);
 
@@ -719,7 +719,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::register_collector call.
+    /// The request builder for [RapidMigrationAssessment::register_collector][super::super::client::RapidMigrationAssessment::register_collector] calls.
     #[derive(Clone, Debug)]
     pub struct RegisterCollector(RequestBuilder<crate::model::RegisterCollectorRequest>);
 
@@ -810,7 +810,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::pause_collector call.
+    /// The request builder for [RapidMigrationAssessment::pause_collector][super::super::client::RapidMigrationAssessment::pause_collector] calls.
     #[derive(Clone, Debug)]
     pub struct PauseCollector(RequestBuilder<crate::model::PauseCollectorRequest>);
 
@@ -898,7 +898,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::list_locations call.
+    /// The request builder for [RapidMigrationAssessment::list_locations][super::super::client::RapidMigrationAssessment::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -978,7 +978,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::get_location call.
+    /// The request builder for [RapidMigrationAssessment::get_location][super::super::client::RapidMigrationAssessment::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1022,7 +1022,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::list_operations call.
+    /// The request builder for [RapidMigrationAssessment::list_operations][super::super::client::RapidMigrationAssessment::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1102,7 +1102,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::get_operation call.
+    /// The request builder for [RapidMigrationAssessment::get_operation][super::super::client::RapidMigrationAssessment::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1149,7 +1149,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::delete_operation call.
+    /// The request builder for [RapidMigrationAssessment::delete_operation][super::super::client::RapidMigrationAssessment::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1196,7 +1196,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for a RapidMigrationAssessment::cancel_operation call.
+    /// The request builder for [RapidMigrationAssessment::cancel_operation][super::super::client::RapidMigrationAssessment::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::create_assessment call.
+    /// The request builder for [RecaptchaEnterpriseService::create_assessment][super::super::client::RecaptchaEnterpriseService::create_assessment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAssessment(RequestBuilder<crate::model::CreateAssessmentRequest>);
 
@@ -125,7 +125,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::annotate_assessment call.
+    /// The request builder for [RecaptchaEnterpriseService::annotate_assessment][super::super::client::RecaptchaEnterpriseService::annotate_assessment] calls.
     #[derive(Clone, Debug)]
     pub struct AnnotateAssessment(RequestBuilder<crate::model::AnnotateAssessmentRequest>);
 
@@ -215,7 +215,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::create_key call.
+    /// The request builder for [RecaptchaEnterpriseService::create_key][super::super::client::RecaptchaEnterpriseService::create_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateKey(RequestBuilder<crate::model::CreateKeyRequest>);
 
@@ -265,7 +265,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::list_keys call.
+    /// The request builder for [RecaptchaEnterpriseService::list_keys][super::super::client::RecaptchaEnterpriseService::list_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListKeys(RequestBuilder<crate::model::ListKeysRequest>);
 
@@ -335,7 +335,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::retrieve_legacy_secret_key call.
+    /// The request builder for [RecaptchaEnterpriseService::retrieve_legacy_secret_key][super::super::client::RecaptchaEnterpriseService::retrieve_legacy_secret_key] calls.
     #[derive(Clone, Debug)]
     pub struct RetrieveLegacySecretKey(
         RequestBuilder<crate::model::RetrieveLegacySecretKeyRequest>,
@@ -384,7 +384,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::get_key call.
+    /// The request builder for [RecaptchaEnterpriseService::get_key][super::super::client::RecaptchaEnterpriseService::get_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetKey(RequestBuilder<crate::model::GetKeyRequest>);
 
@@ -426,7 +426,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::update_key call.
+    /// The request builder for [RecaptchaEnterpriseService::update_key][super::super::client::RecaptchaEnterpriseService::update_key] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateKey(RequestBuilder<crate::model::UpdateKeyRequest>);
 
@@ -479,7 +479,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::delete_key call.
+    /// The request builder for [RecaptchaEnterpriseService::delete_key][super::super::client::RecaptchaEnterpriseService::delete_key] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteKey(RequestBuilder<crate::model::DeleteKeyRequest>);
 
@@ -523,7 +523,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::migrate_key call.
+    /// The request builder for [RecaptchaEnterpriseService::migrate_key][super::super::client::RecaptchaEnterpriseService::migrate_key] calls.
     #[derive(Clone, Debug)]
     pub struct MigrateKey(RequestBuilder<crate::model::MigrateKeyRequest>);
 
@@ -573,7 +573,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::add_ip_override call.
+    /// The request builder for [RecaptchaEnterpriseService::add_ip_override][super::super::client::RecaptchaEnterpriseService::add_ip_override] calls.
     #[derive(Clone, Debug)]
     pub struct AddIpOverride(RequestBuilder<crate::model::AddIpOverrideRequest>);
 
@@ -626,7 +626,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::remove_ip_override call.
+    /// The request builder for [RecaptchaEnterpriseService::remove_ip_override][super::super::client::RecaptchaEnterpriseService::remove_ip_override] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveIpOverride(RequestBuilder<crate::model::RemoveIpOverrideRequest>);
 
@@ -682,7 +682,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::list_ip_overrides call.
+    /// The request builder for [RecaptchaEnterpriseService::list_ip_overrides][super::super::client::RecaptchaEnterpriseService::list_ip_overrides] calls.
     #[derive(Clone, Debug)]
     pub struct ListIpOverrides(RequestBuilder<crate::model::ListIpOverridesRequest>);
 
@@ -753,7 +753,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::get_metrics call.
+    /// The request builder for [RecaptchaEnterpriseService::get_metrics][super::super::client::RecaptchaEnterpriseService::get_metrics] calls.
     #[derive(Clone, Debug)]
     pub struct GetMetrics(RequestBuilder<crate::model::GetMetricsRequest>);
 
@@ -797,7 +797,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::create_firewall_policy call.
+    /// The request builder for [RecaptchaEnterpriseService::create_firewall_policy][super::super::client::RecaptchaEnterpriseService::create_firewall_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFirewallPolicy(RequestBuilder<crate::model::CreateFirewallPolicyRequest>);
 
@@ -853,7 +853,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::list_firewall_policies call.
+    /// The request builder for [RecaptchaEnterpriseService::list_firewall_policies][super::super::client::RecaptchaEnterpriseService::list_firewall_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListFirewallPolicies(RequestBuilder<crate::model::ListFirewallPoliciesRequest>);
 
@@ -927,7 +927,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::get_firewall_policy call.
+    /// The request builder for [RecaptchaEnterpriseService::get_firewall_policy][super::super::client::RecaptchaEnterpriseService::get_firewall_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetFirewallPolicy(RequestBuilder<crate::model::GetFirewallPolicyRequest>);
 
@@ -974,7 +974,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::update_firewall_policy call.
+    /// The request builder for [RecaptchaEnterpriseService::update_firewall_policy][super::super::client::RecaptchaEnterpriseService::update_firewall_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFirewallPolicy(RequestBuilder<crate::model::UpdateFirewallPolicyRequest>);
 
@@ -1033,7 +1033,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::delete_firewall_policy call.
+    /// The request builder for [RecaptchaEnterpriseService::delete_firewall_policy][super::super::client::RecaptchaEnterpriseService::delete_firewall_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFirewallPolicy(RequestBuilder<crate::model::DeleteFirewallPolicyRequest>);
 
@@ -1080,7 +1080,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::reorder_firewall_policies call.
+    /// The request builder for [RecaptchaEnterpriseService::reorder_firewall_policies][super::super::client::RecaptchaEnterpriseService::reorder_firewall_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ReorderFirewallPolicies(
         RequestBuilder<crate::model::ReorderFirewallPoliciesRequest>,
@@ -1140,7 +1140,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::list_related_account_groups call.
+    /// The request builder for [RecaptchaEnterpriseService::list_related_account_groups][super::super::client::RecaptchaEnterpriseService::list_related_account_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListRelatedAccountGroups(
         RequestBuilder<crate::model::ListRelatedAccountGroupsRequest>,
@@ -1218,7 +1218,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::list_related_account_group_memberships call.
+    /// The request builder for [RecaptchaEnterpriseService::list_related_account_group_memberships][super::super::client::RecaptchaEnterpriseService::list_related_account_group_memberships] calls.
     #[derive(Clone, Debug)]
     pub struct ListRelatedAccountGroupMemberships(
         RequestBuilder<crate::model::ListRelatedAccountGroupMembershipsRequest>,
@@ -1298,7 +1298,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for a RecaptchaEnterpriseService::search_related_account_group_memberships call.
+    /// The request builder for [RecaptchaEnterpriseService::search_related_account_group_memberships][super::super::client::RecaptchaEnterpriseService::search_related_account_group_memberships] calls.
     #[derive(Clone, Debug)]
     pub struct SearchRelatedAccountGroupMemberships(
         RequestBuilder<crate::model::SearchRelatedAccountGroupMembershipsRequest>,

--- a/src/generated/cloud/recommender/v1/src/builder.rs
+++ b/src/generated/cloud/recommender/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::list_insights call.
+    /// The request builder for [Recommender::list_insights][super::super::client::Recommender::list_insights] calls.
     #[derive(Clone, Debug)]
     pub struct ListInsights(RequestBuilder<crate::model::ListInsightsRequest>);
 
@@ -142,7 +142,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::get_insight call.
+    /// The request builder for [Recommender::get_insight][super::super::client::Recommender::get_insight] calls.
     #[derive(Clone, Debug)]
     pub struct GetInsight(RequestBuilder<crate::model::GetInsightRequest>);
 
@@ -184,7 +184,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::mark_insight_accepted call.
+    /// The request builder for [Recommender::mark_insight_accepted][super::super::client::Recommender::mark_insight_accepted] calls.
     #[derive(Clone, Debug)]
     pub struct MarkInsightAccepted(RequestBuilder<crate::model::MarkInsightAcceptedRequest>);
 
@@ -247,7 +247,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::list_recommendations call.
+    /// The request builder for [Recommender::list_recommendations][super::super::client::Recommender::list_recommendations] calls.
     #[derive(Clone, Debug)]
     pub struct ListRecommendations(RequestBuilder<crate::model::ListRecommendationsRequest>);
 
@@ -325,7 +325,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::get_recommendation call.
+    /// The request builder for [Recommender::get_recommendation][super::super::client::Recommender::get_recommendation] calls.
     #[derive(Clone, Debug)]
     pub struct GetRecommendation(RequestBuilder<crate::model::GetRecommendationRequest>);
 
@@ -370,7 +370,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::mark_recommendation_dismissed call.
+    /// The request builder for [Recommender::mark_recommendation_dismissed][super::super::client::Recommender::mark_recommendation_dismissed] calls.
     #[derive(Clone, Debug)]
     pub struct MarkRecommendationDismissed(
         RequestBuilder<crate::model::MarkRecommendationDismissedRequest>,
@@ -423,7 +423,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::mark_recommendation_claimed call.
+    /// The request builder for [Recommender::mark_recommendation_claimed][super::super::client::Recommender::mark_recommendation_claimed] calls.
     #[derive(Clone, Debug)]
     pub struct MarkRecommendationClaimed(
         RequestBuilder<crate::model::MarkRecommendationClaimedRequest>,
@@ -488,7 +488,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::mark_recommendation_succeeded call.
+    /// The request builder for [Recommender::mark_recommendation_succeeded][super::super::client::Recommender::mark_recommendation_succeeded] calls.
     #[derive(Clone, Debug)]
     pub struct MarkRecommendationSucceeded(
         RequestBuilder<crate::model::MarkRecommendationSucceededRequest>,
@@ -553,7 +553,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::mark_recommendation_failed call.
+    /// The request builder for [Recommender::mark_recommendation_failed][super::super::client::Recommender::mark_recommendation_failed] calls.
     #[derive(Clone, Debug)]
     pub struct MarkRecommendationFailed(
         RequestBuilder<crate::model::MarkRecommendationFailedRequest>,
@@ -618,7 +618,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::get_recommender_config call.
+    /// The request builder for [Recommender::get_recommender_config][super::super::client::Recommender::get_recommender_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetRecommenderConfig(RequestBuilder<crate::model::GetRecommenderConfigRequest>);
 
@@ -663,7 +663,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::update_recommender_config call.
+    /// The request builder for [Recommender::update_recommender_config][super::super::client::Recommender::update_recommender_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRecommenderConfig(
         RequestBuilder<crate::model::UpdateRecommenderConfigRequest>,
@@ -730,7 +730,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::get_insight_type_config call.
+    /// The request builder for [Recommender::get_insight_type_config][super::super::client::Recommender::get_insight_type_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetInsightTypeConfig(RequestBuilder<crate::model::GetInsightTypeConfigRequest>);
 
@@ -775,7 +775,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for a Recommender::update_insight_type_config call.
+    /// The request builder for [Recommender::update_insight_type_config][super::super::client::Recommender::update_insight_type_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInsightTypeConfig(
         RequestBuilder<crate::model::UpdateInsightTypeConfigRequest>,

--- a/src/generated/cloud/redis/cluster/v1/src/builder.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::list_clusters call.
+    /// The request builder for [CloudRedisCluster::list_clusters][super::super::client::CloudRedisCluster::list_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -136,7 +136,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::get_cluster call.
+    /// The request builder for [CloudRedisCluster::get_cluster][super::super::client::CloudRedisCluster::get_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -178,7 +178,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::update_cluster call.
+    /// The request builder for [CloudRedisCluster::update_cluster][super::super::client::CloudRedisCluster::update_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -273,7 +273,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::delete_cluster call.
+    /// The request builder for [CloudRedisCluster::delete_cluster][super::super::client::CloudRedisCluster::delete_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -356,7 +356,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::create_cluster call.
+    /// The request builder for [CloudRedisCluster::create_cluster][super::super::client::CloudRedisCluster::create_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -454,7 +454,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::get_cluster_certificate_authority call.
+    /// The request builder for [CloudRedisCluster::get_cluster_certificate_authority][super::super::client::CloudRedisCluster::get_cluster_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct GetClusterCertificateAuthority(
         RequestBuilder<crate::model::GetClusterCertificateAuthorityRequest>,
@@ -501,7 +501,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::reschedule_cluster_maintenance call.
+    /// The request builder for [CloudRedisCluster::reschedule_cluster_maintenance][super::super::client::CloudRedisCluster::reschedule_cluster_maintenance] calls.
     #[derive(Clone, Debug)]
     pub struct RescheduleClusterMaintenance(
         RequestBuilder<crate::model::RescheduleClusterMaintenanceRequest>,
@@ -603,7 +603,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::list_backup_collections call.
+    /// The request builder for [CloudRedisCluster::list_backup_collections][super::super::client::CloudRedisCluster::list_backup_collections] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupCollections(RequestBuilder<crate::model::ListBackupCollectionsRequest>);
 
@@ -675,7 +675,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::get_backup_collection call.
+    /// The request builder for [CloudRedisCluster::get_backup_collection][super::super::client::CloudRedisCluster::get_backup_collection] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupCollection(RequestBuilder<crate::model::GetBackupCollectionRequest>);
 
@@ -720,7 +720,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::list_backups call.
+    /// The request builder for [CloudRedisCluster::list_backups][super::super::client::CloudRedisCluster::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -789,7 +789,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::get_backup call.
+    /// The request builder for [CloudRedisCluster::get_backup][super::super::client::CloudRedisCluster::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -831,7 +831,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::delete_backup call.
+    /// The request builder for [CloudRedisCluster::delete_backup][super::super::client::CloudRedisCluster::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -914,7 +914,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::export_backup call.
+    /// The request builder for [CloudRedisCluster::export_backup][super::super::client::CloudRedisCluster::export_backup] calls.
     #[derive(Clone, Debug)]
     pub struct ExportBackup(RequestBuilder<crate::model::ExportBackupRequest>);
 
@@ -1002,7 +1002,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::backup_cluster call.
+    /// The request builder for [CloudRedisCluster::backup_cluster][super::super::client::CloudRedisCluster::backup_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct BackupCluster(RequestBuilder<crate::model::BackupClusterRequest>);
 
@@ -1094,7 +1094,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::list_locations call.
+    /// The request builder for [CloudRedisCluster::list_locations][super::super::client::CloudRedisCluster::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1172,7 +1172,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::get_location call.
+    /// The request builder for [CloudRedisCluster::get_location][super::super::client::CloudRedisCluster::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1214,7 +1214,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::list_operations call.
+    /// The request builder for [CloudRedisCluster::list_operations][super::super::client::CloudRedisCluster::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1292,7 +1292,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::get_operation call.
+    /// The request builder for [CloudRedisCluster::get_operation][super::super::client::CloudRedisCluster::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1337,7 +1337,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::delete_operation call.
+    /// The request builder for [CloudRedisCluster::delete_operation][super::super::client::CloudRedisCluster::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1382,7 +1382,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for a CloudRedisCluster::cancel_operation call.
+    /// The request builder for [CloudRedisCluster::cancel_operation][super::super::client::CloudRedisCluster::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/redis/v1/src/builder.rs
+++ b/src/generated/cloud/redis/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::list_instances call.
+    /// The request builder for [CloudRedis::list_instances][super::super::client::CloudRedis::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -136,7 +136,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::get_instance call.
+    /// The request builder for [CloudRedis::get_instance][super::super::client::CloudRedis::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -178,7 +178,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::get_instance_auth_string call.
+    /// The request builder for [CloudRedis::get_instance_auth_string][super::super::client::CloudRedis::get_instance_auth_string] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstanceAuthString(RequestBuilder<crate::model::GetInstanceAuthStringRequest>);
 
@@ -223,7 +223,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::create_instance call.
+    /// The request builder for [CloudRedis::create_instance][super::super::client::CloudRedis::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -318,7 +318,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::update_instance call.
+    /// The request builder for [CloudRedis::update_instance][super::super::client::CloudRedis::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -410,7 +410,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::upgrade_instance call.
+    /// The request builder for [CloudRedis::upgrade_instance][super::super::client::CloudRedis::upgrade_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpgradeInstance(RequestBuilder<crate::model::UpgradeInstanceRequest>);
 
@@ -496,7 +496,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::import_instance call.
+    /// The request builder for [CloudRedis::import_instance][super::super::client::CloudRedis::import_instance] calls.
     #[derive(Clone, Debug)]
     pub struct ImportInstance(RequestBuilder<crate::model::ImportInstanceRequest>);
 
@@ -585,7 +585,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::export_instance call.
+    /// The request builder for [CloudRedis::export_instance][super::super::client::CloudRedis::export_instance] calls.
     #[derive(Clone, Debug)]
     pub struct ExportInstance(RequestBuilder<crate::model::ExportInstanceRequest>);
 
@@ -674,7 +674,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::failover_instance call.
+    /// The request builder for [CloudRedis::failover_instance][super::super::client::CloudRedis::failover_instance] calls.
     #[derive(Clone, Debug)]
     pub struct FailoverInstance(RequestBuilder<crate::model::FailoverInstanceRequest>);
 
@@ -768,7 +768,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::delete_instance call.
+    /// The request builder for [CloudRedis::delete_instance][super::super::client::CloudRedis::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -845,7 +845,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::reschedule_maintenance call.
+    /// The request builder for [CloudRedis::reschedule_maintenance][super::super::client::CloudRedis::reschedule_maintenance] calls.
     #[derive(Clone, Debug)]
     pub struct RescheduleMaintenance(RequestBuilder<crate::model::RescheduleMaintenanceRequest>);
 
@@ -948,7 +948,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::list_locations call.
+    /// The request builder for [CloudRedis::list_locations][super::super::client::CloudRedis::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1026,7 +1026,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::get_location call.
+    /// The request builder for [CloudRedis::get_location][super::super::client::CloudRedis::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1068,7 +1068,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::list_operations call.
+    /// The request builder for [CloudRedis::list_operations][super::super::client::CloudRedis::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1146,7 +1146,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::get_operation call.
+    /// The request builder for [CloudRedis::get_operation][super::super::client::CloudRedis::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1191,7 +1191,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::delete_operation call.
+    /// The request builder for [CloudRedis::delete_operation][super::super::client::CloudRedis::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1236,7 +1236,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for a CloudRedis::cancel_operation call.
+    /// The request builder for [CloudRedis::cancel_operation][super::super::client::CloudRedis::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/resourcemanager/v3/src/builder.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builder.rs
@@ -67,7 +67,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::get_folder call.
+    /// The request builder for [Folders::get_folder][super::super::client::Folders::get_folder] calls.
     #[derive(Clone, Debug)]
     pub struct GetFolder(RequestBuilder<crate::model::GetFolderRequest>);
 
@@ -109,7 +109,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::list_folders call.
+    /// The request builder for [Folders::list_folders][super::super::client::Folders::list_folders] calls.
     #[derive(Clone, Debug)]
     pub struct ListFolders(RequestBuilder<crate::model::ListFoldersRequest>);
 
@@ -184,7 +184,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::search_folders call.
+    /// The request builder for [Folders::search_folders][super::super::client::Folders::search_folders] calls.
     #[derive(Clone, Debug)]
     pub struct SearchFolders(RequestBuilder<crate::model::SearchFoldersRequest>);
 
@@ -253,7 +253,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::create_folder call.
+    /// The request builder for [Folders::create_folder][super::super::client::Folders::create_folder] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFolder(RequestBuilder<crate::model::CreateFolderRequest>);
 
@@ -336,7 +336,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::update_folder call.
+    /// The request builder for [Folders::update_folder][super::super::client::Folders::update_folder] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFolder(RequestBuilder<crate::model::UpdateFolderRequest>);
 
@@ -428,7 +428,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::move_folder call.
+    /// The request builder for [Folders::move_folder][super::super::client::Folders::move_folder] calls.
     #[derive(Clone, Debug)]
     pub struct MoveFolder(RequestBuilder<crate::model::MoveFolderRequest>);
 
@@ -513,7 +513,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::delete_folder call.
+    /// The request builder for [Folders::delete_folder][super::super::client::Folders::delete_folder] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFolder(RequestBuilder<crate::model::DeleteFolderRequest>);
 
@@ -593,7 +593,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::undelete_folder call.
+    /// The request builder for [Folders::undelete_folder][super::super::client::Folders::undelete_folder] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteFolder(RequestBuilder<crate::model::UndeleteFolderRequest>);
 
@@ -673,7 +673,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::get_iam_policy call.
+    /// The request builder for [Folders::get_iam_policy][super::super::client::Folders::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -724,7 +724,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::set_iam_policy call.
+    /// The request builder for [Folders::set_iam_policy][super::super::client::Folders::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -784,7 +784,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::test_iam_permissions call.
+    /// The request builder for [Folders::test_iam_permissions][super::super::client::Folders::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -840,7 +840,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for a Folders::get_operation call.
+    /// The request builder for [Folders::get_operation][super::super::client::Folders::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -939,7 +939,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for a Organizations::get_organization call.
+    /// The request builder for [Organizations::get_organization][super::super::client::Organizations::get_organization] calls.
     #[derive(Clone, Debug)]
     pub struct GetOrganization(RequestBuilder<crate::model::GetOrganizationRequest>);
 
@@ -981,7 +981,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for a Organizations::search_organizations call.
+    /// The request builder for [Organizations::search_organizations][super::super::client::Organizations::search_organizations] calls.
     #[derive(Clone, Debug)]
     pub struct SearchOrganizations(RequestBuilder<crate::model::SearchOrganizationsRequest>);
 
@@ -1053,7 +1053,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for a Organizations::get_iam_policy call.
+    /// The request builder for [Organizations::get_iam_policy][super::super::client::Organizations::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1104,7 +1104,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for a Organizations::set_iam_policy call.
+    /// The request builder for [Organizations::set_iam_policy][super::super::client::Organizations::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1164,7 +1164,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for a Organizations::test_iam_permissions call.
+    /// The request builder for [Organizations::test_iam_permissions][super::super::client::Organizations::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1220,7 +1220,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for a Organizations::get_operation call.
+    /// The request builder for [Organizations::get_operation][super::super::client::Organizations::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1319,7 +1319,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::get_project call.
+    /// The request builder for [Projects::get_project][super::super::client::Projects::get_project] calls.
     #[derive(Clone, Debug)]
     pub struct GetProject(RequestBuilder<crate::model::GetProjectRequest>);
 
@@ -1361,7 +1361,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::list_projects call.
+    /// The request builder for [Projects::list_projects][super::super::client::Projects::list_projects] calls.
     #[derive(Clone, Debug)]
     pub struct ListProjects(RequestBuilder<crate::model::ListProjectsRequest>);
 
@@ -1436,7 +1436,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::search_projects call.
+    /// The request builder for [Projects::search_projects][super::super::client::Projects::search_projects] calls.
     #[derive(Clone, Debug)]
     pub struct SearchProjects(RequestBuilder<crate::model::SearchProjectsRequest>);
 
@@ -1505,7 +1505,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::create_project call.
+    /// The request builder for [Projects::create_project][super::super::client::Projects::create_project] calls.
     #[derive(Clone, Debug)]
     pub struct CreateProject(RequestBuilder<crate::model::CreateProjectRequest>);
 
@@ -1588,7 +1588,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::update_project call.
+    /// The request builder for [Projects::update_project][super::super::client::Projects::update_project] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProject(RequestBuilder<crate::model::UpdateProjectRequest>);
 
@@ -1680,7 +1680,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::move_project call.
+    /// The request builder for [Projects::move_project][super::super::client::Projects::move_project] calls.
     #[derive(Clone, Debug)]
     pub struct MoveProject(RequestBuilder<crate::model::MoveProjectRequest>);
 
@@ -1766,7 +1766,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::delete_project call.
+    /// The request builder for [Projects::delete_project][super::super::client::Projects::delete_project] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteProject(RequestBuilder<crate::model::DeleteProjectRequest>);
 
@@ -1846,7 +1846,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::undelete_project call.
+    /// The request builder for [Projects::undelete_project][super::super::client::Projects::undelete_project] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteProject(RequestBuilder<crate::model::UndeleteProjectRequest>);
 
@@ -1927,7 +1927,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::get_iam_policy call.
+    /// The request builder for [Projects::get_iam_policy][super::super::client::Projects::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1978,7 +1978,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::set_iam_policy call.
+    /// The request builder for [Projects::set_iam_policy][super::super::client::Projects::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2038,7 +2038,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::test_iam_permissions call.
+    /// The request builder for [Projects::test_iam_permissions][super::super::client::Projects::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2094,7 +2094,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for a Projects::get_operation call.
+    /// The request builder for [Projects::get_operation][super::super::client::Projects::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2193,7 +2193,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for a TagBindings::list_tag_bindings call.
+    /// The request builder for [TagBindings::list_tag_bindings][super::super::client::TagBindings::list_tag_bindings] calls.
     #[derive(Clone, Debug)]
     pub struct ListTagBindings(RequestBuilder<crate::model::ListTagBindingsRequest>);
 
@@ -2262,7 +2262,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for a TagBindings::create_tag_binding call.
+    /// The request builder for [TagBindings::create_tag_binding][super::super::client::TagBindings::create_tag_binding] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTagBinding(RequestBuilder<crate::model::CreateTagBindingRequest>);
 
@@ -2355,7 +2355,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for a TagBindings::delete_tag_binding call.
+    /// The request builder for [TagBindings::delete_tag_binding][super::super::client::TagBindings::delete_tag_binding] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTagBinding(RequestBuilder<crate::model::DeleteTagBindingRequest>);
 
@@ -2437,7 +2437,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for a TagBindings::list_effective_tags call.
+    /// The request builder for [TagBindings::list_effective_tags][super::super::client::TagBindings::list_effective_tags] calls.
     #[derive(Clone, Debug)]
     pub struct ListEffectiveTags(RequestBuilder<crate::model::ListEffectiveTagsRequest>);
 
@@ -2509,7 +2509,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for a TagBindings::get_operation call.
+    /// The request builder for [TagBindings::get_operation][super::super::client::TagBindings::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2608,7 +2608,7 @@ pub mod tag_holds {
         }
     }
 
-    /// The request builder for a TagHolds::create_tag_hold call.
+    /// The request builder for [TagHolds::create_tag_hold][super::super::client::TagHolds::create_tag_hold] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTagHold(RequestBuilder<crate::model::CreateTagHoldRequest>);
 
@@ -2703,7 +2703,7 @@ pub mod tag_holds {
         }
     }
 
-    /// The request builder for a TagHolds::delete_tag_hold call.
+    /// The request builder for [TagHolds::delete_tag_hold][super::super::client::TagHolds::delete_tag_hold] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTagHold(RequestBuilder<crate::model::DeleteTagHoldRequest>);
 
@@ -2786,7 +2786,7 @@ pub mod tag_holds {
         }
     }
 
-    /// The request builder for a TagHolds::list_tag_holds call.
+    /// The request builder for [TagHolds::list_tag_holds][super::super::client::TagHolds::list_tag_holds] calls.
     #[derive(Clone, Debug)]
     pub struct ListTagHolds(RequestBuilder<crate::model::ListTagHoldsRequest>);
 
@@ -2861,7 +2861,7 @@ pub mod tag_holds {
         }
     }
 
-    /// The request builder for a TagHolds::get_operation call.
+    /// The request builder for [TagHolds::get_operation][super::super::client::TagHolds::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2960,7 +2960,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::list_tag_keys call.
+    /// The request builder for [TagKeys::list_tag_keys][super::super::client::TagKeys::list_tag_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListTagKeys(RequestBuilder<crate::model::ListTagKeysRequest>);
 
@@ -3029,7 +3029,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::get_tag_key call.
+    /// The request builder for [TagKeys::get_tag_key][super::super::client::TagKeys::get_tag_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetTagKey(RequestBuilder<crate::model::GetTagKeyRequest>);
 
@@ -3071,7 +3071,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::get_namespaced_tag_key call.
+    /// The request builder for [TagKeys::get_namespaced_tag_key][super::super::client::TagKeys::get_namespaced_tag_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetNamespacedTagKey(RequestBuilder<crate::model::GetNamespacedTagKeyRequest>);
 
@@ -3116,7 +3116,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::create_tag_key call.
+    /// The request builder for [TagKeys::create_tag_key][super::super::client::TagKeys::create_tag_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTagKey(RequestBuilder<crate::model::CreateTagKeyRequest>);
 
@@ -3205,7 +3205,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::update_tag_key call.
+    /// The request builder for [TagKeys::update_tag_key][super::super::client::TagKeys::update_tag_key] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTagKey(RequestBuilder<crate::model::UpdateTagKeyRequest>);
 
@@ -3303,7 +3303,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::delete_tag_key call.
+    /// The request builder for [TagKeys::delete_tag_key][super::super::client::TagKeys::delete_tag_key] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTagKey(RequestBuilder<crate::model::DeleteTagKeyRequest>);
 
@@ -3395,7 +3395,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::get_iam_policy call.
+    /// The request builder for [TagKeys::get_iam_policy][super::super::client::TagKeys::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3446,7 +3446,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::set_iam_policy call.
+    /// The request builder for [TagKeys::set_iam_policy][super::super::client::TagKeys::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3506,7 +3506,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::test_iam_permissions call.
+    /// The request builder for [TagKeys::test_iam_permissions][super::super::client::TagKeys::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3562,7 +3562,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for a TagKeys::get_operation call.
+    /// The request builder for [TagKeys::get_operation][super::super::client::TagKeys::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3661,7 +3661,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::list_tag_values call.
+    /// The request builder for [TagValues::list_tag_values][super::super::client::TagValues::list_tag_values] calls.
     #[derive(Clone, Debug)]
     pub struct ListTagValues(RequestBuilder<crate::model::ListTagValuesRequest>);
 
@@ -3730,7 +3730,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::get_tag_value call.
+    /// The request builder for [TagValues::get_tag_value][super::super::client::TagValues::get_tag_value] calls.
     #[derive(Clone, Debug)]
     pub struct GetTagValue(RequestBuilder<crate::model::GetTagValueRequest>);
 
@@ -3772,7 +3772,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::get_namespaced_tag_value call.
+    /// The request builder for [TagValues::get_namespaced_tag_value][super::super::client::TagValues::get_namespaced_tag_value] calls.
     #[derive(Clone, Debug)]
     pub struct GetNamespacedTagValue(RequestBuilder<crate::model::GetNamespacedTagValueRequest>);
 
@@ -3817,7 +3817,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::create_tag_value call.
+    /// The request builder for [TagValues::create_tag_value][super::super::client::TagValues::create_tag_value] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTagValue(RequestBuilder<crate::model::CreateTagValueRequest>);
 
@@ -3907,7 +3907,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::update_tag_value call.
+    /// The request builder for [TagValues::update_tag_value][super::super::client::TagValues::update_tag_value] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTagValue(RequestBuilder<crate::model::UpdateTagValueRequest>);
 
@@ -4006,7 +4006,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::delete_tag_value call.
+    /// The request builder for [TagValues::delete_tag_value][super::super::client::TagValues::delete_tag_value] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTagValue(RequestBuilder<crate::model::DeleteTagValueRequest>);
 
@@ -4099,7 +4099,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::get_iam_policy call.
+    /// The request builder for [TagValues::get_iam_policy][super::super::client::TagValues::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4150,7 +4150,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::set_iam_policy call.
+    /// The request builder for [TagValues::set_iam_policy][super::super::client::TagValues::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4210,7 +4210,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::test_iam_permissions call.
+    /// The request builder for [TagValues::test_iam_permissions][super::super::client::TagValues::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4266,7 +4266,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for a TagValues::get_operation call.
+    /// The request builder for [TagValues::get_operation][super::super::client::TagValues::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/retail/v2/src/builder.rs
+++ b/src/generated/cloud/retail/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod analytics_service {
         }
     }
 
-    /// The request builder for a AnalyticsService::export_analytics_metrics call.
+    /// The request builder for [AnalyticsService::export_analytics_metrics][super::super::client::AnalyticsService::export_analytics_metrics] calls.
     #[derive(Clone, Debug)]
     pub struct ExportAnalyticsMetrics(RequestBuilder<crate::model::ExportAnalyticsMetricsRequest>);
 
@@ -168,7 +168,7 @@ pub mod analytics_service {
         }
     }
 
-    /// The request builder for a AnalyticsService::list_operations call.
+    /// The request builder for [AnalyticsService::list_operations][super::super::client::AnalyticsService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -246,7 +246,7 @@ pub mod analytics_service {
         }
     }
 
-    /// The request builder for a AnalyticsService::get_operation call.
+    /// The request builder for [AnalyticsService::get_operation][super::super::client::AnalyticsService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -345,7 +345,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::list_catalogs call.
+    /// The request builder for [CatalogService::list_catalogs][super::super::client::CatalogService::list_catalogs] calls.
     #[derive(Clone, Debug)]
     pub struct ListCatalogs(RequestBuilder<crate::model::ListCatalogsRequest>);
 
@@ -414,7 +414,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::update_catalog call.
+    /// The request builder for [CatalogService::update_catalog][super::super::client::CatalogService::update_catalog] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCatalog(RequestBuilder<crate::model::UpdateCatalogRequest>);
 
@@ -468,7 +468,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::set_default_branch call.
+    /// The request builder for [CatalogService::set_default_branch][super::super::client::CatalogService::set_default_branch] calls.
     #[derive(Clone, Debug)]
     pub struct SetDefaultBranch(RequestBuilder<crate::model::SetDefaultBranchRequest>);
 
@@ -531,7 +531,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::get_default_branch call.
+    /// The request builder for [CatalogService::get_default_branch][super::super::client::CatalogService::get_default_branch] calls.
     #[derive(Clone, Debug)]
     pub struct GetDefaultBranch(RequestBuilder<crate::model::GetDefaultBranchRequest>);
 
@@ -576,7 +576,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::get_completion_config call.
+    /// The request builder for [CatalogService::get_completion_config][super::super::client::CatalogService::get_completion_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetCompletionConfig(RequestBuilder<crate::model::GetCompletionConfigRequest>);
 
@@ -621,7 +621,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::update_completion_config call.
+    /// The request builder for [CatalogService::update_completion_config][super::super::client::CatalogService::update_completion_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCompletionConfig(RequestBuilder<crate::model::UpdateCompletionConfigRequest>);
 
@@ -680,7 +680,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::get_attributes_config call.
+    /// The request builder for [CatalogService::get_attributes_config][super::super::client::CatalogService::get_attributes_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetAttributesConfig(RequestBuilder<crate::model::GetAttributesConfigRequest>);
 
@@ -725,7 +725,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::update_attributes_config call.
+    /// The request builder for [CatalogService::update_attributes_config][super::super::client::CatalogService::update_attributes_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAttributesConfig(RequestBuilder<crate::model::UpdateAttributesConfigRequest>);
 
@@ -784,7 +784,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::add_catalog_attribute call.
+    /// The request builder for [CatalogService::add_catalog_attribute][super::super::client::CatalogService::add_catalog_attribute] calls.
     #[derive(Clone, Debug)]
     pub struct AddCatalogAttribute(RequestBuilder<crate::model::AddCatalogAttributeRequest>);
 
@@ -840,7 +840,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::remove_catalog_attribute call.
+    /// The request builder for [CatalogService::remove_catalog_attribute][super::super::client::CatalogService::remove_catalog_attribute] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveCatalogAttribute(RequestBuilder<crate::model::RemoveCatalogAttributeRequest>);
 
@@ -891,7 +891,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::replace_catalog_attribute call.
+    /// The request builder for [CatalogService::replace_catalog_attribute][super::super::client::CatalogService::replace_catalog_attribute] calls.
     #[derive(Clone, Debug)]
     pub struct ReplaceCatalogAttribute(
         RequestBuilder<crate::model::ReplaceCatalogAttributeRequest>,
@@ -958,7 +958,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::list_operations call.
+    /// The request builder for [CatalogService::list_operations][super::super::client::CatalogService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1036,7 +1036,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for a CatalogService::get_operation call.
+    /// The request builder for [CatalogService::get_operation][super::super::client::CatalogService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1135,7 +1135,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::complete_query call.
+    /// The request builder for [CompletionService::complete_query][super::super::client::CompletionService::complete_query] calls.
     #[derive(Clone, Debug)]
     pub struct CompleteQuery(RequestBuilder<crate::model::CompleteQueryRequest>);
 
@@ -1230,7 +1230,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::import_completion_data call.
+    /// The request builder for [CompletionService::import_completion_data][super::super::client::CompletionService::import_completion_data] calls.
     #[derive(Clone, Debug)]
     pub struct ImportCompletionData(RequestBuilder<crate::model::ImportCompletionDataRequest>);
 
@@ -1333,7 +1333,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::list_operations call.
+    /// The request builder for [CompletionService::list_operations][super::super::client::CompletionService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1411,7 +1411,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for a CompletionService::get_operation call.
+    /// The request builder for [CompletionService::get_operation][super::super::client::CompletionService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1510,7 +1510,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::create_control call.
+    /// The request builder for [ControlService::create_control][super::super::client::ControlService::create_control] calls.
     #[derive(Clone, Debug)]
     pub struct CreateControl(RequestBuilder<crate::model::CreateControlRequest>);
 
@@ -1567,7 +1567,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::delete_control call.
+    /// The request builder for [ControlService::delete_control][super::super::client::ControlService::delete_control] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteControl(RequestBuilder<crate::model::DeleteControlRequest>);
 
@@ -1609,7 +1609,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::update_control call.
+    /// The request builder for [ControlService::update_control][super::super::client::ControlService::update_control] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateControl(RequestBuilder<crate::model::UpdateControlRequest>);
 
@@ -1663,7 +1663,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::get_control call.
+    /// The request builder for [ControlService::get_control][super::super::client::ControlService::get_control] calls.
     #[derive(Clone, Debug)]
     pub struct GetControl(RequestBuilder<crate::model::GetControlRequest>);
 
@@ -1705,7 +1705,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::list_controls call.
+    /// The request builder for [ControlService::list_controls][super::super::client::ControlService::list_controls] calls.
     #[derive(Clone, Debug)]
     pub struct ListControls(RequestBuilder<crate::model::ListControlsRequest>);
 
@@ -1780,7 +1780,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::list_operations call.
+    /// The request builder for [ControlService::list_operations][super::super::client::ControlService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1858,7 +1858,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for a ControlService::get_operation call.
+    /// The request builder for [ControlService::get_operation][super::super::client::ControlService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1959,7 +1959,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for a GenerativeQuestionService::update_generative_questions_feature_config call.
+    /// The request builder for [GenerativeQuestionService::update_generative_questions_feature_config][super::super::client::GenerativeQuestionService::update_generative_questions_feature_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGenerativeQuestionsFeatureConfig(
         RequestBuilder<crate::model::UpdateGenerativeQuestionsFeatureConfigRequest>,
@@ -2024,7 +2024,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for a GenerativeQuestionService::get_generative_questions_feature_config call.
+    /// The request builder for [GenerativeQuestionService::get_generative_questions_feature_config][super::super::client::GenerativeQuestionService::get_generative_questions_feature_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetGenerativeQuestionsFeatureConfig(
         RequestBuilder<crate::model::GetGenerativeQuestionsFeatureConfigRequest>,
@@ -2073,7 +2073,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for a GenerativeQuestionService::list_generative_question_configs call.
+    /// The request builder for [GenerativeQuestionService::list_generative_question_configs][super::super::client::GenerativeQuestionService::list_generative_question_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListGenerativeQuestionConfigs(
         RequestBuilder<crate::model::ListGenerativeQuestionConfigsRequest>,
@@ -2122,7 +2122,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for a GenerativeQuestionService::update_generative_question_config call.
+    /// The request builder for [GenerativeQuestionService::update_generative_question_config][super::super::client::GenerativeQuestionService::update_generative_question_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGenerativeQuestionConfig(
         RequestBuilder<crate::model::UpdateGenerativeQuestionConfigRequest>,
@@ -2185,7 +2185,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for a GenerativeQuestionService::batch_update_generative_question_configs call.
+    /// The request builder for [GenerativeQuestionService::batch_update_generative_question_configs][super::super::client::GenerativeQuestionService::batch_update_generative_question_configs] calls.
     #[derive(Clone, Debug)]
     pub struct BatchUpdateGenerativeQuestionConfigs(
         RequestBuilder<crate::model::BatchUpdateGenerativeQuestionConfigsRequest>,
@@ -2247,7 +2247,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for a GenerativeQuestionService::list_operations call.
+    /// The request builder for [GenerativeQuestionService::list_operations][super::super::client::GenerativeQuestionService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2327,7 +2327,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for a GenerativeQuestionService::get_operation call.
+    /// The request builder for [GenerativeQuestionService::get_operation][super::super::client::GenerativeQuestionService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2428,7 +2428,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::create_model call.
+    /// The request builder for [ModelService::create_model][super::super::client::ModelService::create_model] calls.
     #[derive(Clone, Debug)]
     pub struct CreateModel(RequestBuilder<crate::model::CreateModelRequest>);
 
@@ -2522,7 +2522,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_model call.
+    /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -2564,7 +2564,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::pause_model call.
+    /// The request builder for [ModelService::pause_model][super::super::client::ModelService::pause_model] calls.
     #[derive(Clone, Debug)]
     pub struct PauseModel(RequestBuilder<crate::model::PauseModelRequest>);
 
@@ -2606,7 +2606,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::resume_model call.
+    /// The request builder for [ModelService::resume_model][super::super::client::ModelService::resume_model] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeModel(RequestBuilder<crate::model::ResumeModelRequest>);
 
@@ -2648,7 +2648,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::delete_model call.
+    /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -2690,7 +2690,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_models call.
+    /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -2759,7 +2759,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::update_model call.
+    /// The request builder for [ModelService::update_model][super::super::client::ModelService::update_model] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateModel(RequestBuilder<crate::model::UpdateModelRequest>);
 
@@ -2813,7 +2813,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::tune_model call.
+    /// The request builder for [ModelService::tune_model][super::super::client::ModelService::tune_model] calls.
     #[derive(Clone, Debug)]
     pub struct TuneModel(RequestBuilder<crate::model::TuneModelRequest>);
 
@@ -2894,7 +2894,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::list_operations call.
+    /// The request builder for [ModelService::list_operations][super::super::client::ModelService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2972,7 +2972,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for a ModelService::get_operation call.
+    /// The request builder for [ModelService::get_operation][super::super::client::ModelService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3071,7 +3071,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::predict call.
+    /// The request builder for [PredictionService::predict][super::super::client::PredictionService::predict] calls.
     #[derive(Clone, Debug)]
     pub struct Predict(RequestBuilder<crate::model::PredictRequest>);
 
@@ -3166,7 +3166,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::list_operations call.
+    /// The request builder for [PredictionService::list_operations][super::super::client::PredictionService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3244,7 +3244,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for a PredictionService::get_operation call.
+    /// The request builder for [PredictionService::get_operation][super::super::client::PredictionService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3343,7 +3343,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::create_product call.
+    /// The request builder for [ProductService::create_product][super::super::client::ProductService::create_product] calls.
     #[derive(Clone, Debug)]
     pub struct CreateProduct(RequestBuilder<crate::model::CreateProductRequest>);
 
@@ -3400,7 +3400,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::get_product call.
+    /// The request builder for [ProductService::get_product][super::super::client::ProductService::get_product] calls.
     #[derive(Clone, Debug)]
     pub struct GetProduct(RequestBuilder<crate::model::GetProductRequest>);
 
@@ -3442,7 +3442,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::list_products call.
+    /// The request builder for [ProductService::list_products][super::super::client::ProductService::list_products] calls.
     #[derive(Clone, Debug)]
     pub struct ListProducts(RequestBuilder<crate::model::ListProductsRequest>);
 
@@ -3523,7 +3523,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::update_product call.
+    /// The request builder for [ProductService::update_product][super::super::client::ProductService::update_product] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProduct(RequestBuilder<crate::model::UpdateProductRequest>);
 
@@ -3583,7 +3583,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::delete_product call.
+    /// The request builder for [ProductService::delete_product][super::super::client::ProductService::delete_product] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteProduct(RequestBuilder<crate::model::DeleteProductRequest>);
 
@@ -3625,7 +3625,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::purge_products call.
+    /// The request builder for [ProductService::purge_products][super::super::client::ProductService::purge_products] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeProducts(RequestBuilder<crate::model::PurgeProductsRequest>);
 
@@ -3720,7 +3720,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::import_products call.
+    /// The request builder for [ProductService::import_products][super::super::client::ProductService::import_products] calls.
     #[derive(Clone, Debug)]
     pub struct ImportProducts(RequestBuilder<crate::model::ImportProductsRequest>);
 
@@ -3851,7 +3851,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::set_inventory call.
+    /// The request builder for [ProductService::set_inventory][super::super::client::ProductService::set_inventory] calls.
     #[derive(Clone, Debug)]
     pub struct SetInventory(RequestBuilder<crate::model::SetInventoryRequest>);
 
@@ -3955,7 +3955,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::add_fulfillment_places call.
+    /// The request builder for [ProductService::add_fulfillment_places][super::super::client::ProductService::add_fulfillment_places] calls.
     #[derive(Clone, Debug)]
     pub struct AddFulfillmentPlaces(RequestBuilder<crate::model::AddFulfillmentPlacesRequest>);
 
@@ -4072,7 +4072,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::remove_fulfillment_places call.
+    /// The request builder for [ProductService::remove_fulfillment_places][super::super::client::ProductService::remove_fulfillment_places] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveFulfillmentPlaces(
         RequestBuilder<crate::model::RemoveFulfillmentPlacesRequest>,
@@ -4194,7 +4194,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::add_local_inventories call.
+    /// The request builder for [ProductService::add_local_inventories][super::super::client::ProductService::add_local_inventories] calls.
     #[derive(Clone, Debug)]
     pub struct AddLocalInventories(RequestBuilder<crate::model::AddLocalInventoriesRequest>);
 
@@ -4311,7 +4311,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::remove_local_inventories call.
+    /// The request builder for [ProductService::remove_local_inventories][super::super::client::ProductService::remove_local_inventories] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveLocalInventories(RequestBuilder<crate::model::RemoveLocalInventoriesRequest>);
 
@@ -4425,7 +4425,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::list_operations call.
+    /// The request builder for [ProductService::list_operations][super::super::client::ProductService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4503,7 +4503,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for a ProductService::get_operation call.
+    /// The request builder for [ProductService::get_operation][super::super::client::ProductService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4602,7 +4602,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for a SearchService::search call.
+    /// The request builder for [SearchService::search][super::super::client::SearchService::search] calls.
     #[derive(Clone, Debug)]
     pub struct Search(RequestBuilder<crate::model::SearchRequest>);
 
@@ -4855,7 +4855,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for a SearchService::list_operations call.
+    /// The request builder for [SearchService::list_operations][super::super::client::SearchService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4933,7 +4933,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for a SearchService::get_operation call.
+    /// The request builder for [SearchService::get_operation][super::super::client::SearchService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5034,7 +5034,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::create_serving_config call.
+    /// The request builder for [ServingConfigService::create_serving_config][super::super::client::ServingConfigService::create_serving_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServingConfig(RequestBuilder<crate::model::CreateServingConfigRequest>);
 
@@ -5096,7 +5096,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::delete_serving_config call.
+    /// The request builder for [ServingConfigService::delete_serving_config][super::super::client::ServingConfigService::delete_serving_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServingConfig(RequestBuilder<crate::model::DeleteServingConfigRequest>);
 
@@ -5143,7 +5143,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::update_serving_config call.
+    /// The request builder for [ServingConfigService::update_serving_config][super::super::client::ServingConfigService::update_serving_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServingConfig(RequestBuilder<crate::model::UpdateServingConfigRequest>);
 
@@ -5202,7 +5202,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::get_serving_config call.
+    /// The request builder for [ServingConfigService::get_serving_config][super::super::client::ServingConfigService::get_serving_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetServingConfig(RequestBuilder<crate::model::GetServingConfigRequest>);
 
@@ -5249,7 +5249,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::list_serving_configs call.
+    /// The request builder for [ServingConfigService::list_serving_configs][super::super::client::ServingConfigService::list_serving_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListServingConfigs(RequestBuilder<crate::model::ListServingConfigsRequest>);
 
@@ -5323,7 +5323,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::add_control call.
+    /// The request builder for [ServingConfigService::add_control][super::super::client::ServingConfigService::add_control] calls.
     #[derive(Clone, Debug)]
     pub struct AddControl(RequestBuilder<crate::model::AddControlRequest>);
 
@@ -5373,7 +5373,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::remove_control call.
+    /// The request builder for [ServingConfigService::remove_control][super::super::client::ServingConfigService::remove_control] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveControl(RequestBuilder<crate::model::RemoveControlRequest>);
 
@@ -5423,7 +5423,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::list_operations call.
+    /// The request builder for [ServingConfigService::list_operations][super::super::client::ServingConfigService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5503,7 +5503,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for a ServingConfigService::get_operation call.
+    /// The request builder for [ServingConfigService::get_operation][super::super::client::ServingConfigService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5604,7 +5604,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::write_user_event call.
+    /// The request builder for [UserEventService::write_user_event][super::super::client::UserEventService::write_user_event] calls.
     #[derive(Clone, Debug)]
     pub struct WriteUserEvent(RequestBuilder<crate::model::WriteUserEventRequest>);
 
@@ -5661,7 +5661,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::collect_user_event call.
+    /// The request builder for [UserEventService::collect_user_event][super::super::client::UserEventService::collect_user_event] calls.
     #[derive(Clone, Debug)]
     pub struct CollectUserEvent(RequestBuilder<crate::model::CollectUserEventRequest>);
 
@@ -5741,7 +5741,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::purge_user_events call.
+    /// The request builder for [UserEventService::purge_user_events][super::super::client::UserEventService::purge_user_events] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeUserEvents(RequestBuilder<crate::model::PurgeUserEventsRequest>);
 
@@ -5834,7 +5834,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::import_user_events call.
+    /// The request builder for [UserEventService::import_user_events][super::super::client::UserEventService::import_user_events] calls.
     #[derive(Clone, Debug)]
     pub struct ImportUserEvents(RequestBuilder<crate::model::ImportUserEventsRequest>);
 
@@ -5940,7 +5940,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::rejoin_user_events call.
+    /// The request builder for [UserEventService::rejoin_user_events][super::super::client::UserEventService::rejoin_user_events] calls.
     #[derive(Clone, Debug)]
     pub struct RejoinUserEvents(RequestBuilder<crate::model::RejoinUserEventsRequest>);
 
@@ -6039,7 +6039,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::list_operations call.
+    /// The request builder for [UserEventService::list_operations][super::super::client::UserEventService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6117,7 +6117,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for a UserEventService::get_operation call.
+    /// The request builder for [UserEventService::get_operation][super::super::client::UserEventService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/run/v2/src/builder.rs
+++ b/src/generated/cloud/run/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for a Builds::submit_build call.
+    /// The request builder for [Builds::submit_build][super::super::client::Builds::submit_build] calls.
     #[derive(Clone, Debug)]
     pub struct SubmitBuild(RequestBuilder<crate::model::SubmitBuildRequest>);
 
@@ -156,7 +156,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for a Builds::list_operations call.
+    /// The request builder for [Builds::list_operations][super::super::client::Builds::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -234,7 +234,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for a Builds::get_operation call.
+    /// The request builder for [Builds::get_operation][super::super::client::Builds::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -279,7 +279,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for a Builds::delete_operation call.
+    /// The request builder for [Builds::delete_operation][super::super::client::Builds::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -324,7 +324,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for a Builds::wait_operation call.
+    /// The request builder for [Builds::wait_operation][super::super::client::Builds::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -429,7 +429,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::get_execution call.
+    /// The request builder for [Executions::get_execution][super::super::client::Executions::get_execution] calls.
     #[derive(Clone, Debug)]
     pub struct GetExecution(RequestBuilder<crate::model::GetExecutionRequest>);
 
@@ -471,7 +471,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::list_executions call.
+    /// The request builder for [Executions::list_executions][super::super::client::Executions::list_executions] calls.
     #[derive(Clone, Debug)]
     pub struct ListExecutions(RequestBuilder<crate::model::ListExecutionsRequest>);
 
@@ -546,7 +546,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::delete_execution call.
+    /// The request builder for [Executions::delete_execution][super::super::client::Executions::delete_execution] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteExecution(RequestBuilder<crate::model::DeleteExecutionRequest>);
 
@@ -635,7 +635,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::cancel_execution call.
+    /// The request builder for [Executions::cancel_execution][super::super::client::Executions::cancel_execution] calls.
     #[derive(Clone, Debug)]
     pub struct CancelExecution(RequestBuilder<crate::model::CancelExecutionRequest>);
 
@@ -724,7 +724,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::list_operations call.
+    /// The request builder for [Executions::list_operations][super::super::client::Executions::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -802,7 +802,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::get_operation call.
+    /// The request builder for [Executions::get_operation][super::super::client::Executions::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -847,7 +847,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::delete_operation call.
+    /// The request builder for [Executions::delete_operation][super::super::client::Executions::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -892,7 +892,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::wait_operation call.
+    /// The request builder for [Executions::wait_operation][super::super::client::Executions::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -997,7 +997,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::create_job call.
+    /// The request builder for [Jobs::create_job][super::super::client::Jobs::create_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -1092,7 +1092,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::get_job call.
+    /// The request builder for [Jobs::get_job][super::super::client::Jobs::get_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -1132,7 +1132,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::list_jobs call.
+    /// The request builder for [Jobs::list_jobs][super::super::client::Jobs::list_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -1206,7 +1206,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::update_job call.
+    /// The request builder for [Jobs::update_job][super::super::client::Jobs::update_job] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateJob(RequestBuilder<crate::model::UpdateJobRequest>);
 
@@ -1295,7 +1295,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::delete_job call.
+    /// The request builder for [Jobs::delete_job][super::super::client::Jobs::delete_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -1384,7 +1384,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::run_job call.
+    /// The request builder for [Jobs::run_job][super::super::client::Jobs::run_job] calls.
     #[derive(Clone, Debug)]
     pub struct RunJob(RequestBuilder<crate::model::RunJobRequest>);
 
@@ -1482,7 +1482,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::get_iam_policy call.
+    /// The request builder for [Jobs::get_iam_policy][super::super::client::Jobs::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1533,7 +1533,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::set_iam_policy call.
+    /// The request builder for [Jobs::set_iam_policy][super::super::client::Jobs::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1593,7 +1593,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::test_iam_permissions call.
+    /// The request builder for [Jobs::test_iam_permissions][super::super::client::Jobs::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1649,7 +1649,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::list_operations call.
+    /// The request builder for [Jobs::list_operations][super::super::client::Jobs::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1727,7 +1727,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::get_operation call.
+    /// The request builder for [Jobs::get_operation][super::super::client::Jobs::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1772,7 +1772,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::delete_operation call.
+    /// The request builder for [Jobs::delete_operation][super::super::client::Jobs::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1817,7 +1817,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for a Jobs::wait_operation call.
+    /// The request builder for [Jobs::wait_operation][super::super::client::Jobs::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -1922,7 +1922,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for a Revisions::get_revision call.
+    /// The request builder for [Revisions::get_revision][super::super::client::Revisions::get_revision] calls.
     #[derive(Clone, Debug)]
     pub struct GetRevision(RequestBuilder<crate::model::GetRevisionRequest>);
 
@@ -1964,7 +1964,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for a Revisions::list_revisions call.
+    /// The request builder for [Revisions::list_revisions][super::super::client::Revisions::list_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct ListRevisions(RequestBuilder<crate::model::ListRevisionsRequest>);
 
@@ -2039,7 +2039,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for a Revisions::delete_revision call.
+    /// The request builder for [Revisions::delete_revision][super::super::client::Revisions::delete_revision] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRevision(RequestBuilder<crate::model::DeleteRevisionRequest>);
 
@@ -2128,7 +2128,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for a Revisions::list_operations call.
+    /// The request builder for [Revisions::list_operations][super::super::client::Revisions::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2206,7 +2206,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for a Revisions::get_operation call.
+    /// The request builder for [Revisions::get_operation][super::super::client::Revisions::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2251,7 +2251,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for a Revisions::delete_operation call.
+    /// The request builder for [Revisions::delete_operation][super::super::client::Revisions::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2296,7 +2296,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for a Revisions::wait_operation call.
+    /// The request builder for [Revisions::wait_operation][super::super::client::Revisions::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -2401,7 +2401,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::create_service call.
+    /// The request builder for [Services::create_service][super::super::client::Services::create_service] calls.
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -2499,7 +2499,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::get_service call.
+    /// The request builder for [Services::get_service][super::super::client::Services::get_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -2541,7 +2541,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::list_services call.
+    /// The request builder for [Services::list_services][super::super::client::Services::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -2616,7 +2616,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::update_service call.
+    /// The request builder for [Services::update_service][super::super::client::Services::update_service] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -2717,7 +2717,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::delete_service call.
+    /// The request builder for [Services::delete_service][super::super::client::Services::delete_service] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -2806,7 +2806,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::get_iam_policy call.
+    /// The request builder for [Services::get_iam_policy][super::super::client::Services::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2857,7 +2857,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::set_iam_policy call.
+    /// The request builder for [Services::set_iam_policy][super::super::client::Services::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2917,7 +2917,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::test_iam_permissions call.
+    /// The request builder for [Services::test_iam_permissions][super::super::client::Services::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2973,7 +2973,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::list_operations call.
+    /// The request builder for [Services::list_operations][super::super::client::Services::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3051,7 +3051,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::get_operation call.
+    /// The request builder for [Services::get_operation][super::super::client::Services::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3096,7 +3096,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::delete_operation call.
+    /// The request builder for [Services::delete_operation][super::super::client::Services::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3141,7 +3141,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for a Services::wait_operation call.
+    /// The request builder for [Services::wait_operation][super::super::client::Services::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -3246,7 +3246,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for a Tasks::get_task call.
+    /// The request builder for [Tasks::get_task][super::super::client::Tasks::get_task] calls.
     #[derive(Clone, Debug)]
     pub struct GetTask(RequestBuilder<crate::model::GetTaskRequest>);
 
@@ -3288,7 +3288,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for a Tasks::list_tasks call.
+    /// The request builder for [Tasks::list_tasks][super::super::client::Tasks::list_tasks] calls.
     #[derive(Clone, Debug)]
     pub struct ListTasks(RequestBuilder<crate::model::ListTasksRequest>);
 
@@ -3362,7 +3362,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for a Tasks::list_operations call.
+    /// The request builder for [Tasks::list_operations][super::super::client::Tasks::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3440,7 +3440,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for a Tasks::get_operation call.
+    /// The request builder for [Tasks::get_operation][super::super::client::Tasks::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3485,7 +3485,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for a Tasks::delete_operation call.
+    /// The request builder for [Tasks::delete_operation][super::super::client::Tasks::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3530,7 +3530,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for a Tasks::wait_operation call.
+    /// The request builder for [Tasks::wait_operation][super::super::client::Tasks::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 

--- a/src/generated/cloud/scheduler/v1/src/builder.rs
+++ b/src/generated/cloud/scheduler/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::list_jobs call.
+    /// The request builder for [CloudScheduler::list_jobs][super::super::client::CloudScheduler::list_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -135,7 +135,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::get_job call.
+    /// The request builder for [CloudScheduler::get_job][super::super::client::CloudScheduler::get_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -175,7 +175,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::create_job call.
+    /// The request builder for [CloudScheduler::create_job][super::super::client::CloudScheduler::create_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -223,7 +223,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::update_job call.
+    /// The request builder for [CloudScheduler::update_job][super::super::client::CloudScheduler::update_job] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateJob(RequestBuilder<crate::model::UpdateJobRequest>);
 
@@ -274,7 +274,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::delete_job call.
+    /// The request builder for [CloudScheduler::delete_job][super::super::client::CloudScheduler::delete_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -316,7 +316,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::pause_job call.
+    /// The request builder for [CloudScheduler::pause_job][super::super::client::CloudScheduler::pause_job] calls.
     #[derive(Clone, Debug)]
     pub struct PauseJob(RequestBuilder<crate::model::PauseJobRequest>);
 
@@ -358,7 +358,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::resume_job call.
+    /// The request builder for [CloudScheduler::resume_job][super::super::client::CloudScheduler::resume_job] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeJob(RequestBuilder<crate::model::ResumeJobRequest>);
 
@@ -400,7 +400,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::run_job call.
+    /// The request builder for [CloudScheduler::run_job][super::super::client::CloudScheduler::run_job] calls.
     #[derive(Clone, Debug)]
     pub struct RunJob(RequestBuilder<crate::model::RunJobRequest>);
 
@@ -440,7 +440,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::list_locations call.
+    /// The request builder for [CloudScheduler::list_locations][super::super::client::CloudScheduler::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -518,7 +518,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for a CloudScheduler::get_location call.
+    /// The request builder for [CloudScheduler::get_location][super::super::client::CloudScheduler::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/secretmanager/v1/src/builder.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secrets call.
+    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecrets(RequestBuilder<crate::model::ListSecretsRequest>);
 
@@ -146,7 +146,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::create_secret call.
+    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecret(RequestBuilder<crate::model::CreateSecretRequest>);
 
@@ -205,7 +205,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::add_secret_version call.
+    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersion(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -261,7 +261,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret call.
+    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecret(RequestBuilder<crate::model::GetSecretRequest>);
 
@@ -305,7 +305,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::update_secret call.
+    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecret(RequestBuilder<crate::model::UpdateSecretRequest>);
 
@@ -361,7 +361,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::delete_secret call.
+    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecret(RequestBuilder<crate::model::DeleteSecretRequest>);
 
@@ -411,7 +411,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secret_versions call.
+    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersions(RequestBuilder<crate::model::ListSecretVersionsRequest>);
 
@@ -491,7 +491,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret_version call.
+    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersion(RequestBuilder<crate::model::GetSecretVersionRequest>);
 
@@ -538,7 +538,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::access_secret_version call.
+    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersion(RequestBuilder<crate::model::AccessSecretVersionRequest>);
 
@@ -585,7 +585,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::disable_secret_version call.
+    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -638,7 +638,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::enable_secret_version call.
+    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -691,7 +691,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::destroy_secret_version call.
+    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -744,7 +744,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::set_iam_policy call.
+    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -806,7 +806,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_iam_policy call.
+    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -859,7 +859,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::test_iam_permissions call.
+    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -917,7 +917,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_locations call.
+    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -997,7 +997,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_location call.
+    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/securesourcemanager/v1/src/builder.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::list_instances call.
+    /// The request builder for [SecureSourceManager::list_instances][super::super::client::SecureSourceManager::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -148,7 +148,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::get_instance call.
+    /// The request builder for [SecureSourceManager::get_instance][super::super::client::SecureSourceManager::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -190,7 +190,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::create_instance call.
+    /// The request builder for [SecureSourceManager::create_instance][super::super::client::SecureSourceManager::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -291,7 +291,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::delete_instance call.
+    /// The request builder for [SecureSourceManager::delete_instance][super::super::client::SecureSourceManager::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -374,7 +374,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::list_repositories call.
+    /// The request builder for [SecureSourceManager::list_repositories][super::super::client::SecureSourceManager::list_repositories] calls.
     #[derive(Clone, Debug)]
     pub struct ListRepositories(RequestBuilder<crate::model::ListRepositoriesRequest>);
 
@@ -458,7 +458,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::get_repository call.
+    /// The request builder for [SecureSourceManager::get_repository][super::super::client::SecureSourceManager::get_repository] calls.
     #[derive(Clone, Debug)]
     pub struct GetRepository(RequestBuilder<crate::model::GetRepositoryRequest>);
 
@@ -500,7 +500,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::create_repository call.
+    /// The request builder for [SecureSourceManager::create_repository][super::super::client::SecureSourceManager::create_repository] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRepository(RequestBuilder<crate::model::CreateRepositoryRequest>);
 
@@ -598,7 +598,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::delete_repository call.
+    /// The request builder for [SecureSourceManager::delete_repository][super::super::client::SecureSourceManager::delete_repository] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRepository(RequestBuilder<crate::model::DeleteRepositoryRequest>);
 
@@ -684,7 +684,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::get_iam_policy_repo call.
+    /// The request builder for [SecureSourceManager::get_iam_policy_repo][super::super::client::SecureSourceManager::get_iam_policy_repo] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicyRepo(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -735,7 +735,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::set_iam_policy_repo call.
+    /// The request builder for [SecureSourceManager::set_iam_policy_repo][super::super::client::SecureSourceManager::set_iam_policy_repo] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicyRepo(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -795,7 +795,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::test_iam_permissions_repo call.
+    /// The request builder for [SecureSourceManager::test_iam_permissions_repo][super::super::client::SecureSourceManager::test_iam_permissions_repo] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissionsRepo(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -851,7 +851,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::create_branch_rule call.
+    /// The request builder for [SecureSourceManager::create_branch_rule][super::super::client::SecureSourceManager::create_branch_rule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBranchRule(RequestBuilder<crate::model::CreateBranchRuleRequest>);
 
@@ -949,7 +949,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::list_branch_rules call.
+    /// The request builder for [SecureSourceManager::list_branch_rules][super::super::client::SecureSourceManager::list_branch_rules] calls.
     #[derive(Clone, Debug)]
     pub struct ListBranchRules(RequestBuilder<crate::model::ListBranchRulesRequest>);
 
@@ -1018,7 +1018,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::get_branch_rule call.
+    /// The request builder for [SecureSourceManager::get_branch_rule][super::super::client::SecureSourceManager::get_branch_rule] calls.
     #[derive(Clone, Debug)]
     pub struct GetBranchRule(RequestBuilder<crate::model::GetBranchRuleRequest>);
 
@@ -1060,7 +1060,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::update_branch_rule call.
+    /// The request builder for [SecureSourceManager::update_branch_rule][super::super::client::SecureSourceManager::update_branch_rule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBranchRule(RequestBuilder<crate::model::UpdateBranchRuleRequest>);
 
@@ -1161,7 +1161,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::delete_branch_rule call.
+    /// The request builder for [SecureSourceManager::delete_branch_rule][super::super::client::SecureSourceManager::delete_branch_rule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBranchRule(RequestBuilder<crate::model::DeleteBranchRuleRequest>);
 
@@ -1247,7 +1247,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::list_locations call.
+    /// The request builder for [SecureSourceManager::list_locations][super::super::client::SecureSourceManager::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1325,7 +1325,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::get_location call.
+    /// The request builder for [SecureSourceManager::get_location][super::super::client::SecureSourceManager::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1367,7 +1367,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::set_iam_policy call.
+    /// The request builder for [SecureSourceManager::set_iam_policy][super::super::client::SecureSourceManager::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1427,7 +1427,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::get_iam_policy call.
+    /// The request builder for [SecureSourceManager::get_iam_policy][super::super::client::SecureSourceManager::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1478,7 +1478,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::test_iam_permissions call.
+    /// The request builder for [SecureSourceManager::test_iam_permissions][super::super::client::SecureSourceManager::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1534,7 +1534,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::list_operations call.
+    /// The request builder for [SecureSourceManager::list_operations][super::super::client::SecureSourceManager::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1612,7 +1612,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::get_operation call.
+    /// The request builder for [SecureSourceManager::get_operation][super::super::client::SecureSourceManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1657,7 +1657,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::delete_operation call.
+    /// The request builder for [SecureSourceManager::delete_operation][super::super::client::SecureSourceManager::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1702,7 +1702,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for a SecureSourceManager::cancel_operation call.
+    /// The request builder for [SecureSourceManager::cancel_operation][super::super::client::SecureSourceManager::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/security/privateca/v1/src/builder.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::create_certificate call.
+    /// The request builder for [CertificateAuthorityService::create_certificate][super::super::client::CertificateAuthorityService::create_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCertificate(RequestBuilder<crate::model::CreateCertificateRequest>);
 
@@ -152,7 +152,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::get_certificate call.
+    /// The request builder for [CertificateAuthorityService::get_certificate][super::super::client::CertificateAuthorityService::get_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificate(RequestBuilder<crate::model::GetCertificateRequest>);
 
@@ -196,7 +196,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::list_certificates call.
+    /// The request builder for [CertificateAuthorityService::list_certificates][super::super::client::CertificateAuthorityService::list_certificates] calls.
     #[derive(Clone, Debug)]
     pub struct ListCertificates(RequestBuilder<crate::model::ListCertificatesRequest>);
 
@@ -282,7 +282,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::revoke_certificate call.
+    /// The request builder for [CertificateAuthorityService::revoke_certificate][super::super::client::CertificateAuthorityService::revoke_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct RevokeCertificate(RequestBuilder<crate::model::RevokeCertificateRequest>);
 
@@ -341,7 +341,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::update_certificate call.
+    /// The request builder for [CertificateAuthorityService::update_certificate][super::super::client::CertificateAuthorityService::update_certificate] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCertificate(RequestBuilder<crate::model::UpdateCertificateRequest>);
 
@@ -406,7 +406,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::activate_certificate_authority call.
+    /// The request builder for [CertificateAuthorityService::activate_certificate_authority][super::super::client::CertificateAuthorityService::activate_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct ActivateCertificateAuthority(
         RequestBuilder<crate::model::ActivateCertificateAuthorityRequest>,
@@ -517,7 +517,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::create_certificate_authority call.
+    /// The request builder for [CertificateAuthorityService::create_certificate_authority][super::super::client::CertificateAuthorityService::create_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCertificateAuthority(
         RequestBuilder<crate::model::CreateCertificateAuthorityRequest>,
@@ -628,7 +628,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::disable_certificate_authority call.
+    /// The request builder for [CertificateAuthorityService::disable_certificate_authority][super::super::client::CertificateAuthorityService::disable_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct DisableCertificateAuthority(
         RequestBuilder<crate::model::DisableCertificateAuthorityRequest>,
@@ -728,7 +728,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::enable_certificate_authority call.
+    /// The request builder for [CertificateAuthorityService::enable_certificate_authority][super::super::client::CertificateAuthorityService::enable_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct EnableCertificateAuthority(
         RequestBuilder<crate::model::EnableCertificateAuthorityRequest>,
@@ -822,7 +822,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::fetch_certificate_authority_csr call.
+    /// The request builder for [CertificateAuthorityService::fetch_certificate_authority_csr][super::super::client::CertificateAuthorityService::fetch_certificate_authority_csr] calls.
     #[derive(Clone, Debug)]
     pub struct FetchCertificateAuthorityCsr(
         RequestBuilder<crate::model::FetchCertificateAuthorityCsrRequest>,
@@ -871,7 +871,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::get_certificate_authority call.
+    /// The request builder for [CertificateAuthorityService::get_certificate_authority][super::super::client::CertificateAuthorityService::get_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificateAuthority(
         RequestBuilder<crate::model::GetCertificateAuthorityRequest>,
@@ -920,7 +920,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::list_certificate_authorities call.
+    /// The request builder for [CertificateAuthorityService::list_certificate_authorities][super::super::client::CertificateAuthorityService::list_certificate_authorities] calls.
     #[derive(Clone, Debug)]
     pub struct ListCertificateAuthorities(
         RequestBuilder<crate::model::ListCertificateAuthoritiesRequest>,
@@ -1010,7 +1010,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::undelete_certificate_authority call.
+    /// The request builder for [CertificateAuthorityService::undelete_certificate_authority][super::super::client::CertificateAuthorityService::undelete_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteCertificateAuthority(
         RequestBuilder<crate::model::UndeleteCertificateAuthorityRequest>,
@@ -1104,7 +1104,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::delete_certificate_authority call.
+    /// The request builder for [CertificateAuthorityService::delete_certificate_authority][super::super::client::CertificateAuthorityService::delete_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateAuthority(
         RequestBuilder<crate::model::DeleteCertificateAuthorityRequest>,
@@ -1216,7 +1216,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::update_certificate_authority call.
+    /// The request builder for [CertificateAuthorityService::update_certificate_authority][super::super::client::CertificateAuthorityService::update_certificate_authority] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateAuthority(
         RequestBuilder<crate::model::UpdateCertificateAuthorityRequest>,
@@ -1324,7 +1324,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::create_ca_pool call.
+    /// The request builder for [CertificateAuthorityService::create_ca_pool][super::super::client::CertificateAuthorityService::create_ca_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCaPool(RequestBuilder<crate::model::CreateCaPoolRequest>);
 
@@ -1426,7 +1426,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::update_ca_pool call.
+    /// The request builder for [CertificateAuthorityService::update_ca_pool][super::super::client::CertificateAuthorityService::update_ca_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCaPool(RequestBuilder<crate::model::UpdateCaPoolRequest>);
 
@@ -1525,7 +1525,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::get_ca_pool call.
+    /// The request builder for [CertificateAuthorityService::get_ca_pool][super::super::client::CertificateAuthorityService::get_ca_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetCaPool(RequestBuilder<crate::model::GetCaPoolRequest>);
 
@@ -1569,7 +1569,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::list_ca_pools call.
+    /// The request builder for [CertificateAuthorityService::list_ca_pools][super::super::client::CertificateAuthorityService::list_ca_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListCaPools(RequestBuilder<crate::model::ListCaPoolsRequest>);
 
@@ -1652,7 +1652,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::delete_ca_pool call.
+    /// The request builder for [CertificateAuthorityService::delete_ca_pool][super::super::client::CertificateAuthorityService::delete_ca_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCaPool(RequestBuilder<crate::model::DeleteCaPoolRequest>);
 
@@ -1743,7 +1743,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::fetch_ca_certs call.
+    /// The request builder for [CertificateAuthorityService::fetch_ca_certs][super::super::client::CertificateAuthorityService::fetch_ca_certs] calls.
     #[derive(Clone, Debug)]
     pub struct FetchCaCerts(RequestBuilder<crate::model::FetchCaCertsRequest>);
 
@@ -1793,7 +1793,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::get_certificate_revocation_list call.
+    /// The request builder for [CertificateAuthorityService::get_certificate_revocation_list][super::super::client::CertificateAuthorityService::get_certificate_revocation_list] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificateRevocationList(
         RequestBuilder<crate::model::GetCertificateRevocationListRequest>,
@@ -1842,7 +1842,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::list_certificate_revocation_lists call.
+    /// The request builder for [CertificateAuthorityService::list_certificate_revocation_lists][super::super::client::CertificateAuthorityService::list_certificate_revocation_lists] calls.
     #[derive(Clone, Debug)]
     pub struct ListCertificateRevocationLists(
         RequestBuilder<crate::model::ListCertificateRevocationListsRequest>,
@@ -1932,7 +1932,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::update_certificate_revocation_list call.
+    /// The request builder for [CertificateAuthorityService::update_certificate_revocation_list][super::super::client::CertificateAuthorityService::update_certificate_revocation_list] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateRevocationList(
         RequestBuilder<crate::model::UpdateCertificateRevocationListRequest>,
@@ -2042,7 +2042,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::create_certificate_template call.
+    /// The request builder for [CertificateAuthorityService::create_certificate_template][super::super::client::CertificateAuthorityService::create_certificate_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCertificateTemplate(
         RequestBuilder<crate::model::CreateCertificateTemplateRequest>,
@@ -2153,7 +2153,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::delete_certificate_template call.
+    /// The request builder for [CertificateAuthorityService::delete_certificate_template][super::super::client::CertificateAuthorityService::delete_certificate_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateTemplate(
         RequestBuilder<crate::model::DeleteCertificateTemplateRequest>,
@@ -2243,7 +2243,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::get_certificate_template call.
+    /// The request builder for [CertificateAuthorityService::get_certificate_template][super::super::client::CertificateAuthorityService::get_certificate_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetCertificateTemplate(RequestBuilder<crate::model::GetCertificateTemplateRequest>);
 
@@ -2290,7 +2290,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::list_certificate_templates call.
+    /// The request builder for [CertificateAuthorityService::list_certificate_templates][super::super::client::CertificateAuthorityService::list_certificate_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListCertificateTemplates(
         RequestBuilder<crate::model::ListCertificateTemplatesRequest>,
@@ -2380,7 +2380,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::update_certificate_template call.
+    /// The request builder for [CertificateAuthorityService::update_certificate_template][super::super::client::CertificateAuthorityService::update_certificate_template] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateTemplate(
         RequestBuilder<crate::model::UpdateCertificateTemplateRequest>,
@@ -2488,7 +2488,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::list_locations call.
+    /// The request builder for [CertificateAuthorityService::list_locations][super::super::client::CertificateAuthorityService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2568,7 +2568,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::get_location call.
+    /// The request builder for [CertificateAuthorityService::get_location][super::super::client::CertificateAuthorityService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2612,7 +2612,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::set_iam_policy call.
+    /// The request builder for [CertificateAuthorityService::set_iam_policy][super::super::client::CertificateAuthorityService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2674,7 +2674,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::get_iam_policy call.
+    /// The request builder for [CertificateAuthorityService::get_iam_policy][super::super::client::CertificateAuthorityService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2727,7 +2727,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::test_iam_permissions call.
+    /// The request builder for [CertificateAuthorityService::test_iam_permissions][super::super::client::CertificateAuthorityService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2785,7 +2785,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::list_operations call.
+    /// The request builder for [CertificateAuthorityService::list_operations][super::super::client::CertificateAuthorityService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2865,7 +2865,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::get_operation call.
+    /// The request builder for [CertificateAuthorityService::get_operation][super::super::client::CertificateAuthorityService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2912,7 +2912,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::delete_operation call.
+    /// The request builder for [CertificateAuthorityService::delete_operation][super::super::client::CertificateAuthorityService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2959,7 +2959,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for a CertificateAuthorityService::cancel_operation call.
+    /// The request builder for [CertificateAuthorityService::cancel_operation][super::super::client::CertificateAuthorityService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/security/publicca/v1/src/builder.rs
+++ b/src/generated/cloud/security/publicca/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod public_certificate_authority_service {
         }
     }
 
-    /// The request builder for a PublicCertificateAuthorityService::create_external_account_key call.
+    /// The request builder for [PublicCertificateAuthorityService::create_external_account_key][super::super::client::PublicCertificateAuthorityService::create_external_account_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateExternalAccountKey(
         RequestBuilder<crate::model::CreateExternalAccountKeyRequest>,

--- a/src/generated/cloud/securitycenter/v2/src/builder.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::batch_create_resource_value_configs call.
+    /// The request builder for [SecurityCenter::batch_create_resource_value_configs][super::super::client::SecurityCenter::batch_create_resource_value_configs] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateResourceValueConfigs(
         RequestBuilder<crate::model::BatchCreateResourceValueConfigsRequest>,
@@ -125,7 +125,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::bulk_mute_findings call.
+    /// The request builder for [SecurityCenter::bulk_mute_findings][super::super::client::SecurityCenter::bulk_mute_findings] calls.
     #[derive(Clone, Debug)]
     pub struct BulkMuteFindings(RequestBuilder<crate::model::BulkMuteFindingsRequest>);
 
@@ -222,7 +222,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::create_big_query_export call.
+    /// The request builder for [SecurityCenter::create_big_query_export][super::super::client::SecurityCenter::create_big_query_export] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBigQueryExport(RequestBuilder<crate::model::CreateBigQueryExportRequest>);
 
@@ -282,7 +282,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::create_finding call.
+    /// The request builder for [SecurityCenter::create_finding][super::super::client::SecurityCenter::create_finding] calls.
     #[derive(Clone, Debug)]
     pub struct CreateFinding(RequestBuilder<crate::model::CreateFindingRequest>);
 
@@ -339,7 +339,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::create_mute_config call.
+    /// The request builder for [SecurityCenter::create_mute_config][super::super::client::SecurityCenter::create_mute_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMuteConfig(RequestBuilder<crate::model::CreateMuteConfigRequest>);
 
@@ -399,7 +399,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::create_notification_config call.
+    /// The request builder for [SecurityCenter::create_notification_config][super::super::client::SecurityCenter::create_notification_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNotificationConfig(
         RequestBuilder<crate::model::CreateNotificationConfigRequest>,
@@ -463,7 +463,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::create_source call.
+    /// The request builder for [SecurityCenter::create_source][super::super::client::SecurityCenter::create_source] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSource(RequestBuilder<crate::model::CreateSourceRequest>);
 
@@ -514,7 +514,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::delete_big_query_export call.
+    /// The request builder for [SecurityCenter::delete_big_query_export][super::super::client::SecurityCenter::delete_big_query_export] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBigQueryExport(RequestBuilder<crate::model::DeleteBigQueryExportRequest>);
 
@@ -559,7 +559,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::delete_mute_config call.
+    /// The request builder for [SecurityCenter::delete_mute_config][super::super::client::SecurityCenter::delete_mute_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMuteConfig(RequestBuilder<crate::model::DeleteMuteConfigRequest>);
 
@@ -604,7 +604,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::delete_notification_config call.
+    /// The request builder for [SecurityCenter::delete_notification_config][super::super::client::SecurityCenter::delete_notification_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNotificationConfig(
         RequestBuilder<crate::model::DeleteNotificationConfigRequest>,
@@ -651,7 +651,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::delete_resource_value_config call.
+    /// The request builder for [SecurityCenter::delete_resource_value_config][super::super::client::SecurityCenter::delete_resource_value_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteResourceValueConfig(
         RequestBuilder<crate::model::DeleteResourceValueConfigRequest>,
@@ -698,7 +698,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_big_query_export call.
+    /// The request builder for [SecurityCenter::get_big_query_export][super::super::client::SecurityCenter::get_big_query_export] calls.
     #[derive(Clone, Debug)]
     pub struct GetBigQueryExport(RequestBuilder<crate::model::GetBigQueryExportRequest>);
 
@@ -743,7 +743,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_simulation call.
+    /// The request builder for [SecurityCenter::get_simulation][super::super::client::SecurityCenter::get_simulation] calls.
     #[derive(Clone, Debug)]
     pub struct GetSimulation(RequestBuilder<crate::model::GetSimulationRequest>);
 
@@ -785,7 +785,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_valued_resource call.
+    /// The request builder for [SecurityCenter::get_valued_resource][super::super::client::SecurityCenter::get_valued_resource] calls.
     #[derive(Clone, Debug)]
     pub struct GetValuedResource(RequestBuilder<crate::model::GetValuedResourceRequest>);
 
@@ -830,7 +830,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_iam_policy call.
+    /// The request builder for [SecurityCenter::get_iam_policy][super::super::client::SecurityCenter::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -881,7 +881,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_mute_config call.
+    /// The request builder for [SecurityCenter::get_mute_config][super::super::client::SecurityCenter::get_mute_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetMuteConfig(RequestBuilder<crate::model::GetMuteConfigRequest>);
 
@@ -923,7 +923,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_notification_config call.
+    /// The request builder for [SecurityCenter::get_notification_config][super::super::client::SecurityCenter::get_notification_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetNotificationConfig(RequestBuilder<crate::model::GetNotificationConfigRequest>);
 
@@ -968,7 +968,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_resource_value_config call.
+    /// The request builder for [SecurityCenter::get_resource_value_config][super::super::client::SecurityCenter::get_resource_value_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetResourceValueConfig(RequestBuilder<crate::model::GetResourceValueConfigRequest>);
 
@@ -1013,7 +1013,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_source call.
+    /// The request builder for [SecurityCenter::get_source][super::super::client::SecurityCenter::get_source] calls.
     #[derive(Clone, Debug)]
     pub struct GetSource(RequestBuilder<crate::model::GetSourceRequest>);
 
@@ -1055,7 +1055,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::group_findings call.
+    /// The request builder for [SecurityCenter::group_findings][super::super::client::SecurityCenter::group_findings] calls.
     #[derive(Clone, Debug)]
     pub struct GroupFindings(RequestBuilder<crate::model::GroupFindingsRequest>);
 
@@ -1136,7 +1136,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_attack_paths call.
+    /// The request builder for [SecurityCenter::list_attack_paths][super::super::client::SecurityCenter::list_attack_paths] calls.
     #[derive(Clone, Debug)]
     pub struct ListAttackPaths(RequestBuilder<crate::model::ListAttackPathsRequest>);
 
@@ -1211,7 +1211,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_big_query_exports call.
+    /// The request builder for [SecurityCenter::list_big_query_exports][super::super::client::SecurityCenter::list_big_query_exports] calls.
     #[derive(Clone, Debug)]
     pub struct ListBigQueryExports(RequestBuilder<crate::model::ListBigQueryExportsRequest>);
 
@@ -1283,7 +1283,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_findings call.
+    /// The request builder for [SecurityCenter::list_findings][super::super::client::SecurityCenter::list_findings] calls.
     #[derive(Clone, Debug)]
     pub struct ListFindings(RequestBuilder<crate::model::ListFindingsRequest>);
 
@@ -1373,7 +1373,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_mute_configs call.
+    /// The request builder for [SecurityCenter::list_mute_configs][super::super::client::SecurityCenter::list_mute_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListMuteConfigs(RequestBuilder<crate::model::ListMuteConfigsRequest>);
 
@@ -1442,7 +1442,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_notification_configs call.
+    /// The request builder for [SecurityCenter::list_notification_configs][super::super::client::SecurityCenter::list_notification_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListNotificationConfigs(
         RequestBuilder<crate::model::ListNotificationConfigsRequest>,
@@ -1518,7 +1518,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_resource_value_configs call.
+    /// The request builder for [SecurityCenter::list_resource_value_configs][super::super::client::SecurityCenter::list_resource_value_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListResourceValueConfigs(
         RequestBuilder<crate::model::ListResourceValueConfigsRequest>,
@@ -1594,7 +1594,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_sources call.
+    /// The request builder for [SecurityCenter::list_sources][super::super::client::SecurityCenter::list_sources] calls.
     #[derive(Clone, Debug)]
     pub struct ListSources(RequestBuilder<crate::model::ListSourcesRequest>);
 
@@ -1663,7 +1663,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_valued_resources call.
+    /// The request builder for [SecurityCenter::list_valued_resources][super::super::client::SecurityCenter::list_valued_resources] calls.
     #[derive(Clone, Debug)]
     pub struct ListValuedResources(RequestBuilder<crate::model::ListValuedResourcesRequest>);
 
@@ -1747,7 +1747,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::set_finding_state call.
+    /// The request builder for [SecurityCenter::set_finding_state][super::super::client::SecurityCenter::set_finding_state] calls.
     #[derive(Clone, Debug)]
     pub struct SetFindingState(RequestBuilder<crate::model::SetFindingStateRequest>);
 
@@ -1795,7 +1795,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::set_iam_policy call.
+    /// The request builder for [SecurityCenter::set_iam_policy][super::super::client::SecurityCenter::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1855,7 +1855,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::set_mute call.
+    /// The request builder for [SecurityCenter::set_mute][super::super::client::SecurityCenter::set_mute] calls.
     #[derive(Clone, Debug)]
     pub struct SetMute(RequestBuilder<crate::model::SetMuteRequest>);
 
@@ -1903,7 +1903,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::test_iam_permissions call.
+    /// The request builder for [SecurityCenter::test_iam_permissions][super::super::client::SecurityCenter::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1959,7 +1959,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::update_big_query_export call.
+    /// The request builder for [SecurityCenter::update_big_query_export][super::super::client::SecurityCenter::update_big_query_export] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBigQueryExport(RequestBuilder<crate::model::UpdateBigQueryExportRequest>);
 
@@ -2016,7 +2016,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::update_external_system call.
+    /// The request builder for [SecurityCenter::update_external_system][super::super::client::SecurityCenter::update_external_system] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateExternalSystem(RequestBuilder<crate::model::UpdateExternalSystemRequest>);
 
@@ -2073,7 +2073,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::update_finding call.
+    /// The request builder for [SecurityCenter::update_finding][super::super::client::SecurityCenter::update_finding] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFinding(RequestBuilder<crate::model::UpdateFindingRequest>);
 
@@ -2127,7 +2127,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::update_mute_config call.
+    /// The request builder for [SecurityCenter::update_mute_config][super::super::client::SecurityCenter::update_mute_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMuteConfig(RequestBuilder<crate::model::UpdateMuteConfigRequest>);
 
@@ -2184,7 +2184,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::update_notification_config call.
+    /// The request builder for [SecurityCenter::update_notification_config][super::super::client::SecurityCenter::update_notification_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNotificationConfig(
         RequestBuilder<crate::model::UpdateNotificationConfigRequest>,
@@ -2245,7 +2245,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::update_resource_value_config call.
+    /// The request builder for [SecurityCenter::update_resource_value_config][super::super::client::SecurityCenter::update_resource_value_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateResourceValueConfig(
         RequestBuilder<crate::model::UpdateResourceValueConfigRequest>,
@@ -2306,7 +2306,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::update_security_marks call.
+    /// The request builder for [SecurityCenter::update_security_marks][super::super::client::SecurityCenter::update_security_marks] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecurityMarks(RequestBuilder<crate::model::UpdateSecurityMarksRequest>);
 
@@ -2363,7 +2363,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::update_source call.
+    /// The request builder for [SecurityCenter::update_source][super::super::client::SecurityCenter::update_source] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSource(RequestBuilder<crate::model::UpdateSourceRequest>);
 
@@ -2417,7 +2417,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::list_operations call.
+    /// The request builder for [SecurityCenter::list_operations][super::super::client::SecurityCenter::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2495,7 +2495,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::get_operation call.
+    /// The request builder for [SecurityCenter::get_operation][super::super::client::SecurityCenter::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2540,7 +2540,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::delete_operation call.
+    /// The request builder for [SecurityCenter::delete_operation][super::super::client::SecurityCenter::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2585,7 +2585,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for a SecurityCenter::cancel_operation call.
+    /// The request builder for [SecurityCenter::cancel_operation][super::super::client::SecurityCenter::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/securityposture/v1/src/builder.rs
+++ b/src/generated/cloud/securityposture/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::list_postures call.
+    /// The request builder for [SecurityPosture::list_postures][super::super::client::SecurityPosture::list_postures] calls.
     #[derive(Clone, Debug)]
     pub struct ListPostures(RequestBuilder<crate::model::ListPosturesRequest>);
 
@@ -136,7 +136,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::list_posture_revisions call.
+    /// The request builder for [SecurityPosture::list_posture_revisions][super::super::client::SecurityPosture::list_posture_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct ListPostureRevisions(RequestBuilder<crate::model::ListPostureRevisionsRequest>);
 
@@ -208,7 +208,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::get_posture call.
+    /// The request builder for [SecurityPosture::get_posture][super::super::client::SecurityPosture::get_posture] calls.
     #[derive(Clone, Debug)]
     pub struct GetPosture(RequestBuilder<crate::model::GetPostureRequest>);
 
@@ -256,7 +256,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::create_posture call.
+    /// The request builder for [SecurityPosture::create_posture][super::super::client::SecurityPosture::create_posture] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePosture(RequestBuilder<crate::model::CreatePostureRequest>);
 
@@ -350,7 +350,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::update_posture call.
+    /// The request builder for [SecurityPosture::update_posture][super::super::client::SecurityPosture::update_posture] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePosture(RequestBuilder<crate::model::UpdatePostureRequest>);
 
@@ -447,7 +447,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::delete_posture call.
+    /// The request builder for [SecurityPosture::delete_posture][super::super::client::SecurityPosture::delete_posture] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePosture(RequestBuilder<crate::model::DeletePostureRequest>);
 
@@ -530,7 +530,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::extract_posture call.
+    /// The request builder for [SecurityPosture::extract_posture][super::super::client::SecurityPosture::extract_posture] calls.
     #[derive(Clone, Debug)]
     pub struct ExtractPosture(RequestBuilder<crate::model::ExtractPostureRequest>);
 
@@ -621,7 +621,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::list_posture_deployments call.
+    /// The request builder for [SecurityPosture::list_posture_deployments][super::super::client::SecurityPosture::list_posture_deployments] calls.
     #[derive(Clone, Debug)]
     pub struct ListPostureDeployments(RequestBuilder<crate::model::ListPostureDeploymentsRequest>);
 
@@ -701,7 +701,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::get_posture_deployment call.
+    /// The request builder for [SecurityPosture::get_posture_deployment][super::super::client::SecurityPosture::get_posture_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct GetPostureDeployment(RequestBuilder<crate::model::GetPostureDeploymentRequest>);
 
@@ -746,7 +746,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::create_posture_deployment call.
+    /// The request builder for [SecurityPosture::create_posture_deployment][super::super::client::SecurityPosture::create_posture_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePostureDeployment(
         RequestBuilder<crate::model::CreatePostureDeploymentRequest>,
@@ -849,7 +849,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::update_posture_deployment call.
+    /// The request builder for [SecurityPosture::update_posture_deployment][super::super::client::SecurityPosture::update_posture_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePostureDeployment(
         RequestBuilder<crate::model::UpdatePostureDeploymentRequest>,
@@ -949,7 +949,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::delete_posture_deployment call.
+    /// The request builder for [SecurityPosture::delete_posture_deployment][super::super::client::SecurityPosture::delete_posture_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePostureDeployment(
         RequestBuilder<crate::model::DeletePostureDeploymentRequest>,
@@ -1037,7 +1037,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::list_posture_templates call.
+    /// The request builder for [SecurityPosture::list_posture_templates][super::super::client::SecurityPosture::list_posture_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListPostureTemplates(RequestBuilder<crate::model::ListPostureTemplatesRequest>);
 
@@ -1115,7 +1115,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::get_posture_template call.
+    /// The request builder for [SecurityPosture::get_posture_template][super::super::client::SecurityPosture::get_posture_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetPostureTemplate(RequestBuilder<crate::model::GetPostureTemplateRequest>);
 
@@ -1166,7 +1166,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::list_locations call.
+    /// The request builder for [SecurityPosture::list_locations][super::super::client::SecurityPosture::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1244,7 +1244,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::get_location call.
+    /// The request builder for [SecurityPosture::get_location][super::super::client::SecurityPosture::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1286,7 +1286,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::list_operations call.
+    /// The request builder for [SecurityPosture::list_operations][super::super::client::SecurityPosture::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1364,7 +1364,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::get_operation call.
+    /// The request builder for [SecurityPosture::get_operation][super::super::client::SecurityPosture::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1409,7 +1409,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::delete_operation call.
+    /// The request builder for [SecurityPosture::delete_operation][super::super::client::SecurityPosture::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1454,7 +1454,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for a SecurityPosture::cancel_operation call.
+    /// The request builder for [SecurityPosture::cancel_operation][super::super::client::SecurityPosture::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/servicedirectory/v1/src/builder.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod lookup_service {
         }
     }
 
-    /// The request builder for a LookupService::resolve_service call.
+    /// The request builder for [LookupService::resolve_service][super::super::client::LookupService::resolve_service] calls.
     #[derive(Clone, Debug)]
     pub struct ResolveService(RequestBuilder<crate::model::ResolveServiceRequest>);
 
@@ -121,7 +121,7 @@ pub mod lookup_service {
         }
     }
 
-    /// The request builder for a LookupService::list_locations call.
+    /// The request builder for [LookupService::list_locations][super::super::client::LookupService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -199,7 +199,7 @@ pub mod lookup_service {
         }
     }
 
-    /// The request builder for a LookupService::get_location call.
+    /// The request builder for [LookupService::get_location][super::super::client::LookupService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -295,7 +295,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::create_namespace call.
+    /// The request builder for [RegistrationService::create_namespace][super::super::client::RegistrationService::create_namespace] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNamespace(RequestBuilder<crate::model::CreateNamespaceRequest>);
 
@@ -352,7 +352,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::list_namespaces call.
+    /// The request builder for [RegistrationService::list_namespaces][super::super::client::RegistrationService::list_namespaces] calls.
     #[derive(Clone, Debug)]
     pub struct ListNamespaces(RequestBuilder<crate::model::ListNamespacesRequest>);
 
@@ -433,7 +433,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::get_namespace call.
+    /// The request builder for [RegistrationService::get_namespace][super::super::client::RegistrationService::get_namespace] calls.
     #[derive(Clone, Debug)]
     pub struct GetNamespace(RequestBuilder<crate::model::GetNamespaceRequest>);
 
@@ -475,7 +475,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::update_namespace call.
+    /// The request builder for [RegistrationService::update_namespace][super::super::client::RegistrationService::update_namespace] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNamespace(RequestBuilder<crate::model::UpdateNamespaceRequest>);
 
@@ -529,7 +529,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::delete_namespace call.
+    /// The request builder for [RegistrationService::delete_namespace][super::super::client::RegistrationService::delete_namespace] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNamespace(RequestBuilder<crate::model::DeleteNamespaceRequest>);
 
@@ -571,7 +571,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::create_service call.
+    /// The request builder for [RegistrationService::create_service][super::super::client::RegistrationService::create_service] calls.
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -628,7 +628,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::list_services call.
+    /// The request builder for [RegistrationService::list_services][super::super::client::RegistrationService::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -709,7 +709,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::get_service call.
+    /// The request builder for [RegistrationService::get_service][super::super::client::RegistrationService::get_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -751,7 +751,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::update_service call.
+    /// The request builder for [RegistrationService::update_service][super::super::client::RegistrationService::update_service] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -805,7 +805,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::delete_service call.
+    /// The request builder for [RegistrationService::delete_service][super::super::client::RegistrationService::delete_service] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -847,7 +847,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::create_endpoint call.
+    /// The request builder for [RegistrationService::create_endpoint][super::super::client::RegistrationService::create_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEndpoint(RequestBuilder<crate::model::CreateEndpointRequest>);
 
@@ -904,7 +904,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::list_endpoints call.
+    /// The request builder for [RegistrationService::list_endpoints][super::super::client::RegistrationService::list_endpoints] calls.
     #[derive(Clone, Debug)]
     pub struct ListEndpoints(RequestBuilder<crate::model::ListEndpointsRequest>);
 
@@ -985,7 +985,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::get_endpoint call.
+    /// The request builder for [RegistrationService::get_endpoint][super::super::client::RegistrationService::get_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct GetEndpoint(RequestBuilder<crate::model::GetEndpointRequest>);
 
@@ -1027,7 +1027,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::update_endpoint call.
+    /// The request builder for [RegistrationService::update_endpoint][super::super::client::RegistrationService::update_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateEndpoint(RequestBuilder<crate::model::UpdateEndpointRequest>);
 
@@ -1081,7 +1081,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::delete_endpoint call.
+    /// The request builder for [RegistrationService::delete_endpoint][super::super::client::RegistrationService::delete_endpoint] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEndpoint(RequestBuilder<crate::model::DeleteEndpointRequest>);
 
@@ -1123,7 +1123,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::get_iam_policy call.
+    /// The request builder for [RegistrationService::get_iam_policy][super::super::client::RegistrationService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1174,7 +1174,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::set_iam_policy call.
+    /// The request builder for [RegistrationService::set_iam_policy][super::super::client::RegistrationService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1234,7 +1234,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::test_iam_permissions call.
+    /// The request builder for [RegistrationService::test_iam_permissions][super::super::client::RegistrationService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1290,7 +1290,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::list_locations call.
+    /// The request builder for [RegistrationService::list_locations][super::super::client::RegistrationService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1368,7 +1368,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for a RegistrationService::get_location call.
+    /// The request builder for [RegistrationService::get_location][super::super::client::RegistrationService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/servicehealth/v1/src/builder.rs
+++ b/src/generated/cloud/servicehealth/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for a ServiceHealth::list_events call.
+    /// The request builder for [ServiceHealth::list_events][super::super::client::ServiceHealth::list_events] calls.
     #[derive(Clone, Debug)]
     pub struct ListEvents(RequestBuilder<crate::model::ListEventsRequest>);
 
@@ -148,7 +148,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for a ServiceHealth::get_event call.
+    /// The request builder for [ServiceHealth::get_event][super::super::client::ServiceHealth::get_event] calls.
     #[derive(Clone, Debug)]
     pub struct GetEvent(RequestBuilder<crate::model::GetEventRequest>);
 
@@ -190,7 +190,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for a ServiceHealth::list_organization_events call.
+    /// The request builder for [ServiceHealth::list_organization_events][super::super::client::ServiceHealth::list_organization_events] calls.
     #[derive(Clone, Debug)]
     pub struct ListOrganizationEvents(RequestBuilder<crate::model::ListOrganizationEventsRequest>);
 
@@ -276,7 +276,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for a ServiceHealth::get_organization_event call.
+    /// The request builder for [ServiceHealth::get_organization_event][super::super::client::ServiceHealth::get_organization_event] calls.
     #[derive(Clone, Debug)]
     pub struct GetOrganizationEvent(RequestBuilder<crate::model::GetOrganizationEventRequest>);
 
@@ -321,7 +321,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for a ServiceHealth::list_organization_impacts call.
+    /// The request builder for [ServiceHealth::list_organization_impacts][super::super::client::ServiceHealth::list_organization_impacts] calls.
     #[derive(Clone, Debug)]
     pub struct ListOrganizationImpacts(
         RequestBuilder<crate::model::ListOrganizationImpactsRequest>,
@@ -403,7 +403,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for a ServiceHealth::get_organization_impact call.
+    /// The request builder for [ServiceHealth::get_organization_impact][super::super::client::ServiceHealth::get_organization_impact] calls.
     #[derive(Clone, Debug)]
     pub struct GetOrganizationImpact(RequestBuilder<crate::model::GetOrganizationImpactRequest>);
 
@@ -448,7 +448,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for a ServiceHealth::list_locations call.
+    /// The request builder for [ServiceHealth::list_locations][super::super::client::ServiceHealth::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -526,7 +526,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for a ServiceHealth::get_location call.
+    /// The request builder for [ServiceHealth::get_location][super::super::client::ServiceHealth::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/shell/v1/src/builder.rs
+++ b/src/generated/cloud/shell/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for a CloudShellService::get_environment call.
+    /// The request builder for [CloudShellService::get_environment][super::super::client::CloudShellService::get_environment] calls.
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -109,7 +109,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for a CloudShellService::start_environment call.
+    /// The request builder for [CloudShellService::start_environment][super::super::client::CloudShellService::start_environment] calls.
     #[derive(Clone, Debug)]
     pub struct StartEnvironment(RequestBuilder<crate::model::StartEnvironmentRequest>);
 
@@ -214,7 +214,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for a CloudShellService::authorize_environment call.
+    /// The request builder for [CloudShellService::authorize_environment][super::super::client::CloudShellService::authorize_environment] calls.
     #[derive(Clone, Debug)]
     pub struct AuthorizeEnvironment(RequestBuilder<crate::model::AuthorizeEnvironmentRequest>);
 
@@ -323,7 +323,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for a CloudShellService::add_public_key call.
+    /// The request builder for [CloudShellService::add_public_key][super::super::client::CloudShellService::add_public_key] calls.
     #[derive(Clone, Debug)]
     pub struct AddPublicKey(RequestBuilder<crate::model::AddPublicKeyRequest>);
 
@@ -412,7 +412,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for a CloudShellService::remove_public_key call.
+    /// The request builder for [CloudShellService::remove_public_key][super::super::client::CloudShellService::remove_public_key] calls.
     #[derive(Clone, Debug)]
     pub struct RemovePublicKey(RequestBuilder<crate::model::RemovePublicKeyRequest>);
 
@@ -501,7 +501,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for a CloudShellService::get_operation call.
+    /// The request builder for [CloudShellService::get_operation][super::super::client::CloudShellService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/speech/v2/src/builder.rs
+++ b/src/generated/cloud/speech/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::create_recognizer call.
+    /// The request builder for [Speech::create_recognizer][super::super::client::Speech::create_recognizer] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRecognizer(RequestBuilder<crate::model::CreateRecognizerRequest>);
 
@@ -171,7 +171,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::list_recognizers call.
+    /// The request builder for [Speech::list_recognizers][super::super::client::Speech::list_recognizers] calls.
     #[derive(Clone, Debug)]
     pub struct ListRecognizers(RequestBuilder<crate::model::ListRecognizersRequest>);
 
@@ -246,7 +246,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::get_recognizer call.
+    /// The request builder for [Speech::get_recognizer][super::super::client::Speech::get_recognizer] calls.
     #[derive(Clone, Debug)]
     pub struct GetRecognizer(RequestBuilder<crate::model::GetRecognizerRequest>);
 
@@ -288,7 +288,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::update_recognizer call.
+    /// The request builder for [Speech::update_recognizer][super::super::client::Speech::update_recognizer] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRecognizer(RequestBuilder<crate::model::UpdateRecognizerRequest>);
 
@@ -389,7 +389,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::delete_recognizer call.
+    /// The request builder for [Speech::delete_recognizer][super::super::client::Speech::delete_recognizer] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRecognizer(RequestBuilder<crate::model::DeleteRecognizerRequest>);
 
@@ -490,7 +490,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::undelete_recognizer call.
+    /// The request builder for [Speech::undelete_recognizer][super::super::client::Speech::undelete_recognizer] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteRecognizer(RequestBuilder<crate::model::UndeleteRecognizerRequest>);
 
@@ -585,7 +585,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::recognize call.
+    /// The request builder for [Speech::recognize][super::super::client::Speech::recognize] calls.
     #[derive(Clone, Debug)]
     pub struct Recognize(RequestBuilder<crate::model::RecognizeRequest>);
 
@@ -654,7 +654,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::batch_recognize call.
+    /// The request builder for [Speech::batch_recognize][super::super::client::Speech::batch_recognize] calls.
     #[derive(Clone, Debug)]
     pub struct BatchRecognize(RequestBuilder<crate::model::BatchRecognizeRequest>);
 
@@ -788,7 +788,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::get_config call.
+    /// The request builder for [Speech::get_config][super::super::client::Speech::get_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetConfig(RequestBuilder<crate::model::GetConfigRequest>);
 
@@ -830,7 +830,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::update_config call.
+    /// The request builder for [Speech::update_config][super::super::client::Speech::update_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConfig(RequestBuilder<crate::model::UpdateConfigRequest>);
 
@@ -884,7 +884,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::create_custom_class call.
+    /// The request builder for [Speech::create_custom_class][super::super::client::Speech::create_custom_class] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCustomClass(RequestBuilder<crate::model::CreateCustomClassRequest>);
 
@@ -988,7 +988,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::list_custom_classes call.
+    /// The request builder for [Speech::list_custom_classes][super::super::client::Speech::list_custom_classes] calls.
     #[derive(Clone, Debug)]
     pub struct ListCustomClasses(RequestBuilder<crate::model::ListCustomClassesRequest>);
 
@@ -1066,7 +1066,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::get_custom_class call.
+    /// The request builder for [Speech::get_custom_class][super::super::client::Speech::get_custom_class] calls.
     #[derive(Clone, Debug)]
     pub struct GetCustomClass(RequestBuilder<crate::model::GetCustomClassRequest>);
 
@@ -1108,7 +1108,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::update_custom_class call.
+    /// The request builder for [Speech::update_custom_class][super::super::client::Speech::update_custom_class] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCustomClass(RequestBuilder<crate::model::UpdateCustomClassRequest>);
 
@@ -1209,7 +1209,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::delete_custom_class call.
+    /// The request builder for [Speech::delete_custom_class][super::super::client::Speech::delete_custom_class] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCustomClass(RequestBuilder<crate::model::DeleteCustomClassRequest>);
 
@@ -1310,7 +1310,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::undelete_custom_class call.
+    /// The request builder for [Speech::undelete_custom_class][super::super::client::Speech::undelete_custom_class] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteCustomClass(RequestBuilder<crate::model::UndeleteCustomClassRequest>);
 
@@ -1405,7 +1405,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::create_phrase_set call.
+    /// The request builder for [Speech::create_phrase_set][super::super::client::Speech::create_phrase_set] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePhraseSet(RequestBuilder<crate::model::CreatePhraseSetRequest>);
 
@@ -1506,7 +1506,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::list_phrase_sets call.
+    /// The request builder for [Speech::list_phrase_sets][super::super::client::Speech::list_phrase_sets] calls.
     #[derive(Clone, Debug)]
     pub struct ListPhraseSets(RequestBuilder<crate::model::ListPhraseSetsRequest>);
 
@@ -1581,7 +1581,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::get_phrase_set call.
+    /// The request builder for [Speech::get_phrase_set][super::super::client::Speech::get_phrase_set] calls.
     #[derive(Clone, Debug)]
     pub struct GetPhraseSet(RequestBuilder<crate::model::GetPhraseSetRequest>);
 
@@ -1623,7 +1623,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::update_phrase_set call.
+    /// The request builder for [Speech::update_phrase_set][super::super::client::Speech::update_phrase_set] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePhraseSet(RequestBuilder<crate::model::UpdatePhraseSetRequest>);
 
@@ -1721,7 +1721,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::delete_phrase_set call.
+    /// The request builder for [Speech::delete_phrase_set][super::super::client::Speech::delete_phrase_set] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePhraseSet(RequestBuilder<crate::model::DeletePhraseSetRequest>);
 
@@ -1819,7 +1819,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::undelete_phrase_set call.
+    /// The request builder for [Speech::undelete_phrase_set][super::super::client::Speech::undelete_phrase_set] calls.
     #[derive(Clone, Debug)]
     pub struct UndeletePhraseSet(RequestBuilder<crate::model::UndeletePhraseSetRequest>);
 
@@ -1914,7 +1914,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::list_locations call.
+    /// The request builder for [Speech::list_locations][super::super::client::Speech::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1992,7 +1992,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::get_location call.
+    /// The request builder for [Speech::get_location][super::super::client::Speech::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2034,7 +2034,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::list_operations call.
+    /// The request builder for [Speech::list_operations][super::super::client::Speech::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2112,7 +2112,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::get_operation call.
+    /// The request builder for [Speech::get_operation][super::super::client::Speech::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2157,7 +2157,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::delete_operation call.
+    /// The request builder for [Speech::delete_operation][super::super::client::Speech::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2202,7 +2202,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for a Speech::cancel_operation call.
+    /// The request builder for [Speech::cancel_operation][super::super::client::Speech::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/sql/v1/src/builder.rs
+++ b/src/generated/cloud/sql/v1/src/builder.rs
@@ -65,7 +65,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// The request builder for a SqlBackupRunsService::delete call.
+    /// The request builder for [SqlBackupRunsService::delete][super::super::client::SqlBackupRunsService::delete] calls.
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlBackupRunsDeleteRequest>);
 
@@ -119,7 +119,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// The request builder for a SqlBackupRunsService::get call.
+    /// The request builder for [SqlBackupRunsService::get][super::super::client::SqlBackupRunsService::get] calls.
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlBackupRunsGetRequest>);
 
@@ -173,7 +173,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// The request builder for a SqlBackupRunsService::insert call.
+    /// The request builder for [SqlBackupRunsService::insert][super::super::client::SqlBackupRunsService::insert] calls.
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlBackupRunsInsertRequest>);
 
@@ -227,7 +227,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// The request builder for a SqlBackupRunsService::list call.
+    /// The request builder for [SqlBackupRunsService::list][super::super::client::SqlBackupRunsService::list] calls.
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlBackupRunsListRequest>);
 
@@ -340,7 +340,7 @@ pub mod sql_connect_service {
         }
     }
 
-    /// The request builder for a SqlConnectService::get_connect_settings call.
+    /// The request builder for [SqlConnectService::get_connect_settings][super::super::client::SqlConnectService::get_connect_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnectSettings(RequestBuilder<crate::model::GetConnectSettingsRequest>);
 
@@ -394,7 +394,7 @@ pub mod sql_connect_service {
         }
     }
 
-    /// The request builder for a SqlConnectService::generate_ephemeral_cert call.
+    /// The request builder for [SqlConnectService::generate_ephemeral_cert][super::super::client::SqlConnectService::generate_ephemeral_cert] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateEphemeralCert(RequestBuilder<crate::model::GenerateEphemeralCertRequest>);
 
@@ -519,7 +519,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for a SqlDatabasesService::delete call.
+    /// The request builder for [SqlDatabasesService::delete][super::super::client::SqlDatabasesService::delete] calls.
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlDatabasesDeleteRequest>);
 
@@ -573,7 +573,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for a SqlDatabasesService::get call.
+    /// The request builder for [SqlDatabasesService::get][super::super::client::SqlDatabasesService::get] calls.
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlDatabasesGetRequest>);
 
@@ -627,7 +627,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for a SqlDatabasesService::insert call.
+    /// The request builder for [SqlDatabasesService::insert][super::super::client::SqlDatabasesService::insert] calls.
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlDatabasesInsertRequest>);
 
@@ -681,7 +681,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for a SqlDatabasesService::list call.
+    /// The request builder for [SqlDatabasesService::list][super::super::client::SqlDatabasesService::list] calls.
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlDatabasesListRequest>);
 
@@ -729,7 +729,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for a SqlDatabasesService::patch call.
+    /// The request builder for [SqlDatabasesService::patch][super::super::client::SqlDatabasesService::patch] calls.
     #[derive(Clone, Debug)]
     pub struct Patch(RequestBuilder<crate::model::SqlDatabasesUpdateRequest>);
 
@@ -789,7 +789,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for a SqlDatabasesService::update call.
+    /// The request builder for [SqlDatabasesService::update][super::super::client::SqlDatabasesService::update] calls.
     #[derive(Clone, Debug)]
     pub struct Update(RequestBuilder<crate::model::SqlDatabasesUpdateRequest>);
 
@@ -902,7 +902,7 @@ pub mod sql_flags_service {
         }
     }
 
-    /// The request builder for a SqlFlagsService::list call.
+    /// The request builder for [SqlFlagsService::list][super::super::client::SqlFlagsService::list] calls.
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlFlagsListRequest>);
 
@@ -997,7 +997,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::add_server_ca call.
+    /// The request builder for [SqlInstancesService::add_server_ca][super::super::client::SqlInstancesService::add_server_ca] calls.
     #[derive(Clone, Debug)]
     pub struct AddServerCa(RequestBuilder<crate::model::SqlInstancesAddServerCaRequest>);
 
@@ -1045,7 +1045,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::clone call.
+    /// The request builder for [SqlInstancesService::clone][super::super::client::SqlInstancesService::clone] calls.
     #[derive(Clone, Debug)]
     pub struct Clone(RequestBuilder<crate::model::SqlInstancesCloneRequest>);
 
@@ -1099,7 +1099,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::delete call.
+    /// The request builder for [SqlInstancesService::delete][super::super::client::SqlInstancesService::delete] calls.
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlInstancesDeleteRequest>);
 
@@ -1147,7 +1147,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::demote_master call.
+    /// The request builder for [SqlInstancesService::demote_master][super::super::client::SqlInstancesService::demote_master] calls.
     #[derive(Clone, Debug)]
     pub struct DemoteMaster(RequestBuilder<crate::model::SqlInstancesDemoteMasterRequest>);
 
@@ -1201,7 +1201,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::demote call.
+    /// The request builder for [SqlInstancesService::demote][super::super::client::SqlInstancesService::demote] calls.
     #[derive(Clone, Debug)]
     pub struct Demote(RequestBuilder<crate::model::SqlInstancesDemoteRequest>);
 
@@ -1255,7 +1255,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::export call.
+    /// The request builder for [SqlInstancesService::export][super::super::client::SqlInstancesService::export] calls.
     #[derive(Clone, Debug)]
     pub struct Export(RequestBuilder<crate::model::SqlInstancesExportRequest>);
 
@@ -1309,7 +1309,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::failover call.
+    /// The request builder for [SqlInstancesService::failover][super::super::client::SqlInstancesService::failover] calls.
     #[derive(Clone, Debug)]
     pub struct Failover(RequestBuilder<crate::model::SqlInstancesFailoverRequest>);
 
@@ -1363,7 +1363,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::reencrypt call.
+    /// The request builder for [SqlInstancesService::reencrypt][super::super::client::SqlInstancesService::reencrypt] calls.
     #[derive(Clone, Debug)]
     pub struct Reencrypt(RequestBuilder<crate::model::SqlInstancesReencryptRequest>);
 
@@ -1417,7 +1417,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::get call.
+    /// The request builder for [SqlInstancesService::get][super::super::client::SqlInstancesService::get] calls.
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlInstancesGetRequest>);
 
@@ -1465,7 +1465,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::import call.
+    /// The request builder for [SqlInstancesService::import][super::super::client::SqlInstancesService::import] calls.
     #[derive(Clone, Debug)]
     pub struct Import(RequestBuilder<crate::model::SqlInstancesImportRequest>);
 
@@ -1519,7 +1519,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::insert call.
+    /// The request builder for [SqlInstancesService::insert][super::super::client::SqlInstancesService::insert] calls.
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlInstancesInsertRequest>);
 
@@ -1567,7 +1567,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::list call.
+    /// The request builder for [SqlInstancesService::list][super::super::client::SqlInstancesService::list] calls.
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlInstancesListRequest>);
 
@@ -1627,7 +1627,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::list_server_cas call.
+    /// The request builder for [SqlInstancesService::list_server_cas][super::super::client::SqlInstancesService::list_server_cas] calls.
     #[derive(Clone, Debug)]
     pub struct ListServerCas(RequestBuilder<crate::model::SqlInstancesListServerCasRequest>);
 
@@ -1675,7 +1675,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::patch call.
+    /// The request builder for [SqlInstancesService::patch][super::super::client::SqlInstancesService::patch] calls.
     #[derive(Clone, Debug)]
     pub struct Patch(RequestBuilder<crate::model::SqlInstancesPatchRequest>);
 
@@ -1729,7 +1729,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::promote_replica call.
+    /// The request builder for [SqlInstancesService::promote_replica][super::super::client::SqlInstancesService::promote_replica] calls.
     #[derive(Clone, Debug)]
     pub struct PromoteReplica(RequestBuilder<crate::model::SqlInstancesPromoteReplicaRequest>);
 
@@ -1783,7 +1783,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::switchover call.
+    /// The request builder for [SqlInstancesService::switchover][super::super::client::SqlInstancesService::switchover] calls.
     #[derive(Clone, Debug)]
     pub struct Switchover(RequestBuilder<crate::model::SqlInstancesSwitchoverRequest>);
 
@@ -1837,7 +1837,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::reset_ssl_config call.
+    /// The request builder for [SqlInstancesService::reset_ssl_config][super::super::client::SqlInstancesService::reset_ssl_config] calls.
     #[derive(Clone, Debug)]
     pub struct ResetSslConfig(RequestBuilder<crate::model::SqlInstancesResetSslConfigRequest>);
 
@@ -1885,7 +1885,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::restart call.
+    /// The request builder for [SqlInstancesService::restart][super::super::client::SqlInstancesService::restart] calls.
     #[derive(Clone, Debug)]
     pub struct Restart(RequestBuilder<crate::model::SqlInstancesRestartRequest>);
 
@@ -1933,7 +1933,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::restore_backup call.
+    /// The request builder for [SqlInstancesService::restore_backup][super::super::client::SqlInstancesService::restore_backup] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreBackup(RequestBuilder<crate::model::SqlInstancesRestoreBackupRequest>);
 
@@ -1987,7 +1987,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::rotate_server_ca call.
+    /// The request builder for [SqlInstancesService::rotate_server_ca][super::super::client::SqlInstancesService::rotate_server_ca] calls.
     #[derive(Clone, Debug)]
     pub struct RotateServerCa(RequestBuilder<crate::model::SqlInstancesRotateServerCaRequest>);
 
@@ -2041,7 +2041,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::start_replica call.
+    /// The request builder for [SqlInstancesService::start_replica][super::super::client::SqlInstancesService::start_replica] calls.
     #[derive(Clone, Debug)]
     pub struct StartReplica(RequestBuilder<crate::model::SqlInstancesStartReplicaRequest>);
 
@@ -2089,7 +2089,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::stop_replica call.
+    /// The request builder for [SqlInstancesService::stop_replica][super::super::client::SqlInstancesService::stop_replica] calls.
     #[derive(Clone, Debug)]
     pub struct StopReplica(RequestBuilder<crate::model::SqlInstancesStopReplicaRequest>);
 
@@ -2137,7 +2137,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::truncate_log call.
+    /// The request builder for [SqlInstancesService::truncate_log][super::super::client::SqlInstancesService::truncate_log] calls.
     #[derive(Clone, Debug)]
     pub struct TruncateLog(RequestBuilder<crate::model::SqlInstancesTruncateLogRequest>);
 
@@ -2191,7 +2191,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::update call.
+    /// The request builder for [SqlInstancesService::update][super::super::client::SqlInstancesService::update] calls.
     #[derive(Clone, Debug)]
     pub struct Update(RequestBuilder<crate::model::SqlInstancesUpdateRequest>);
 
@@ -2245,7 +2245,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::create_ephemeral call.
+    /// The request builder for [SqlInstancesService::create_ephemeral][super::super::client::SqlInstancesService::create_ephemeral] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEphemeral(RequestBuilder<crate::model::SqlInstancesCreateEphemeralCertRequest>);
 
@@ -2299,7 +2299,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::reschedule_maintenance call.
+    /// The request builder for [SqlInstancesService::reschedule_maintenance][super::super::client::SqlInstancesService::reschedule_maintenance] calls.
     #[derive(Clone, Debug)]
     pub struct RescheduleMaintenance(RequestBuilder<crate::model::SqlInstancesRescheduleMaintenanceRequest>);
 
@@ -2353,7 +2353,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::verify_external_sync_settings call.
+    /// The request builder for [SqlInstancesService::verify_external_sync_settings][super::super::client::SqlInstancesService::verify_external_sync_settings] calls.
     #[derive(Clone, Debug)]
     pub struct VerifyExternalSyncSettings(RequestBuilder<crate::model::SqlInstancesVerifyExternalSyncSettingsRequest>);
 
@@ -2437,7 +2437,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::start_external_sync call.
+    /// The request builder for [SqlInstancesService::start_external_sync][super::super::client::SqlInstancesService::start_external_sync] calls.
     #[derive(Clone, Debug)]
     pub struct StartExternalSync(RequestBuilder<crate::model::SqlInstancesStartExternalSyncRequest>);
 
@@ -2515,7 +2515,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::perform_disk_shrink call.
+    /// The request builder for [SqlInstancesService::perform_disk_shrink][super::super::client::SqlInstancesService::perform_disk_shrink] calls.
     #[derive(Clone, Debug)]
     pub struct PerformDiskShrink(RequestBuilder<crate::model::SqlInstancesPerformDiskShrinkRequest>);
 
@@ -2569,7 +2569,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::get_disk_shrink_config call.
+    /// The request builder for [SqlInstancesService::get_disk_shrink_config][super::super::client::SqlInstancesService::get_disk_shrink_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetDiskShrinkConfig(RequestBuilder<crate::model::SqlInstancesGetDiskShrinkConfigRequest>);
 
@@ -2617,7 +2617,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::reset_replica_size call.
+    /// The request builder for [SqlInstancesService::reset_replica_size][super::super::client::SqlInstancesService::reset_replica_size] calls.
     #[derive(Clone, Debug)]
     pub struct ResetReplicaSize(RequestBuilder<crate::model::SqlInstancesResetReplicaSizeRequest>);
 
@@ -2665,7 +2665,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::get_latest_recovery_time call.
+    /// The request builder for [SqlInstancesService::get_latest_recovery_time][super::super::client::SqlInstancesService::get_latest_recovery_time] calls.
     #[derive(Clone, Debug)]
     pub struct GetLatestRecoveryTime(RequestBuilder<crate::model::SqlInstancesGetLatestRecoveryTimeRequest>);
 
@@ -2713,7 +2713,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::acquire_ssrs_lease call.
+    /// The request builder for [SqlInstancesService::acquire_ssrs_lease][super::super::client::SqlInstancesService::acquire_ssrs_lease] calls.
     #[derive(Clone, Debug)]
     pub struct AcquireSsrsLease(RequestBuilder<crate::model::SqlInstancesAcquireSsrsLeaseRequest>);
 
@@ -2767,7 +2767,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for a SqlInstancesService::release_ssrs_lease call.
+    /// The request builder for [SqlInstancesService::release_ssrs_lease][super::super::client::SqlInstancesService::release_ssrs_lease] calls.
     #[derive(Clone, Debug)]
     pub struct ReleaseSsrsLease(RequestBuilder<crate::model::SqlInstancesReleaseSsrsLeaseRequest>);
 
@@ -2868,7 +2868,7 @@ pub mod sql_operations_service {
         }
     }
 
-    /// The request builder for a SqlOperationsService::get call.
+    /// The request builder for [SqlOperationsService::get][super::super::client::SqlOperationsService::get] calls.
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlOperationsGetRequest>);
 
@@ -2916,7 +2916,7 @@ pub mod sql_operations_service {
         }
     }
 
-    /// The request builder for a SqlOperationsService::list call.
+    /// The request builder for [SqlOperationsService::list][super::super::client::SqlOperationsService::list] calls.
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlOperationsListRequest>);
 
@@ -2976,7 +2976,7 @@ pub mod sql_operations_service {
         }
     }
 
-    /// The request builder for a SqlOperationsService::cancel call.
+    /// The request builder for [SqlOperationsService::cancel][super::super::client::SqlOperationsService::cancel] calls.
     #[derive(Clone, Debug)]
     pub struct Cancel(RequestBuilder<crate::model::SqlOperationsCancelRequest>);
 
@@ -3077,7 +3077,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// The request builder for a SqlSslCertsService::delete call.
+    /// The request builder for [SqlSslCertsService::delete][super::super::client::SqlSslCertsService::delete] calls.
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlSslCertsDeleteRequest>);
 
@@ -3131,7 +3131,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// The request builder for a SqlSslCertsService::get call.
+    /// The request builder for [SqlSslCertsService::get][super::super::client::SqlSslCertsService::get] calls.
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlSslCertsGetRequest>);
 
@@ -3185,7 +3185,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// The request builder for a SqlSslCertsService::insert call.
+    /// The request builder for [SqlSslCertsService::insert][super::super::client::SqlSslCertsService::insert] calls.
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlSslCertsInsertRequest>);
 
@@ -3239,7 +3239,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// The request builder for a SqlSslCertsService::list call.
+    /// The request builder for [SqlSslCertsService::list][super::super::client::SqlSslCertsService::list] calls.
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlSslCertsListRequest>);
 
@@ -3340,7 +3340,7 @@ pub mod sql_tiers_service {
         }
     }
 
-    /// The request builder for a SqlTiersService::list call.
+    /// The request builder for [SqlTiersService::list][super::super::client::SqlTiersService::list] calls.
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlTiersListRequest>);
 
@@ -3435,7 +3435,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for a SqlUsersService::delete call.
+    /// The request builder for [SqlUsersService::delete][super::super::client::SqlUsersService::delete] calls.
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlUsersDeleteRequest>);
 
@@ -3495,7 +3495,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for a SqlUsersService::get call.
+    /// The request builder for [SqlUsersService::get][super::super::client::SqlUsersService::get] calls.
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlUsersGetRequest>);
 
@@ -3555,7 +3555,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for a SqlUsersService::insert call.
+    /// The request builder for [SqlUsersService::insert][super::super::client::SqlUsersService::insert] calls.
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlUsersInsertRequest>);
 
@@ -3609,7 +3609,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for a SqlUsersService::list call.
+    /// The request builder for [SqlUsersService::list][super::super::client::SqlUsersService::list] calls.
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlUsersListRequest>);
 
@@ -3657,7 +3657,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for a SqlUsersService::update call.
+    /// The request builder for [SqlUsersService::update][super::super::client::SqlUsersService::update] calls.
     #[derive(Clone, Debug)]
     pub struct Update(RequestBuilder<crate::model::SqlUsersUpdateRequest>);
 

--- a/src/generated/cloud/storagebatchoperations/v1/src/builder.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::list_jobs call.
+    /// The request builder for [StorageBatchOperations::list_jobs][super::super::client::StorageBatchOperations::list_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -151,7 +151,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::get_job call.
+    /// The request builder for [StorageBatchOperations::get_job][super::super::client::StorageBatchOperations::get_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -193,7 +193,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::create_job call.
+    /// The request builder for [StorageBatchOperations::create_job][super::super::client::StorageBatchOperations::create_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -292,7 +292,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::delete_job call.
+    /// The request builder for [StorageBatchOperations::delete_job][super::super::client::StorageBatchOperations::delete_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -342,7 +342,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::cancel_job call.
+    /// The request builder for [StorageBatchOperations::cancel_job][super::super::client::StorageBatchOperations::cancel_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelJob(RequestBuilder<crate::model::CancelJobRequest>);
 
@@ -392,7 +392,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::list_locations call.
+    /// The request builder for [StorageBatchOperations::list_locations][super::super::client::StorageBatchOperations::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -472,7 +472,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::get_location call.
+    /// The request builder for [StorageBatchOperations::get_location][super::super::client::StorageBatchOperations::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -516,7 +516,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::list_operations call.
+    /// The request builder for [StorageBatchOperations::list_operations][super::super::client::StorageBatchOperations::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -596,7 +596,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::get_operation call.
+    /// The request builder for [StorageBatchOperations::get_operation][super::super::client::StorageBatchOperations::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -643,7 +643,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::delete_operation call.
+    /// The request builder for [StorageBatchOperations::delete_operation][super::super::client::StorageBatchOperations::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -690,7 +690,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for a StorageBatchOperations::cancel_operation call.
+    /// The request builder for [StorageBatchOperations::cancel_operation][super::super::client::StorageBatchOperations::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/storageinsights/v1/src/builder.rs
+++ b/src/generated/cloud/storageinsights/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::list_report_configs call.
+    /// The request builder for [StorageInsights::list_report_configs][super::super::client::StorageInsights::list_report_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListReportConfigs(RequestBuilder<crate::model::ListReportConfigsRequest>);
 
@@ -151,7 +151,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::get_report_config call.
+    /// The request builder for [StorageInsights::get_report_config][super::super::client::StorageInsights::get_report_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetReportConfig(RequestBuilder<crate::model::GetReportConfigRequest>);
 
@@ -193,7 +193,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::create_report_config call.
+    /// The request builder for [StorageInsights::create_report_config][super::super::client::StorageInsights::create_report_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateReportConfig(RequestBuilder<crate::model::CreateReportConfigRequest>);
 
@@ -253,7 +253,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::update_report_config call.
+    /// The request builder for [StorageInsights::update_report_config][super::super::client::StorageInsights::update_report_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateReportConfig(RequestBuilder<crate::model::UpdateReportConfigRequest>);
 
@@ -316,7 +316,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::delete_report_config call.
+    /// The request builder for [StorageInsights::delete_report_config][super::super::client::StorageInsights::delete_report_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteReportConfig(RequestBuilder<crate::model::DeleteReportConfigRequest>);
 
@@ -373,7 +373,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::list_report_details call.
+    /// The request builder for [StorageInsights::list_report_details][super::super::client::StorageInsights::list_report_details] calls.
     #[derive(Clone, Debug)]
     pub struct ListReportDetails(RequestBuilder<crate::model::ListReportDetailsRequest>);
 
@@ -457,7 +457,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::get_report_detail call.
+    /// The request builder for [StorageInsights::get_report_detail][super::super::client::StorageInsights::get_report_detail] calls.
     #[derive(Clone, Debug)]
     pub struct GetReportDetail(RequestBuilder<crate::model::GetReportDetailRequest>);
 
@@ -499,7 +499,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::list_locations call.
+    /// The request builder for [StorageInsights::list_locations][super::super::client::StorageInsights::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -577,7 +577,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::get_location call.
+    /// The request builder for [StorageInsights::get_location][super::super::client::StorageInsights::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -619,7 +619,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::list_operations call.
+    /// The request builder for [StorageInsights::list_operations][super::super::client::StorageInsights::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -697,7 +697,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::get_operation call.
+    /// The request builder for [StorageInsights::get_operation][super::super::client::StorageInsights::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -742,7 +742,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::delete_operation call.
+    /// The request builder for [StorageInsights::delete_operation][super::super::client::StorageInsights::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -787,7 +787,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for a StorageInsights::cancel_operation call.
+    /// The request builder for [StorageInsights::cancel_operation][super::super::client::StorageInsights::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/support/v2/src/builder.rs
+++ b/src/generated/cloud/support/v2/src/builder.rs
@@ -69,7 +69,7 @@ pub mod case_attachment_service {
         }
     }
 
-    /// The request builder for a CaseAttachmentService::list_attachments call.
+    /// The request builder for [CaseAttachmentService::list_attachments][super::super::client::CaseAttachmentService::list_attachments] calls.
     #[derive(Clone, Debug)]
     pub struct ListAttachments(RequestBuilder<crate::model::ListAttachmentsRequest>);
 
@@ -194,7 +194,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for a CaseService::get_case call.
+    /// The request builder for [CaseService::get_case][super::super::client::CaseService::get_case] calls.
     #[derive(Clone, Debug)]
     pub struct GetCase(RequestBuilder<crate::model::GetCaseRequest>);
 
@@ -236,7 +236,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for a CaseService::list_cases call.
+    /// The request builder for [CaseService::list_cases][super::super::client::CaseService::list_cases] calls.
     #[derive(Clone, Debug)]
     pub struct ListCases(RequestBuilder<crate::model::ListCasesRequest>);
 
@@ -310,7 +310,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for a CaseService::search_cases call.
+    /// The request builder for [CaseService::search_cases][super::super::client::CaseService::search_cases] calls.
     #[derive(Clone, Debug)]
     pub struct SearchCases(RequestBuilder<crate::model::SearchCasesRequest>);
 
@@ -385,7 +385,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for a CaseService::create_case call.
+    /// The request builder for [CaseService::create_case][super::super::client::CaseService::create_case] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCase(RequestBuilder<crate::model::CreateCaseRequest>);
 
@@ -433,7 +433,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for a CaseService::update_case call.
+    /// The request builder for [CaseService::update_case][super::super::client::CaseService::update_case] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCase(RequestBuilder<crate::model::UpdateCaseRequest>);
 
@@ -484,7 +484,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for a CaseService::escalate_case call.
+    /// The request builder for [CaseService::escalate_case][super::super::client::CaseService::escalate_case] calls.
     #[derive(Clone, Debug)]
     pub struct EscalateCase(RequestBuilder<crate::model::EscalateCaseRequest>);
 
@@ -535,7 +535,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for a CaseService::close_case call.
+    /// The request builder for [CaseService::close_case][super::super::client::CaseService::close_case] calls.
     #[derive(Clone, Debug)]
     pub struct CloseCase(RequestBuilder<crate::model::CloseCaseRequest>);
 
@@ -577,7 +577,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for a CaseService::search_case_classifications call.
+    /// The request builder for [CaseService::search_case_classifications][super::super::client::CaseService::search_case_classifications] calls.
     #[derive(Clone, Debug)]
     pub struct SearchCaseClassifications(
         RequestBuilder<crate::model::SearchCaseClassificationsRequest>,
@@ -707,7 +707,7 @@ pub mod comment_service {
         }
     }
 
-    /// The request builder for a CommentService::list_comments call.
+    /// The request builder for [CommentService::list_comments][super::super::client::CommentService::list_comments] calls.
     #[derive(Clone, Debug)]
     pub struct ListComments(RequestBuilder<crate::model::ListCommentsRequest>);
 
@@ -776,7 +776,7 @@ pub mod comment_service {
         }
     }
 
-    /// The request builder for a CommentService::create_comment call.
+    /// The request builder for [CommentService::create_comment][super::super::client::CommentService::create_comment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateComment(RequestBuilder<crate::model::CreateCommentRequest>);
 

--- a/src/generated/cloud/talent/v4/src/builder.rs
+++ b/src/generated/cloud/talent/v4/src/builder.rs
@@ -67,7 +67,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for a CompanyService::create_company call.
+    /// The request builder for [CompanyService::create_company][super::super::client::CompanyService::create_company] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCompany(RequestBuilder<crate::model::CreateCompanyRequest>);
 
@@ -118,7 +118,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for a CompanyService::get_company call.
+    /// The request builder for [CompanyService::get_company][super::super::client::CompanyService::get_company] calls.
     #[derive(Clone, Debug)]
     pub struct GetCompany(RequestBuilder<crate::model::GetCompanyRequest>);
 
@@ -160,7 +160,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for a CompanyService::update_company call.
+    /// The request builder for [CompanyService::update_company][super::super::client::CompanyService::update_company] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCompany(RequestBuilder<crate::model::UpdateCompanyRequest>);
 
@@ -214,7 +214,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for a CompanyService::delete_company call.
+    /// The request builder for [CompanyService::delete_company][super::super::client::CompanyService::delete_company] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCompany(RequestBuilder<crate::model::DeleteCompanyRequest>);
 
@@ -256,7 +256,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for a CompanyService::list_companies call.
+    /// The request builder for [CompanyService::list_companies][super::super::client::CompanyService::list_companies] calls.
     #[derive(Clone, Debug)]
     pub struct ListCompanies(RequestBuilder<crate::model::ListCompaniesRequest>);
 
@@ -331,7 +331,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for a CompanyService::get_operation call.
+    /// The request builder for [CompanyService::get_operation][super::super::client::CompanyService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -430,7 +430,7 @@ pub mod completion {
         }
     }
 
-    /// The request builder for a Completion::complete_query call.
+    /// The request builder for [Completion::complete_query][super::super::client::Completion::complete_query] calls.
     #[derive(Clone, Debug)]
     pub struct CompleteQuery(RequestBuilder<crate::model::CompleteQueryRequest>);
 
@@ -519,7 +519,7 @@ pub mod completion {
         }
     }
 
-    /// The request builder for a Completion::get_operation call.
+    /// The request builder for [Completion::get_operation][super::super::client::Completion::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -618,7 +618,7 @@ pub mod event_service {
         }
     }
 
-    /// The request builder for a EventService::create_client_event call.
+    /// The request builder for [EventService::create_client_event][super::super::client::EventService::create_client_event] calls.
     #[derive(Clone, Debug)]
     pub struct CreateClientEvent(RequestBuilder<crate::model::CreateClientEventRequest>);
 
@@ -672,7 +672,7 @@ pub mod event_service {
         }
     }
 
-    /// The request builder for a EventService::get_operation call.
+    /// The request builder for [EventService::get_operation][super::super::client::EventService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -771,7 +771,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::create_job call.
+    /// The request builder for [JobService::create_job][super::super::client::JobService::create_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -819,7 +819,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::batch_create_jobs call.
+    /// The request builder for [JobService::batch_create_jobs][super::super::client::JobService::batch_create_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateJobs(RequestBuilder<crate::model::BatchCreateJobsRequest>);
 
@@ -913,7 +913,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_job call.
+    /// The request builder for [JobService::get_job][super::super::client::JobService::get_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -953,7 +953,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::update_job call.
+    /// The request builder for [JobService::update_job][super::super::client::JobService::update_job] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateJob(RequestBuilder<crate::model::UpdateJobRequest>);
 
@@ -1004,7 +1004,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::batch_update_jobs call.
+    /// The request builder for [JobService::batch_update_jobs][super::super::client::JobService::batch_update_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct BatchUpdateJobs(RequestBuilder<crate::model::BatchUpdateJobsRequest>);
 
@@ -1107,7 +1107,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::delete_job call.
+    /// The request builder for [JobService::delete_job][super::super::client::JobService::delete_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -1149,7 +1149,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::batch_delete_jobs call.
+    /// The request builder for [JobService::batch_delete_jobs][super::super::client::JobService::batch_delete_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeleteJobs(RequestBuilder<crate::model::BatchDeleteJobsRequest>);
 
@@ -1243,7 +1243,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::list_jobs call.
+    /// The request builder for [JobService::list_jobs][super::super::client::JobService::list_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -1323,7 +1323,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::search_jobs call.
+    /// The request builder for [JobService::search_jobs][super::super::client::JobService::search_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct SearchJobs(RequestBuilder<crate::model::SearchJobsRequest>);
 
@@ -1489,7 +1489,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::search_jobs_for_alert call.
+    /// The request builder for [JobService::search_jobs_for_alert][super::super::client::JobService::search_jobs_for_alert] calls.
     #[derive(Clone, Debug)]
     pub struct SearchJobsForAlert(RequestBuilder<crate::model::SearchJobsRequest>);
 
@@ -1655,7 +1655,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for a JobService::get_operation call.
+    /// The request builder for [JobService::get_operation][super::super::client::JobService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1754,7 +1754,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for a TenantService::create_tenant call.
+    /// The request builder for [TenantService::create_tenant][super::super::client::TenantService::create_tenant] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTenant(RequestBuilder<crate::model::CreateTenantRequest>);
 
@@ -1805,7 +1805,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for a TenantService::get_tenant call.
+    /// The request builder for [TenantService::get_tenant][super::super::client::TenantService::get_tenant] calls.
     #[derive(Clone, Debug)]
     pub struct GetTenant(RequestBuilder<crate::model::GetTenantRequest>);
 
@@ -1847,7 +1847,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for a TenantService::update_tenant call.
+    /// The request builder for [TenantService::update_tenant][super::super::client::TenantService::update_tenant] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTenant(RequestBuilder<crate::model::UpdateTenantRequest>);
 
@@ -1901,7 +1901,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for a TenantService::delete_tenant call.
+    /// The request builder for [TenantService::delete_tenant][super::super::client::TenantService::delete_tenant] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTenant(RequestBuilder<crate::model::DeleteTenantRequest>);
 
@@ -1943,7 +1943,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for a TenantService::list_tenants call.
+    /// The request builder for [TenantService::list_tenants][super::super::client::TenantService::list_tenants] calls.
     #[derive(Clone, Debug)]
     pub struct ListTenants(RequestBuilder<crate::model::ListTenantsRequest>);
 
@@ -2012,7 +2012,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for a TenantService::get_operation call.
+    /// The request builder for [TenantService::get_operation][super::super::client::TenantService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/tasks/v2/src/builder.rs
+++ b/src/generated/cloud/tasks/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::list_queues call.
+    /// The request builder for [CloudTasks::list_queues][super::super::client::CloudTasks::list_queues] calls.
     #[derive(Clone, Debug)]
     pub struct ListQueues(RequestBuilder<crate::model::ListQueuesRequest>);
 
@@ -142,7 +142,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::get_queue call.
+    /// The request builder for [CloudTasks::get_queue][super::super::client::CloudTasks::get_queue] calls.
     #[derive(Clone, Debug)]
     pub struct GetQueue(RequestBuilder<crate::model::GetQueueRequest>);
 
@@ -184,7 +184,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::create_queue call.
+    /// The request builder for [CloudTasks::create_queue][super::super::client::CloudTasks::create_queue] calls.
     #[derive(Clone, Debug)]
     pub struct CreateQueue(RequestBuilder<crate::model::CreateQueueRequest>);
 
@@ -235,7 +235,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::update_queue call.
+    /// The request builder for [CloudTasks::update_queue][super::super::client::CloudTasks::update_queue] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateQueue(RequestBuilder<crate::model::UpdateQueueRequest>);
 
@@ -289,7 +289,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::delete_queue call.
+    /// The request builder for [CloudTasks::delete_queue][super::super::client::CloudTasks::delete_queue] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteQueue(RequestBuilder<crate::model::DeleteQueueRequest>);
 
@@ -331,7 +331,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::purge_queue call.
+    /// The request builder for [CloudTasks::purge_queue][super::super::client::CloudTasks::purge_queue] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeQueue(RequestBuilder<crate::model::PurgeQueueRequest>);
 
@@ -373,7 +373,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::pause_queue call.
+    /// The request builder for [CloudTasks::pause_queue][super::super::client::CloudTasks::pause_queue] calls.
     #[derive(Clone, Debug)]
     pub struct PauseQueue(RequestBuilder<crate::model::PauseQueueRequest>);
 
@@ -415,7 +415,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::resume_queue call.
+    /// The request builder for [CloudTasks::resume_queue][super::super::client::CloudTasks::resume_queue] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeQueue(RequestBuilder<crate::model::ResumeQueueRequest>);
 
@@ -457,7 +457,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::get_iam_policy call.
+    /// The request builder for [CloudTasks::get_iam_policy][super::super::client::CloudTasks::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -508,7 +508,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::set_iam_policy call.
+    /// The request builder for [CloudTasks::set_iam_policy][super::super::client::CloudTasks::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -568,7 +568,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::test_iam_permissions call.
+    /// The request builder for [CloudTasks::test_iam_permissions][super::super::client::CloudTasks::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -624,7 +624,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::list_tasks call.
+    /// The request builder for [CloudTasks::list_tasks][super::super::client::CloudTasks::list_tasks] calls.
     #[derive(Clone, Debug)]
     pub struct ListTasks(RequestBuilder<crate::model::ListTasksRequest>);
 
@@ -698,7 +698,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::get_task call.
+    /// The request builder for [CloudTasks::get_task][super::super::client::CloudTasks::get_task] calls.
     #[derive(Clone, Debug)]
     pub struct GetTask(RequestBuilder<crate::model::GetTaskRequest>);
 
@@ -746,7 +746,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::create_task call.
+    /// The request builder for [CloudTasks::create_task][super::super::client::CloudTasks::create_task] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTask(RequestBuilder<crate::model::CreateTaskRequest>);
 
@@ -800,7 +800,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::delete_task call.
+    /// The request builder for [CloudTasks::delete_task][super::super::client::CloudTasks::delete_task] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTask(RequestBuilder<crate::model::DeleteTaskRequest>);
 
@@ -842,7 +842,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::run_task call.
+    /// The request builder for [CloudTasks::run_task][super::super::client::CloudTasks::run_task] calls.
     #[derive(Clone, Debug)]
     pub struct RunTask(RequestBuilder<crate::model::RunTaskRequest>);
 
@@ -890,7 +890,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::list_locations call.
+    /// The request builder for [CloudTasks::list_locations][super::super::client::CloudTasks::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -968,7 +968,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for a CloudTasks::get_location call.
+    /// The request builder for [CloudTasks::get_location][super::super::client::CloudTasks::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/telcoautomation/v1/src/builder.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_orchestration_clusters call.
+    /// The request builder for [TelcoAutomation::list_orchestration_clusters][super::super::client::TelcoAutomation::list_orchestration_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListOrchestrationClusters(
         RequestBuilder<crate::model::ListOrchestrationClustersRequest>,
@@ -155,7 +155,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::get_orchestration_cluster call.
+    /// The request builder for [TelcoAutomation::get_orchestration_cluster][super::super::client::TelcoAutomation::get_orchestration_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetOrchestrationCluster(
         RequestBuilder<crate::model::GetOrchestrationClusterRequest>,
@@ -202,7 +202,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::create_orchestration_cluster call.
+    /// The request builder for [TelcoAutomation::create_orchestration_cluster][super::super::client::TelcoAutomation::create_orchestration_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateOrchestrationCluster(
         RequestBuilder<crate::model::CreateOrchestrationClusterRequest>,
@@ -311,7 +311,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::delete_orchestration_cluster call.
+    /// The request builder for [TelcoAutomation::delete_orchestration_cluster][super::super::client::TelcoAutomation::delete_orchestration_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOrchestrationCluster(
         RequestBuilder<crate::model::DeleteOrchestrationClusterRequest>,
@@ -399,7 +399,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_edge_slms call.
+    /// The request builder for [TelcoAutomation::list_edge_slms][super::super::client::TelcoAutomation::list_edge_slms] calls.
     #[derive(Clone, Debug)]
     pub struct ListEdgeSlms(RequestBuilder<crate::model::ListEdgeSlmsRequest>);
 
@@ -480,7 +480,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::get_edge_slm call.
+    /// The request builder for [TelcoAutomation::get_edge_slm][super::super::client::TelcoAutomation::get_edge_slm] calls.
     #[derive(Clone, Debug)]
     pub struct GetEdgeSlm(RequestBuilder<crate::model::GetEdgeSlmRequest>);
 
@@ -522,7 +522,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::create_edge_slm call.
+    /// The request builder for [TelcoAutomation::create_edge_slm][super::super::client::TelcoAutomation::create_edge_slm] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEdgeSlm(RequestBuilder<crate::model::CreateEdgeSlmRequest>);
 
@@ -622,7 +622,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::delete_edge_slm call.
+    /// The request builder for [TelcoAutomation::delete_edge_slm][super::super::client::TelcoAutomation::delete_edge_slm] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEdgeSlm(RequestBuilder<crate::model::DeleteEdgeSlmRequest>);
 
@@ -705,7 +705,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::create_blueprint call.
+    /// The request builder for [TelcoAutomation::create_blueprint][super::super::client::TelcoAutomation::create_blueprint] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBlueprint(RequestBuilder<crate::model::CreateBlueprintRequest>);
 
@@ -762,7 +762,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::update_blueprint call.
+    /// The request builder for [TelcoAutomation::update_blueprint][super::super::client::TelcoAutomation::update_blueprint] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBlueprint(RequestBuilder<crate::model::UpdateBlueprintRequest>);
 
@@ -816,7 +816,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::get_blueprint call.
+    /// The request builder for [TelcoAutomation::get_blueprint][super::super::client::TelcoAutomation::get_blueprint] calls.
     #[derive(Clone, Debug)]
     pub struct GetBlueprint(RequestBuilder<crate::model::GetBlueprintRequest>);
 
@@ -864,7 +864,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::delete_blueprint call.
+    /// The request builder for [TelcoAutomation::delete_blueprint][super::super::client::TelcoAutomation::delete_blueprint] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBlueprint(RequestBuilder<crate::model::DeleteBlueprintRequest>);
 
@@ -906,7 +906,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_blueprints call.
+    /// The request builder for [TelcoAutomation::list_blueprints][super::super::client::TelcoAutomation::list_blueprints] calls.
     #[derive(Clone, Debug)]
     pub struct ListBlueprints(RequestBuilder<crate::model::ListBlueprintsRequest>);
 
@@ -981,7 +981,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::approve_blueprint call.
+    /// The request builder for [TelcoAutomation::approve_blueprint][super::super::client::TelcoAutomation::approve_blueprint] calls.
     #[derive(Clone, Debug)]
     pub struct ApproveBlueprint(RequestBuilder<crate::model::ApproveBlueprintRequest>);
 
@@ -1026,7 +1026,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::propose_blueprint call.
+    /// The request builder for [TelcoAutomation::propose_blueprint][super::super::client::TelcoAutomation::propose_blueprint] calls.
     #[derive(Clone, Debug)]
     pub struct ProposeBlueprint(RequestBuilder<crate::model::ProposeBlueprintRequest>);
 
@@ -1071,7 +1071,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::reject_blueprint call.
+    /// The request builder for [TelcoAutomation::reject_blueprint][super::super::client::TelcoAutomation::reject_blueprint] calls.
     #[derive(Clone, Debug)]
     pub struct RejectBlueprint(RequestBuilder<crate::model::RejectBlueprintRequest>);
 
@@ -1113,7 +1113,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_blueprint_revisions call.
+    /// The request builder for [TelcoAutomation::list_blueprint_revisions][super::super::client::TelcoAutomation::list_blueprint_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct ListBlueprintRevisions(RequestBuilder<crate::model::ListBlueprintRevisionsRequest>);
 
@@ -1187,7 +1187,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::search_blueprint_revisions call.
+    /// The request builder for [TelcoAutomation::search_blueprint_revisions][super::super::client::TelcoAutomation::search_blueprint_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct SearchBlueprintRevisions(
         RequestBuilder<crate::model::SearchBlueprintRevisionsRequest>,
@@ -1269,7 +1269,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::search_deployment_revisions call.
+    /// The request builder for [TelcoAutomation::search_deployment_revisions][super::super::client::TelcoAutomation::search_deployment_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct SearchDeploymentRevisions(
         RequestBuilder<crate::model::SearchDeploymentRevisionsRequest>,
@@ -1351,7 +1351,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::discard_blueprint_changes call.
+    /// The request builder for [TelcoAutomation::discard_blueprint_changes][super::super::client::TelcoAutomation::discard_blueprint_changes] calls.
     #[derive(Clone, Debug)]
     pub struct DiscardBlueprintChanges(
         RequestBuilder<crate::model::DiscardBlueprintChangesRequest>,
@@ -1398,7 +1398,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_public_blueprints call.
+    /// The request builder for [TelcoAutomation::list_public_blueprints][super::super::client::TelcoAutomation::list_public_blueprints] calls.
     #[derive(Clone, Debug)]
     pub struct ListPublicBlueprints(RequestBuilder<crate::model::ListPublicBlueprintsRequest>);
 
@@ -1470,7 +1470,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::get_public_blueprint call.
+    /// The request builder for [TelcoAutomation::get_public_blueprint][super::super::client::TelcoAutomation::get_public_blueprint] calls.
     #[derive(Clone, Debug)]
     pub struct GetPublicBlueprint(RequestBuilder<crate::model::GetPublicBlueprintRequest>);
 
@@ -1515,7 +1515,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::create_deployment call.
+    /// The request builder for [TelcoAutomation::create_deployment][super::super::client::TelcoAutomation::create_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDeployment(RequestBuilder<crate::model::CreateDeploymentRequest>);
 
@@ -1575,7 +1575,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::update_deployment call.
+    /// The request builder for [TelcoAutomation::update_deployment][super::super::client::TelcoAutomation::update_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDeployment(RequestBuilder<crate::model::UpdateDeploymentRequest>);
 
@@ -1632,7 +1632,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::get_deployment call.
+    /// The request builder for [TelcoAutomation::get_deployment][super::super::client::TelcoAutomation::get_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -1680,7 +1680,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::remove_deployment call.
+    /// The request builder for [TelcoAutomation::remove_deployment][super::super::client::TelcoAutomation::remove_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveDeployment(RequestBuilder<crate::model::RemoveDeploymentRequest>);
 
@@ -1725,7 +1725,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_deployments call.
+    /// The request builder for [TelcoAutomation::list_deployments][super::super::client::TelcoAutomation::list_deployments] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -1800,7 +1800,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_deployment_revisions call.
+    /// The request builder for [TelcoAutomation::list_deployment_revisions][super::super::client::TelcoAutomation::list_deployment_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeploymentRevisions(
         RequestBuilder<crate::model::ListDeploymentRevisionsRequest>,
@@ -1876,7 +1876,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::discard_deployment_changes call.
+    /// The request builder for [TelcoAutomation::discard_deployment_changes][super::super::client::TelcoAutomation::discard_deployment_changes] calls.
     #[derive(Clone, Debug)]
     pub struct DiscardDeploymentChanges(
         RequestBuilder<crate::model::DiscardDeploymentChangesRequest>,
@@ -1923,7 +1923,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::apply_deployment call.
+    /// The request builder for [TelcoAutomation::apply_deployment][super::super::client::TelcoAutomation::apply_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct ApplyDeployment(RequestBuilder<crate::model::ApplyDeploymentRequest>);
 
@@ -1965,7 +1965,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::compute_deployment_status call.
+    /// The request builder for [TelcoAutomation::compute_deployment_status][super::super::client::TelcoAutomation::compute_deployment_status] calls.
     #[derive(Clone, Debug)]
     pub struct ComputeDeploymentStatus(
         RequestBuilder<crate::model::ComputeDeploymentStatusRequest>,
@@ -2012,7 +2012,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::rollback_deployment call.
+    /// The request builder for [TelcoAutomation::rollback_deployment][super::super::client::TelcoAutomation::rollback_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct RollbackDeployment(RequestBuilder<crate::model::RollbackDeploymentRequest>);
 
@@ -2063,7 +2063,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::get_hydrated_deployment call.
+    /// The request builder for [TelcoAutomation::get_hydrated_deployment][super::super::client::TelcoAutomation::get_hydrated_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct GetHydratedDeployment(RequestBuilder<crate::model::GetHydratedDeploymentRequest>);
 
@@ -2108,7 +2108,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_hydrated_deployments call.
+    /// The request builder for [TelcoAutomation::list_hydrated_deployments][super::super::client::TelcoAutomation::list_hydrated_deployments] calls.
     #[derive(Clone, Debug)]
     pub struct ListHydratedDeployments(
         RequestBuilder<crate::model::ListHydratedDeploymentsRequest>,
@@ -2184,7 +2184,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::update_hydrated_deployment call.
+    /// The request builder for [TelcoAutomation::update_hydrated_deployment][super::super::client::TelcoAutomation::update_hydrated_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateHydratedDeployment(
         RequestBuilder<crate::model::UpdateHydratedDeploymentRequest>,
@@ -2245,7 +2245,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::apply_hydrated_deployment call.
+    /// The request builder for [TelcoAutomation::apply_hydrated_deployment][super::super::client::TelcoAutomation::apply_hydrated_deployment] calls.
     #[derive(Clone, Debug)]
     pub struct ApplyHydratedDeployment(
         RequestBuilder<crate::model::ApplyHydratedDeploymentRequest>,
@@ -2292,7 +2292,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_locations call.
+    /// The request builder for [TelcoAutomation::list_locations][super::super::client::TelcoAutomation::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2370,7 +2370,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::get_location call.
+    /// The request builder for [TelcoAutomation::get_location][super::super::client::TelcoAutomation::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2412,7 +2412,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::list_operations call.
+    /// The request builder for [TelcoAutomation::list_operations][super::super::client::TelcoAutomation::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2490,7 +2490,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::get_operation call.
+    /// The request builder for [TelcoAutomation::get_operation][super::super::client::TelcoAutomation::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2535,7 +2535,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::delete_operation call.
+    /// The request builder for [TelcoAutomation::delete_operation][super::super::client::TelcoAutomation::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2580,7 +2580,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for a TelcoAutomation::cancel_operation call.
+    /// The request builder for [TelcoAutomation::cancel_operation][super::super::client::TelcoAutomation::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/texttospeech/v1/src/builder.rs
+++ b/src/generated/cloud/texttospeech/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// The request builder for a TextToSpeech::list_voices call.
+    /// The request builder for [TextToSpeech::list_voices][super::super::client::TextToSpeech::list_voices] calls.
     #[derive(Clone, Debug)]
     pub struct ListVoices(RequestBuilder<crate::model::ListVoicesRequest>);
 
@@ -109,7 +109,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// The request builder for a TextToSpeech::synthesize_speech call.
+    /// The request builder for [TextToSpeech::synthesize_speech][super::super::client::TextToSpeech::synthesize_speech] calls.
     #[derive(Clone, Debug)]
     pub struct SynthesizeSpeech(RequestBuilder<crate::model::SynthesizeSpeechRequest>);
 
@@ -186,7 +186,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// The request builder for a TextToSpeech::list_operations call.
+    /// The request builder for [TextToSpeech::list_operations][super::super::client::TextToSpeech::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -264,7 +264,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// The request builder for a TextToSpeech::get_operation call.
+    /// The request builder for [TextToSpeech::get_operation][super::super::client::TextToSpeech::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -365,7 +365,7 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    /// The request builder for a TextToSpeechLongAudioSynthesize::synthesize_long_audio call.
+    /// The request builder for [TextToSpeechLongAudioSynthesize::synthesize_long_audio][super::super::client::TextToSpeechLongAudioSynthesize::synthesize_long_audio] calls.
     #[derive(Clone, Debug)]
     pub struct SynthesizeLongAudio(RequestBuilder<crate::model::SynthesizeLongAudioRequest>);
 
@@ -488,7 +488,7 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    /// The request builder for a TextToSpeechLongAudioSynthesize::list_operations call.
+    /// The request builder for [TextToSpeechLongAudioSynthesize::list_operations][super::super::client::TextToSpeechLongAudioSynthesize::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -568,7 +568,7 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    /// The request builder for a TextToSpeechLongAudioSynthesize::get_operation call.
+    /// The request builder for [TextToSpeechLongAudioSynthesize::get_operation][super::super::client::TextToSpeechLongAudioSynthesize::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for a TimeseriesInsightsController::list_data_sets call.
+    /// The request builder for [TimeseriesInsightsController::list_data_sets][super::super::client::TimeseriesInsightsController::list_data_sets] calls.
     #[derive(Clone, Debug)]
     pub struct ListDataSets(RequestBuilder<crate::model::ListDataSetsRequest>);
 
@@ -140,7 +140,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for a TimeseriesInsightsController::create_data_set call.
+    /// The request builder for [TimeseriesInsightsController::create_data_set][super::super::client::TimeseriesInsightsController::create_data_set] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDataSet(RequestBuilder<crate::model::CreateDataSetRequest>);
 
@@ -193,7 +193,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for a TimeseriesInsightsController::delete_data_set call.
+    /// The request builder for [TimeseriesInsightsController::delete_data_set][super::super::client::TimeseriesInsightsController::delete_data_set] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataSet(RequestBuilder<crate::model::DeleteDataSetRequest>);
 
@@ -237,7 +237,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for a TimeseriesInsightsController::append_events call.
+    /// The request builder for [TimeseriesInsightsController::append_events][super::super::client::TimeseriesInsightsController::append_events] calls.
     #[derive(Clone, Debug)]
     pub struct AppendEvents(RequestBuilder<crate::model::AppendEventsRequest>);
 
@@ -292,7 +292,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for a TimeseriesInsightsController::query_data_set call.
+    /// The request builder for [TimeseriesInsightsController::query_data_set][super::super::client::TimeseriesInsightsController::query_data_set] calls.
     #[derive(Clone, Debug)]
     pub struct QueryDataSet(RequestBuilder<crate::model::QueryDataSetRequest>);
 
@@ -386,7 +386,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for a TimeseriesInsightsController::evaluate_slice call.
+    /// The request builder for [TimeseriesInsightsController::evaluate_slice][super::super::client::TimeseriesInsightsController::evaluate_slice] calls.
     #[derive(Clone, Debug)]
     pub struct EvaluateSlice(RequestBuilder<crate::model::EvaluateSliceRequest>);
 
@@ -470,7 +470,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for a TimeseriesInsightsController::evaluate_timeseries call.
+    /// The request builder for [TimeseriesInsightsController::evaluate_timeseries][super::super::client::TimeseriesInsightsController::evaluate_timeseries] calls.
     #[derive(Clone, Debug)]
     pub struct EvaluateTimeseries(RequestBuilder<crate::model::EvaluateTimeseriesRequest>);
 

--- a/src/generated/cloud/tpu/v2/src/builder.rs
+++ b/src/generated/cloud/tpu/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::list_nodes call.
+    /// The request builder for [Tpu::list_nodes][super::super::client::Tpu::list_nodes] calls.
     #[derive(Clone, Debug)]
     pub struct ListNodes(RequestBuilder<crate::model::ListNodesRequest>);
 
@@ -135,7 +135,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::get_node call.
+    /// The request builder for [Tpu::get_node][super::super::client::Tpu::get_node] calls.
     #[derive(Clone, Debug)]
     pub struct GetNode(RequestBuilder<crate::model::GetNodeRequest>);
 
@@ -177,7 +177,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::create_node call.
+    /// The request builder for [Tpu::create_node][super::super::client::Tpu::create_node] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNode(RequestBuilder<crate::model::CreateNodeRequest>);
 
@@ -268,7 +268,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::delete_node call.
+    /// The request builder for [Tpu::delete_node][super::super::client::Tpu::delete_node] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNode(RequestBuilder<crate::model::DeleteNodeRequest>);
 
@@ -345,7 +345,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::stop_node call.
+    /// The request builder for [Tpu::stop_node][super::super::client::Tpu::stop_node] calls.
     #[derive(Clone, Debug)]
     pub struct StopNode(RequestBuilder<crate::model::StopNodeRequest>);
 
@@ -424,7 +424,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::start_node call.
+    /// The request builder for [Tpu::start_node][super::super::client::Tpu::start_node] calls.
     #[derive(Clone, Debug)]
     pub struct StartNode(RequestBuilder<crate::model::StartNodeRequest>);
 
@@ -503,7 +503,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::update_node call.
+    /// The request builder for [Tpu::update_node][super::super::client::Tpu::update_node] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNode(RequestBuilder<crate::model::UpdateNodeRequest>);
 
@@ -591,7 +591,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::list_queued_resources call.
+    /// The request builder for [Tpu::list_queued_resources][super::super::client::Tpu::list_queued_resources] calls.
     #[derive(Clone, Debug)]
     pub struct ListQueuedResources(RequestBuilder<crate::model::ListQueuedResourcesRequest>);
 
@@ -663,7 +663,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::get_queued_resource call.
+    /// The request builder for [Tpu::get_queued_resource][super::super::client::Tpu::get_queued_resource] calls.
     #[derive(Clone, Debug)]
     pub struct GetQueuedResource(RequestBuilder<crate::model::GetQueuedResourceRequest>);
 
@@ -708,7 +708,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::create_queued_resource call.
+    /// The request builder for [Tpu::create_queued_resource][super::super::client::Tpu::create_queued_resource] calls.
     #[derive(Clone, Debug)]
     pub struct CreateQueuedResource(RequestBuilder<crate::model::CreateQueuedResourceRequest>);
 
@@ -813,7 +813,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::delete_queued_resource call.
+    /// The request builder for [Tpu::delete_queued_resource][super::super::client::Tpu::delete_queued_resource] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteQueuedResource(RequestBuilder<crate::model::DeleteQueuedResourceRequest>);
 
@@ -905,7 +905,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::reset_queued_resource call.
+    /// The request builder for [Tpu::reset_queued_resource][super::super::client::Tpu::reset_queued_resource] calls.
     #[derive(Clone, Debug)]
     pub struct ResetQueuedResource(RequestBuilder<crate::model::ResetQueuedResourceRequest>);
 
@@ -989,7 +989,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::generate_service_identity call.
+    /// The request builder for [Tpu::generate_service_identity][super::super::client::Tpu::generate_service_identity] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateServiceIdentity(
         RequestBuilder<crate::model::GenerateServiceIdentityRequest>,
@@ -1036,7 +1036,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::list_accelerator_types call.
+    /// The request builder for [Tpu::list_accelerator_types][super::super::client::Tpu::list_accelerator_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListAcceleratorTypes(RequestBuilder<crate::model::ListAcceleratorTypesRequest>);
 
@@ -1120,7 +1120,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::get_accelerator_type call.
+    /// The request builder for [Tpu::get_accelerator_type][super::super::client::Tpu::get_accelerator_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetAcceleratorType(RequestBuilder<crate::model::GetAcceleratorTypeRequest>);
 
@@ -1165,7 +1165,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::list_runtime_versions call.
+    /// The request builder for [Tpu::list_runtime_versions][super::super::client::Tpu::list_runtime_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListRuntimeVersions(RequestBuilder<crate::model::ListRuntimeVersionsRequest>);
 
@@ -1249,7 +1249,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::get_runtime_version call.
+    /// The request builder for [Tpu::get_runtime_version][super::super::client::Tpu::get_runtime_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetRuntimeVersion(RequestBuilder<crate::model::GetRuntimeVersionRequest>);
 
@@ -1294,7 +1294,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::get_guest_attributes call.
+    /// The request builder for [Tpu::get_guest_attributes][super::super::client::Tpu::get_guest_attributes] calls.
     #[derive(Clone, Debug)]
     pub struct GetGuestAttributes(RequestBuilder<crate::model::GetGuestAttributesRequest>);
 
@@ -1356,7 +1356,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::list_locations call.
+    /// The request builder for [Tpu::list_locations][super::super::client::Tpu::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1434,7 +1434,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::get_location call.
+    /// The request builder for [Tpu::get_location][super::super::client::Tpu::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1476,7 +1476,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::list_operations call.
+    /// The request builder for [Tpu::list_operations][super::super::client::Tpu::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1554,7 +1554,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::get_operation call.
+    /// The request builder for [Tpu::get_operation][super::super::client::Tpu::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1599,7 +1599,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::delete_operation call.
+    /// The request builder for [Tpu::delete_operation][super::super::client::Tpu::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1644,7 +1644,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for a Tpu::cancel_operation call.
+    /// The request builder for [Tpu::cancel_operation][super::super::client::Tpu::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/translate/v3/src/builder.rs
+++ b/src/generated/cloud/translate/v3/src/builder.rs
@@ -67,7 +67,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::translate_text call.
+    /// The request builder for [TranslationService::translate_text][super::super::client::TranslationService::translate_text] calls.
     #[derive(Clone, Debug)]
     pub struct TranslateText(RequestBuilder<crate::model::TranslateTextRequest>);
 
@@ -177,7 +177,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::romanize_text call.
+    /// The request builder for [TranslationService::romanize_text][super::super::client::TranslationService::romanize_text] calls.
     #[derive(Clone, Debug)]
     pub struct RomanizeText(RequestBuilder<crate::model::RomanizeTextRequest>);
 
@@ -236,7 +236,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::detect_language call.
+    /// The request builder for [TranslationService::detect_language][super::super::client::TranslationService::detect_language] calls.
     #[derive(Clone, Debug)]
     pub struct DetectLanguage(RequestBuilder<crate::model::DetectLanguageRequest>);
 
@@ -310,7 +310,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_supported_languages call.
+    /// The request builder for [TranslationService::get_supported_languages][super::super::client::TranslationService::get_supported_languages] calls.
     #[derive(Clone, Debug)]
     pub struct GetSupportedLanguages(RequestBuilder<crate::model::GetSupportedLanguagesRequest>);
 
@@ -367,7 +367,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::translate_document call.
+    /// The request builder for [TranslationService::translate_document][super::super::client::TranslationService::translate_document] calls.
     #[derive(Clone, Debug)]
     pub struct TranslateDocument(RequestBuilder<crate::model::TranslateDocumentRequest>);
 
@@ -498,7 +498,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::batch_translate_text call.
+    /// The request builder for [TranslationService::batch_translate_text][super::super::client::TranslationService::batch_translate_text] calls.
     #[derive(Clone, Debug)]
     pub struct BatchTranslateText(RequestBuilder<crate::model::BatchTranslateTextRequest>);
 
@@ -654,7 +654,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::batch_translate_document call.
+    /// The request builder for [TranslationService::batch_translate_document][super::super::client::TranslationService::batch_translate_document] calls.
     #[derive(Clone, Debug)]
     pub struct BatchTranslateDocument(RequestBuilder<crate::model::BatchTranslateDocumentRequest>);
 
@@ -833,7 +833,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::create_glossary call.
+    /// The request builder for [TranslationService::create_glossary][super::super::client::TranslationService::create_glossary] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGlossary(RequestBuilder<crate::model::CreateGlossaryRequest>);
 
@@ -923,7 +923,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::update_glossary call.
+    /// The request builder for [TranslationService::update_glossary][super::super::client::TranslationService::update_glossary] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGlossary(RequestBuilder<crate::model::UpdateGlossaryRequest>);
 
@@ -1016,7 +1016,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_glossaries call.
+    /// The request builder for [TranslationService::list_glossaries][super::super::client::TranslationService::list_glossaries] calls.
     #[derive(Clone, Debug)]
     pub struct ListGlossaries(RequestBuilder<crate::model::ListGlossariesRequest>);
 
@@ -1091,7 +1091,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_glossary call.
+    /// The request builder for [TranslationService::get_glossary][super::super::client::TranslationService::get_glossary] calls.
     #[derive(Clone, Debug)]
     pub struct GetGlossary(RequestBuilder<crate::model::GetGlossaryRequest>);
 
@@ -1133,7 +1133,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::delete_glossary call.
+    /// The request builder for [TranslationService::delete_glossary][super::super::client::TranslationService::delete_glossary] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGlossary(RequestBuilder<crate::model::DeleteGlossaryRequest>);
 
@@ -1216,7 +1216,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_glossary_entry call.
+    /// The request builder for [TranslationService::get_glossary_entry][super::super::client::TranslationService::get_glossary_entry] calls.
     #[derive(Clone, Debug)]
     pub struct GetGlossaryEntry(RequestBuilder<crate::model::GetGlossaryEntryRequest>);
 
@@ -1261,7 +1261,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_glossary_entries call.
+    /// The request builder for [TranslationService::list_glossary_entries][super::super::client::TranslationService::list_glossary_entries] calls.
     #[derive(Clone, Debug)]
     pub struct ListGlossaryEntries(RequestBuilder<crate::model::ListGlossaryEntriesRequest>);
 
@@ -1333,7 +1333,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::create_glossary_entry call.
+    /// The request builder for [TranslationService::create_glossary_entry][super::super::client::TranslationService::create_glossary_entry] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGlossaryEntry(RequestBuilder<crate::model::CreateGlossaryEntryRequest>);
 
@@ -1387,7 +1387,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::update_glossary_entry call.
+    /// The request builder for [TranslationService::update_glossary_entry][super::super::client::TranslationService::update_glossary_entry] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGlossaryEntry(RequestBuilder<crate::model::UpdateGlossaryEntryRequest>);
 
@@ -1435,7 +1435,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::delete_glossary_entry call.
+    /// The request builder for [TranslationService::delete_glossary_entry][super::super::client::TranslationService::delete_glossary_entry] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGlossaryEntry(RequestBuilder<crate::model::DeleteGlossaryEntryRequest>);
 
@@ -1480,7 +1480,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::create_dataset call.
+    /// The request builder for [TranslationService::create_dataset][super::super::client::TranslationService::create_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDataset(RequestBuilder<crate::model::CreateDatasetRequest>);
 
@@ -1569,7 +1569,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_dataset call.
+    /// The request builder for [TranslationService::get_dataset][super::super::client::TranslationService::get_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct GetDataset(RequestBuilder<crate::model::GetDatasetRequest>);
 
@@ -1611,7 +1611,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_datasets call.
+    /// The request builder for [TranslationService::list_datasets][super::super::client::TranslationService::list_datasets] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatasets(RequestBuilder<crate::model::ListDatasetsRequest>);
 
@@ -1680,7 +1680,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::delete_dataset call.
+    /// The request builder for [TranslationService::delete_dataset][super::super::client::TranslationService::delete_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDataset(RequestBuilder<crate::model::DeleteDatasetRequest>);
 
@@ -1757,7 +1757,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::create_adaptive_mt_dataset call.
+    /// The request builder for [TranslationService::create_adaptive_mt_dataset][super::super::client::TranslationService::create_adaptive_mt_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAdaptiveMtDataset(
         RequestBuilder<crate::model::CreateAdaptiveMtDatasetRequest>,
@@ -1815,7 +1815,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::delete_adaptive_mt_dataset call.
+    /// The request builder for [TranslationService::delete_adaptive_mt_dataset][super::super::client::TranslationService::delete_adaptive_mt_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAdaptiveMtDataset(
         RequestBuilder<crate::model::DeleteAdaptiveMtDatasetRequest>,
@@ -1862,7 +1862,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_adaptive_mt_dataset call.
+    /// The request builder for [TranslationService::get_adaptive_mt_dataset][super::super::client::TranslationService::get_adaptive_mt_dataset] calls.
     #[derive(Clone, Debug)]
     pub struct GetAdaptiveMtDataset(RequestBuilder<crate::model::GetAdaptiveMtDatasetRequest>);
 
@@ -1907,7 +1907,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_adaptive_mt_datasets call.
+    /// The request builder for [TranslationService::list_adaptive_mt_datasets][super::super::client::TranslationService::list_adaptive_mt_datasets] calls.
     #[derive(Clone, Debug)]
     pub struct ListAdaptiveMtDatasets(RequestBuilder<crate::model::ListAdaptiveMtDatasetsRequest>);
 
@@ -1987,7 +1987,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::adaptive_mt_translate call.
+    /// The request builder for [TranslationService::adaptive_mt_translate][super::super::client::TranslationService::adaptive_mt_translate] calls.
     #[derive(Clone, Debug)]
     pub struct AdaptiveMtTranslate(RequestBuilder<crate::model::AdaptiveMtTranslateRequest>);
 
@@ -2075,7 +2075,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_adaptive_mt_file call.
+    /// The request builder for [TranslationService::get_adaptive_mt_file][super::super::client::TranslationService::get_adaptive_mt_file] calls.
     #[derive(Clone, Debug)]
     pub struct GetAdaptiveMtFile(RequestBuilder<crate::model::GetAdaptiveMtFileRequest>);
 
@@ -2120,7 +2120,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::delete_adaptive_mt_file call.
+    /// The request builder for [TranslationService::delete_adaptive_mt_file][super::super::client::TranslationService::delete_adaptive_mt_file] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAdaptiveMtFile(RequestBuilder<crate::model::DeleteAdaptiveMtFileRequest>);
 
@@ -2165,7 +2165,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::import_adaptive_mt_file call.
+    /// The request builder for [TranslationService::import_adaptive_mt_file][super::super::client::TranslationService::import_adaptive_mt_file] calls.
     #[derive(Clone, Debug)]
     pub struct ImportAdaptiveMtFile(RequestBuilder<crate::model::ImportAdaptiveMtFileRequest>);
 
@@ -2221,7 +2221,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_adaptive_mt_files call.
+    /// The request builder for [TranslationService::list_adaptive_mt_files][super::super::client::TranslationService::list_adaptive_mt_files] calls.
     #[derive(Clone, Debug)]
     pub struct ListAdaptiveMtFiles(RequestBuilder<crate::model::ListAdaptiveMtFilesRequest>);
 
@@ -2293,7 +2293,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_adaptive_mt_sentences call.
+    /// The request builder for [TranslationService::list_adaptive_mt_sentences][super::super::client::TranslationService::list_adaptive_mt_sentences] calls.
     #[derive(Clone, Debug)]
     pub struct ListAdaptiveMtSentences(
         RequestBuilder<crate::model::ListAdaptiveMtSentencesRequest>,
@@ -2369,7 +2369,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::import_data call.
+    /// The request builder for [TranslationService::import_data][super::super::client::TranslationService::import_data] calls.
     #[derive(Clone, Debug)]
     pub struct ImportData(RequestBuilder<crate::model::ImportDataRequest>);
 
@@ -2455,7 +2455,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::export_data call.
+    /// The request builder for [TranslationService::export_data][super::super::client::TranslationService::export_data] calls.
     #[derive(Clone, Debug)]
     pub struct ExportData(RequestBuilder<crate::model::ExportDataRequest>);
 
@@ -2543,7 +2543,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_examples call.
+    /// The request builder for [TranslationService::list_examples][super::super::client::TranslationService::list_examples] calls.
     #[derive(Clone, Debug)]
     pub struct ListExamples(RequestBuilder<crate::model::ListExamplesRequest>);
 
@@ -2618,7 +2618,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::create_model call.
+    /// The request builder for [TranslationService::create_model][super::super::client::TranslationService::create_model] calls.
     #[derive(Clone, Debug)]
     pub struct CreateModel(RequestBuilder<crate::model::CreateModelRequest>);
 
@@ -2706,7 +2706,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_models call.
+    /// The request builder for [TranslationService::list_models][super::super::client::TranslationService::list_models] calls.
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -2781,7 +2781,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_model call.
+    /// The request builder for [TranslationService::get_model][super::super::client::TranslationService::get_model] calls.
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -2823,7 +2823,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::delete_model call.
+    /// The request builder for [TranslationService::delete_model][super::super::client::TranslationService::delete_model] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -2900,7 +2900,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_locations call.
+    /// The request builder for [TranslationService::list_locations][super::super::client::TranslationService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2978,7 +2978,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_location call.
+    /// The request builder for [TranslationService::get_location][super::super::client::TranslationService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3020,7 +3020,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::list_operations call.
+    /// The request builder for [TranslationService::list_operations][super::super::client::TranslationService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3098,7 +3098,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::get_operation call.
+    /// The request builder for [TranslationService::get_operation][super::super::client::TranslationService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3143,7 +3143,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::delete_operation call.
+    /// The request builder for [TranslationService::delete_operation][super::super::client::TranslationService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3188,7 +3188,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::cancel_operation call.
+    /// The request builder for [TranslationService::cancel_operation][super::super::client::TranslationService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3233,7 +3233,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for a TranslationService::wait_operation call.
+    /// The request builder for [TranslationService::wait_operation][super::super::client::TranslationService::wait_operation] calls.
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 

--- a/src/generated/cloud/video/livestream/v1/src/builder.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::create_channel call.
+    /// The request builder for [LivestreamService::create_channel][super::super::client::LivestreamService::create_channel] calls.
     #[derive(Clone, Debug)]
     pub struct CreateChannel(RequestBuilder<crate::model::CreateChannelRequest>);
 
@@ -167,7 +167,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::list_channels call.
+    /// The request builder for [LivestreamService::list_channels][super::super::client::LivestreamService::list_channels] calls.
     #[derive(Clone, Debug)]
     pub struct ListChannels(RequestBuilder<crate::model::ListChannelsRequest>);
 
@@ -248,7 +248,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::get_channel call.
+    /// The request builder for [LivestreamService::get_channel][super::super::client::LivestreamService::get_channel] calls.
     #[derive(Clone, Debug)]
     pub struct GetChannel(RequestBuilder<crate::model::GetChannelRequest>);
 
@@ -290,7 +290,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::delete_channel call.
+    /// The request builder for [LivestreamService::delete_channel][super::super::client::LivestreamService::delete_channel] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteChannel(RequestBuilder<crate::model::DeleteChannelRequest>);
 
@@ -379,7 +379,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::update_channel call.
+    /// The request builder for [LivestreamService::update_channel][super::super::client::LivestreamService::update_channel] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateChannel(RequestBuilder<crate::model::UpdateChannelRequest>);
 
@@ -476,7 +476,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::start_channel call.
+    /// The request builder for [LivestreamService::start_channel][super::super::client::LivestreamService::start_channel] calls.
     #[derive(Clone, Debug)]
     pub struct StartChannel(RequestBuilder<crate::model::StartChannelRequest>);
 
@@ -565,7 +565,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::stop_channel call.
+    /// The request builder for [LivestreamService::stop_channel][super::super::client::LivestreamService::stop_channel] calls.
     #[derive(Clone, Debug)]
     pub struct StopChannel(RequestBuilder<crate::model::StopChannelRequest>);
 
@@ -654,7 +654,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::create_input call.
+    /// The request builder for [LivestreamService::create_input][super::super::client::LivestreamService::create_input] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInput(RequestBuilder<crate::model::CreateInputRequest>);
 
@@ -754,7 +754,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::list_inputs call.
+    /// The request builder for [LivestreamService::list_inputs][super::super::client::LivestreamService::list_inputs] calls.
     #[derive(Clone, Debug)]
     pub struct ListInputs(RequestBuilder<crate::model::ListInputsRequest>);
 
@@ -835,7 +835,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::get_input call.
+    /// The request builder for [LivestreamService::get_input][super::super::client::LivestreamService::get_input] calls.
     #[derive(Clone, Debug)]
     pub struct GetInput(RequestBuilder<crate::model::GetInputRequest>);
 
@@ -877,7 +877,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::delete_input call.
+    /// The request builder for [LivestreamService::delete_input][super::super::client::LivestreamService::delete_input] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInput(RequestBuilder<crate::model::DeleteInputRequest>);
 
@@ -960,7 +960,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::update_input call.
+    /// The request builder for [LivestreamService::update_input][super::super::client::LivestreamService::update_input] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInput(RequestBuilder<crate::model::UpdateInputRequest>);
 
@@ -1057,7 +1057,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::create_event call.
+    /// The request builder for [LivestreamService::create_event][super::super::client::LivestreamService::create_event] calls.
     #[derive(Clone, Debug)]
     pub struct CreateEvent(RequestBuilder<crate::model::CreateEventRequest>);
 
@@ -1120,7 +1120,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::list_events call.
+    /// The request builder for [LivestreamService::list_events][super::super::client::LivestreamService::list_events] calls.
     #[derive(Clone, Debug)]
     pub struct ListEvents(RequestBuilder<crate::model::ListEventsRequest>);
 
@@ -1201,7 +1201,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::get_event call.
+    /// The request builder for [LivestreamService::get_event][super::super::client::LivestreamService::get_event] calls.
     #[derive(Clone, Debug)]
     pub struct GetEvent(RequestBuilder<crate::model::GetEventRequest>);
 
@@ -1243,7 +1243,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::delete_event call.
+    /// The request builder for [LivestreamService::delete_event][super::super::client::LivestreamService::delete_event] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteEvent(RequestBuilder<crate::model::DeleteEventRequest>);
 
@@ -1291,7 +1291,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::list_clips call.
+    /// The request builder for [LivestreamService::list_clips][super::super::client::LivestreamService::list_clips] calls.
     #[derive(Clone, Debug)]
     pub struct ListClips(RequestBuilder<crate::model::ListClipsRequest>);
 
@@ -1371,7 +1371,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::get_clip call.
+    /// The request builder for [LivestreamService::get_clip][super::super::client::LivestreamService::get_clip] calls.
     #[derive(Clone, Debug)]
     pub struct GetClip(RequestBuilder<crate::model::GetClipRequest>);
 
@@ -1413,7 +1413,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::create_clip call.
+    /// The request builder for [LivestreamService::create_clip][super::super::client::LivestreamService::create_clip] calls.
     #[derive(Clone, Debug)]
     pub struct CreateClip(RequestBuilder<crate::model::CreateClipRequest>);
 
@@ -1510,7 +1510,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::delete_clip call.
+    /// The request builder for [LivestreamService::delete_clip][super::super::client::LivestreamService::delete_clip] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteClip(RequestBuilder<crate::model::DeleteClipRequest>);
 
@@ -1593,7 +1593,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::create_asset call.
+    /// The request builder for [LivestreamService::create_asset][super::super::client::LivestreamService::create_asset] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAsset(RequestBuilder<crate::model::CreateAssetRequest>);
 
@@ -1693,7 +1693,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::delete_asset call.
+    /// The request builder for [LivestreamService::delete_asset][super::super::client::LivestreamService::delete_asset] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAsset(RequestBuilder<crate::model::DeleteAssetRequest>);
 
@@ -1776,7 +1776,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::get_asset call.
+    /// The request builder for [LivestreamService::get_asset][super::super::client::LivestreamService::get_asset] calls.
     #[derive(Clone, Debug)]
     pub struct GetAsset(RequestBuilder<crate::model::GetAssetRequest>);
 
@@ -1818,7 +1818,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::list_assets call.
+    /// The request builder for [LivestreamService::list_assets][super::super::client::LivestreamService::list_assets] calls.
     #[derive(Clone, Debug)]
     pub struct ListAssets(RequestBuilder<crate::model::ListAssetsRequest>);
 
@@ -1899,7 +1899,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::get_pool call.
+    /// The request builder for [LivestreamService::get_pool][super::super::client::LivestreamService::get_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetPool(RequestBuilder<crate::model::GetPoolRequest>);
 
@@ -1941,7 +1941,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::update_pool call.
+    /// The request builder for [LivestreamService::update_pool][super::super::client::LivestreamService::update_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePool(RequestBuilder<crate::model::UpdatePoolRequest>);
 
@@ -2035,7 +2035,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::list_locations call.
+    /// The request builder for [LivestreamService::list_locations][super::super::client::LivestreamService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2113,7 +2113,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::get_location call.
+    /// The request builder for [LivestreamService::get_location][super::super::client::LivestreamService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2155,7 +2155,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::list_operations call.
+    /// The request builder for [LivestreamService::list_operations][super::super::client::LivestreamService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2233,7 +2233,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::get_operation call.
+    /// The request builder for [LivestreamService::get_operation][super::super::client::LivestreamService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2278,7 +2278,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::delete_operation call.
+    /// The request builder for [LivestreamService::delete_operation][super::super::client::LivestreamService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2323,7 +2323,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for a LivestreamService::cancel_operation call.
+    /// The request builder for [LivestreamService::cancel_operation][super::super::client::LivestreamService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/video/stitcher/v1/src/builder.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::create_cdn_key call.
+    /// The request builder for [VideoStitcherService::create_cdn_key][super::super::client::VideoStitcherService::create_cdn_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCdnKey(RequestBuilder<crate::model::CreateCdnKeyRequest>);
 
@@ -165,7 +165,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::list_cdn_keys call.
+    /// The request builder for [VideoStitcherService::list_cdn_keys][super::super::client::VideoStitcherService::list_cdn_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListCdnKeys(RequestBuilder<crate::model::ListCdnKeysRequest>);
 
@@ -248,7 +248,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_cdn_key call.
+    /// The request builder for [VideoStitcherService::get_cdn_key][super::super::client::VideoStitcherService::get_cdn_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetCdnKey(RequestBuilder<crate::model::GetCdnKeyRequest>);
 
@@ -292,7 +292,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::delete_cdn_key call.
+    /// The request builder for [VideoStitcherService::delete_cdn_key][super::super::client::VideoStitcherService::delete_cdn_key] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCdnKey(RequestBuilder<crate::model::DeleteCdnKeyRequest>);
 
@@ -371,7 +371,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::update_cdn_key call.
+    /// The request builder for [VideoStitcherService::update_cdn_key][super::super::client::VideoStitcherService::update_cdn_key] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCdnKey(RequestBuilder<crate::model::UpdateCdnKeyRequest>);
 
@@ -464,7 +464,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::create_vod_session call.
+    /// The request builder for [VideoStitcherService::create_vod_session][super::super::client::VideoStitcherService::create_vod_session] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVodSession(RequestBuilder<crate::model::CreateVodSessionRequest>);
 
@@ -520,7 +520,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_vod_session call.
+    /// The request builder for [VideoStitcherService::get_vod_session][super::super::client::VideoStitcherService::get_vod_session] calls.
     #[derive(Clone, Debug)]
     pub struct GetVodSession(RequestBuilder<crate::model::GetVodSessionRequest>);
 
@@ -564,7 +564,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::list_vod_stitch_details call.
+    /// The request builder for [VideoStitcherService::list_vod_stitch_details][super::super::client::VideoStitcherService::list_vod_stitch_details] calls.
     #[derive(Clone, Debug)]
     pub struct ListVodStitchDetails(RequestBuilder<crate::model::ListVodStitchDetailsRequest>);
 
@@ -638,7 +638,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_vod_stitch_detail call.
+    /// The request builder for [VideoStitcherService::get_vod_stitch_detail][super::super::client::VideoStitcherService::get_vod_stitch_detail] calls.
     #[derive(Clone, Debug)]
     pub struct GetVodStitchDetail(RequestBuilder<crate::model::GetVodStitchDetailRequest>);
 
@@ -685,7 +685,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::list_vod_ad_tag_details call.
+    /// The request builder for [VideoStitcherService::list_vod_ad_tag_details][super::super::client::VideoStitcherService::list_vod_ad_tag_details] calls.
     #[derive(Clone, Debug)]
     pub struct ListVodAdTagDetails(RequestBuilder<crate::model::ListVodAdTagDetailsRequest>);
 
@@ -759,7 +759,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_vod_ad_tag_detail call.
+    /// The request builder for [VideoStitcherService::get_vod_ad_tag_detail][super::super::client::VideoStitcherService::get_vod_ad_tag_detail] calls.
     #[derive(Clone, Debug)]
     pub struct GetVodAdTagDetail(RequestBuilder<crate::model::GetVodAdTagDetailRequest>);
 
@@ -806,7 +806,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::list_live_ad_tag_details call.
+    /// The request builder for [VideoStitcherService::list_live_ad_tag_details][super::super::client::VideoStitcherService::list_live_ad_tag_details] calls.
     #[derive(Clone, Debug)]
     pub struct ListLiveAdTagDetails(RequestBuilder<crate::model::ListLiveAdTagDetailsRequest>);
 
@@ -880,7 +880,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_live_ad_tag_detail call.
+    /// The request builder for [VideoStitcherService::get_live_ad_tag_detail][super::super::client::VideoStitcherService::get_live_ad_tag_detail] calls.
     #[derive(Clone, Debug)]
     pub struct GetLiveAdTagDetail(RequestBuilder<crate::model::GetLiveAdTagDetailRequest>);
 
@@ -927,7 +927,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::create_slate call.
+    /// The request builder for [VideoStitcherService::create_slate][super::super::client::VideoStitcherService::create_slate] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSlate(RequestBuilder<crate::model::CreateSlateRequest>);
 
@@ -1029,7 +1029,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::list_slates call.
+    /// The request builder for [VideoStitcherService::list_slates][super::super::client::VideoStitcherService::list_slates] calls.
     #[derive(Clone, Debug)]
     pub struct ListSlates(RequestBuilder<crate::model::ListSlatesRequest>);
 
@@ -1112,7 +1112,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_slate call.
+    /// The request builder for [VideoStitcherService::get_slate][super::super::client::VideoStitcherService::get_slate] calls.
     #[derive(Clone, Debug)]
     pub struct GetSlate(RequestBuilder<crate::model::GetSlateRequest>);
 
@@ -1156,7 +1156,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::update_slate call.
+    /// The request builder for [VideoStitcherService::update_slate][super::super::client::VideoStitcherService::update_slate] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSlate(RequestBuilder<crate::model::UpdateSlateRequest>);
 
@@ -1249,7 +1249,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::delete_slate call.
+    /// The request builder for [VideoStitcherService::delete_slate][super::super::client::VideoStitcherService::delete_slate] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSlate(RequestBuilder<crate::model::DeleteSlateRequest>);
 
@@ -1328,7 +1328,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::create_live_session call.
+    /// The request builder for [VideoStitcherService::create_live_session][super::super::client::VideoStitcherService::create_live_session] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLiveSession(RequestBuilder<crate::model::CreateLiveSessionRequest>);
 
@@ -1384,7 +1384,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_live_session call.
+    /// The request builder for [VideoStitcherService::get_live_session][super::super::client::VideoStitcherService::get_live_session] calls.
     #[derive(Clone, Debug)]
     pub struct GetLiveSession(RequestBuilder<crate::model::GetLiveSessionRequest>);
 
@@ -1428,7 +1428,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::create_live_config call.
+    /// The request builder for [VideoStitcherService::create_live_config][super::super::client::VideoStitcherService::create_live_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLiveConfig(RequestBuilder<crate::model::CreateLiveConfigRequest>);
 
@@ -1534,7 +1534,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::list_live_configs call.
+    /// The request builder for [VideoStitcherService::list_live_configs][super::super::client::VideoStitcherService::list_live_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListLiveConfigs(RequestBuilder<crate::model::ListLiveConfigsRequest>);
 
@@ -1617,7 +1617,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_live_config call.
+    /// The request builder for [VideoStitcherService::get_live_config][super::super::client::VideoStitcherService::get_live_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetLiveConfig(RequestBuilder<crate::model::GetLiveConfigRequest>);
 
@@ -1661,7 +1661,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::delete_live_config call.
+    /// The request builder for [VideoStitcherService::delete_live_config][super::super::client::VideoStitcherService::delete_live_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLiveConfig(RequestBuilder<crate::model::DeleteLiveConfigRequest>);
 
@@ -1743,7 +1743,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::update_live_config call.
+    /// The request builder for [VideoStitcherService::update_live_config][super::super::client::VideoStitcherService::update_live_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateLiveConfig(RequestBuilder<crate::model::UpdateLiveConfigRequest>);
 
@@ -1840,7 +1840,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::create_vod_config call.
+    /// The request builder for [VideoStitcherService::create_vod_config][super::super::client::VideoStitcherService::create_vod_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVodConfig(RequestBuilder<crate::model::CreateVodConfigRequest>);
 
@@ -1943,7 +1943,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::list_vod_configs call.
+    /// The request builder for [VideoStitcherService::list_vod_configs][super::super::client::VideoStitcherService::list_vod_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListVodConfigs(RequestBuilder<crate::model::ListVodConfigsRequest>);
 
@@ -2026,7 +2026,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_vod_config call.
+    /// The request builder for [VideoStitcherService::get_vod_config][super::super::client::VideoStitcherService::get_vod_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetVodConfig(RequestBuilder<crate::model::GetVodConfigRequest>);
 
@@ -2070,7 +2070,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::delete_vod_config call.
+    /// The request builder for [VideoStitcherService::delete_vod_config][super::super::client::VideoStitcherService::delete_vod_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVodConfig(RequestBuilder<crate::model::DeleteVodConfigRequest>);
 
@@ -2149,7 +2149,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::update_vod_config call.
+    /// The request builder for [VideoStitcherService::update_vod_config][super::super::client::VideoStitcherService::update_vod_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVodConfig(RequestBuilder<crate::model::UpdateVodConfigRequest>);
 
@@ -2243,7 +2243,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::list_operations call.
+    /// The request builder for [VideoStitcherService::list_operations][super::super::client::VideoStitcherService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2323,7 +2323,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::get_operation call.
+    /// The request builder for [VideoStitcherService::get_operation][super::super::client::VideoStitcherService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2370,7 +2370,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::delete_operation call.
+    /// The request builder for [VideoStitcherService::delete_operation][super::super::client::VideoStitcherService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2417,7 +2417,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for a VideoStitcherService::cancel_operation call.
+    /// The request builder for [VideoStitcherService::cancel_operation][super::super::client::VideoStitcherService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/video/transcoder/v1/src/builder.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for a TranscoderService::create_job call.
+    /// The request builder for [TranscoderService::create_job][super::super::client::TranscoderService::create_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -115,7 +115,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for a TranscoderService::list_jobs call.
+    /// The request builder for [TranscoderService::list_jobs][super::super::client::TranscoderService::list_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -195,7 +195,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for a TranscoderService::get_job call.
+    /// The request builder for [TranscoderService::get_job][super::super::client::TranscoderService::get_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -235,7 +235,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for a TranscoderService::delete_job call.
+    /// The request builder for [TranscoderService::delete_job][super::super::client::TranscoderService::delete_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -283,7 +283,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for a TranscoderService::create_job_template call.
+    /// The request builder for [TranscoderService::create_job_template][super::super::client::TranscoderService::create_job_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateJobTemplate(RequestBuilder<crate::model::CreateJobTemplateRequest>);
 
@@ -343,7 +343,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for a TranscoderService::list_job_templates call.
+    /// The request builder for [TranscoderService::list_job_templates][super::super::client::TranscoderService::list_job_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobTemplates(RequestBuilder<crate::model::ListJobTemplatesRequest>);
 
@@ -427,7 +427,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for a TranscoderService::get_job_template call.
+    /// The request builder for [TranscoderService::get_job_template][super::super::client::TranscoderService::get_job_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetJobTemplate(RequestBuilder<crate::model::GetJobTemplateRequest>);
 
@@ -469,7 +469,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for a TranscoderService::delete_job_template call.
+    /// The request builder for [TranscoderService::delete_job_template][super::super::client::TranscoderService::delete_job_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteJobTemplate(RequestBuilder<crate::model::DeleteJobTemplateRequest>);
 

--- a/src/generated/cloud/videointelligence/v1/src/builder.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for a VideoIntelligenceService::annotate_video call.
+    /// The request builder for [VideoIntelligenceService::annotate_video][super::super::client::VideoIntelligenceService::annotate_video] calls.
     #[derive(Clone, Debug)]
     pub struct AnnotateVideo(RequestBuilder<crate::model::AnnotateVideoRequest>);
 
@@ -192,7 +192,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for a VideoIntelligenceService::list_operations call.
+    /// The request builder for [VideoIntelligenceService::list_operations][super::super::client::VideoIntelligenceService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -272,7 +272,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for a VideoIntelligenceService::get_operation call.
+    /// The request builder for [VideoIntelligenceService::get_operation][super::super::client::VideoIntelligenceService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -319,7 +319,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for a VideoIntelligenceService::delete_operation call.
+    /// The request builder for [VideoIntelligenceService::delete_operation][super::super::client::VideoIntelligenceService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -366,7 +366,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for a VideoIntelligenceService::cancel_operation call.
+    /// The request builder for [VideoIntelligenceService::cancel_operation][super::super::client::VideoIntelligenceService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/vision/v1/src/builder.rs
+++ b/src/generated/cloud/vision/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for a ImageAnnotator::batch_annotate_images call.
+    /// The request builder for [ImageAnnotator::batch_annotate_images][super::super::client::ImageAnnotator::batch_annotate_images] calls.
     #[derive(Clone, Debug)]
     pub struct BatchAnnotateImages(RequestBuilder<crate::model::BatchAnnotateImagesRequest>);
 
@@ -134,7 +134,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for a ImageAnnotator::batch_annotate_files call.
+    /// The request builder for [ImageAnnotator::batch_annotate_files][super::super::client::ImageAnnotator::batch_annotate_files] calls.
     #[derive(Clone, Debug)]
     pub struct BatchAnnotateFiles(RequestBuilder<crate::model::BatchAnnotateFilesRequest>);
 
@@ -201,7 +201,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for a ImageAnnotator::async_batch_annotate_images call.
+    /// The request builder for [ImageAnnotator::async_batch_annotate_images][super::super::client::ImageAnnotator::async_batch_annotate_images] calls.
     #[derive(Clone, Debug)]
     pub struct AsyncBatchAnnotateImages(
         RequestBuilder<crate::model::AsyncBatchAnnotateImagesRequest>,
@@ -322,7 +322,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for a ImageAnnotator::async_batch_annotate_files call.
+    /// The request builder for [ImageAnnotator::async_batch_annotate_files][super::super::client::ImageAnnotator::async_batch_annotate_files] calls.
     #[derive(Clone, Debug)]
     pub struct AsyncBatchAnnotateFiles(
         RequestBuilder<crate::model::AsyncBatchAnnotateFilesRequest>,
@@ -434,7 +434,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for a ImageAnnotator::get_operation call.
+    /// The request builder for [ImageAnnotator::get_operation][super::super::client::ImageAnnotator::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -533,7 +533,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::create_product_set call.
+    /// The request builder for [ProductSearch::create_product_set][super::super::client::ProductSearch::create_product_set] calls.
     #[derive(Clone, Debug)]
     pub struct CreateProductSet(RequestBuilder<crate::model::CreateProductSetRequest>);
 
@@ -593,7 +593,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::list_product_sets call.
+    /// The request builder for [ProductSearch::list_product_sets][super::super::client::ProductSearch::list_product_sets] calls.
     #[derive(Clone, Debug)]
     pub struct ListProductSets(RequestBuilder<crate::model::ListProductSetsRequest>);
 
@@ -662,7 +662,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::get_product_set call.
+    /// The request builder for [ProductSearch::get_product_set][super::super::client::ProductSearch::get_product_set] calls.
     #[derive(Clone, Debug)]
     pub struct GetProductSet(RequestBuilder<crate::model::GetProductSetRequest>);
 
@@ -704,7 +704,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::update_product_set call.
+    /// The request builder for [ProductSearch::update_product_set][super::super::client::ProductSearch::update_product_set] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProductSet(RequestBuilder<crate::model::UpdateProductSetRequest>);
 
@@ -761,7 +761,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::delete_product_set call.
+    /// The request builder for [ProductSearch::delete_product_set][super::super::client::ProductSearch::delete_product_set] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteProductSet(RequestBuilder<crate::model::DeleteProductSetRequest>);
 
@@ -806,7 +806,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::create_product call.
+    /// The request builder for [ProductSearch::create_product][super::super::client::ProductSearch::create_product] calls.
     #[derive(Clone, Debug)]
     pub struct CreateProduct(RequestBuilder<crate::model::CreateProductRequest>);
 
@@ -863,7 +863,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::list_products call.
+    /// The request builder for [ProductSearch::list_products][super::super::client::ProductSearch::list_products] calls.
     #[derive(Clone, Debug)]
     pub struct ListProducts(RequestBuilder<crate::model::ListProductsRequest>);
 
@@ -932,7 +932,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::get_product call.
+    /// The request builder for [ProductSearch::get_product][super::super::client::ProductSearch::get_product] calls.
     #[derive(Clone, Debug)]
     pub struct GetProduct(RequestBuilder<crate::model::GetProductRequest>);
 
@@ -974,7 +974,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::update_product call.
+    /// The request builder for [ProductSearch::update_product][super::super::client::ProductSearch::update_product] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProduct(RequestBuilder<crate::model::UpdateProductRequest>);
 
@@ -1028,7 +1028,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::delete_product call.
+    /// The request builder for [ProductSearch::delete_product][super::super::client::ProductSearch::delete_product] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteProduct(RequestBuilder<crate::model::DeleteProductRequest>);
 
@@ -1070,7 +1070,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::create_reference_image call.
+    /// The request builder for [ProductSearch::create_reference_image][super::super::client::ProductSearch::create_reference_image] calls.
     #[derive(Clone, Debug)]
     pub struct CreateReferenceImage(RequestBuilder<crate::model::CreateReferenceImageRequest>);
 
@@ -1130,7 +1130,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::delete_reference_image call.
+    /// The request builder for [ProductSearch::delete_reference_image][super::super::client::ProductSearch::delete_reference_image] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteReferenceImage(RequestBuilder<crate::model::DeleteReferenceImageRequest>);
 
@@ -1175,7 +1175,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::list_reference_images call.
+    /// The request builder for [ProductSearch::list_reference_images][super::super::client::ProductSearch::list_reference_images] calls.
     #[derive(Clone, Debug)]
     pub struct ListReferenceImages(RequestBuilder<crate::model::ListReferenceImagesRequest>);
 
@@ -1247,7 +1247,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::get_reference_image call.
+    /// The request builder for [ProductSearch::get_reference_image][super::super::client::ProductSearch::get_reference_image] calls.
     #[derive(Clone, Debug)]
     pub struct GetReferenceImage(RequestBuilder<crate::model::GetReferenceImageRequest>);
 
@@ -1292,7 +1292,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::add_product_to_product_set call.
+    /// The request builder for [ProductSearch::add_product_to_product_set][super::super::client::ProductSearch::add_product_to_product_set] calls.
     #[derive(Clone, Debug)]
     pub struct AddProductToProductSet(RequestBuilder<crate::model::AddProductToProductSetRequest>);
 
@@ -1343,7 +1343,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::remove_product_from_product_set call.
+    /// The request builder for [ProductSearch::remove_product_from_product_set][super::super::client::ProductSearch::remove_product_from_product_set] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveProductFromProductSet(
         RequestBuilder<crate::model::RemoveProductFromProductSetRequest>,
@@ -1396,7 +1396,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::list_products_in_product_set call.
+    /// The request builder for [ProductSearch::list_products_in_product_set][super::super::client::ProductSearch::list_products_in_product_set] calls.
     #[derive(Clone, Debug)]
     pub struct ListProductsInProductSet(
         RequestBuilder<crate::model::ListProductsInProductSetRequest>,
@@ -1472,7 +1472,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::import_product_sets call.
+    /// The request builder for [ProductSearch::import_product_sets][super::super::client::ProductSearch::import_product_sets] calls.
     #[derive(Clone, Debug)]
     pub struct ImportProductSets(RequestBuilder<crate::model::ImportProductSetsRequest>);
 
@@ -1571,7 +1571,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::purge_products call.
+    /// The request builder for [ProductSearch::purge_products][super::super::client::ProductSearch::purge_products] calls.
     #[derive(Clone, Debug)]
     pub struct PurgeProducts(RequestBuilder<crate::model::PurgeProductsRequest>);
 
@@ -1663,7 +1663,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for a ProductSearch::get_operation call.
+    /// The request builder for [ProductSearch::get_operation][super::super::client::ProductSearch::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/vmmigration/v1/src/builder.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_sources call.
+    /// The request builder for [VmMigration::list_sources][super::super::client::VmMigration::list_sources] calls.
     #[derive(Clone, Debug)]
     pub struct ListSources(RequestBuilder<crate::model::ListSourcesRequest>);
 
@@ -148,7 +148,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_source call.
+    /// The request builder for [VmMigration::get_source][super::super::client::VmMigration::get_source] calls.
     #[derive(Clone, Debug)]
     pub struct GetSource(RequestBuilder<crate::model::GetSourceRequest>);
 
@@ -190,7 +190,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::create_source call.
+    /// The request builder for [VmMigration::create_source][super::super::client::VmMigration::create_source] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSource(RequestBuilder<crate::model::CreateSourceRequest>);
 
@@ -290,7 +290,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::update_source call.
+    /// The request builder for [VmMigration::update_source][super::super::client::VmMigration::update_source] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSource(RequestBuilder<crate::model::UpdateSourceRequest>);
 
@@ -387,7 +387,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::delete_source call.
+    /// The request builder for [VmMigration::delete_source][super::super::client::VmMigration::delete_source] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSource(RequestBuilder<crate::model::DeleteSourceRequest>);
 
@@ -470,7 +470,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::fetch_inventory call.
+    /// The request builder for [VmMigration::fetch_inventory][super::super::client::VmMigration::fetch_inventory] calls.
     #[derive(Clone, Debug)]
     pub struct FetchInventory(RequestBuilder<crate::model::FetchInventoryRequest>);
 
@@ -518,7 +518,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_utilization_reports call.
+    /// The request builder for [VmMigration::list_utilization_reports][super::super::client::VmMigration::list_utilization_reports] calls.
     #[derive(Clone, Debug)]
     pub struct ListUtilizationReports(RequestBuilder<crate::model::ListUtilizationReportsRequest>);
 
@@ -610,7 +610,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_utilization_report call.
+    /// The request builder for [VmMigration::get_utilization_report][super::super::client::VmMigration::get_utilization_report] calls.
     #[derive(Clone, Debug)]
     pub struct GetUtilizationReport(RequestBuilder<crate::model::GetUtilizationReportRequest>);
 
@@ -661,7 +661,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::create_utilization_report call.
+    /// The request builder for [VmMigration::create_utilization_report][super::super::client::VmMigration::create_utilization_report] calls.
     #[derive(Clone, Debug)]
     pub struct CreateUtilizationReport(
         RequestBuilder<crate::model::CreateUtilizationReportRequest>,
@@ -770,7 +770,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::delete_utilization_report call.
+    /// The request builder for [VmMigration::delete_utilization_report][super::super::client::VmMigration::delete_utilization_report] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteUtilizationReport(
         RequestBuilder<crate::model::DeleteUtilizationReportRequest>,
@@ -858,7 +858,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_datacenter_connectors call.
+    /// The request builder for [VmMigration::list_datacenter_connectors][super::super::client::VmMigration::list_datacenter_connectors] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatacenterConnectors(
         RequestBuilder<crate::model::ListDatacenterConnectorsRequest>,
@@ -946,7 +946,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_datacenter_connector call.
+    /// The request builder for [VmMigration::get_datacenter_connector][super::super::client::VmMigration::get_datacenter_connector] calls.
     #[derive(Clone, Debug)]
     pub struct GetDatacenterConnector(RequestBuilder<crate::model::GetDatacenterConnectorRequest>);
 
@@ -991,7 +991,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::create_datacenter_connector call.
+    /// The request builder for [VmMigration::create_datacenter_connector][super::super::client::VmMigration::create_datacenter_connector] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDatacenterConnector(
         RequestBuilder<crate::model::CreateDatacenterConnectorRequest>,
@@ -1100,7 +1100,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::delete_datacenter_connector call.
+    /// The request builder for [VmMigration::delete_datacenter_connector][super::super::client::VmMigration::delete_datacenter_connector] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDatacenterConnector(
         RequestBuilder<crate::model::DeleteDatacenterConnectorRequest>,
@@ -1188,7 +1188,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::upgrade_appliance call.
+    /// The request builder for [VmMigration::upgrade_appliance][super::super::client::VmMigration::upgrade_appliance] calls.
     #[derive(Clone, Debug)]
     pub struct UpgradeAppliance(RequestBuilder<crate::model::UpgradeApplianceRequest>);
 
@@ -1280,7 +1280,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::create_migrating_vm call.
+    /// The request builder for [VmMigration::create_migrating_vm][super::super::client::VmMigration::create_migrating_vm] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMigratingVm(RequestBuilder<crate::model::CreateMigratingVmRequest>);
 
@@ -1384,7 +1384,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_migrating_vms call.
+    /// The request builder for [VmMigration::list_migrating_vms][super::super::client::VmMigration::list_migrating_vms] calls.
     #[derive(Clone, Debug)]
     pub struct ListMigratingVms(RequestBuilder<crate::model::ListMigratingVmsRequest>);
 
@@ -1474,7 +1474,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_migrating_vm call.
+    /// The request builder for [VmMigration::get_migrating_vm][super::super::client::VmMigration::get_migrating_vm] calls.
     #[derive(Clone, Debug)]
     pub struct GetMigratingVm(RequestBuilder<crate::model::GetMigratingVmRequest>);
 
@@ -1522,7 +1522,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::update_migrating_vm call.
+    /// The request builder for [VmMigration::update_migrating_vm][super::super::client::VmMigration::update_migrating_vm] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMigratingVm(RequestBuilder<crate::model::UpdateMigratingVmRequest>);
 
@@ -1623,7 +1623,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::delete_migrating_vm call.
+    /// The request builder for [VmMigration::delete_migrating_vm][super::super::client::VmMigration::delete_migrating_vm] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMigratingVm(RequestBuilder<crate::model::DeleteMigratingVmRequest>);
 
@@ -1703,7 +1703,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::start_migration call.
+    /// The request builder for [VmMigration::start_migration][super::super::client::VmMigration::start_migration] calls.
     #[derive(Clone, Debug)]
     pub struct StartMigration(RequestBuilder<crate::model::StartMigrationRequest>);
 
@@ -1786,7 +1786,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::resume_migration call.
+    /// The request builder for [VmMigration::resume_migration][super::super::client::VmMigration::resume_migration] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeMigration(RequestBuilder<crate::model::ResumeMigrationRequest>);
 
@@ -1869,7 +1869,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::pause_migration call.
+    /// The request builder for [VmMigration::pause_migration][super::super::client::VmMigration::pause_migration] calls.
     #[derive(Clone, Debug)]
     pub struct PauseMigration(RequestBuilder<crate::model::PauseMigrationRequest>);
 
@@ -1952,7 +1952,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::finalize_migration call.
+    /// The request builder for [VmMigration::finalize_migration][super::super::client::VmMigration::finalize_migration] calls.
     #[derive(Clone, Debug)]
     pub struct FinalizeMigration(RequestBuilder<crate::model::FinalizeMigrationRequest>);
 
@@ -2038,7 +2038,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::create_clone_job call.
+    /// The request builder for [VmMigration::create_clone_job][super::super::client::VmMigration::create_clone_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCloneJob(RequestBuilder<crate::model::CreateCloneJobRequest>);
 
@@ -2139,7 +2139,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::cancel_clone_job call.
+    /// The request builder for [VmMigration::cancel_clone_job][super::super::client::VmMigration::cancel_clone_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelCloneJob(RequestBuilder<crate::model::CancelCloneJobRequest>);
 
@@ -2222,7 +2222,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_clone_jobs call.
+    /// The request builder for [VmMigration::list_clone_jobs][super::super::client::VmMigration::list_clone_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListCloneJobs(RequestBuilder<crate::model::ListCloneJobsRequest>);
 
@@ -2303,7 +2303,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_clone_job call.
+    /// The request builder for [VmMigration::get_clone_job][super::super::client::VmMigration::get_clone_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetCloneJob(RequestBuilder<crate::model::GetCloneJobRequest>);
 
@@ -2345,7 +2345,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::create_cutover_job call.
+    /// The request builder for [VmMigration::create_cutover_job][super::super::client::VmMigration::create_cutover_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCutoverJob(RequestBuilder<crate::model::CreateCutoverJobRequest>);
 
@@ -2449,7 +2449,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::cancel_cutover_job call.
+    /// The request builder for [VmMigration::cancel_cutover_job][super::super::client::VmMigration::cancel_cutover_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelCutoverJob(RequestBuilder<crate::model::CancelCutoverJobRequest>);
 
@@ -2535,7 +2535,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_cutover_jobs call.
+    /// The request builder for [VmMigration::list_cutover_jobs][super::super::client::VmMigration::list_cutover_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListCutoverJobs(RequestBuilder<crate::model::ListCutoverJobsRequest>);
 
@@ -2616,7 +2616,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_cutover_job call.
+    /// The request builder for [VmMigration::get_cutover_job][super::super::client::VmMigration::get_cutover_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetCutoverJob(RequestBuilder<crate::model::GetCutoverJobRequest>);
 
@@ -2658,7 +2658,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_groups call.
+    /// The request builder for [VmMigration::list_groups][super::super::client::VmMigration::list_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListGroups(RequestBuilder<crate::model::ListGroupsRequest>);
 
@@ -2739,7 +2739,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_group call.
+    /// The request builder for [VmMigration::get_group][super::super::client::VmMigration::get_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetGroup(RequestBuilder<crate::model::GetGroupRequest>);
 
@@ -2781,7 +2781,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::create_group call.
+    /// The request builder for [VmMigration::create_group][super::super::client::VmMigration::create_group] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGroup(RequestBuilder<crate::model::CreateGroupRequest>);
 
@@ -2881,7 +2881,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::update_group call.
+    /// The request builder for [VmMigration::update_group][super::super::client::VmMigration::update_group] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGroup(RequestBuilder<crate::model::UpdateGroupRequest>);
 
@@ -2978,7 +2978,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::delete_group call.
+    /// The request builder for [VmMigration::delete_group][super::super::client::VmMigration::delete_group] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGroup(RequestBuilder<crate::model::DeleteGroupRequest>);
 
@@ -3061,7 +3061,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::add_group_migration call.
+    /// The request builder for [VmMigration::add_group_migration][super::super::client::VmMigration::add_group_migration] calls.
     #[derive(Clone, Debug)]
     pub struct AddGroupMigration(RequestBuilder<crate::model::AddGroupMigrationRequest>);
 
@@ -3153,7 +3153,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::remove_group_migration call.
+    /// The request builder for [VmMigration::remove_group_migration][super::super::client::VmMigration::remove_group_migration] calls.
     #[derive(Clone, Debug)]
     pub struct RemoveGroupMigration(RequestBuilder<crate::model::RemoveGroupMigrationRequest>);
 
@@ -3245,7 +3245,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_target_projects call.
+    /// The request builder for [VmMigration::list_target_projects][super::super::client::VmMigration::list_target_projects] calls.
     #[derive(Clone, Debug)]
     pub struct ListTargetProjects(RequestBuilder<crate::model::ListTargetProjectsRequest>);
 
@@ -3329,7 +3329,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_target_project call.
+    /// The request builder for [VmMigration::get_target_project][super::super::client::VmMigration::get_target_project] calls.
     #[derive(Clone, Debug)]
     pub struct GetTargetProject(RequestBuilder<crate::model::GetTargetProjectRequest>);
 
@@ -3374,7 +3374,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::create_target_project call.
+    /// The request builder for [VmMigration::create_target_project][super::super::client::VmMigration::create_target_project] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTargetProject(RequestBuilder<crate::model::CreateTargetProjectRequest>);
 
@@ -3479,7 +3479,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::update_target_project call.
+    /// The request builder for [VmMigration::update_target_project][super::super::client::VmMigration::update_target_project] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTargetProject(RequestBuilder<crate::model::UpdateTargetProjectRequest>);
 
@@ -3581,7 +3581,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::delete_target_project call.
+    /// The request builder for [VmMigration::delete_target_project][super::super::client::VmMigration::delete_target_project] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTargetProject(RequestBuilder<crate::model::DeleteTargetProjectRequest>);
 
@@ -3667,7 +3667,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_replication_cycles call.
+    /// The request builder for [VmMigration::list_replication_cycles][super::super::client::VmMigration::list_replication_cycles] calls.
     #[derive(Clone, Debug)]
     pub struct ListReplicationCycles(RequestBuilder<crate::model::ListReplicationCyclesRequest>);
 
@@ -3751,7 +3751,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_replication_cycle call.
+    /// The request builder for [VmMigration::get_replication_cycle][super::super::client::VmMigration::get_replication_cycle] calls.
     #[derive(Clone, Debug)]
     pub struct GetReplicationCycle(RequestBuilder<crate::model::GetReplicationCycleRequest>);
 
@@ -3796,7 +3796,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_locations call.
+    /// The request builder for [VmMigration::list_locations][super::super::client::VmMigration::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3874,7 +3874,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_location call.
+    /// The request builder for [VmMigration::get_location][super::super::client::VmMigration::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3916,7 +3916,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::list_operations call.
+    /// The request builder for [VmMigration::list_operations][super::super::client::VmMigration::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3994,7 +3994,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::get_operation call.
+    /// The request builder for [VmMigration::get_operation][super::super::client::VmMigration::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4039,7 +4039,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::delete_operation call.
+    /// The request builder for [VmMigration::delete_operation][super::super::client::VmMigration::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4084,7 +4084,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for a VmMigration::cancel_operation call.
+    /// The request builder for [VmMigration::cancel_operation][super::super::client::VmMigration::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/vmwareengine/v1/src/builder.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_private_clouds call.
+    /// The request builder for [VmwareEngine::list_private_clouds][super::super::client::VmwareEngine::list_private_clouds] calls.
     #[derive(Clone, Debug)]
     pub struct ListPrivateClouds(RequestBuilder<crate::model::ListPrivateCloudsRequest>);
 
@@ -151,7 +151,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_private_cloud call.
+    /// The request builder for [VmwareEngine::get_private_cloud][super::super::client::VmwareEngine::get_private_cloud] calls.
     #[derive(Clone, Debug)]
     pub struct GetPrivateCloud(RequestBuilder<crate::model::GetPrivateCloudRequest>);
 
@@ -193,7 +193,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_private_cloud call.
+    /// The request builder for [VmwareEngine::create_private_cloud][super::super::client::VmwareEngine::create_private_cloud] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePrivateCloud(RequestBuilder<crate::model::CreatePrivateCloudRequest>);
 
@@ -303,7 +303,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_private_cloud call.
+    /// The request builder for [VmwareEngine::update_private_cloud][super::super::client::VmwareEngine::update_private_cloud] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePrivateCloud(RequestBuilder<crate::model::UpdatePrivateCloudRequest>);
 
@@ -404,7 +404,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_private_cloud call.
+    /// The request builder for [VmwareEngine::delete_private_cloud][super::super::client::VmwareEngine::delete_private_cloud] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePrivateCloud(RequestBuilder<crate::model::DeletePrivateCloudRequest>);
 
@@ -505,7 +505,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::undelete_private_cloud call.
+    /// The request builder for [VmwareEngine::undelete_private_cloud][super::super::client::VmwareEngine::undelete_private_cloud] calls.
     #[derive(Clone, Debug)]
     pub struct UndeletePrivateCloud(RequestBuilder<crate::model::UndeletePrivateCloudRequest>);
 
@@ -594,7 +594,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_clusters call.
+    /// The request builder for [VmwareEngine::list_clusters][super::super::client::VmwareEngine::list_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -675,7 +675,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_cluster call.
+    /// The request builder for [VmwareEngine::get_cluster][super::super::client::VmwareEngine::get_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -717,7 +717,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_cluster call.
+    /// The request builder for [VmwareEngine::create_cluster][super::super::client::VmwareEngine::create_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -823,7 +823,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_cluster call.
+    /// The request builder for [VmwareEngine::update_cluster][super::super::client::VmwareEngine::update_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -926,7 +926,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_cluster call.
+    /// The request builder for [VmwareEngine::delete_cluster][super::super::client::VmwareEngine::delete_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -1009,7 +1009,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_nodes call.
+    /// The request builder for [VmwareEngine::list_nodes][super::super::client::VmwareEngine::list_nodes] calls.
     #[derive(Clone, Debug)]
     pub struct ListNodes(RequestBuilder<crate::model::ListNodesRequest>);
 
@@ -1077,7 +1077,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_node call.
+    /// The request builder for [VmwareEngine::get_node][super::super::client::VmwareEngine::get_node] calls.
     #[derive(Clone, Debug)]
     pub struct GetNode(RequestBuilder<crate::model::GetNodeRequest>);
 
@@ -1119,7 +1119,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_external_addresses call.
+    /// The request builder for [VmwareEngine::list_external_addresses][super::super::client::VmwareEngine::list_external_addresses] calls.
     #[derive(Clone, Debug)]
     pub struct ListExternalAddresses(RequestBuilder<crate::model::ListExternalAddressesRequest>);
 
@@ -1203,7 +1203,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::fetch_network_policy_external_addresses call.
+    /// The request builder for [VmwareEngine::fetch_network_policy_external_addresses][super::super::client::VmwareEngine::fetch_network_policy_external_addresses] calls.
     #[derive(Clone, Debug)]
     pub struct FetchNetworkPolicyExternalAddresses(
         RequestBuilder<crate::model::FetchNetworkPolicyExternalAddressesRequest>,
@@ -1281,7 +1281,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_external_address call.
+    /// The request builder for [VmwareEngine::get_external_address][super::super::client::VmwareEngine::get_external_address] calls.
     #[derive(Clone, Debug)]
     pub struct GetExternalAddress(RequestBuilder<crate::model::GetExternalAddressRequest>);
 
@@ -1326,7 +1326,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_external_address call.
+    /// The request builder for [VmwareEngine::create_external_address][super::super::client::VmwareEngine::create_external_address] calls.
     #[derive(Clone, Debug)]
     pub struct CreateExternalAddress(RequestBuilder<crate::model::CreateExternalAddressRequest>);
 
@@ -1431,7 +1431,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_external_address call.
+    /// The request builder for [VmwareEngine::update_external_address][super::super::client::VmwareEngine::update_external_address] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateExternalAddress(RequestBuilder<crate::model::UpdateExternalAddressRequest>);
 
@@ -1533,7 +1533,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_external_address call.
+    /// The request builder for [VmwareEngine::delete_external_address][super::super::client::VmwareEngine::delete_external_address] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteExternalAddress(RequestBuilder<crate::model::DeleteExternalAddressRequest>);
 
@@ -1619,7 +1619,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_subnets call.
+    /// The request builder for [VmwareEngine::list_subnets][super::super::client::VmwareEngine::list_subnets] calls.
     #[derive(Clone, Debug)]
     pub struct ListSubnets(RequestBuilder<crate::model::ListSubnetsRequest>);
 
@@ -1688,7 +1688,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_subnet call.
+    /// The request builder for [VmwareEngine::get_subnet][super::super::client::VmwareEngine::get_subnet] calls.
     #[derive(Clone, Debug)]
     pub struct GetSubnet(RequestBuilder<crate::model::GetSubnetRequest>);
 
@@ -1730,7 +1730,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_subnet call.
+    /// The request builder for [VmwareEngine::update_subnet][super::super::client::VmwareEngine::update_subnet] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSubnet(RequestBuilder<crate::model::UpdateSubnetRequest>);
 
@@ -1821,7 +1821,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_external_access_rules call.
+    /// The request builder for [VmwareEngine::list_external_access_rules][super::super::client::VmwareEngine::list_external_access_rules] calls.
     #[derive(Clone, Debug)]
     pub struct ListExternalAccessRules(
         RequestBuilder<crate::model::ListExternalAccessRulesRequest>,
@@ -1909,7 +1909,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_external_access_rule call.
+    /// The request builder for [VmwareEngine::get_external_access_rule][super::super::client::VmwareEngine::get_external_access_rule] calls.
     #[derive(Clone, Debug)]
     pub struct GetExternalAccessRule(RequestBuilder<crate::model::GetExternalAccessRuleRequest>);
 
@@ -1954,7 +1954,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_external_access_rule call.
+    /// The request builder for [VmwareEngine::create_external_access_rule][super::super::client::VmwareEngine::create_external_access_rule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateExternalAccessRule(
         RequestBuilder<crate::model::CreateExternalAccessRuleRequest>,
@@ -2063,7 +2063,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_external_access_rule call.
+    /// The request builder for [VmwareEngine::update_external_access_rule][super::super::client::VmwareEngine::update_external_access_rule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateExternalAccessRule(
         RequestBuilder<crate::model::UpdateExternalAccessRuleRequest>,
@@ -2169,7 +2169,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_external_access_rule call.
+    /// The request builder for [VmwareEngine::delete_external_access_rule][super::super::client::VmwareEngine::delete_external_access_rule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteExternalAccessRule(
         RequestBuilder<crate::model::DeleteExternalAccessRuleRequest>,
@@ -2257,7 +2257,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_logging_servers call.
+    /// The request builder for [VmwareEngine::list_logging_servers][super::super::client::VmwareEngine::list_logging_servers] calls.
     #[derive(Clone, Debug)]
     pub struct ListLoggingServers(RequestBuilder<crate::model::ListLoggingServersRequest>);
 
@@ -2341,7 +2341,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_logging_server call.
+    /// The request builder for [VmwareEngine::get_logging_server][super::super::client::VmwareEngine::get_logging_server] calls.
     #[derive(Clone, Debug)]
     pub struct GetLoggingServer(RequestBuilder<crate::model::GetLoggingServerRequest>);
 
@@ -2386,7 +2386,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_logging_server call.
+    /// The request builder for [VmwareEngine::create_logging_server][super::super::client::VmwareEngine::create_logging_server] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLoggingServer(RequestBuilder<crate::model::CreateLoggingServerRequest>);
 
@@ -2491,7 +2491,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_logging_server call.
+    /// The request builder for [VmwareEngine::update_logging_server][super::super::client::VmwareEngine::update_logging_server] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateLoggingServer(RequestBuilder<crate::model::UpdateLoggingServerRequest>);
 
@@ -2593,7 +2593,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_logging_server call.
+    /// The request builder for [VmwareEngine::delete_logging_server][super::super::client::VmwareEngine::delete_logging_server] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLoggingServer(RequestBuilder<crate::model::DeleteLoggingServerRequest>);
 
@@ -2679,7 +2679,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_node_types call.
+    /// The request builder for [VmwareEngine::list_node_types][super::super::client::VmwareEngine::list_node_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListNodeTypes(RequestBuilder<crate::model::ListNodeTypesRequest>);
 
@@ -2754,7 +2754,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_node_type call.
+    /// The request builder for [VmwareEngine::get_node_type][super::super::client::VmwareEngine::get_node_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetNodeType(RequestBuilder<crate::model::GetNodeTypeRequest>);
 
@@ -2796,7 +2796,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::show_nsx_credentials call.
+    /// The request builder for [VmwareEngine::show_nsx_credentials][super::super::client::VmwareEngine::show_nsx_credentials] calls.
     #[derive(Clone, Debug)]
     pub struct ShowNsxCredentials(RequestBuilder<crate::model::ShowNsxCredentialsRequest>);
 
@@ -2841,7 +2841,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::show_vcenter_credentials call.
+    /// The request builder for [VmwareEngine::show_vcenter_credentials][super::super::client::VmwareEngine::show_vcenter_credentials] calls.
     #[derive(Clone, Debug)]
     pub struct ShowVcenterCredentials(RequestBuilder<crate::model::ShowVcenterCredentialsRequest>);
 
@@ -2892,7 +2892,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::reset_nsx_credentials call.
+    /// The request builder for [VmwareEngine::reset_nsx_credentials][super::super::client::VmwareEngine::reset_nsx_credentials] calls.
     #[derive(Clone, Debug)]
     pub struct ResetNsxCredentials(RequestBuilder<crate::model::ResetNsxCredentialsRequest>);
 
@@ -2981,7 +2981,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::reset_vcenter_credentials call.
+    /// The request builder for [VmwareEngine::reset_vcenter_credentials][super::super::client::VmwareEngine::reset_vcenter_credentials] calls.
     #[derive(Clone, Debug)]
     pub struct ResetVcenterCredentials(
         RequestBuilder<crate::model::ResetVcenterCredentialsRequest>,
@@ -3078,7 +3078,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_dns_forwarding call.
+    /// The request builder for [VmwareEngine::get_dns_forwarding][super::super::client::VmwareEngine::get_dns_forwarding] calls.
     #[derive(Clone, Debug)]
     pub struct GetDnsForwarding(RequestBuilder<crate::model::GetDnsForwardingRequest>);
 
@@ -3123,7 +3123,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_dns_forwarding call.
+    /// The request builder for [VmwareEngine::update_dns_forwarding][super::super::client::VmwareEngine::update_dns_forwarding] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDnsForwarding(RequestBuilder<crate::model::UpdateDnsForwardingRequest>);
 
@@ -3225,7 +3225,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_network_peering call.
+    /// The request builder for [VmwareEngine::get_network_peering][super::super::client::VmwareEngine::get_network_peering] calls.
     #[derive(Clone, Debug)]
     pub struct GetNetworkPeering(RequestBuilder<crate::model::GetNetworkPeeringRequest>);
 
@@ -3270,7 +3270,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_network_peerings call.
+    /// The request builder for [VmwareEngine::list_network_peerings][super::super::client::VmwareEngine::list_network_peerings] calls.
     #[derive(Clone, Debug)]
     pub struct ListNetworkPeerings(RequestBuilder<crate::model::ListNetworkPeeringsRequest>);
 
@@ -3354,7 +3354,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_network_peering call.
+    /// The request builder for [VmwareEngine::create_network_peering][super::super::client::VmwareEngine::create_network_peering] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNetworkPeering(RequestBuilder<crate::model::CreateNetworkPeeringRequest>);
 
@@ -3459,7 +3459,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_network_peering call.
+    /// The request builder for [VmwareEngine::delete_network_peering][super::super::client::VmwareEngine::delete_network_peering] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNetworkPeering(RequestBuilder<crate::model::DeleteNetworkPeeringRequest>);
 
@@ -3545,7 +3545,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_network_peering call.
+    /// The request builder for [VmwareEngine::update_network_peering][super::super::client::VmwareEngine::update_network_peering] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNetworkPeering(RequestBuilder<crate::model::UpdateNetworkPeeringRequest>);
 
@@ -3647,7 +3647,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_peering_routes call.
+    /// The request builder for [VmwareEngine::list_peering_routes][super::super::client::VmwareEngine::list_peering_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListPeeringRoutes(RequestBuilder<crate::model::ListPeeringRoutesRequest>);
 
@@ -3725,7 +3725,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_hcx_activation_key call.
+    /// The request builder for [VmwareEngine::create_hcx_activation_key][super::super::client::VmwareEngine::create_hcx_activation_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateHcxActivationKey(RequestBuilder<crate::model::CreateHcxActivationKeyRequest>);
 
@@ -3832,7 +3832,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_hcx_activation_keys call.
+    /// The request builder for [VmwareEngine::list_hcx_activation_keys][super::super::client::VmwareEngine::list_hcx_activation_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListHcxActivationKeys(RequestBuilder<crate::model::ListHcxActivationKeysRequest>);
 
@@ -3904,7 +3904,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_hcx_activation_key call.
+    /// The request builder for [VmwareEngine::get_hcx_activation_key][super::super::client::VmwareEngine::get_hcx_activation_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetHcxActivationKey(RequestBuilder<crate::model::GetHcxActivationKeyRequest>);
 
@@ -3949,7 +3949,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_network_policy call.
+    /// The request builder for [VmwareEngine::get_network_policy][super::super::client::VmwareEngine::get_network_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetNetworkPolicy(RequestBuilder<crate::model::GetNetworkPolicyRequest>);
 
@@ -3994,7 +3994,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_network_policies call.
+    /// The request builder for [VmwareEngine::list_network_policies][super::super::client::VmwareEngine::list_network_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListNetworkPolicies(RequestBuilder<crate::model::ListNetworkPoliciesRequest>);
 
@@ -4078,7 +4078,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_network_policy call.
+    /// The request builder for [VmwareEngine::create_network_policy][super::super::client::VmwareEngine::create_network_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNetworkPolicy(RequestBuilder<crate::model::CreateNetworkPolicyRequest>);
 
@@ -4183,7 +4183,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_network_policy call.
+    /// The request builder for [VmwareEngine::update_network_policy][super::super::client::VmwareEngine::update_network_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNetworkPolicy(RequestBuilder<crate::model::UpdateNetworkPolicyRequest>);
 
@@ -4285,7 +4285,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_network_policy call.
+    /// The request builder for [VmwareEngine::delete_network_policy][super::super::client::VmwareEngine::delete_network_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNetworkPolicy(RequestBuilder<crate::model::DeleteNetworkPolicyRequest>);
 
@@ -4371,7 +4371,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_management_dns_zone_bindings call.
+    /// The request builder for [VmwareEngine::list_management_dns_zone_bindings][super::super::client::VmwareEngine::list_management_dns_zone_bindings] calls.
     #[derive(Clone, Debug)]
     pub struct ListManagementDnsZoneBindings(
         RequestBuilder<crate::model::ListManagementDnsZoneBindingsRequest>,
@@ -4459,7 +4459,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_management_dns_zone_binding call.
+    /// The request builder for [VmwareEngine::get_management_dns_zone_binding][super::super::client::VmwareEngine::get_management_dns_zone_binding] calls.
     #[derive(Clone, Debug)]
     pub struct GetManagementDnsZoneBinding(
         RequestBuilder<crate::model::GetManagementDnsZoneBindingRequest>,
@@ -4506,7 +4506,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_management_dns_zone_binding call.
+    /// The request builder for [VmwareEngine::create_management_dns_zone_binding][super::super::client::VmwareEngine::create_management_dns_zone_binding] calls.
     #[derive(Clone, Debug)]
     pub struct CreateManagementDnsZoneBinding(
         RequestBuilder<crate::model::CreateManagementDnsZoneBindingRequest>,
@@ -4620,7 +4620,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_management_dns_zone_binding call.
+    /// The request builder for [VmwareEngine::update_management_dns_zone_binding][super::super::client::VmwareEngine::update_management_dns_zone_binding] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateManagementDnsZoneBinding(
         RequestBuilder<crate::model::UpdateManagementDnsZoneBindingRequest>,
@@ -4728,7 +4728,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_management_dns_zone_binding call.
+    /// The request builder for [VmwareEngine::delete_management_dns_zone_binding][super::super::client::VmwareEngine::delete_management_dns_zone_binding] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteManagementDnsZoneBinding(
         RequestBuilder<crate::model::DeleteManagementDnsZoneBindingRequest>,
@@ -4816,7 +4816,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::repair_management_dns_zone_binding call.
+    /// The request builder for [VmwareEngine::repair_management_dns_zone_binding][super::super::client::VmwareEngine::repair_management_dns_zone_binding] calls.
     #[derive(Clone, Debug)]
     pub struct RepairManagementDnsZoneBinding(
         RequestBuilder<crate::model::RepairManagementDnsZoneBindingRequest>,
@@ -4910,7 +4910,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_vmware_engine_network call.
+    /// The request builder for [VmwareEngine::create_vmware_engine_network][super::super::client::VmwareEngine::create_vmware_engine_network] calls.
     #[derive(Clone, Debug)]
     pub struct CreateVmwareEngineNetwork(
         RequestBuilder<crate::model::CreateVmwareEngineNetworkRequest>,
@@ -5019,7 +5019,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_vmware_engine_network call.
+    /// The request builder for [VmwareEngine::update_vmware_engine_network][super::super::client::VmwareEngine::update_vmware_engine_network] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVmwareEngineNetwork(
         RequestBuilder<crate::model::UpdateVmwareEngineNetworkRequest>,
@@ -5125,7 +5125,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_vmware_engine_network call.
+    /// The request builder for [VmwareEngine::delete_vmware_engine_network][super::super::client::VmwareEngine::delete_vmware_engine_network] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVmwareEngineNetwork(
         RequestBuilder<crate::model::DeleteVmwareEngineNetworkRequest>,
@@ -5219,7 +5219,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_vmware_engine_network call.
+    /// The request builder for [VmwareEngine::get_vmware_engine_network][super::super::client::VmwareEngine::get_vmware_engine_network] calls.
     #[derive(Clone, Debug)]
     pub struct GetVmwareEngineNetwork(RequestBuilder<crate::model::GetVmwareEngineNetworkRequest>);
 
@@ -5264,7 +5264,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_vmware_engine_networks call.
+    /// The request builder for [VmwareEngine::list_vmware_engine_networks][super::super::client::VmwareEngine::list_vmware_engine_networks] calls.
     #[derive(Clone, Debug)]
     pub struct ListVmwareEngineNetworks(
         RequestBuilder<crate::model::ListVmwareEngineNetworksRequest>,
@@ -5352,7 +5352,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::create_private_connection call.
+    /// The request builder for [VmwareEngine::create_private_connection][super::super::client::VmwareEngine::create_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePrivateConnection(
         RequestBuilder<crate::model::CreatePrivateConnectionRequest>,
@@ -5461,7 +5461,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_private_connection call.
+    /// The request builder for [VmwareEngine::get_private_connection][super::super::client::VmwareEngine::get_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetPrivateConnection(RequestBuilder<crate::model::GetPrivateConnectionRequest>);
 
@@ -5506,7 +5506,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_private_connections call.
+    /// The request builder for [VmwareEngine::list_private_connections][super::super::client::VmwareEngine::list_private_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListPrivateConnections(RequestBuilder<crate::model::ListPrivateConnectionsRequest>);
 
@@ -5592,7 +5592,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::update_private_connection call.
+    /// The request builder for [VmwareEngine::update_private_connection][super::super::client::VmwareEngine::update_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePrivateConnection(
         RequestBuilder<crate::model::UpdatePrivateConnectionRequest>,
@@ -5698,7 +5698,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_private_connection call.
+    /// The request builder for [VmwareEngine::delete_private_connection][super::super::client::VmwareEngine::delete_private_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePrivateConnection(
         RequestBuilder<crate::model::DeletePrivateConnectionRequest>,
@@ -5786,7 +5786,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_private_connection_peering_routes call.
+    /// The request builder for [VmwareEngine::list_private_connection_peering_routes][super::super::client::VmwareEngine::list_private_connection_peering_routes] calls.
     #[derive(Clone, Debug)]
     pub struct ListPrivateConnectionPeeringRoutes(
         RequestBuilder<crate::model::ListPrivateConnectionPeeringRoutesRequest>,
@@ -5864,7 +5864,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::grant_dns_bind_permission call.
+    /// The request builder for [VmwareEngine::grant_dns_bind_permission][super::super::client::VmwareEngine::grant_dns_bind_permission] calls.
     #[derive(Clone, Debug)]
     pub struct GrantDnsBindPermission(RequestBuilder<crate::model::GrantDnsBindPermissionRequest>);
 
@@ -5963,7 +5963,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_dns_bind_permission call.
+    /// The request builder for [VmwareEngine::get_dns_bind_permission][super::super::client::VmwareEngine::get_dns_bind_permission] calls.
     #[derive(Clone, Debug)]
     pub struct GetDnsBindPermission(RequestBuilder<crate::model::GetDnsBindPermissionRequest>);
 
@@ -6008,7 +6008,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::revoke_dns_bind_permission call.
+    /// The request builder for [VmwareEngine::revoke_dns_bind_permission][super::super::client::VmwareEngine::revoke_dns_bind_permission] calls.
     #[derive(Clone, Debug)]
     pub struct RevokeDnsBindPermission(
         RequestBuilder<crate::model::RevokeDnsBindPermissionRequest>,
@@ -6109,7 +6109,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_locations call.
+    /// The request builder for [VmwareEngine::list_locations][super::super::client::VmwareEngine::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6187,7 +6187,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_location call.
+    /// The request builder for [VmwareEngine::get_location][super::super::client::VmwareEngine::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6229,7 +6229,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::set_iam_policy call.
+    /// The request builder for [VmwareEngine::set_iam_policy][super::super::client::VmwareEngine::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -6289,7 +6289,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_iam_policy call.
+    /// The request builder for [VmwareEngine::get_iam_policy][super::super::client::VmwareEngine::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -6340,7 +6340,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::test_iam_permissions call.
+    /// The request builder for [VmwareEngine::test_iam_permissions][super::super::client::VmwareEngine::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -6396,7 +6396,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::list_operations call.
+    /// The request builder for [VmwareEngine::list_operations][super::super::client::VmwareEngine::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6474,7 +6474,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::get_operation call.
+    /// The request builder for [VmwareEngine::get_operation][super::super::client::VmwareEngine::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6519,7 +6519,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for a VmwareEngine::delete_operation call.
+    /// The request builder for [VmwareEngine::delete_operation][super::super::client::VmwareEngine::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 

--- a/src/generated/cloud/vpcaccess/v1/src/builder.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for a VpcAccessService::create_connector call.
+    /// The request builder for [VpcAccessService::create_connector][super::super::client::VpcAccessService::create_connector] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnector(RequestBuilder<crate::model::CreateConnectorRequest>);
 
@@ -162,7 +162,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for a VpcAccessService::get_connector call.
+    /// The request builder for [VpcAccessService::get_connector][super::super::client::VpcAccessService::get_connector] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnector(RequestBuilder<crate::model::GetConnectorRequest>);
 
@@ -204,7 +204,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for a VpcAccessService::list_connectors call.
+    /// The request builder for [VpcAccessService::list_connectors][super::super::client::VpcAccessService::list_connectors] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnectors(RequestBuilder<crate::model::ListConnectorsRequest>);
 
@@ -273,7 +273,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for a VpcAccessService::delete_connector call.
+    /// The request builder for [VpcAccessService::delete_connector][super::super::client::VpcAccessService::delete_connector] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnector(RequestBuilder<crate::model::DeleteConnectorRequest>);
 
@@ -350,7 +350,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for a VpcAccessService::list_locations call.
+    /// The request builder for [VpcAccessService::list_locations][super::super::client::VpcAccessService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -428,7 +428,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for a VpcAccessService::list_operations call.
+    /// The request builder for [VpcAccessService::list_operations][super::super::client::VpcAccessService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -506,7 +506,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for a VpcAccessService::get_operation call.
+    /// The request builder for [VpcAccessService::get_operation][super::super::client::VpcAccessService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/webrisk/v1/src/builder.rs
+++ b/src/generated/cloud/webrisk/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::compute_threat_list_diff call.
+    /// The request builder for [WebRiskService::compute_threat_list_diff][super::super::client::WebRiskService::compute_threat_list_diff] calls.
     #[derive(Clone, Debug)]
     pub struct ComputeThreatListDiff(RequestBuilder<crate::model::ComputeThreatListDiffRequest>);
 
@@ -129,7 +129,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::search_uris call.
+    /// The request builder for [WebRiskService::search_uris][super::super::client::WebRiskService::search_uris] calls.
     #[derive(Clone, Debug)]
     pub struct SearchUris(RequestBuilder<crate::model::SearchUrisRequest>);
 
@@ -182,7 +182,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::search_hashes call.
+    /// The request builder for [WebRiskService::search_hashes][super::super::client::WebRiskService::search_hashes] calls.
     #[derive(Clone, Debug)]
     pub struct SearchHashes(RequestBuilder<crate::model::SearchHashesRequest>);
 
@@ -235,7 +235,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::create_submission call.
+    /// The request builder for [WebRiskService::create_submission][super::super::client::WebRiskService::create_submission] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSubmission(RequestBuilder<crate::model::CreateSubmissionRequest>);
 
@@ -289,7 +289,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::submit_uri call.
+    /// The request builder for [WebRiskService::submit_uri][super::super::client::WebRiskService::submit_uri] calls.
     #[derive(Clone, Debug)]
     pub struct SubmitUri(RequestBuilder<crate::model::SubmitUriRequest>);
 
@@ -396,7 +396,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::list_operations call.
+    /// The request builder for [WebRiskService::list_operations][super::super::client::WebRiskService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -474,7 +474,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::get_operation call.
+    /// The request builder for [WebRiskService::get_operation][super::super::client::WebRiskService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -519,7 +519,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::delete_operation call.
+    /// The request builder for [WebRiskService::delete_operation][super::super::client::WebRiskService::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -564,7 +564,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for a WebRiskService::cancel_operation call.
+    /// The request builder for [WebRiskService::cancel_operation][super::super::client::WebRiskService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/websecurityscanner/v1/src/builder.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::create_scan_config call.
+    /// The request builder for [WebSecurityScanner::create_scan_config][super::super::client::WebSecurityScanner::create_scan_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateScanConfig(RequestBuilder<crate::model::CreateScanConfigRequest>);
 
@@ -121,7 +121,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::delete_scan_config call.
+    /// The request builder for [WebSecurityScanner::delete_scan_config][super::super::client::WebSecurityScanner::delete_scan_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteScanConfig(RequestBuilder<crate::model::DeleteScanConfigRequest>);
 
@@ -166,7 +166,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::get_scan_config call.
+    /// The request builder for [WebSecurityScanner::get_scan_config][super::super::client::WebSecurityScanner::get_scan_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetScanConfig(RequestBuilder<crate::model::GetScanConfigRequest>);
 
@@ -208,7 +208,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::list_scan_configs call.
+    /// The request builder for [WebSecurityScanner::list_scan_configs][super::super::client::WebSecurityScanner::list_scan_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListScanConfigs(RequestBuilder<crate::model::ListScanConfigsRequest>);
 
@@ -277,7 +277,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::update_scan_config call.
+    /// The request builder for [WebSecurityScanner::update_scan_config][super::super::client::WebSecurityScanner::update_scan_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateScanConfig(RequestBuilder<crate::model::UpdateScanConfigRequest>);
 
@@ -334,7 +334,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::start_scan_run call.
+    /// The request builder for [WebSecurityScanner::start_scan_run][super::super::client::WebSecurityScanner::start_scan_run] calls.
     #[derive(Clone, Debug)]
     pub struct StartScanRun(RequestBuilder<crate::model::StartScanRunRequest>);
 
@@ -376,7 +376,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::get_scan_run call.
+    /// The request builder for [WebSecurityScanner::get_scan_run][super::super::client::WebSecurityScanner::get_scan_run] calls.
     #[derive(Clone, Debug)]
     pub struct GetScanRun(RequestBuilder<crate::model::GetScanRunRequest>);
 
@@ -418,7 +418,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::list_scan_runs call.
+    /// The request builder for [WebSecurityScanner::list_scan_runs][super::super::client::WebSecurityScanner::list_scan_runs] calls.
     #[derive(Clone, Debug)]
     pub struct ListScanRuns(RequestBuilder<crate::model::ListScanRunsRequest>);
 
@@ -487,7 +487,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::stop_scan_run call.
+    /// The request builder for [WebSecurityScanner::stop_scan_run][super::super::client::WebSecurityScanner::stop_scan_run] calls.
     #[derive(Clone, Debug)]
     pub struct StopScanRun(RequestBuilder<crate::model::StopScanRunRequest>);
 
@@ -529,7 +529,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::list_crawled_urls call.
+    /// The request builder for [WebSecurityScanner::list_crawled_urls][super::super::client::WebSecurityScanner::list_crawled_urls] calls.
     #[derive(Clone, Debug)]
     pub struct ListCrawledUrls(RequestBuilder<crate::model::ListCrawledUrlsRequest>);
 
@@ -598,7 +598,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::get_finding call.
+    /// The request builder for [WebSecurityScanner::get_finding][super::super::client::WebSecurityScanner::get_finding] calls.
     #[derive(Clone, Debug)]
     pub struct GetFinding(RequestBuilder<crate::model::GetFindingRequest>);
 
@@ -640,7 +640,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::list_findings call.
+    /// The request builder for [WebSecurityScanner::list_findings][super::super::client::WebSecurityScanner::list_findings] calls.
     #[derive(Clone, Debug)]
     pub struct ListFindings(RequestBuilder<crate::model::ListFindingsRequest>);
 
@@ -715,7 +715,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for a WebSecurityScanner::list_finding_type_stats call.
+    /// The request builder for [WebSecurityScanner::list_finding_type_stats][super::super::client::WebSecurityScanner::list_finding_type_stats] calls.
     #[derive(Clone, Debug)]
     pub struct ListFindingTypeStats(RequestBuilder<crate::model::ListFindingTypeStatsRequest>);
 

--- a/src/generated/cloud/workflows/executions/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::list_executions call.
+    /// The request builder for [Executions::list_executions][super::super::client::Executions::list_executions] calls.
     #[derive(Clone, Debug)]
     pub struct ListExecutions(RequestBuilder<crate::model::ListExecutionsRequest>);
 
@@ -154,7 +154,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::create_execution call.
+    /// The request builder for [Executions::create_execution][super::super::client::Executions::create_execution] calls.
     #[derive(Clone, Debug)]
     pub struct CreateExecution(RequestBuilder<crate::model::CreateExecutionRequest>);
 
@@ -205,7 +205,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::get_execution call.
+    /// The request builder for [Executions::get_execution][super::super::client::Executions::get_execution] calls.
     #[derive(Clone, Debug)]
     pub struct GetExecution(RequestBuilder<crate::model::GetExecutionRequest>);
 
@@ -253,7 +253,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for a Executions::cancel_execution call.
+    /// The request builder for [Executions::cancel_execution][super::super::client::Executions::cancel_execution] calls.
     #[derive(Clone, Debug)]
     pub struct CancelExecution(RequestBuilder<crate::model::CancelExecutionRequest>);
 

--- a/src/generated/cloud/workflows/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::list_workflows call.
+    /// The request builder for [Workflows::list_workflows][super::super::client::Workflows::list_workflows] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkflows(RequestBuilder<crate::model::ListWorkflowsRequest>);
 
@@ -148,7 +148,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::get_workflow call.
+    /// The request builder for [Workflows::get_workflow][super::super::client::Workflows::get_workflow] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkflow(RequestBuilder<crate::model::GetWorkflowRequest>);
 
@@ -196,7 +196,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::create_workflow call.
+    /// The request builder for [Workflows::create_workflow][super::super::client::Workflows::create_workflow] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWorkflow(RequestBuilder<crate::model::CreateWorkflowRequest>);
 
@@ -291,7 +291,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::delete_workflow call.
+    /// The request builder for [Workflows::delete_workflow][super::super::client::Workflows::delete_workflow] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWorkflow(RequestBuilder<crate::model::DeleteWorkflowRequest>);
 
@@ -368,7 +368,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::update_workflow call.
+    /// The request builder for [Workflows::update_workflow][super::super::client::Workflows::update_workflow] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWorkflow(RequestBuilder<crate::model::UpdateWorkflowRequest>);
 
@@ -460,7 +460,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::list_workflow_revisions call.
+    /// The request builder for [Workflows::list_workflow_revisions][super::super::client::Workflows::list_workflow_revisions] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkflowRevisions(RequestBuilder<crate::model::ListWorkflowRevisionsRequest>);
 
@@ -532,7 +532,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::list_locations call.
+    /// The request builder for [Workflows::list_locations][super::super::client::Workflows::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -610,7 +610,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::get_location call.
+    /// The request builder for [Workflows::get_location][super::super::client::Workflows::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -652,7 +652,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::list_operations call.
+    /// The request builder for [Workflows::list_operations][super::super::client::Workflows::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -730,7 +730,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::get_operation call.
+    /// The request builder for [Workflows::get_operation][super::super::client::Workflows::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -775,7 +775,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for a Workflows::delete_operation call.
+    /// The request builder for [Workflows::delete_operation][super::super::client::Workflows::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 

--- a/src/generated/cloud/workstations/v1/src/builder.rs
+++ b/src/generated/cloud/workstations/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::get_workstation_cluster call.
+    /// The request builder for [Workstations::get_workstation_cluster][super::super::client::Workstations::get_workstation_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkstationCluster(RequestBuilder<crate::model::GetWorkstationClusterRequest>);
 
@@ -112,7 +112,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::list_workstation_clusters call.
+    /// The request builder for [Workstations::list_workstation_clusters][super::super::client::Workstations::list_workstation_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkstationClusters(
         RequestBuilder<crate::model::ListWorkstationClustersRequest>,
@@ -188,7 +188,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::create_workstation_cluster call.
+    /// The request builder for [Workstations::create_workstation_cluster][super::super::client::Workstations::create_workstation_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWorkstationCluster(
         RequestBuilder<crate::model::CreateWorkstationClusterRequest>,
@@ -297,7 +297,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::update_workstation_cluster call.
+    /// The request builder for [Workstations::update_workstation_cluster][super::super::client::Workstations::update_workstation_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWorkstationCluster(
         RequestBuilder<crate::model::UpdateWorkstationClusterRequest>,
@@ -409,7 +409,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::delete_workstation_cluster call.
+    /// The request builder for [Workstations::delete_workstation_cluster][super::super::client::Workstations::delete_workstation_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWorkstationCluster(
         RequestBuilder<crate::model::DeleteWorkstationClusterRequest>,
@@ -513,7 +513,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::get_workstation_config call.
+    /// The request builder for [Workstations::get_workstation_config][super::super::client::Workstations::get_workstation_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkstationConfig(RequestBuilder<crate::model::GetWorkstationConfigRequest>);
 
@@ -558,7 +558,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::list_workstation_configs call.
+    /// The request builder for [Workstations::list_workstation_configs][super::super::client::Workstations::list_workstation_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkstationConfigs(RequestBuilder<crate::model::ListWorkstationConfigsRequest>);
 
@@ -632,7 +632,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::list_usable_workstation_configs call.
+    /// The request builder for [Workstations::list_usable_workstation_configs][super::super::client::Workstations::list_usable_workstation_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListUsableWorkstationConfigs(
         RequestBuilder<crate::model::ListUsableWorkstationConfigsRequest>,
@@ -708,7 +708,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::create_workstation_config call.
+    /// The request builder for [Workstations::create_workstation_config][super::super::client::Workstations::create_workstation_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWorkstationConfig(
         RequestBuilder<crate::model::CreateWorkstationConfigRequest>,
@@ -817,7 +817,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::update_workstation_config call.
+    /// The request builder for [Workstations::update_workstation_config][super::super::client::Workstations::update_workstation_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWorkstationConfig(
         RequestBuilder<crate::model::UpdateWorkstationConfigRequest>,
@@ -929,7 +929,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::delete_workstation_config call.
+    /// The request builder for [Workstations::delete_workstation_config][super::super::client::Workstations::delete_workstation_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWorkstationConfig(
         RequestBuilder<crate::model::DeleteWorkstationConfigRequest>,
@@ -1033,7 +1033,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::get_workstation call.
+    /// The request builder for [Workstations::get_workstation][super::super::client::Workstations::get_workstation] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkstation(RequestBuilder<crate::model::GetWorkstationRequest>);
 
@@ -1075,7 +1075,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::list_workstations call.
+    /// The request builder for [Workstations::list_workstations][super::super::client::Workstations::list_workstations] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkstations(RequestBuilder<crate::model::ListWorkstationsRequest>);
 
@@ -1147,7 +1147,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::list_usable_workstations call.
+    /// The request builder for [Workstations::list_usable_workstations][super::super::client::Workstations::list_usable_workstations] calls.
     #[derive(Clone, Debug)]
     pub struct ListUsableWorkstations(RequestBuilder<crate::model::ListUsableWorkstationsRequest>);
 
@@ -1221,7 +1221,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::create_workstation call.
+    /// The request builder for [Workstations::create_workstation][super::super::client::Workstations::create_workstation] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWorkstation(RequestBuilder<crate::model::CreateWorkstationRequest>);
 
@@ -1325,7 +1325,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::update_workstation call.
+    /// The request builder for [Workstations::update_workstation][super::super::client::Workstations::update_workstation] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWorkstation(RequestBuilder<crate::model::UpdateWorkstationRequest>);
 
@@ -1432,7 +1432,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::delete_workstation call.
+    /// The request builder for [Workstations::delete_workstation][super::super::client::Workstations::delete_workstation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWorkstation(RequestBuilder<crate::model::DeleteWorkstationRequest>);
 
@@ -1527,7 +1527,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::start_workstation call.
+    /// The request builder for [Workstations::start_workstation][super::super::client::Workstations::start_workstation] calls.
     #[derive(Clone, Debug)]
     pub struct StartWorkstation(RequestBuilder<crate::model::StartWorkstationRequest>);
 
@@ -1622,7 +1622,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::stop_workstation call.
+    /// The request builder for [Workstations::stop_workstation][super::super::client::Workstations::stop_workstation] calls.
     #[derive(Clone, Debug)]
     pub struct StopWorkstation(RequestBuilder<crate::model::StopWorkstationRequest>);
 
@@ -1714,7 +1714,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::generate_access_token call.
+    /// The request builder for [Workstations::generate_access_token][super::super::client::Workstations::generate_access_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAccessToken(RequestBuilder<crate::model::GenerateAccessTokenRequest>);
 
@@ -1770,7 +1770,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::set_iam_policy call.
+    /// The request builder for [Workstations::set_iam_policy][super::super::client::Workstations::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1830,7 +1830,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::get_iam_policy call.
+    /// The request builder for [Workstations::get_iam_policy][super::super::client::Workstations::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1881,7 +1881,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::test_iam_permissions call.
+    /// The request builder for [Workstations::test_iam_permissions][super::super::client::Workstations::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1937,7 +1937,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::list_operations call.
+    /// The request builder for [Workstations::list_operations][super::super::client::Workstations::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2015,7 +2015,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::get_operation call.
+    /// The request builder for [Workstations::get_operation][super::super::client::Workstations::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2060,7 +2060,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::delete_operation call.
+    /// The request builder for [Workstations::delete_operation][super::super::client::Workstations::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2105,7 +2105,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for a Workstations::cancel_operation call.
+    /// The request builder for [Workstations::cancel_operation][super::super::client::Workstations::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/container/v1/src/builder.rs
+++ b/src/generated/container/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::list_clusters call.
+    /// The request builder for [ClusterManager::list_clusters][super::super::client::ClusterManager::list_clusters] calls.
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -121,7 +121,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::get_cluster call.
+    /// The request builder for [ClusterManager::get_cluster][super::super::client::ClusterManager::get_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -181,7 +181,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::create_cluster call.
+    /// The request builder for [ClusterManager::create_cluster][super::super::client::ClusterManager::create_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -244,7 +244,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::update_cluster call.
+    /// The request builder for [ClusterManager::update_cluster][super::super::client::ClusterManager::update_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -313,7 +313,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::update_node_pool call.
+    /// The request builder for [ClusterManager::update_node_pool][super::super::client::ClusterManager::update_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNodePool(RequestBuilder<crate::model::UpdateNodePoolRequest>);
 
@@ -630,7 +630,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_node_pool_autoscaling call.
+    /// The request builder for [ClusterManager::set_node_pool_autoscaling][super::super::client::ClusterManager::set_node_pool_autoscaling] calls.
     #[derive(Clone, Debug)]
     pub struct SetNodePoolAutoscaling(RequestBuilder<crate::model::SetNodePoolAutoscalingRequest>);
 
@@ -708,7 +708,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_logging_service call.
+    /// The request builder for [ClusterManager::set_logging_service][super::super::client::ClusterManager::set_logging_service] calls.
     #[derive(Clone, Debug)]
     pub struct SetLoggingService(RequestBuilder<crate::model::SetLoggingServiceRequest>);
 
@@ -777,7 +777,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_monitoring_service call.
+    /// The request builder for [ClusterManager::set_monitoring_service][super::super::client::ClusterManager::set_monitoring_service] calls.
     #[derive(Clone, Debug)]
     pub struct SetMonitoringService(RequestBuilder<crate::model::SetMonitoringServiceRequest>);
 
@@ -846,7 +846,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_addons_config call.
+    /// The request builder for [ClusterManager::set_addons_config][super::super::client::ClusterManager::set_addons_config] calls.
     #[derive(Clone, Debug)]
     pub struct SetAddonsConfig(RequestBuilder<crate::model::SetAddonsConfigRequest>);
 
@@ -915,7 +915,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_locations call.
+    /// The request builder for [ClusterManager::set_locations][super::super::client::ClusterManager::set_locations] calls.
     #[derive(Clone, Debug)]
     pub struct SetLocations(RequestBuilder<crate::model::SetLocationsRequest>);
 
@@ -986,7 +986,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::update_master call.
+    /// The request builder for [ClusterManager::update_master][super::super::client::ClusterManager::update_master] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateMaster(RequestBuilder<crate::model::UpdateMasterRequest>);
 
@@ -1052,7 +1052,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_master_auth call.
+    /// The request builder for [ClusterManager::set_master_auth][super::super::client::ClusterManager::set_master_auth] calls.
     #[derive(Clone, Debug)]
     pub struct SetMasterAuth(RequestBuilder<crate::model::SetMasterAuthRequest>);
 
@@ -1130,7 +1130,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::delete_cluster call.
+    /// The request builder for [ClusterManager::delete_cluster][super::super::client::ClusterManager::delete_cluster] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -1190,7 +1190,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::list_operations call.
+    /// The request builder for [ClusterManager::list_operations][super::super::client::ClusterManager::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<crate::model::ListOperationsRequest>);
 
@@ -1244,7 +1244,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::get_operation call.
+    /// The request builder for [ClusterManager::get_operation][super::super::client::ClusterManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<crate::model::GetOperationRequest>);
 
@@ -1304,7 +1304,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::cancel_operation call.
+    /// The request builder for [ClusterManager::cancel_operation][super::super::client::ClusterManager::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<crate::model::CancelOperationRequest>);
 
@@ -1364,7 +1364,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::get_server_config call.
+    /// The request builder for [ClusterManager::get_server_config][super::super::client::ClusterManager::get_server_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetServerConfig(RequestBuilder<crate::model::GetServerConfigRequest>);
 
@@ -1418,7 +1418,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::get_json_web_keys call.
+    /// The request builder for [ClusterManager::get_json_web_keys][super::super::client::ClusterManager::get_json_web_keys] calls.
     #[derive(Clone, Debug)]
     pub struct GetJSONWebKeys(RequestBuilder<crate::model::GetJSONWebKeysRequest>);
 
@@ -1460,7 +1460,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::list_node_pools call.
+    /// The request builder for [ClusterManager::list_node_pools][super::super::client::ClusterManager::list_node_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListNodePools(RequestBuilder<crate::model::ListNodePoolsRequest>);
 
@@ -1520,7 +1520,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::get_node_pool call.
+    /// The request builder for [ClusterManager::get_node_pool][super::super::client::ClusterManager::get_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetNodePool(RequestBuilder<crate::model::GetNodePoolRequest>);
 
@@ -1586,7 +1586,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::create_node_pool call.
+    /// The request builder for [ClusterManager::create_node_pool][super::super::client::ClusterManager::create_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNodePool(RequestBuilder<crate::model::CreateNodePoolRequest>);
 
@@ -1655,7 +1655,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::delete_node_pool call.
+    /// The request builder for [ClusterManager::delete_node_pool][super::super::client::ClusterManager::delete_node_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNodePool(RequestBuilder<crate::model::DeleteNodePoolRequest>);
 
@@ -1721,7 +1721,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::complete_node_pool_upgrade call.
+    /// The request builder for [ClusterManager::complete_node_pool_upgrade][super::super::client::ClusterManager::complete_node_pool_upgrade] calls.
     #[derive(Clone, Debug)]
     pub struct CompleteNodePoolUpgrade(
         RequestBuilder<crate::model::CompleteNodePoolUpgradeRequest>,
@@ -1768,7 +1768,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::rollback_node_pool_upgrade call.
+    /// The request builder for [ClusterManager::rollback_node_pool_upgrade][super::super::client::ClusterManager::rollback_node_pool_upgrade] calls.
     #[derive(Clone, Debug)]
     pub struct RollbackNodePoolUpgrade(
         RequestBuilder<crate::model::RollbackNodePoolUpgradeRequest>,
@@ -1845,7 +1845,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_node_pool_management call.
+    /// The request builder for [ClusterManager::set_node_pool_management][super::super::client::ClusterManager::set_node_pool_management] calls.
     #[derive(Clone, Debug)]
     pub struct SetNodePoolManagement(RequestBuilder<crate::model::SetNodePoolManagementRequest>);
 
@@ -1923,7 +1923,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_labels call.
+    /// The request builder for [ClusterManager::set_labels][super::super::client::ClusterManager::set_labels] calls.
     #[derive(Clone, Debug)]
     pub struct SetLabels(RequestBuilder<crate::model::SetLabelsRequest>);
 
@@ -2001,7 +2001,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_legacy_abac call.
+    /// The request builder for [ClusterManager::set_legacy_abac][super::super::client::ClusterManager::set_legacy_abac] calls.
     #[derive(Clone, Debug)]
     pub struct SetLegacyAbac(RequestBuilder<crate::model::SetLegacyAbacRequest>);
 
@@ -2067,7 +2067,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::start_ip_rotation call.
+    /// The request builder for [ClusterManager::start_ip_rotation][super::super::client::ClusterManager::start_ip_rotation] calls.
     #[derive(Clone, Debug)]
     pub struct StartIPRotation(RequestBuilder<crate::model::StartIPRotationRequest>);
 
@@ -2133,7 +2133,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::complete_ip_rotation call.
+    /// The request builder for [ClusterManager::complete_ip_rotation][super::super::client::ClusterManager::complete_ip_rotation] calls.
     #[derive(Clone, Debug)]
     pub struct CompleteIPRotation(RequestBuilder<crate::model::CompleteIPRotationRequest>);
 
@@ -2196,7 +2196,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_node_pool_size call.
+    /// The request builder for [ClusterManager::set_node_pool_size][super::super::client::ClusterManager::set_node_pool_size] calls.
     #[derive(Clone, Debug)]
     pub struct SetNodePoolSize(RequestBuilder<crate::model::SetNodePoolSizeRequest>);
 
@@ -2268,7 +2268,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_network_policy call.
+    /// The request builder for [ClusterManager::set_network_policy][super::super::client::ClusterManager::set_network_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetNetworkPolicy(RequestBuilder<crate::model::SetNetworkPolicyRequest>);
 
@@ -2340,7 +2340,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::set_maintenance_policy call.
+    /// The request builder for [ClusterManager::set_maintenance_policy][super::super::client::ClusterManager::set_maintenance_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetMaintenancePolicy(RequestBuilder<crate::model::SetMaintenancePolicyRequest>);
 
@@ -2414,7 +2414,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::list_usable_subnetworks call.
+    /// The request builder for [ClusterManager::list_usable_subnetworks][super::super::client::ClusterManager::list_usable_subnetworks] calls.
     #[derive(Clone, Debug)]
     pub struct ListUsableSubnetworks(RequestBuilder<crate::model::ListUsableSubnetworksRequest>);
 
@@ -2492,7 +2492,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for a ClusterManager::check_autopilot_compatibility call.
+    /// The request builder for [ClusterManager::check_autopilot_compatibility][super::super::client::ClusterManager::check_autopilot_compatibility] calls.
     #[derive(Clone, Debug)]
     pub struct CheckAutopilotCompatibility(
         RequestBuilder<crate::model::CheckAutopilotCompatibilityRequest>,

--- a/src/generated/datastore/admin/v1/src/builder.rs
+++ b/src/generated/datastore/admin/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::export_entities call.
+    /// The request builder for [DatastoreAdmin::export_entities][super::super::client::DatastoreAdmin::export_entities] calls.
     #[derive(Clone, Debug)]
     pub struct ExportEntities(RequestBuilder<crate::model::ExportEntitiesRequest>);
 
@@ -176,7 +176,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::import_entities call.
+    /// The request builder for [DatastoreAdmin::import_entities][super::super::client::DatastoreAdmin::import_entities] calls.
     #[derive(Clone, Debug)]
     pub struct ImportEntities(RequestBuilder<crate::model::ImportEntitiesRequest>);
 
@@ -279,7 +279,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::create_index call.
+    /// The request builder for [DatastoreAdmin::create_index][super::super::client::DatastoreAdmin::create_index] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIndex(RequestBuilder<crate::model::CreateIndexRequest>);
 
@@ -368,7 +368,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::delete_index call.
+    /// The request builder for [DatastoreAdmin::delete_index][super::super::client::DatastoreAdmin::delete_index] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIndex(RequestBuilder<crate::model::DeleteIndexRequest>);
 
@@ -454,7 +454,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::get_index call.
+    /// The request builder for [DatastoreAdmin::get_index][super::super::client::DatastoreAdmin::get_index] calls.
     #[derive(Clone, Debug)]
     pub struct GetIndex(RequestBuilder<crate::model::GetIndexRequest>);
 
@@ -502,7 +502,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::list_indexes call.
+    /// The request builder for [DatastoreAdmin::list_indexes][super::super::client::DatastoreAdmin::list_indexes] calls.
     #[derive(Clone, Debug)]
     pub struct ListIndexes(RequestBuilder<crate::model::ListIndexesRequest>);
 
@@ -577,7 +577,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::list_operations call.
+    /// The request builder for [DatastoreAdmin::list_operations][super::super::client::DatastoreAdmin::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -655,7 +655,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::get_operation call.
+    /// The request builder for [DatastoreAdmin::get_operation][super::super::client::DatastoreAdmin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -700,7 +700,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::delete_operation call.
+    /// The request builder for [DatastoreAdmin::delete_operation][super::super::client::DatastoreAdmin::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -745,7 +745,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for a DatastoreAdmin::cancel_operation call.
+    /// The request builder for [DatastoreAdmin::cancel_operation][super::super::client::DatastoreAdmin::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/devtools/artifactregistry/v1/src/builder.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_docker_images call.
+    /// The request builder for [ArtifactRegistry::list_docker_images][super::super::client::ArtifactRegistry::list_docker_images] calls.
     #[derive(Clone, Debug)]
     pub struct ListDockerImages(RequestBuilder<crate::model::ListDockerImagesRequest>);
 
@@ -145,7 +145,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_docker_image call.
+    /// The request builder for [ArtifactRegistry::get_docker_image][super::super::client::ArtifactRegistry::get_docker_image] calls.
     #[derive(Clone, Debug)]
     pub struct GetDockerImage(RequestBuilder<crate::model::GetDockerImageRequest>);
 
@@ -187,7 +187,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_maven_artifacts call.
+    /// The request builder for [ArtifactRegistry::list_maven_artifacts][super::super::client::ArtifactRegistry::list_maven_artifacts] calls.
     #[derive(Clone, Debug)]
     pub struct ListMavenArtifacts(RequestBuilder<crate::model::ListMavenArtifactsRequest>);
 
@@ -259,7 +259,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_maven_artifact call.
+    /// The request builder for [ArtifactRegistry::get_maven_artifact][super::super::client::ArtifactRegistry::get_maven_artifact] calls.
     #[derive(Clone, Debug)]
     pub struct GetMavenArtifact(RequestBuilder<crate::model::GetMavenArtifactRequest>);
 
@@ -304,7 +304,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_npm_packages call.
+    /// The request builder for [ArtifactRegistry::list_npm_packages][super::super::client::ArtifactRegistry::list_npm_packages] calls.
     #[derive(Clone, Debug)]
     pub struct ListNpmPackages(RequestBuilder<crate::model::ListNpmPackagesRequest>);
 
@@ -373,7 +373,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_npm_package call.
+    /// The request builder for [ArtifactRegistry::get_npm_package][super::super::client::ArtifactRegistry::get_npm_package] calls.
     #[derive(Clone, Debug)]
     pub struct GetNpmPackage(RequestBuilder<crate::model::GetNpmPackageRequest>);
 
@@ -415,7 +415,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_python_packages call.
+    /// The request builder for [ArtifactRegistry::list_python_packages][super::super::client::ArtifactRegistry::list_python_packages] calls.
     #[derive(Clone, Debug)]
     pub struct ListPythonPackages(RequestBuilder<crate::model::ListPythonPackagesRequest>);
 
@@ -487,7 +487,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_python_package call.
+    /// The request builder for [ArtifactRegistry::get_python_package][super::super::client::ArtifactRegistry::get_python_package] calls.
     #[derive(Clone, Debug)]
     pub struct GetPythonPackage(RequestBuilder<crate::model::GetPythonPackageRequest>);
 
@@ -532,7 +532,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::import_apt_artifacts call.
+    /// The request builder for [ArtifactRegistry::import_apt_artifacts][super::super::client::ArtifactRegistry::import_apt_artifacts] calls.
     #[derive(Clone, Debug)]
     pub struct ImportAptArtifacts(RequestBuilder<crate::model::ImportAptArtifactsRequest>);
 
@@ -629,7 +629,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::import_yum_artifacts call.
+    /// The request builder for [ArtifactRegistry::import_yum_artifacts][super::super::client::ArtifactRegistry::import_yum_artifacts] calls.
     #[derive(Clone, Debug)]
     pub struct ImportYumArtifacts(RequestBuilder<crate::model::ImportYumArtifactsRequest>);
 
@@ -726,7 +726,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_repositories call.
+    /// The request builder for [ArtifactRegistry::list_repositories][super::super::client::ArtifactRegistry::list_repositories] calls.
     #[derive(Clone, Debug)]
     pub struct ListRepositories(RequestBuilder<crate::model::ListRepositoriesRequest>);
 
@@ -810,7 +810,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_repository call.
+    /// The request builder for [ArtifactRegistry::get_repository][super::super::client::ArtifactRegistry::get_repository] calls.
     #[derive(Clone, Debug)]
     pub struct GetRepository(RequestBuilder<crate::model::GetRepositoryRequest>);
 
@@ -852,7 +852,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::create_repository call.
+    /// The request builder for [ArtifactRegistry::create_repository][super::super::client::ArtifactRegistry::create_repository] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRepository(RequestBuilder<crate::model::CreateRepositoryRequest>);
 
@@ -950,7 +950,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::update_repository call.
+    /// The request builder for [ArtifactRegistry::update_repository][super::super::client::ArtifactRegistry::update_repository] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRepository(RequestBuilder<crate::model::UpdateRepositoryRequest>);
 
@@ -1007,7 +1007,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::delete_repository call.
+    /// The request builder for [ArtifactRegistry::delete_repository][super::super::client::ArtifactRegistry::delete_repository] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRepository(RequestBuilder<crate::model::DeleteRepositoryRequest>);
 
@@ -1087,7 +1087,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_packages call.
+    /// The request builder for [ArtifactRegistry::list_packages][super::super::client::ArtifactRegistry::list_packages] calls.
     #[derive(Clone, Debug)]
     pub struct ListPackages(RequestBuilder<crate::model::ListPackagesRequest>);
 
@@ -1168,7 +1168,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_package call.
+    /// The request builder for [ArtifactRegistry::get_package][super::super::client::ArtifactRegistry::get_package] calls.
     #[derive(Clone, Debug)]
     pub struct GetPackage(RequestBuilder<crate::model::GetPackageRequest>);
 
@@ -1210,7 +1210,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::delete_package call.
+    /// The request builder for [ArtifactRegistry::delete_package][super::super::client::ArtifactRegistry::delete_package] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePackage(RequestBuilder<crate::model::DeletePackageRequest>);
 
@@ -1287,7 +1287,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_versions call.
+    /// The request builder for [ArtifactRegistry::list_versions][super::super::client::ArtifactRegistry::list_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -1374,7 +1374,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_version call.
+    /// The request builder for [ArtifactRegistry::get_version][super::super::client::ArtifactRegistry::get_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -1422,7 +1422,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::delete_version call.
+    /// The request builder for [ArtifactRegistry::delete_version][super::super::client::ArtifactRegistry::delete_version] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -1505,7 +1505,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::batch_delete_versions call.
+    /// The request builder for [ArtifactRegistry::batch_delete_versions][super::super::client::ArtifactRegistry::batch_delete_versions] calls.
     #[derive(Clone, Debug)]
     pub struct BatchDeleteVersions(RequestBuilder<crate::model::BatchDeleteVersionsRequest>);
 
@@ -1604,7 +1604,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::update_version call.
+    /// The request builder for [ArtifactRegistry::update_version][super::super::client::ArtifactRegistry::update_version] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -1658,7 +1658,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_files call.
+    /// The request builder for [ArtifactRegistry::list_files][super::super::client::ArtifactRegistry::list_files] calls.
     #[derive(Clone, Debug)]
     pub struct ListFiles(RequestBuilder<crate::model::ListFilesRequest>);
 
@@ -1738,7 +1738,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_file call.
+    /// The request builder for [ArtifactRegistry::get_file][super::super::client::ArtifactRegistry::get_file] calls.
     #[derive(Clone, Debug)]
     pub struct GetFile(RequestBuilder<crate::model::GetFileRequest>);
 
@@ -1780,7 +1780,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::delete_file call.
+    /// The request builder for [ArtifactRegistry::delete_file][super::super::client::ArtifactRegistry::delete_file] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFile(RequestBuilder<crate::model::DeleteFileRequest>);
 
@@ -1857,7 +1857,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::update_file call.
+    /// The request builder for [ArtifactRegistry::update_file][super::super::client::ArtifactRegistry::update_file] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateFile(RequestBuilder<crate::model::UpdateFileRequest>);
 
@@ -1908,7 +1908,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_tags call.
+    /// The request builder for [ArtifactRegistry::list_tags][super::super::client::ArtifactRegistry::list_tags] calls.
     #[derive(Clone, Debug)]
     pub struct ListTags(RequestBuilder<crate::model::ListTagsRequest>);
 
@@ -1982,7 +1982,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_tag call.
+    /// The request builder for [ArtifactRegistry::get_tag][super::super::client::ArtifactRegistry::get_tag] calls.
     #[derive(Clone, Debug)]
     pub struct GetTag(RequestBuilder<crate::model::GetTagRequest>);
 
@@ -2022,7 +2022,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::create_tag call.
+    /// The request builder for [ArtifactRegistry::create_tag][super::super::client::ArtifactRegistry::create_tag] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTag(RequestBuilder<crate::model::CreateTagRequest>);
 
@@ -2076,7 +2076,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::update_tag call.
+    /// The request builder for [ArtifactRegistry::update_tag][super::super::client::ArtifactRegistry::update_tag] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTag(RequestBuilder<crate::model::UpdateTagRequest>);
 
@@ -2127,7 +2127,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::delete_tag call.
+    /// The request builder for [ArtifactRegistry::delete_tag][super::super::client::ArtifactRegistry::delete_tag] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTag(RequestBuilder<crate::model::DeleteTagRequest>);
 
@@ -2169,7 +2169,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::create_rule call.
+    /// The request builder for [ArtifactRegistry::create_rule][super::super::client::ArtifactRegistry::create_rule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRule(RequestBuilder<crate::model::CreateRuleRequest>);
 
@@ -2223,7 +2223,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_rules call.
+    /// The request builder for [ArtifactRegistry::list_rules][super::super::client::ArtifactRegistry::list_rules] calls.
     #[derive(Clone, Debug)]
     pub struct ListRules(RequestBuilder<crate::model::ListRulesRequest>);
 
@@ -2291,7 +2291,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_rule call.
+    /// The request builder for [ArtifactRegistry::get_rule][super::super::client::ArtifactRegistry::get_rule] calls.
     #[derive(Clone, Debug)]
     pub struct GetRule(RequestBuilder<crate::model::GetRuleRequest>);
 
@@ -2333,7 +2333,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::update_rule call.
+    /// The request builder for [ArtifactRegistry::update_rule][super::super::client::ArtifactRegistry::update_rule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRule(RequestBuilder<crate::model::UpdateRuleRequest>);
 
@@ -2384,7 +2384,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::delete_rule call.
+    /// The request builder for [ArtifactRegistry::delete_rule][super::super::client::ArtifactRegistry::delete_rule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRule(RequestBuilder<crate::model::DeleteRuleRequest>);
 
@@ -2426,7 +2426,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::set_iam_policy call.
+    /// The request builder for [ArtifactRegistry::set_iam_policy][super::super::client::ArtifactRegistry::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2486,7 +2486,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_iam_policy call.
+    /// The request builder for [ArtifactRegistry::get_iam_policy][super::super::client::ArtifactRegistry::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2537,7 +2537,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::test_iam_permissions call.
+    /// The request builder for [ArtifactRegistry::test_iam_permissions][super::super::client::ArtifactRegistry::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2593,7 +2593,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_project_settings call.
+    /// The request builder for [ArtifactRegistry::get_project_settings][super::super::client::ArtifactRegistry::get_project_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetProjectSettings(RequestBuilder<crate::model::GetProjectSettingsRequest>);
 
@@ -2638,7 +2638,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::update_project_settings call.
+    /// The request builder for [ArtifactRegistry::update_project_settings][super::super::client::ArtifactRegistry::update_project_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProjectSettings(RequestBuilder<crate::model::UpdateProjectSettingsRequest>);
 
@@ -2695,7 +2695,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_vpcsc_config call.
+    /// The request builder for [ArtifactRegistry::get_vpcsc_config][super::super::client::ArtifactRegistry::get_vpcsc_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetVPCSCConfig(RequestBuilder<crate::model::GetVPCSCConfigRequest>);
 
@@ -2737,7 +2737,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::update_vpcsc_config call.
+    /// The request builder for [ArtifactRegistry::update_vpcsc_config][super::super::client::ArtifactRegistry::update_vpcsc_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateVPCSCConfig(RequestBuilder<crate::model::UpdateVPCSCConfigRequest>);
 
@@ -2794,7 +2794,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::update_package call.
+    /// The request builder for [ArtifactRegistry::update_package][super::super::client::ArtifactRegistry::update_package] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePackage(RequestBuilder<crate::model::UpdatePackageRequest>);
 
@@ -2848,7 +2848,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_attachments call.
+    /// The request builder for [ArtifactRegistry::list_attachments][super::super::client::ArtifactRegistry::list_attachments] calls.
     #[derive(Clone, Debug)]
     pub struct ListAttachments(RequestBuilder<crate::model::ListAttachmentsRequest>);
 
@@ -2923,7 +2923,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_attachment call.
+    /// The request builder for [ArtifactRegistry::get_attachment][super::super::client::ArtifactRegistry::get_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct GetAttachment(RequestBuilder<crate::model::GetAttachmentRequest>);
 
@@ -2965,7 +2965,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::create_attachment call.
+    /// The request builder for [ArtifactRegistry::create_attachment][super::super::client::ArtifactRegistry::create_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAttachment(RequestBuilder<crate::model::CreateAttachmentRequest>);
 
@@ -3063,7 +3063,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::delete_attachment call.
+    /// The request builder for [ArtifactRegistry::delete_attachment][super::super::client::ArtifactRegistry::delete_attachment] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAttachment(RequestBuilder<crate::model::DeleteAttachmentRequest>);
 
@@ -3143,7 +3143,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::list_locations call.
+    /// The request builder for [ArtifactRegistry::list_locations][super::super::client::ArtifactRegistry::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3221,7 +3221,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_location call.
+    /// The request builder for [ArtifactRegistry::get_location][super::super::client::ArtifactRegistry::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3263,7 +3263,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for a ArtifactRegistry::get_operation call.
+    /// The request builder for [ArtifactRegistry::get_operation][super::super::client::ArtifactRegistry::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/devtools/cloudbuild/v1/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::create_build call.
+    /// The request builder for [CloudBuild::create_build][super::super::client::CloudBuild::create_build] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBuild(RequestBuilder<crate::model::CreateBuildRequest>);
 
@@ -162,7 +162,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::get_build call.
+    /// The request builder for [CloudBuild::get_build][super::super::client::CloudBuild::get_build] calls.
     #[derive(Clone, Debug)]
     pub struct GetBuild(RequestBuilder<crate::model::GetBuildRequest>);
 
@@ -216,7 +216,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::list_builds call.
+    /// The request builder for [CloudBuild::list_builds][super::super::client::CloudBuild::list_builds] calls.
     #[derive(Clone, Debug)]
     pub struct ListBuilds(RequestBuilder<crate::model::ListBuildsRequest>);
 
@@ -297,7 +297,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::cancel_build call.
+    /// The request builder for [CloudBuild::cancel_build][super::super::client::CloudBuild::cancel_build] calls.
     #[derive(Clone, Debug)]
     pub struct CancelBuild(RequestBuilder<crate::model::CancelBuildRequest>);
 
@@ -351,7 +351,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::retry_build call.
+    /// The request builder for [CloudBuild::retry_build][super::super::client::CloudBuild::retry_build] calls.
     #[derive(Clone, Debug)]
     pub struct RetryBuild(RequestBuilder<crate::model::RetryBuildRequest>);
 
@@ -443,7 +443,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::approve_build call.
+    /// The request builder for [CloudBuild::approve_build][super::super::client::CloudBuild::approve_build] calls.
     #[derive(Clone, Debug)]
     pub struct ApproveBuild(RequestBuilder<crate::model::ApproveBuildRequest>);
 
@@ -532,7 +532,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::create_build_trigger call.
+    /// The request builder for [CloudBuild::create_build_trigger][super::super::client::CloudBuild::create_build_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBuildTrigger(RequestBuilder<crate::model::CreateBuildTriggerRequest>);
 
@@ -592,7 +592,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::get_build_trigger call.
+    /// The request builder for [CloudBuild::get_build_trigger][super::super::client::CloudBuild::get_build_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct GetBuildTrigger(RequestBuilder<crate::model::GetBuildTriggerRequest>);
 
@@ -646,7 +646,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::list_build_triggers call.
+    /// The request builder for [CloudBuild::list_build_triggers][super::super::client::CloudBuild::list_build_triggers] calls.
     #[derive(Clone, Debug)]
     pub struct ListBuildTriggers(RequestBuilder<crate::model::ListBuildTriggersRequest>);
 
@@ -724,7 +724,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::delete_build_trigger call.
+    /// The request builder for [CloudBuild::delete_build_trigger][super::super::client::CloudBuild::delete_build_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBuildTrigger(RequestBuilder<crate::model::DeleteBuildTriggerRequest>);
 
@@ -781,7 +781,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::update_build_trigger call.
+    /// The request builder for [CloudBuild::update_build_trigger][super::super::client::CloudBuild::update_build_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBuildTrigger(RequestBuilder<crate::model::UpdateBuildTriggerRequest>);
 
@@ -850,7 +850,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::run_build_trigger call.
+    /// The request builder for [CloudBuild::run_build_trigger][super::super::client::CloudBuild::run_build_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct RunBuildTrigger(RequestBuilder<crate::model::RunBuildTriggerRequest>);
 
@@ -951,7 +951,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::receive_trigger_webhook call.
+    /// The request builder for [CloudBuild::receive_trigger_webhook][super::super::client::CloudBuild::receive_trigger_webhook] calls.
     #[derive(Clone, Debug)]
     pub struct ReceiveTriggerWebhook(RequestBuilder<crate::model::ReceiveTriggerWebhookRequest>);
 
@@ -1023,7 +1023,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::create_worker_pool call.
+    /// The request builder for [CloudBuild::create_worker_pool][super::super::client::CloudBuild::create_worker_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateWorkerPool(RequestBuilder<crate::model::CreateWorkerPoolRequest>);
 
@@ -1130,7 +1130,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::get_worker_pool call.
+    /// The request builder for [CloudBuild::get_worker_pool][super::super::client::CloudBuild::get_worker_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetWorkerPool(RequestBuilder<crate::model::GetWorkerPoolRequest>);
 
@@ -1172,7 +1172,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::delete_worker_pool call.
+    /// The request builder for [CloudBuild::delete_worker_pool][super::super::client::CloudBuild::delete_worker_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteWorkerPool(RequestBuilder<crate::model::DeleteWorkerPoolRequest>);
 
@@ -1273,7 +1273,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::update_worker_pool call.
+    /// The request builder for [CloudBuild::update_worker_pool][super::super::client::CloudBuild::update_worker_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateWorkerPool(RequestBuilder<crate::model::UpdateWorkerPoolRequest>);
 
@@ -1377,7 +1377,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::list_worker_pools call.
+    /// The request builder for [CloudBuild::list_worker_pools][super::super::client::CloudBuild::list_worker_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListWorkerPools(RequestBuilder<crate::model::ListWorkerPoolsRequest>);
 
@@ -1446,7 +1446,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::get_operation call.
+    /// The request builder for [CloudBuild::get_operation][super::super::client::CloudBuild::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1491,7 +1491,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for a CloudBuild::cancel_operation call.
+    /// The request builder for [CloudBuild::cancel_operation][super::super::client::CloudBuild::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/devtools/cloudbuild/v2/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::create_connection call.
+    /// The request builder for [RepositoryManager::create_connection][super::super::client::RepositoryManager::create_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -165,7 +165,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::get_connection call.
+    /// The request builder for [RepositoryManager::get_connection][super::super::client::RepositoryManager::get_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -207,7 +207,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::list_connections call.
+    /// The request builder for [RepositoryManager::list_connections][super::super::client::RepositoryManager::list_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -276,7 +276,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::update_connection call.
+    /// The request builder for [RepositoryManager::update_connection][super::super::client::RepositoryManager::update_connection] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 
@@ -383,7 +383,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::delete_connection call.
+    /// The request builder for [RepositoryManager::delete_connection][super::super::client::RepositoryManager::delete_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -475,7 +475,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::create_repository call.
+    /// The request builder for [RepositoryManager::create_repository][super::super::client::RepositoryManager::create_repository] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRepository(RequestBuilder<crate::model::CreateRepositoryRequest>);
 
@@ -573,7 +573,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::batch_create_repositories call.
+    /// The request builder for [RepositoryManager::batch_create_repositories][super::super::client::RepositoryManager::batch_create_repositories] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateRepositories(
         RequestBuilder<crate::model::BatchCreateRepositoriesRequest>,
@@ -674,7 +674,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::get_repository call.
+    /// The request builder for [RepositoryManager::get_repository][super::super::client::RepositoryManager::get_repository] calls.
     #[derive(Clone, Debug)]
     pub struct GetRepository(RequestBuilder<crate::model::GetRepositoryRequest>);
 
@@ -716,7 +716,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::list_repositories call.
+    /// The request builder for [RepositoryManager::list_repositories][super::super::client::RepositoryManager::list_repositories] calls.
     #[derive(Clone, Debug)]
     pub struct ListRepositories(RequestBuilder<crate::model::ListRepositoriesRequest>);
 
@@ -794,7 +794,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::delete_repository call.
+    /// The request builder for [RepositoryManager::delete_repository][super::super::client::RepositoryManager::delete_repository] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRepository(RequestBuilder<crate::model::DeleteRepositoryRequest>);
 
@@ -886,7 +886,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::fetch_read_write_token call.
+    /// The request builder for [RepositoryManager::fetch_read_write_token][super::super::client::RepositoryManager::fetch_read_write_token] calls.
     #[derive(Clone, Debug)]
     pub struct FetchReadWriteToken(RequestBuilder<crate::model::FetchReadWriteTokenRequest>);
 
@@ -931,7 +931,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::fetch_read_token call.
+    /// The request builder for [RepositoryManager::fetch_read_token][super::super::client::RepositoryManager::fetch_read_token] calls.
     #[derive(Clone, Debug)]
     pub struct FetchReadToken(RequestBuilder<crate::model::FetchReadTokenRequest>);
 
@@ -973,7 +973,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::fetch_linkable_repositories call.
+    /// The request builder for [RepositoryManager::fetch_linkable_repositories][super::super::client::RepositoryManager::fetch_linkable_repositories] calls.
     #[derive(Clone, Debug)]
     pub struct FetchLinkableRepositories(
         RequestBuilder<crate::model::FetchLinkableRepositoriesRequest>,
@@ -1049,7 +1049,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::fetch_git_refs call.
+    /// The request builder for [RepositoryManager::fetch_git_refs][super::super::client::RepositoryManager::fetch_git_refs] calls.
     #[derive(Clone, Debug)]
     pub struct FetchGitRefs(RequestBuilder<crate::model::FetchGitRefsRequest>);
 
@@ -1100,7 +1100,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::set_iam_policy call.
+    /// The request builder for [RepositoryManager::set_iam_policy][super::super::client::RepositoryManager::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1160,7 +1160,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::get_iam_policy call.
+    /// The request builder for [RepositoryManager::get_iam_policy][super::super::client::RepositoryManager::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1211,7 +1211,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::test_iam_permissions call.
+    /// The request builder for [RepositoryManager::test_iam_permissions][super::super::client::RepositoryManager::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1267,7 +1267,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::get_operation call.
+    /// The request builder for [RepositoryManager::get_operation][super::super::client::RepositoryManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1312,7 +1312,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for a RepositoryManager::cancel_operation call.
+    /// The request builder for [RepositoryManager::cancel_operation][super::super::client::RepositoryManager::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/devtools/cloudprofiler/v2/src/builder.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod profiler_service {
         }
     }
 
-    /// The request builder for a ProfilerService::create_profile call.
+    /// The request builder for [ProfilerService::create_profile][super::super::client::ProfilerService::create_profile] calls.
     #[derive(Clone, Debug)]
     pub struct CreateProfile(RequestBuilder<crate::model::CreateProfileRequest>);
 
@@ -129,7 +129,7 @@ pub mod profiler_service {
         }
     }
 
-    /// The request builder for a ProfilerService::create_offline_profile call.
+    /// The request builder for [ProfilerService::create_offline_profile][super::super::client::ProfilerService::create_offline_profile] calls.
     #[derive(Clone, Debug)]
     pub struct CreateOfflineProfile(RequestBuilder<crate::model::CreateOfflineProfileRequest>);
 
@@ -183,7 +183,7 @@ pub mod profiler_service {
         }
     }
 
-    /// The request builder for a ProfilerService::update_profile call.
+    /// The request builder for [ProfilerService::update_profile][super::super::client::ProfilerService::update_profile] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateProfile(RequestBuilder<crate::model::UpdateProfileRequest>);
 
@@ -291,7 +291,7 @@ pub mod export_service {
         }
     }
 
-    /// The request builder for a ExportService::list_profiles call.
+    /// The request builder for [ExportService::list_profiles][super::super::client::ExportService::list_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListProfiles(RequestBuilder<crate::model::ListProfilesRequest>);
 

--- a/src/generated/devtools/cloudtrace/v2/src/builder.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod trace_service {
         }
     }
 
-    /// The request builder for a TraceService::batch_write_spans call.
+    /// The request builder for [TraceService::batch_write_spans][super::super::client::TraceService::batch_write_spans] calls.
     #[derive(Clone, Debug)]
     pub struct BatchWriteSpans(RequestBuilder<crate::model::BatchWriteSpansRequest>);
 
@@ -120,7 +120,7 @@ pub mod trace_service {
         }
     }
 
-    /// The request builder for a TraceService::create_span call.
+    /// The request builder for [TraceService::create_span][super::super::client::TraceService::create_span] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSpan(RequestBuilder<crate::model::Span>);
 

--- a/src/generated/devtools/containeranalysis/v1/src/builder.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for a ContainerAnalysis::set_iam_policy call.
+    /// The request builder for [ContainerAnalysis::set_iam_policy][super::super::client::ContainerAnalysis::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -127,7 +127,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for a ContainerAnalysis::get_iam_policy call.
+    /// The request builder for [ContainerAnalysis::get_iam_policy][super::super::client::ContainerAnalysis::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -178,7 +178,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for a ContainerAnalysis::test_iam_permissions call.
+    /// The request builder for [ContainerAnalysis::test_iam_permissions][super::super::client::ContainerAnalysis::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -234,7 +234,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for a ContainerAnalysis::get_vulnerability_occurrences_summary call.
+    /// The request builder for [ContainerAnalysis::get_vulnerability_occurrences_summary][super::super::client::ContainerAnalysis::get_vulnerability_occurrences_summary] calls.
     #[derive(Clone, Debug)]
     pub struct GetVulnerabilityOccurrencesSummary(
         RequestBuilder<crate::model::GetVulnerabilityOccurrencesSummaryRequest>,
@@ -287,7 +287,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for a ContainerAnalysis::export_sbom call.
+    /// The request builder for [ContainerAnalysis::export_sbom][super::super::client::ContainerAnalysis::export_sbom] calls.
     #[derive(Clone, Debug)]
     pub struct ExportSBOM(RequestBuilder<crate::model::ExportSBOMRequest>);
 

--- a/src/generated/firestore/admin/v1/src/builder.rs
+++ b/src/generated/firestore/admin/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::create_index call.
+    /// The request builder for [FirestoreAdmin::create_index][super::super::client::FirestoreAdmin::create_index] calls.
     #[derive(Clone, Debug)]
     pub struct CreateIndex(RequestBuilder<crate::model::CreateIndexRequest>);
 
@@ -156,7 +156,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::list_indexes call.
+    /// The request builder for [FirestoreAdmin::list_indexes][super::super::client::FirestoreAdmin::list_indexes] calls.
     #[derive(Clone, Debug)]
     pub struct ListIndexes(RequestBuilder<crate::model::ListIndexesRequest>);
 
@@ -231,7 +231,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::get_index call.
+    /// The request builder for [FirestoreAdmin::get_index][super::super::client::FirestoreAdmin::get_index] calls.
     #[derive(Clone, Debug)]
     pub struct GetIndex(RequestBuilder<crate::model::GetIndexRequest>);
 
@@ -273,7 +273,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::delete_index call.
+    /// The request builder for [FirestoreAdmin::delete_index][super::super::client::FirestoreAdmin::delete_index] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteIndex(RequestBuilder<crate::model::DeleteIndexRequest>);
 
@@ -315,7 +315,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::get_field call.
+    /// The request builder for [FirestoreAdmin::get_field][super::super::client::FirestoreAdmin::get_field] calls.
     #[derive(Clone, Debug)]
     pub struct GetField(RequestBuilder<crate::model::GetFieldRequest>);
 
@@ -357,7 +357,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::update_field call.
+    /// The request builder for [FirestoreAdmin::update_field][super::super::client::FirestoreAdmin::update_field] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateField(RequestBuilder<crate::model::UpdateFieldRequest>);
 
@@ -449,7 +449,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::list_fields call.
+    /// The request builder for [FirestoreAdmin::list_fields][super::super::client::FirestoreAdmin::list_fields] calls.
     #[derive(Clone, Debug)]
     pub struct ListFields(RequestBuilder<crate::model::ListFieldsRequest>);
 
@@ -524,7 +524,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::export_documents call.
+    /// The request builder for [FirestoreAdmin::export_documents][super::super::client::FirestoreAdmin::export_documents] calls.
     #[derive(Clone, Debug)]
     pub struct ExportDocuments(RequestBuilder<crate::model::ExportDocumentsRequest>);
 
@@ -644,7 +644,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::import_documents call.
+    /// The request builder for [FirestoreAdmin::import_documents][super::super::client::FirestoreAdmin::import_documents] calls.
     #[derive(Clone, Debug)]
     pub struct ImportDocuments(RequestBuilder<crate::model::ImportDocumentsRequest>);
 
@@ -749,7 +749,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::bulk_delete_documents call.
+    /// The request builder for [FirestoreAdmin::bulk_delete_documents][super::super::client::FirestoreAdmin::bulk_delete_documents] calls.
     #[derive(Clone, Debug)]
     pub struct BulkDeleteDocuments(RequestBuilder<crate::model::BulkDeleteDocumentsRequest>);
 
@@ -859,7 +859,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::create_database call.
+    /// The request builder for [FirestoreAdmin::create_database][super::super::client::FirestoreAdmin::create_database] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDatabase(RequestBuilder<crate::model::CreateDatabaseRequest>);
 
@@ -955,7 +955,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::get_database call.
+    /// The request builder for [FirestoreAdmin::get_database][super::super::client::FirestoreAdmin::get_database] calls.
     #[derive(Clone, Debug)]
     pub struct GetDatabase(RequestBuilder<crate::model::GetDatabaseRequest>);
 
@@ -997,7 +997,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::list_databases call.
+    /// The request builder for [FirestoreAdmin::list_databases][super::super::client::FirestoreAdmin::list_databases] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatabases(RequestBuilder<crate::model::ListDatabasesRequest>);
 
@@ -1045,7 +1045,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::update_database call.
+    /// The request builder for [FirestoreAdmin::update_database][super::super::client::FirestoreAdmin::update_database] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDatabase(RequestBuilder<crate::model::UpdateDatabaseRequest>);
 
@@ -1138,7 +1138,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::delete_database call.
+    /// The request builder for [FirestoreAdmin::delete_database][super::super::client::FirestoreAdmin::delete_database] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDatabase(RequestBuilder<crate::model::DeleteDatabaseRequest>);
 
@@ -1225,7 +1225,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::get_backup call.
+    /// The request builder for [FirestoreAdmin::get_backup][super::super::client::FirestoreAdmin::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1267,7 +1267,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::list_backups call.
+    /// The request builder for [FirestoreAdmin::list_backups][super::super::client::FirestoreAdmin::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1315,7 +1315,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::delete_backup call.
+    /// The request builder for [FirestoreAdmin::delete_backup][super::super::client::FirestoreAdmin::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1357,7 +1357,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::restore_database call.
+    /// The request builder for [FirestoreAdmin::restore_database][super::super::client::FirestoreAdmin::restore_database] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreDatabase(RequestBuilder<crate::model::RestoreDatabaseRequest>);
 
@@ -1461,7 +1461,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::create_backup_schedule call.
+    /// The request builder for [FirestoreAdmin::create_backup_schedule][super::super::client::FirestoreAdmin::create_backup_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackupSchedule(RequestBuilder<crate::model::CreateBackupScheduleRequest>);
 
@@ -1515,7 +1515,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::get_backup_schedule call.
+    /// The request builder for [FirestoreAdmin::get_backup_schedule][super::super::client::FirestoreAdmin::get_backup_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupSchedule(RequestBuilder<crate::model::GetBackupScheduleRequest>);
 
@@ -1560,7 +1560,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::list_backup_schedules call.
+    /// The request builder for [FirestoreAdmin::list_backup_schedules][super::super::client::FirestoreAdmin::list_backup_schedules] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupSchedules(RequestBuilder<crate::model::ListBackupSchedulesRequest>);
 
@@ -1605,7 +1605,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::update_backup_schedule call.
+    /// The request builder for [FirestoreAdmin::update_backup_schedule][super::super::client::FirestoreAdmin::update_backup_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackupSchedule(RequestBuilder<crate::model::UpdateBackupScheduleRequest>);
 
@@ -1662,7 +1662,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::delete_backup_schedule call.
+    /// The request builder for [FirestoreAdmin::delete_backup_schedule][super::super::client::FirestoreAdmin::delete_backup_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackupSchedule(RequestBuilder<crate::model::DeleteBackupScheduleRequest>);
 
@@ -1707,7 +1707,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::list_operations call.
+    /// The request builder for [FirestoreAdmin::list_operations][super::super::client::FirestoreAdmin::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1785,7 +1785,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::get_operation call.
+    /// The request builder for [FirestoreAdmin::get_operation][super::super::client::FirestoreAdmin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1830,7 +1830,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::delete_operation call.
+    /// The request builder for [FirestoreAdmin::delete_operation][super::super::client::FirestoreAdmin::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1875,7 +1875,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for a FirestoreAdmin::cancel_operation call.
+    /// The request builder for [FirestoreAdmin::cancel_operation][super::super::client::FirestoreAdmin::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/grafeas/v1/src/builder.rs
+++ b/src/generated/grafeas/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::get_occurrence call.
+    /// The request builder for [Grafeas::get_occurrence][super::super::client::Grafeas::get_occurrence] calls.
     #[derive(Clone, Debug)]
     pub struct GetOccurrence(RequestBuilder<crate::model::GetOccurrenceRequest>);
 
@@ -109,7 +109,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::list_occurrences call.
+    /// The request builder for [Grafeas::list_occurrences][super::super::client::Grafeas::list_occurrences] calls.
     #[derive(Clone, Debug)]
     pub struct ListOccurrences(RequestBuilder<crate::model::ListOccurrencesRequest>);
 
@@ -184,7 +184,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::delete_occurrence call.
+    /// The request builder for [Grafeas::delete_occurrence][super::super::client::Grafeas::delete_occurrence] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOccurrence(RequestBuilder<crate::model::DeleteOccurrenceRequest>);
 
@@ -229,7 +229,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::create_occurrence call.
+    /// The request builder for [Grafeas::create_occurrence][super::super::client::Grafeas::create_occurrence] calls.
     #[derive(Clone, Debug)]
     pub struct CreateOccurrence(RequestBuilder<crate::model::CreateOccurrenceRequest>);
 
@@ -283,7 +283,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::batch_create_occurrences call.
+    /// The request builder for [Grafeas::batch_create_occurrences][super::super::client::Grafeas::batch_create_occurrences] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateOccurrences(RequestBuilder<crate::model::BatchCreateOccurrencesRequest>);
 
@@ -339,7 +339,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::update_occurrence call.
+    /// The request builder for [Grafeas::update_occurrence][super::super::client::Grafeas::update_occurrence] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateOccurrence(RequestBuilder<crate::model::UpdateOccurrenceRequest>);
 
@@ -402,7 +402,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::get_occurrence_note call.
+    /// The request builder for [Grafeas::get_occurrence_note][super::super::client::Grafeas::get_occurrence_note] calls.
     #[derive(Clone, Debug)]
     pub struct GetOccurrenceNote(RequestBuilder<crate::model::GetOccurrenceNoteRequest>);
 
@@ -447,7 +447,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::get_note call.
+    /// The request builder for [Grafeas::get_note][super::super::client::Grafeas::get_note] calls.
     #[derive(Clone, Debug)]
     pub struct GetNote(RequestBuilder<crate::model::GetNoteRequest>);
 
@@ -489,7 +489,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::list_notes call.
+    /// The request builder for [Grafeas::list_notes][super::super::client::Grafeas::list_notes] calls.
     #[derive(Clone, Debug)]
     pub struct ListNotes(RequestBuilder<crate::model::ListNotesRequest>);
 
@@ -563,7 +563,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::delete_note call.
+    /// The request builder for [Grafeas::delete_note][super::super::client::Grafeas::delete_note] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNote(RequestBuilder<crate::model::DeleteNoteRequest>);
 
@@ -605,7 +605,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::create_note call.
+    /// The request builder for [Grafeas::create_note][super::super::client::Grafeas::create_note] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNote(RequestBuilder<crate::model::CreateNoteRequest>);
 
@@ -659,7 +659,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::batch_create_notes call.
+    /// The request builder for [Grafeas::batch_create_notes][super::super::client::Grafeas::batch_create_notes] calls.
     #[derive(Clone, Debug)]
     pub struct BatchCreateNotes(RequestBuilder<crate::model::BatchCreateNotesRequest>);
 
@@ -715,7 +715,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::update_note call.
+    /// The request builder for [Grafeas::update_note][super::super::client::Grafeas::update_note] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNote(RequestBuilder<crate::model::UpdateNoteRequest>);
 
@@ -772,7 +772,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for a Grafeas::list_note_occurrences call.
+    /// The request builder for [Grafeas::list_note_occurrences][super::super::client::Grafeas::list_note_occurrences] calls.
     #[derive(Clone, Debug)]
     pub struct ListNoteOccurrences(RequestBuilder<crate::model::ListNoteOccurrencesRequest>);
 

--- a/src/generated/iam/admin/v1/src/builder.rs
+++ b/src/generated/iam/admin/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::list_service_accounts call.
+    /// The request builder for [Iam::list_service_accounts][super::super::client::Iam::list_service_accounts] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceAccounts(RequestBuilder<crate::model::ListServiceAccountsRequest>);
 
@@ -139,7 +139,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::get_service_account call.
+    /// The request builder for [Iam::get_service_account][super::super::client::Iam::get_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceAccount(RequestBuilder<crate::model::GetServiceAccountRequest>);
 
@@ -184,7 +184,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::create_service_account call.
+    /// The request builder for [Iam::create_service_account][super::super::client::Iam::create_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceAccount(RequestBuilder<crate::model::CreateServiceAccountRequest>);
 
@@ -244,7 +244,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::update_service_account call.
+    /// The request builder for [Iam::update_service_account][super::super::client::Iam::update_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServiceAccount(RequestBuilder<crate::model::ServiceAccount>);
 
@@ -334,7 +334,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::patch_service_account call.
+    /// The request builder for [Iam::patch_service_account][super::super::client::Iam::patch_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct PatchServiceAccount(RequestBuilder<crate::model::PatchServiceAccountRequest>);
 
@@ -391,7 +391,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::delete_service_account call.
+    /// The request builder for [Iam::delete_service_account][super::super::client::Iam::delete_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceAccount(RequestBuilder<crate::model::DeleteServiceAccountRequest>);
 
@@ -436,7 +436,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::undelete_service_account call.
+    /// The request builder for [Iam::undelete_service_account][super::super::client::Iam::undelete_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteServiceAccount(RequestBuilder<crate::model::UndeleteServiceAccountRequest>);
 
@@ -481,7 +481,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::enable_service_account call.
+    /// The request builder for [Iam::enable_service_account][super::super::client::Iam::enable_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct EnableServiceAccount(RequestBuilder<crate::model::EnableServiceAccountRequest>);
 
@@ -526,7 +526,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::disable_service_account call.
+    /// The request builder for [Iam::disable_service_account][super::super::client::Iam::disable_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct DisableServiceAccount(RequestBuilder<crate::model::DisableServiceAccountRequest>);
 
@@ -571,7 +571,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::list_service_account_keys call.
+    /// The request builder for [Iam::list_service_account_keys][super::super::client::Iam::list_service_account_keys] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceAccountKeys(RequestBuilder<crate::model::ListServiceAccountKeysRequest>);
 
@@ -627,7 +627,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::get_service_account_key call.
+    /// The request builder for [Iam::get_service_account_key][super::super::client::Iam::get_service_account_key] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceAccountKey(RequestBuilder<crate::model::GetServiceAccountKeyRequest>);
 
@@ -681,7 +681,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::create_service_account_key call.
+    /// The request builder for [Iam::create_service_account_key][super::super::client::Iam::create_service_account_key] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceAccountKey(
         RequestBuilder<crate::model::CreateServiceAccountKeyRequest>,
@@ -746,7 +746,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::upload_service_account_key call.
+    /// The request builder for [Iam::upload_service_account_key][super::super::client::Iam::upload_service_account_key] calls.
     #[derive(Clone, Debug)]
     pub struct UploadServiceAccountKey(
         RequestBuilder<crate::model::UploadServiceAccountKeyRequest>,
@@ -799,7 +799,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::delete_service_account_key call.
+    /// The request builder for [Iam::delete_service_account_key][super::super::client::Iam::delete_service_account_key] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceAccountKey(
         RequestBuilder<crate::model::DeleteServiceAccountKeyRequest>,
@@ -846,7 +846,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::disable_service_account_key call.
+    /// The request builder for [Iam::disable_service_account_key][super::super::client::Iam::disable_service_account_key] calls.
     #[derive(Clone, Debug)]
     pub struct DisableServiceAccountKey(
         RequestBuilder<crate::model::DisableServiceAccountKeyRequest>,
@@ -893,7 +893,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::enable_service_account_key call.
+    /// The request builder for [Iam::enable_service_account_key][super::super::client::Iam::enable_service_account_key] calls.
     #[derive(Clone, Debug)]
     pub struct EnableServiceAccountKey(
         RequestBuilder<crate::model::EnableServiceAccountKeyRequest>,
@@ -940,7 +940,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::sign_blob call.
+    /// The request builder for [Iam::sign_blob][super::super::client::Iam::sign_blob] calls.
     #[derive(Clone, Debug)]
     pub struct SignBlob(RequestBuilder<crate::model::SignBlobRequest>);
 
@@ -988,7 +988,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::sign_jwt call.
+    /// The request builder for [Iam::sign_jwt][super::super::client::Iam::sign_jwt] calls.
     #[derive(Clone, Debug)]
     pub struct SignJwt(RequestBuilder<crate::model::SignJwtRequest>);
 
@@ -1036,7 +1036,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::get_iam_policy call.
+    /// The request builder for [Iam::get_iam_policy][super::super::client::Iam::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1087,7 +1087,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::set_iam_policy call.
+    /// The request builder for [Iam::set_iam_policy][super::super::client::Iam::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1147,7 +1147,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::test_iam_permissions call.
+    /// The request builder for [Iam::test_iam_permissions][super::super::client::Iam::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1203,7 +1203,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::query_grantable_roles call.
+    /// The request builder for [Iam::query_grantable_roles][super::super::client::Iam::query_grantable_roles] calls.
     #[derive(Clone, Debug)]
     pub struct QueryGrantableRoles(RequestBuilder<crate::model::QueryGrantableRolesRequest>);
 
@@ -1281,7 +1281,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::list_roles call.
+    /// The request builder for [Iam::list_roles][super::super::client::Iam::list_roles] calls.
     #[derive(Clone, Debug)]
     pub struct ListRoles(RequestBuilder<crate::model::ListRolesRequest>);
 
@@ -1361,7 +1361,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::get_role call.
+    /// The request builder for [Iam::get_role][super::super::client::Iam::get_role] calls.
     #[derive(Clone, Debug)]
     pub struct GetRole(RequestBuilder<crate::model::GetRoleRequest>);
 
@@ -1403,7 +1403,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::create_role call.
+    /// The request builder for [Iam::create_role][super::super::client::Iam::create_role] calls.
     #[derive(Clone, Debug)]
     pub struct CreateRole(RequestBuilder<crate::model::CreateRoleRequest>);
 
@@ -1457,7 +1457,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::update_role call.
+    /// The request builder for [Iam::update_role][super::super::client::Iam::update_role] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateRole(RequestBuilder<crate::model::UpdateRoleRequest>);
 
@@ -1514,7 +1514,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::delete_role call.
+    /// The request builder for [Iam::delete_role][super::super::client::Iam::delete_role] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteRole(RequestBuilder<crate::model::DeleteRoleRequest>);
 
@@ -1562,7 +1562,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::undelete_role call.
+    /// The request builder for [Iam::undelete_role][super::super::client::Iam::undelete_role] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteRole(RequestBuilder<crate::model::UndeleteRoleRequest>);
 
@@ -1610,7 +1610,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::query_testable_permissions call.
+    /// The request builder for [Iam::query_testable_permissions][super::super::client::Iam::query_testable_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct QueryTestablePermissions(
         RequestBuilder<crate::model::QueryTestablePermissionsRequest>,
@@ -1686,7 +1686,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::query_auditable_services call.
+    /// The request builder for [Iam::query_auditable_services][super::super::client::Iam::query_auditable_services] calls.
     #[derive(Clone, Debug)]
     pub struct QueryAuditableServices(RequestBuilder<crate::model::QueryAuditableServicesRequest>);
 
@@ -1731,7 +1731,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for a Iam::lint_policy call.
+    /// The request builder for [Iam::lint_policy][super::super::client::Iam::lint_policy] calls.
     #[derive(Clone, Debug)]
     pub struct LintPolicy(RequestBuilder<crate::model::LintPolicyRequest>);
 

--- a/src/generated/iam/credentials/v1/src/builder.rs
+++ b/src/generated/iam/credentials/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// The request builder for a IAMCredentials::generate_access_token call.
+    /// The request builder for [IAMCredentials::generate_access_token][super::super::client::IAMCredentials::generate_access_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateAccessToken(RequestBuilder<crate::model::GenerateAccessTokenRequest>);
 
@@ -140,7 +140,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// The request builder for a IAMCredentials::generate_id_token call.
+    /// The request builder for [IAMCredentials::generate_id_token][super::super::client::IAMCredentials::generate_id_token] calls.
     #[derive(Clone, Debug)]
     pub struct GenerateIdToken(RequestBuilder<crate::model::GenerateIdTokenRequest>);
 
@@ -205,7 +205,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// The request builder for a IAMCredentials::sign_blob call.
+    /// The request builder for [IAMCredentials::sign_blob][super::super::client::IAMCredentials::sign_blob] calls.
     #[derive(Clone, Debug)]
     pub struct SignBlob(RequestBuilder<crate::model::SignBlobRequest>);
 
@@ -264,7 +264,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// The request builder for a IAMCredentials::sign_jwt call.
+    /// The request builder for [IAMCredentials::sign_jwt][super::super::client::IAMCredentials::sign_jwt] calls.
     #[derive(Clone, Debug)]
     pub struct SignJwt(RequestBuilder<crate::model::SignJwtRequest>);
 

--- a/src/generated/iam/v1/src/builder.rs
+++ b/src/generated/iam/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for a IAMPolicy::set_iam_policy call.
+    /// The request builder for [IAMPolicy::set_iam_policy][super::super::client::IAMPolicy::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -127,7 +127,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for a IAMPolicy::get_iam_policy call.
+    /// The request builder for [IAMPolicy::get_iam_policy][super::super::client::IAMPolicy::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<crate::model::GetIamPolicyRequest>);
 
@@ -178,7 +178,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for a IAMPolicy::test_iam_permissions call.
+    /// The request builder for [IAMPolicy::test_iam_permissions][super::super::client::IAMPolicy::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 

--- a/src/generated/iam/v2/src/builder.rs
+++ b/src/generated/iam/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for a Policies::list_policies call.
+    /// The request builder for [Policies::list_policies][super::super::client::Policies::list_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListPolicies(RequestBuilder<crate::model::ListPoliciesRequest>);
 
@@ -136,7 +136,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for a Policies::get_policy call.
+    /// The request builder for [Policies::get_policy][super::super::client::Policies::get_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetPolicy(RequestBuilder<crate::model::GetPolicyRequest>);
 
@@ -178,7 +178,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for a Policies::create_policy call.
+    /// The request builder for [Policies::create_policy][super::super::client::Policies::create_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePolicy(RequestBuilder<crate::model::CreatePolicyRequest>);
 
@@ -273,7 +273,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for a Policies::update_policy call.
+    /// The request builder for [Policies::update_policy][super::super::client::Policies::update_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePolicy(RequestBuilder<crate::model::UpdatePolicyRequest>);
 
@@ -356,7 +356,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for a Policies::delete_policy call.
+    /// The request builder for [Policies::delete_policy][super::super::client::Policies::delete_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePolicy(RequestBuilder<crate::model::DeletePolicyRequest>);
 
@@ -442,7 +442,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for a Policies::get_operation call.
+    /// The request builder for [Policies::get_operation][super::super::client::Policies::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/iam/v3/src/builder.rs
+++ b/src/generated/iam/v3/src/builder.rs
@@ -67,7 +67,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for a PolicyBindings::create_policy_binding call.
+    /// The request builder for [PolicyBindings::create_policy_binding][super::super::client::PolicyBindings::create_policy_binding] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePolicyBinding(RequestBuilder<crate::model::CreatePolicyBindingRequest>);
 
@@ -172,7 +172,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for a PolicyBindings::get_policy_binding call.
+    /// The request builder for [PolicyBindings::get_policy_binding][super::super::client::PolicyBindings::get_policy_binding] calls.
     #[derive(Clone, Debug)]
     pub struct GetPolicyBinding(RequestBuilder<crate::model::GetPolicyBindingRequest>);
 
@@ -217,7 +217,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for a PolicyBindings::update_policy_binding call.
+    /// The request builder for [PolicyBindings::update_policy_binding][super::super::client::PolicyBindings::update_policy_binding] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePolicyBinding(RequestBuilder<crate::model::UpdatePolicyBindingRequest>);
 
@@ -319,7 +319,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for a PolicyBindings::delete_policy_binding call.
+    /// The request builder for [PolicyBindings::delete_policy_binding][super::super::client::PolicyBindings::delete_policy_binding] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePolicyBinding(RequestBuilder<crate::model::DeletePolicyBindingRequest>);
 
@@ -411,7 +411,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for a PolicyBindings::list_policy_bindings call.
+    /// The request builder for [PolicyBindings::list_policy_bindings][super::super::client::PolicyBindings::list_policy_bindings] calls.
     #[derive(Clone, Debug)]
     pub struct ListPolicyBindings(RequestBuilder<crate::model::ListPolicyBindingsRequest>);
 
@@ -489,7 +489,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for a PolicyBindings::search_target_policy_bindings call.
+    /// The request builder for [PolicyBindings::search_target_policy_bindings][super::super::client::PolicyBindings::search_target_policy_bindings] calls.
     #[derive(Clone, Debug)]
     pub struct SearchTargetPolicyBindings(
         RequestBuilder<crate::model::SearchTargetPolicyBindingsRequest>,
@@ -571,7 +571,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for a PolicyBindings::get_operation call.
+    /// The request builder for [PolicyBindings::get_operation][super::super::client::PolicyBindings::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -672,7 +672,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for a PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy call.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreatePrincipalAccessBoundaryPolicy(
         RequestBuilder<crate::model::CreatePrincipalAccessBoundaryPolicyRequest>,
@@ -788,7 +788,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for a PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy call.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetPrincipalAccessBoundaryPolicy(
         RequestBuilder<crate::model::GetPrincipalAccessBoundaryPolicyRequest>,
@@ -837,7 +837,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for a PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy call.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdatePrincipalAccessBoundaryPolicy(
         RequestBuilder<crate::model::UpdatePrincipalAccessBoundaryPolicyRequest>,
@@ -947,7 +947,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for a PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy call.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeletePrincipalAccessBoundaryPolicy(
         RequestBuilder<crate::model::DeletePrincipalAccessBoundaryPolicyRequest>,
@@ -1049,7 +1049,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for a PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies call.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies][super::super::client::PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListPrincipalAccessBoundaryPolicies(
         RequestBuilder<crate::model::ListPrincipalAccessBoundaryPoliciesRequest>,
@@ -1129,7 +1129,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for a PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings call.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings][super::super::client::PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings] calls.
     #[derive(Clone, Debug)]
     pub struct SearchPrincipalAccessBoundaryPolicyBindings(
         RequestBuilder<crate::model::SearchPrincipalAccessBoundaryPolicyBindingsRequest>,
@@ -1211,7 +1211,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for a PrincipalAccessBoundaryPolicies::get_operation call.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::get_operation][super::super::client::PrincipalAccessBoundaryPolicies::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/identity/accesscontextmanager/v1/src/builder.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::list_access_policies call.
+    /// The request builder for [AccessContextManager::list_access_policies][super::super::client::AccessContextManager::list_access_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListAccessPolicies(RequestBuilder<crate::model::ListAccessPoliciesRequest>);
 
@@ -143,7 +143,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::get_access_policy call.
+    /// The request builder for [AccessContextManager::get_access_policy][super::super::client::AccessContextManager::get_access_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetAccessPolicy(RequestBuilder<crate::model::GetAccessPolicyRequest>);
 
@@ -187,7 +187,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::create_access_policy call.
+    /// The request builder for [AccessContextManager::create_access_policy][super::super::client::AccessContextManager::create_access_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAccessPolicy(RequestBuilder<crate::model::AccessPolicy>);
 
@@ -321,7 +321,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::update_access_policy call.
+    /// The request builder for [AccessContextManager::update_access_policy][super::super::client::AccessContextManager::update_access_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAccessPolicy(RequestBuilder<crate::model::UpdateAccessPolicyRequest>);
 
@@ -423,7 +423,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::delete_access_policy call.
+    /// The request builder for [AccessContextManager::delete_access_policy][super::super::client::AccessContextManager::delete_access_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAccessPolicy(RequestBuilder<crate::model::DeleteAccessPolicyRequest>);
 
@@ -509,7 +509,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::list_access_levels call.
+    /// The request builder for [AccessContextManager::list_access_levels][super::super::client::AccessContextManager::list_access_levels] calls.
     #[derive(Clone, Debug)]
     pub struct ListAccessLevels(RequestBuilder<crate::model::ListAccessLevelsRequest>);
 
@@ -589,7 +589,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::get_access_level call.
+    /// The request builder for [AccessContextManager::get_access_level][super::super::client::AccessContextManager::get_access_level] calls.
     #[derive(Clone, Debug)]
     pub struct GetAccessLevel(RequestBuilder<crate::model::GetAccessLevelRequest>);
 
@@ -639,7 +639,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::create_access_level call.
+    /// The request builder for [AccessContextManager::create_access_level][super::super::client::AccessContextManager::create_access_level] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAccessLevel(RequestBuilder<crate::model::CreateAccessLevelRequest>);
 
@@ -738,7 +738,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::update_access_level call.
+    /// The request builder for [AccessContextManager::update_access_level][super::super::client::AccessContextManager::update_access_level] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAccessLevel(RequestBuilder<crate::model::UpdateAccessLevelRequest>);
 
@@ -840,7 +840,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::delete_access_level call.
+    /// The request builder for [AccessContextManager::delete_access_level][super::super::client::AccessContextManager::delete_access_level] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAccessLevel(RequestBuilder<crate::model::DeleteAccessLevelRequest>);
 
@@ -926,7 +926,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::replace_access_levels call.
+    /// The request builder for [AccessContextManager::replace_access_levels][super::super::client::AccessContextManager::replace_access_levels] calls.
     #[derive(Clone, Debug)]
     pub struct ReplaceAccessLevels(RequestBuilder<crate::model::ReplaceAccessLevelsRequest>);
 
@@ -1033,7 +1033,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::list_service_perimeters call.
+    /// The request builder for [AccessContextManager::list_service_perimeters][super::super::client::AccessContextManager::list_service_perimeters] calls.
     #[derive(Clone, Debug)]
     pub struct ListServicePerimeters(RequestBuilder<crate::model::ListServicePerimetersRequest>);
 
@@ -1107,7 +1107,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::get_service_perimeter call.
+    /// The request builder for [AccessContextManager::get_service_perimeter][super::super::client::AccessContextManager::get_service_perimeter] calls.
     #[derive(Clone, Debug)]
     pub struct GetServicePerimeter(RequestBuilder<crate::model::GetServicePerimeterRequest>);
 
@@ -1154,7 +1154,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::create_service_perimeter call.
+    /// The request builder for [AccessContextManager::create_service_perimeter][super::super::client::AccessContextManager::create_service_perimeter] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServicePerimeter(RequestBuilder<crate::model::CreateServicePerimeterRequest>);
 
@@ -1255,7 +1255,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::update_service_perimeter call.
+    /// The request builder for [AccessContextManager::update_service_perimeter][super::super::client::AccessContextManager::update_service_perimeter] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServicePerimeter(RequestBuilder<crate::model::UpdateServicePerimeterRequest>);
 
@@ -1359,7 +1359,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::delete_service_perimeter call.
+    /// The request builder for [AccessContextManager::delete_service_perimeter][super::super::client::AccessContextManager::delete_service_perimeter] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServicePerimeter(RequestBuilder<crate::model::DeleteServicePerimeterRequest>);
 
@@ -1445,7 +1445,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::replace_service_perimeters call.
+    /// The request builder for [AccessContextManager::replace_service_perimeters][super::super::client::AccessContextManager::replace_service_perimeters] calls.
     #[derive(Clone, Debug)]
     pub struct ReplaceServicePerimeters(
         RequestBuilder<crate::model::ReplaceServicePerimetersRequest>,
@@ -1554,7 +1554,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::commit_service_perimeters call.
+    /// The request builder for [AccessContextManager::commit_service_perimeters][super::super::client::AccessContextManager::commit_service_perimeters] calls.
     #[derive(Clone, Debug)]
     pub struct CommitServicePerimeters(
         RequestBuilder<crate::model::CommitServicePerimetersRequest>,
@@ -1652,7 +1652,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::list_gcp_user_access_bindings call.
+    /// The request builder for [AccessContextManager::list_gcp_user_access_bindings][super::super::client::AccessContextManager::list_gcp_user_access_bindings] calls.
     #[derive(Clone, Debug)]
     pub struct ListGcpUserAccessBindings(
         RequestBuilder<crate::model::ListGcpUserAccessBindingsRequest>,
@@ -1730,7 +1730,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::get_gcp_user_access_binding call.
+    /// The request builder for [AccessContextManager::get_gcp_user_access_binding][super::super::client::AccessContextManager::get_gcp_user_access_binding] calls.
     #[derive(Clone, Debug)]
     pub struct GetGcpUserAccessBinding(
         RequestBuilder<crate::model::GetGcpUserAccessBindingRequest>,
@@ -1779,7 +1779,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::create_gcp_user_access_binding call.
+    /// The request builder for [AccessContextManager::create_gcp_user_access_binding][super::super::client::AccessContextManager::create_gcp_user_access_binding] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGcpUserAccessBinding(
         RequestBuilder<crate::model::CreateGcpUserAccessBindingRequest>,
@@ -1882,7 +1882,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::update_gcp_user_access_binding call.
+    /// The request builder for [AccessContextManager::update_gcp_user_access_binding][super::super::client::AccessContextManager::update_gcp_user_access_binding] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGcpUserAccessBinding(
         RequestBuilder<crate::model::UpdateGcpUserAccessBindingRequest>,
@@ -1988,7 +1988,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::delete_gcp_user_access_binding call.
+    /// The request builder for [AccessContextManager::delete_gcp_user_access_binding][super::super::client::AccessContextManager::delete_gcp_user_access_binding] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGcpUserAccessBinding(
         RequestBuilder<crate::model::DeleteGcpUserAccessBindingRequest>,
@@ -2076,7 +2076,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::set_iam_policy call.
+    /// The request builder for [AccessContextManager::set_iam_policy][super::super::client::AccessContextManager::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2138,7 +2138,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::get_iam_policy call.
+    /// The request builder for [AccessContextManager::get_iam_policy][super::super::client::AccessContextManager::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2191,7 +2191,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::test_iam_permissions call.
+    /// The request builder for [AccessContextManager::test_iam_permissions][super::super::client::AccessContextManager::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2249,7 +2249,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for a AccessContextManager::get_operation call.
+    /// The request builder for [AccessContextManager::get_operation][super::super::client::AccessContextManager::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/logging/v2/src/builder.rs
+++ b/src/generated/logging/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for a LoggingServiceV2::delete_log call.
+    /// The request builder for [LoggingServiceV2::delete_log][super::super::client::LoggingServiceV2::delete_log] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLog(RequestBuilder<crate::model::DeleteLogRequest>);
 
@@ -109,7 +109,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for a LoggingServiceV2::write_log_entries call.
+    /// The request builder for [LoggingServiceV2::write_log_entries][super::super::client::LoggingServiceV2::write_log_entries] calls.
     #[derive(Clone, Debug)]
     pub struct WriteLogEntries(RequestBuilder<crate::model::WriteLogEntriesRequest>);
 
@@ -194,7 +194,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for a LoggingServiceV2::list_log_entries call.
+    /// The request builder for [LoggingServiceV2::list_log_entries][super::super::client::LoggingServiceV2::list_log_entries] calls.
     #[derive(Clone, Debug)]
     pub struct ListLogEntries(RequestBuilder<crate::model::ListLogEntriesRequest>);
 
@@ -280,7 +280,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for a LoggingServiceV2::list_monitored_resource_descriptors call.
+    /// The request builder for [LoggingServiceV2::list_monitored_resource_descriptors][super::super::client::LoggingServiceV2::list_monitored_resource_descriptors] calls.
     #[derive(Clone, Debug)]
     pub struct ListMonitoredResourceDescriptors(
         RequestBuilder<crate::model::ListMonitoredResourceDescriptorsRequest>,
@@ -350,7 +350,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for a LoggingServiceV2::list_logs call.
+    /// The request builder for [LoggingServiceV2::list_logs][super::super::client::LoggingServiceV2::list_logs] calls.
     #[derive(Clone, Debug)]
     pub struct ListLogs(RequestBuilder<crate::model::ListLogsRequest>);
 
@@ -415,7 +415,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for a LoggingServiceV2::list_operations call.
+    /// The request builder for [LoggingServiceV2::list_operations][super::super::client::LoggingServiceV2::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -493,7 +493,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for a LoggingServiceV2::get_operation call.
+    /// The request builder for [LoggingServiceV2::get_operation][super::super::client::LoggingServiceV2::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -538,7 +538,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for a LoggingServiceV2::cancel_operation call.
+    /// The request builder for [LoggingServiceV2::cancel_operation][super::super::client::LoggingServiceV2::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -637,7 +637,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::list_buckets call.
+    /// The request builder for [ConfigServiceV2::list_buckets][super::super::client::ConfigServiceV2::list_buckets] calls.
     #[derive(Clone, Debug)]
     pub struct ListBuckets(RequestBuilder<crate::model::ListBucketsRequest>);
 
@@ -706,7 +706,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::get_bucket call.
+    /// The request builder for [ConfigServiceV2::get_bucket][super::super::client::ConfigServiceV2::get_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct GetBucket(RequestBuilder<crate::model::GetBucketRequest>);
 
@@ -748,7 +748,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::create_bucket_async call.
+    /// The request builder for [ConfigServiceV2::create_bucket_async][super::super::client::ConfigServiceV2::create_bucket_async] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBucketAsync(RequestBuilder<crate::model::CreateBucketRequest>);
 
@@ -842,7 +842,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::update_bucket_async call.
+    /// The request builder for [ConfigServiceV2::update_bucket_async][super::super::client::ConfigServiceV2::update_bucket_async] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBucketAsync(RequestBuilder<crate::model::UpdateBucketRequest>);
 
@@ -939,7 +939,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::create_bucket call.
+    /// The request builder for [ConfigServiceV2::create_bucket][super::super::client::ConfigServiceV2::create_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBucket(RequestBuilder<crate::model::CreateBucketRequest>);
 
@@ -996,7 +996,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::update_bucket call.
+    /// The request builder for [ConfigServiceV2::update_bucket][super::super::client::ConfigServiceV2::update_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBucket(RequestBuilder<crate::model::UpdateBucketRequest>);
 
@@ -1056,7 +1056,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::delete_bucket call.
+    /// The request builder for [ConfigServiceV2::delete_bucket][super::super::client::ConfigServiceV2::delete_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBucket(RequestBuilder<crate::model::DeleteBucketRequest>);
 
@@ -1098,7 +1098,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::undelete_bucket call.
+    /// The request builder for [ConfigServiceV2::undelete_bucket][super::super::client::ConfigServiceV2::undelete_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct UndeleteBucket(RequestBuilder<crate::model::UndeleteBucketRequest>);
 
@@ -1140,7 +1140,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::list_views call.
+    /// The request builder for [ConfigServiceV2::list_views][super::super::client::ConfigServiceV2::list_views] calls.
     #[derive(Clone, Debug)]
     pub struct ListViews(RequestBuilder<crate::model::ListViewsRequest>);
 
@@ -1208,7 +1208,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::get_view call.
+    /// The request builder for [ConfigServiceV2::get_view][super::super::client::ConfigServiceV2::get_view] calls.
     #[derive(Clone, Debug)]
     pub struct GetView(RequestBuilder<crate::model::GetViewRequest>);
 
@@ -1250,7 +1250,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::create_view call.
+    /// The request builder for [ConfigServiceV2::create_view][super::super::client::ConfigServiceV2::create_view] calls.
     #[derive(Clone, Debug)]
     pub struct CreateView(RequestBuilder<crate::model::CreateViewRequest>);
 
@@ -1307,7 +1307,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::update_view call.
+    /// The request builder for [ConfigServiceV2::update_view][super::super::client::ConfigServiceV2::update_view] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateView(RequestBuilder<crate::model::UpdateViewRequest>);
 
@@ -1367,7 +1367,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::delete_view call.
+    /// The request builder for [ConfigServiceV2::delete_view][super::super::client::ConfigServiceV2::delete_view] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteView(RequestBuilder<crate::model::DeleteViewRequest>);
 
@@ -1409,7 +1409,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::list_sinks call.
+    /// The request builder for [ConfigServiceV2::list_sinks][super::super::client::ConfigServiceV2::list_sinks] calls.
     #[derive(Clone, Debug)]
     pub struct ListSinks(RequestBuilder<crate::model::ListSinksRequest>);
 
@@ -1477,7 +1477,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::get_sink call.
+    /// The request builder for [ConfigServiceV2::get_sink][super::super::client::ConfigServiceV2::get_sink] calls.
     #[derive(Clone, Debug)]
     pub struct GetSink(RequestBuilder<crate::model::GetSinkRequest>);
 
@@ -1519,7 +1519,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::create_sink call.
+    /// The request builder for [ConfigServiceV2::create_sink][super::super::client::ConfigServiceV2::create_sink] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSink(RequestBuilder<crate::model::CreateSinkRequest>);
 
@@ -1576,7 +1576,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::update_sink call.
+    /// The request builder for [ConfigServiceV2::update_sink][super::super::client::ConfigServiceV2::update_sink] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSink(RequestBuilder<crate::model::UpdateSinkRequest>);
 
@@ -1642,7 +1642,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::delete_sink call.
+    /// The request builder for [ConfigServiceV2::delete_sink][super::super::client::ConfigServiceV2::delete_sink] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSink(RequestBuilder<crate::model::DeleteSinkRequest>);
 
@@ -1684,7 +1684,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::create_link call.
+    /// The request builder for [ConfigServiceV2::create_link][super::super::client::ConfigServiceV2::create_link] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLink(RequestBuilder<crate::model::CreateLinkRequest>);
 
@@ -1773,7 +1773,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::delete_link call.
+    /// The request builder for [ConfigServiceV2::delete_link][super::super::client::ConfigServiceV2::delete_link] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLink(RequestBuilder<crate::model::DeleteLinkRequest>);
 
@@ -1850,7 +1850,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::list_links call.
+    /// The request builder for [ConfigServiceV2::list_links][super::super::client::ConfigServiceV2::list_links] calls.
     #[derive(Clone, Debug)]
     pub struct ListLinks(RequestBuilder<crate::model::ListLinksRequest>);
 
@@ -1918,7 +1918,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::get_link call.
+    /// The request builder for [ConfigServiceV2::get_link][super::super::client::ConfigServiceV2::get_link] calls.
     #[derive(Clone, Debug)]
     pub struct GetLink(RequestBuilder<crate::model::GetLinkRequest>);
 
@@ -1960,7 +1960,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::list_exclusions call.
+    /// The request builder for [ConfigServiceV2::list_exclusions][super::super::client::ConfigServiceV2::list_exclusions] calls.
     #[derive(Clone, Debug)]
     pub struct ListExclusions(RequestBuilder<crate::model::ListExclusionsRequest>);
 
@@ -2029,7 +2029,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::get_exclusion call.
+    /// The request builder for [ConfigServiceV2::get_exclusion][super::super::client::ConfigServiceV2::get_exclusion] calls.
     #[derive(Clone, Debug)]
     pub struct GetExclusion(RequestBuilder<crate::model::GetExclusionRequest>);
 
@@ -2071,7 +2071,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::create_exclusion call.
+    /// The request builder for [ConfigServiceV2::create_exclusion][super::super::client::ConfigServiceV2::create_exclusion] calls.
     #[derive(Clone, Debug)]
     pub struct CreateExclusion(RequestBuilder<crate::model::CreateExclusionRequest>);
 
@@ -2122,7 +2122,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::update_exclusion call.
+    /// The request builder for [ConfigServiceV2::update_exclusion][super::super::client::ConfigServiceV2::update_exclusion] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateExclusion(RequestBuilder<crate::model::UpdateExclusionRequest>);
 
@@ -2182,7 +2182,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::delete_exclusion call.
+    /// The request builder for [ConfigServiceV2::delete_exclusion][super::super::client::ConfigServiceV2::delete_exclusion] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteExclusion(RequestBuilder<crate::model::DeleteExclusionRequest>);
 
@@ -2224,7 +2224,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::get_cmek_settings call.
+    /// The request builder for [ConfigServiceV2::get_cmek_settings][super::super::client::ConfigServiceV2::get_cmek_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetCmekSettings(RequestBuilder<crate::model::GetCmekSettingsRequest>);
 
@@ -2266,7 +2266,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::update_cmek_settings call.
+    /// The request builder for [ConfigServiceV2::update_cmek_settings][super::super::client::ConfigServiceV2::update_cmek_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateCmekSettings(RequestBuilder<crate::model::UpdateCmekSettingsRequest>);
 
@@ -2329,7 +2329,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::get_settings call.
+    /// The request builder for [ConfigServiceV2::get_settings][super::super::client::ConfigServiceV2::get_settings] calls.
     #[derive(Clone, Debug)]
     pub struct GetSettings(RequestBuilder<crate::model::GetSettingsRequest>);
 
@@ -2371,7 +2371,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::update_settings call.
+    /// The request builder for [ConfigServiceV2::update_settings][super::super::client::ConfigServiceV2::update_settings] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSettings(RequestBuilder<crate::model::UpdateSettingsRequest>);
 
@@ -2431,7 +2431,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::copy_log_entries call.
+    /// The request builder for [ConfigServiceV2::copy_log_entries][super::super::client::ConfigServiceV2::copy_log_entries] calls.
     #[derive(Clone, Debug)]
     pub struct CopyLogEntries(RequestBuilder<crate::model::CopyLogEntriesRequest>);
 
@@ -2526,7 +2526,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::list_operations call.
+    /// The request builder for [ConfigServiceV2::list_operations][super::super::client::ConfigServiceV2::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2604,7 +2604,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::get_operation call.
+    /// The request builder for [ConfigServiceV2::get_operation][super::super::client::ConfigServiceV2::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2649,7 +2649,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for a ConfigServiceV2::cancel_operation call.
+    /// The request builder for [ConfigServiceV2::cancel_operation][super::super::client::ConfigServiceV2::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2748,7 +2748,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for a MetricsServiceV2::list_log_metrics call.
+    /// The request builder for [MetricsServiceV2::list_log_metrics][super::super::client::MetricsServiceV2::list_log_metrics] calls.
     #[derive(Clone, Debug)]
     pub struct ListLogMetrics(RequestBuilder<crate::model::ListLogMetricsRequest>);
 
@@ -2817,7 +2817,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for a MetricsServiceV2::get_log_metric call.
+    /// The request builder for [MetricsServiceV2::get_log_metric][super::super::client::MetricsServiceV2::get_log_metric] calls.
     #[derive(Clone, Debug)]
     pub struct GetLogMetric(RequestBuilder<crate::model::GetLogMetricRequest>);
 
@@ -2859,7 +2859,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for a MetricsServiceV2::create_log_metric call.
+    /// The request builder for [MetricsServiceV2::create_log_metric][super::super::client::MetricsServiceV2::create_log_metric] calls.
     #[derive(Clone, Debug)]
     pub struct CreateLogMetric(RequestBuilder<crate::model::CreateLogMetricRequest>);
 
@@ -2910,7 +2910,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for a MetricsServiceV2::update_log_metric call.
+    /// The request builder for [MetricsServiceV2::update_log_metric][super::super::client::MetricsServiceV2::update_log_metric] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateLogMetric(RequestBuilder<crate::model::UpdateLogMetricRequest>);
 
@@ -2961,7 +2961,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for a MetricsServiceV2::delete_log_metric call.
+    /// The request builder for [MetricsServiceV2::delete_log_metric][super::super::client::MetricsServiceV2::delete_log_metric] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteLogMetric(RequestBuilder<crate::model::DeleteLogMetricRequest>);
 
@@ -3003,7 +3003,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for a MetricsServiceV2::list_operations call.
+    /// The request builder for [MetricsServiceV2::list_operations][super::super::client::MetricsServiceV2::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3081,7 +3081,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for a MetricsServiceV2::get_operation call.
+    /// The request builder for [MetricsServiceV2::get_operation][super::super::client::MetricsServiceV2::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3126,7 +3126,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for a MetricsServiceV2::cancel_operation call.
+    /// The request builder for [MetricsServiceV2::cancel_operation][super::super::client::MetricsServiceV2::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/longrunning/src/builder.rs
+++ b/src/generated/longrunning/src/builder.rs
@@ -67,7 +67,7 @@ pub mod operations {
         }
     }
 
-    /// The request builder for a Operations::list_operations call.
+    /// The request builder for [Operations::list_operations][super::super::client::Operations::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<crate::model::ListOperationsRequest>);
 
@@ -142,7 +142,7 @@ pub mod operations {
         }
     }
 
-    /// The request builder for a Operations::get_operation call.
+    /// The request builder for [Operations::get_operation][super::super::client::Operations::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<crate::model::GetOperationRequest>);
 
@@ -184,7 +184,7 @@ pub mod operations {
         }
     }
 
-    /// The request builder for a Operations::delete_operation call.
+    /// The request builder for [Operations::delete_operation][super::super::client::Operations::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<crate::model::DeleteOperationRequest>);
 
@@ -226,7 +226,7 @@ pub mod operations {
         }
     }
 
-    /// The request builder for a Operations::cancel_operation call.
+    /// The request builder for [Operations::cancel_operation][super::super::client::Operations::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<crate::model::CancelOperationRequest>);
 

--- a/src/generated/monitoring/dashboard/v1/src/builder.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for a DashboardsService::create_dashboard call.
+    /// The request builder for [DashboardsService::create_dashboard][super::super::client::DashboardsService::create_dashboard] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDashboard(RequestBuilder<crate::model::CreateDashboardRequest>);
 
@@ -124,7 +124,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for a DashboardsService::list_dashboards call.
+    /// The request builder for [DashboardsService::list_dashboards][super::super::client::DashboardsService::list_dashboards] calls.
     #[derive(Clone, Debug)]
     pub struct ListDashboards(RequestBuilder<crate::model::ListDashboardsRequest>);
 
@@ -193,7 +193,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for a DashboardsService::get_dashboard call.
+    /// The request builder for [DashboardsService::get_dashboard][super::super::client::DashboardsService::get_dashboard] calls.
     #[derive(Clone, Debug)]
     pub struct GetDashboard(RequestBuilder<crate::model::GetDashboardRequest>);
 
@@ -235,7 +235,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for a DashboardsService::delete_dashboard call.
+    /// The request builder for [DashboardsService::delete_dashboard][super::super::client::DashboardsService::delete_dashboard] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDashboard(RequestBuilder<crate::model::DeleteDashboardRequest>);
 
@@ -277,7 +277,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for a DashboardsService::update_dashboard call.
+    /// The request builder for [DashboardsService::update_dashboard][super::super::client::DashboardsService::update_dashboard] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDashboard(RequestBuilder<crate::model::UpdateDashboardRequest>);
 

--- a/src/generated/monitoring/metricsscope/v1/src/builder.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for a MetricsScopes::get_metrics_scope call.
+    /// The request builder for [MetricsScopes::get_metrics_scope][super::super::client::MetricsScopes::get_metrics_scope] calls.
     #[derive(Clone, Debug)]
     pub struct GetMetricsScope(RequestBuilder<crate::model::GetMetricsScopeRequest>);
 
@@ -109,7 +109,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for a MetricsScopes::list_metrics_scopes_by_monitored_project call.
+    /// The request builder for [MetricsScopes::list_metrics_scopes_by_monitored_project][super::super::client::MetricsScopes::list_metrics_scopes_by_monitored_project] calls.
     #[derive(Clone, Debug)]
     pub struct ListMetricsScopesByMonitoredProject(
         RequestBuilder<crate::model::ListMetricsScopesByMonitoredProjectRequest>,
@@ -161,7 +161,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for a MetricsScopes::create_monitored_project call.
+    /// The request builder for [MetricsScopes::create_monitored_project][super::super::client::MetricsScopes::create_monitored_project] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMonitoredProject(RequestBuilder<crate::model::CreateMonitoredProjectRequest>);
 
@@ -256,7 +256,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for a MetricsScopes::delete_monitored_project call.
+    /// The request builder for [MetricsScopes::delete_monitored_project][super::super::client::MetricsScopes::delete_monitored_project] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMonitoredProject(RequestBuilder<crate::model::DeleteMonitoredProjectRequest>);
 
@@ -336,7 +336,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for a MetricsScopes::get_operation call.
+    /// The request builder for [MetricsScopes::get_operation][super::super::client::MetricsScopes::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/monitoring/v3/src/builder.rs
+++ b/src/generated/monitoring/v3/src/builder.rs
@@ -67,7 +67,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for a AlertPolicyService::list_alert_policies call.
+    /// The request builder for [AlertPolicyService::list_alert_policies][super::super::client::AlertPolicyService::list_alert_policies] calls.
     #[derive(Clone, Debug)]
     pub struct ListAlertPolicies(RequestBuilder<crate::model::ListAlertPoliciesRequest>);
 
@@ -151,7 +151,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for a AlertPolicyService::get_alert_policy call.
+    /// The request builder for [AlertPolicyService::get_alert_policy][super::super::client::AlertPolicyService::get_alert_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetAlertPolicy(RequestBuilder<crate::model::GetAlertPolicyRequest>);
 
@@ -193,7 +193,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for a AlertPolicyService::create_alert_policy call.
+    /// The request builder for [AlertPolicyService::create_alert_policy][super::super::client::AlertPolicyService::create_alert_policy] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAlertPolicy(RequestBuilder<crate::model::CreateAlertPolicyRequest>);
 
@@ -247,7 +247,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for a AlertPolicyService::delete_alert_policy call.
+    /// The request builder for [AlertPolicyService::delete_alert_policy][super::super::client::AlertPolicyService::delete_alert_policy] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAlertPolicy(RequestBuilder<crate::model::DeleteAlertPolicyRequest>);
 
@@ -292,7 +292,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for a AlertPolicyService::update_alert_policy call.
+    /// The request builder for [AlertPolicyService::update_alert_policy][super::super::client::AlertPolicyService::update_alert_policy] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAlertPolicy(RequestBuilder<crate::model::UpdateAlertPolicyRequest>);
 
@@ -403,7 +403,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for a GroupService::list_groups call.
+    /// The request builder for [GroupService::list_groups][super::super::client::GroupService::list_groups] calls.
     #[derive(Clone, Debug)]
     pub struct ListGroups(RequestBuilder<crate::model::ListGroupsRequest>);
 
@@ -481,7 +481,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for a GroupService::get_group call.
+    /// The request builder for [GroupService::get_group][super::super::client::GroupService::get_group] calls.
     #[derive(Clone, Debug)]
     pub struct GetGroup(RequestBuilder<crate::model::GetGroupRequest>);
 
@@ -523,7 +523,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for a GroupService::create_group call.
+    /// The request builder for [GroupService::create_group][super::super::client::GroupService::create_group] calls.
     #[derive(Clone, Debug)]
     pub struct CreateGroup(RequestBuilder<crate::model::CreateGroupRequest>);
 
@@ -580,7 +580,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for a GroupService::update_group call.
+    /// The request builder for [GroupService::update_group][super::super::client::GroupService::update_group] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateGroup(RequestBuilder<crate::model::UpdateGroupRequest>);
 
@@ -631,7 +631,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for a GroupService::delete_group call.
+    /// The request builder for [GroupService::delete_group][super::super::client::GroupService::delete_group] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteGroup(RequestBuilder<crate::model::DeleteGroupRequest>);
 
@@ -679,7 +679,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for a GroupService::list_group_members call.
+    /// The request builder for [GroupService::list_group_members][super::super::client::GroupService::list_group_members] calls.
     #[derive(Clone, Debug)]
     pub struct ListGroupMembers(RequestBuilder<crate::model::ListGroupMembersRequest>);
 
@@ -820,7 +820,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::list_monitored_resource_descriptors call.
+    /// The request builder for [MetricService::list_monitored_resource_descriptors][super::super::client::MetricService::list_monitored_resource_descriptors] calls.
     #[derive(Clone, Debug)]
     pub struct ListMonitoredResourceDescriptors(
         RequestBuilder<crate::model::ListMonitoredResourceDescriptorsRequest>,
@@ -902,7 +902,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::get_monitored_resource_descriptor call.
+    /// The request builder for [MetricService::get_monitored_resource_descriptor][super::super::client::MetricService::get_monitored_resource_descriptor] calls.
     #[derive(Clone, Debug)]
     pub struct GetMonitoredResourceDescriptor(
         RequestBuilder<crate::model::GetMonitoredResourceDescriptorRequest>,
@@ -949,7 +949,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::list_metric_descriptors call.
+    /// The request builder for [MetricService::list_metric_descriptors][super::super::client::MetricService::list_metric_descriptors] calls.
     #[derive(Clone, Debug)]
     pub struct ListMetricDescriptors(RequestBuilder<crate::model::ListMetricDescriptorsRequest>);
 
@@ -1033,7 +1033,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::get_metric_descriptor call.
+    /// The request builder for [MetricService::get_metric_descriptor][super::super::client::MetricService::get_metric_descriptor] calls.
     #[derive(Clone, Debug)]
     pub struct GetMetricDescriptor(RequestBuilder<crate::model::GetMetricDescriptorRequest>);
 
@@ -1078,7 +1078,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::create_metric_descriptor call.
+    /// The request builder for [MetricService::create_metric_descriptor][super::super::client::MetricService::create_metric_descriptor] calls.
     #[derive(Clone, Debug)]
     pub struct CreateMetricDescriptor(RequestBuilder<crate::model::CreateMetricDescriptorRequest>);
 
@@ -1132,7 +1132,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::delete_metric_descriptor call.
+    /// The request builder for [MetricService::delete_metric_descriptor][super::super::client::MetricService::delete_metric_descriptor] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteMetricDescriptor(RequestBuilder<crate::model::DeleteMetricDescriptorRequest>);
 
@@ -1177,7 +1177,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::list_time_series call.
+    /// The request builder for [MetricService::list_time_series][super::super::client::MetricService::list_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct ListTimeSeries(RequestBuilder<crate::model::ListTimeSeriesRequest>);
 
@@ -1296,7 +1296,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::create_time_series call.
+    /// The request builder for [MetricService::create_time_series][super::super::client::MetricService::create_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTimeSeries(RequestBuilder<crate::model::CreateTimeSeriesRequest>);
 
@@ -1352,7 +1352,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for a MetricService::create_service_time_series call.
+    /// The request builder for [MetricService::create_service_time_series][super::super::client::MetricService::create_service_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceTimeSeries(RequestBuilder<crate::model::CreateTimeSeriesRequest>);
 
@@ -1464,7 +1464,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::list_notification_channel_descriptors call.
+    /// The request builder for [NotificationChannelService::list_notification_channel_descriptors][super::super::client::NotificationChannelService::list_notification_channel_descriptors] calls.
     #[derive(Clone, Debug)]
     pub struct ListNotificationChannelDescriptors(
         RequestBuilder<crate::model::ListNotificationChannelDescriptorsRequest>,
@@ -1544,7 +1544,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::get_notification_channel_descriptor call.
+    /// The request builder for [NotificationChannelService::get_notification_channel_descriptor][super::super::client::NotificationChannelService::get_notification_channel_descriptor] calls.
     #[derive(Clone, Debug)]
     pub struct GetNotificationChannelDescriptor(
         RequestBuilder<crate::model::GetNotificationChannelDescriptorRequest>,
@@ -1593,7 +1593,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::list_notification_channels call.
+    /// The request builder for [NotificationChannelService::list_notification_channels][super::super::client::NotificationChannelService::list_notification_channels] calls.
     #[derive(Clone, Debug)]
     pub struct ListNotificationChannels(
         RequestBuilder<crate::model::ListNotificationChannelsRequest>,
@@ -1683,7 +1683,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::get_notification_channel call.
+    /// The request builder for [NotificationChannelService::get_notification_channel][super::super::client::NotificationChannelService::get_notification_channel] calls.
     #[derive(Clone, Debug)]
     pub struct GetNotificationChannel(RequestBuilder<crate::model::GetNotificationChannelRequest>);
 
@@ -1730,7 +1730,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::create_notification_channel call.
+    /// The request builder for [NotificationChannelService::create_notification_channel][super::super::client::NotificationChannelService::create_notification_channel] calls.
     #[derive(Clone, Debug)]
     pub struct CreateNotificationChannel(
         RequestBuilder<crate::model::CreateNotificationChannelRequest>,
@@ -1790,7 +1790,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::update_notification_channel call.
+    /// The request builder for [NotificationChannelService::update_notification_channel][super::super::client::NotificationChannelService::update_notification_channel] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateNotificationChannel(
         RequestBuilder<crate::model::UpdateNotificationChannelRequest>,
@@ -1853,7 +1853,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::delete_notification_channel call.
+    /// The request builder for [NotificationChannelService::delete_notification_channel][super::super::client::NotificationChannelService::delete_notification_channel] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteNotificationChannel(
         RequestBuilder<crate::model::DeleteNotificationChannelRequest>,
@@ -1908,7 +1908,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::send_notification_channel_verification_code call.
+    /// The request builder for [NotificationChannelService::send_notification_channel_verification_code][super::super::client::NotificationChannelService::send_notification_channel_verification_code] calls.
     #[derive(Clone, Debug)]
     pub struct SendNotificationChannelVerificationCode(
         RequestBuilder<crate::model::SendNotificationChannelVerificationCodeRequest>,
@@ -1959,7 +1959,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::get_notification_channel_verification_code call.
+    /// The request builder for [NotificationChannelService::get_notification_channel_verification_code][super::super::client::NotificationChannelService::get_notification_channel_verification_code] calls.
     #[derive(Clone, Debug)]
     pub struct GetNotificationChannelVerificationCode(
         RequestBuilder<crate::model::GetNotificationChannelVerificationCodeRequest>,
@@ -2021,7 +2021,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for a NotificationChannelService::verify_notification_channel call.
+    /// The request builder for [NotificationChannelService::verify_notification_channel][super::super::client::NotificationChannelService::verify_notification_channel] calls.
     #[derive(Clone, Debug)]
     pub struct VerifyNotificationChannel(
         RequestBuilder<crate::model::VerifyNotificationChannelRequest>,
@@ -2130,7 +2130,7 @@ pub mod query_service {
         }
     }
 
-    /// The request builder for a QueryService::query_time_series call.
+    /// The request builder for [QueryService::query_time_series][super::super::client::QueryService::query_time_series] calls.
     #[derive(Clone, Debug)]
     pub struct QueryTimeSeries(RequestBuilder<crate::model::QueryTimeSeriesRequest>);
 
@@ -2261,7 +2261,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::create_service call.
+    /// The request builder for [ServiceMonitoringService::create_service][super::super::client::ServiceMonitoringService::create_service] calls.
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -2320,7 +2320,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::get_service call.
+    /// The request builder for [ServiceMonitoringService::get_service][super::super::client::ServiceMonitoringService::get_service] calls.
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -2364,7 +2364,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::list_services call.
+    /// The request builder for [ServiceMonitoringService::list_services][super::super::client::ServiceMonitoringService::list_services] calls.
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -2441,7 +2441,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::update_service call.
+    /// The request builder for [ServiceMonitoringService::update_service][super::super::client::ServiceMonitoringService::update_service] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -2497,7 +2497,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::delete_service call.
+    /// The request builder for [ServiceMonitoringService::delete_service][super::super::client::ServiceMonitoringService::delete_service] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -2541,7 +2541,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::create_service_level_objective call.
+    /// The request builder for [ServiceMonitoringService::create_service_level_objective][super::super::client::ServiceMonitoringService::create_service_level_objective] calls.
     #[derive(Clone, Debug)]
     pub struct CreateServiceLevelObjective(
         RequestBuilder<crate::model::CreateServiceLevelObjectiveRequest>,
@@ -2610,7 +2610,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::get_service_level_objective call.
+    /// The request builder for [ServiceMonitoringService::get_service_level_objective][super::super::client::ServiceMonitoringService::get_service_level_objective] calls.
     #[derive(Clone, Debug)]
     pub struct GetServiceLevelObjective(
         RequestBuilder<crate::model::GetServiceLevelObjectiveRequest>,
@@ -2668,7 +2668,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::list_service_level_objectives call.
+    /// The request builder for [ServiceMonitoringService::list_service_level_objectives][super::super::client::ServiceMonitoringService::list_service_level_objectives] calls.
     #[derive(Clone, Debug)]
     pub struct ListServiceLevelObjectives(
         RequestBuilder<crate::model::ListServiceLevelObjectivesRequest>,
@@ -2761,7 +2761,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::update_service_level_objective call.
+    /// The request builder for [ServiceMonitoringService::update_service_level_objective][super::super::client::ServiceMonitoringService::update_service_level_objective] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateServiceLevelObjective(
         RequestBuilder<crate::model::UpdateServiceLevelObjectiveRequest>,
@@ -2824,7 +2824,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for a ServiceMonitoringService::delete_service_level_objective call.
+    /// The request builder for [ServiceMonitoringService::delete_service_level_objective][super::super::client::ServiceMonitoringService::delete_service_level_objective] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteServiceLevelObjective(
         RequestBuilder<crate::model::DeleteServiceLevelObjectiveRequest>,
@@ -2927,7 +2927,7 @@ pub mod snooze_service {
         }
     }
 
-    /// The request builder for a SnoozeService::create_snooze call.
+    /// The request builder for [SnoozeService::create_snooze][super::super::client::SnoozeService::create_snooze] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSnooze(RequestBuilder<crate::model::CreateSnoozeRequest>);
 
@@ -2978,7 +2978,7 @@ pub mod snooze_service {
         }
     }
 
-    /// The request builder for a SnoozeService::list_snoozes call.
+    /// The request builder for [SnoozeService::list_snoozes][super::super::client::SnoozeService::list_snoozes] calls.
     #[derive(Clone, Debug)]
     pub struct ListSnoozes(RequestBuilder<crate::model::ListSnoozesRequest>);
 
@@ -3053,7 +3053,7 @@ pub mod snooze_service {
         }
     }
 
-    /// The request builder for a SnoozeService::get_snooze call.
+    /// The request builder for [SnoozeService::get_snooze][super::super::client::SnoozeService::get_snooze] calls.
     #[derive(Clone, Debug)]
     pub struct GetSnooze(RequestBuilder<crate::model::GetSnoozeRequest>);
 
@@ -3095,7 +3095,7 @@ pub mod snooze_service {
         }
     }
 
-    /// The request builder for a SnoozeService::update_snooze call.
+    /// The request builder for [SnoozeService::update_snooze][super::super::client::SnoozeService::update_snooze] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSnooze(RequestBuilder<crate::model::UpdateSnoozeRequest>);
 
@@ -3203,7 +3203,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for a UptimeCheckService::list_uptime_check_configs call.
+    /// The request builder for [UptimeCheckService::list_uptime_check_configs][super::super::client::UptimeCheckService::list_uptime_check_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListUptimeCheckConfigs(RequestBuilder<crate::model::ListUptimeCheckConfigsRequest>);
 
@@ -3283,7 +3283,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for a UptimeCheckService::get_uptime_check_config call.
+    /// The request builder for [UptimeCheckService::get_uptime_check_config][super::super::client::UptimeCheckService::get_uptime_check_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetUptimeCheckConfig(RequestBuilder<crate::model::GetUptimeCheckConfigRequest>);
 
@@ -3328,7 +3328,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for a UptimeCheckService::create_uptime_check_config call.
+    /// The request builder for [UptimeCheckService::create_uptime_check_config][super::super::client::UptimeCheckService::create_uptime_check_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateUptimeCheckConfig(
         RequestBuilder<crate::model::CreateUptimeCheckConfigRequest>,
@@ -3386,7 +3386,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for a UptimeCheckService::update_uptime_check_config call.
+    /// The request builder for [UptimeCheckService::update_uptime_check_config][super::super::client::UptimeCheckService::update_uptime_check_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateUptimeCheckConfig(
         RequestBuilder<crate::model::UpdateUptimeCheckConfigRequest>,
@@ -3447,7 +3447,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for a UptimeCheckService::delete_uptime_check_config call.
+    /// The request builder for [UptimeCheckService::delete_uptime_check_config][super::super::client::UptimeCheckService::delete_uptime_check_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteUptimeCheckConfig(
         RequestBuilder<crate::model::DeleteUptimeCheckConfigRequest>,
@@ -3494,7 +3494,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for a UptimeCheckService::list_uptime_check_ips call.
+    /// The request builder for [UptimeCheckService::list_uptime_check_ips][super::super::client::UptimeCheckService::list_uptime_check_ips] calls.
     #[derive(Clone, Debug)]
     pub struct ListUptimeCheckIps(RequestBuilder<crate::model::ListUptimeCheckIpsRequest>);
 

--- a/src/generated/openapi-validation/src/builder.rs
+++ b/src/generated/openapi-validation/src/builder.rs
@@ -69,7 +69,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_locations call.
+    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations] calls.
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<crate::model::ListLocationsRequest>);
 
@@ -152,7 +152,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_location call.
+    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location] calls.
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<crate::model::GetLocationRequest>);
 
@@ -202,7 +202,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secrets call.
+    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecrets(RequestBuilder<crate::model::ListSecretsRequest>);
 
@@ -285,7 +285,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::create_secret call.
+    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecret(RequestBuilder<crate::model::CreateSecretRequest>);
 
@@ -344,7 +344,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secrets_by_project_and_location call.
+    /// The request builder for [SecretManagerService::list_secrets_by_project_and_location][super::super::client::SecretManagerService::list_secrets_by_project_and_location] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretsByProjectAndLocation(
         RequestBuilder<crate::model::ListSecretsByProjectAndLocationRequest>,
@@ -438,7 +438,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::create_secret_by_project_and_location call.
+    /// The request builder for [SecretManagerService::create_secret_by_project_and_location][super::super::client::SecretManagerService::create_secret_by_project_and_location] calls.
     #[derive(Clone, Debug)]
     pub struct CreateSecretByProjectAndLocation(
         RequestBuilder<crate::model::CreateSecretByProjectAndLocationRequest>,
@@ -508,7 +508,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::add_secret_version call.
+    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersion(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -576,7 +576,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::add_secret_version_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::add_secret_version_by_project_and_location_and_secret][super::super::client::SecretManagerService::add_secret_version_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct AddSecretVersionByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::AddSecretVersionRequest>,
@@ -649,7 +649,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret call.
+    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecret(RequestBuilder<crate::model::GetSecretRequest>);
 
@@ -699,7 +699,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::delete_secret call.
+    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecret(RequestBuilder<crate::model::DeleteSecretRequest>);
 
@@ -755,7 +755,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::update_secret call.
+    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecret(RequestBuilder<crate::model::UpdateSecretRequest>);
 
@@ -820,7 +820,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::get_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_secret_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::GetSecretByProjectAndLocationAndSecretRequest>,
@@ -883,7 +883,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::delete_secret_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::delete_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::delete_secret_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteSecretByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::DeleteSecretByProjectAndLocationAndSecretRequest>,
@@ -952,7 +952,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::update_secret_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::update_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::update_secret_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateSecretByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::UpdateSecretByProjectAndLocationAndSecretRequest>,
@@ -1030,7 +1030,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secret_versions call.
+    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersions(RequestBuilder<crate::model::ListSecretVersionsRequest>);
 
@@ -1122,7 +1122,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::list_secret_versions_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::list_secret_versions_by_project_and_location_and_secret][super::super::client::SecretManagerService::list_secret_versions_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct ListSecretVersionsByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest>,
@@ -1227,7 +1227,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret_version call.
+    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersion(RequestBuilder<crate::model::GetSecretVersionRequest>);
 
@@ -1286,7 +1286,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct GetSecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<
@@ -1362,7 +1362,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::access_secret_version call.
+    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersion(RequestBuilder<crate::model::AccessSecretVersionRequest>);
 
@@ -1421,7 +1421,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<
@@ -1497,7 +1497,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::disable_secret_version call.
+    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -1568,7 +1568,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<crate::model::DisableSecretVersionRequest>,
@@ -1646,7 +1646,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::enable_secret_version call.
+    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -1717,7 +1717,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<crate::model::EnableSecretVersionRequest>,
@@ -1795,7 +1795,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::destroy_secret_version call.
+    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -1866,7 +1866,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version call.
+    /// The request builder for [SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version] calls.
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<crate::model::DestroySecretVersionRequest>,
@@ -1944,7 +1944,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::set_iam_policy call.
+    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -2018,7 +2018,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::set_iam_policy_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::set_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::set_iam_policy_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicyByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::SetIamPolicyRequest>,
@@ -2094,7 +2094,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_iam_policy call.
+    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<crate::model::GetIamPolicyRequest>);
 
@@ -2153,7 +2153,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::get_iam_policy_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::get_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_iam_policy_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicyByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest>,
@@ -2225,7 +2225,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::test_iam_permissions call.
+    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 
@@ -2295,7 +2295,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for a SecretManagerService::test_iam_permissions_by_project_and_location_and_secret call.
+    /// The request builder for [SecretManagerService::test_iam_permissions_by_project_and_location_and_secret][super::super::client::SecretManagerService::test_iam_permissions_by_project_and_location_and_secret] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissionsByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::TestIamPermissionsRequest>,

--- a/src/generated/privacy/dlp/v2/src/builder.rs
+++ b/src/generated/privacy/dlp/v2/src/builder.rs
@@ -67,7 +67,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::inspect_content call.
+    /// The request builder for [DlpService::inspect_content][super::super::client::DlpService::inspect_content] calls.
     #[derive(Clone, Debug)]
     pub struct InspectContent(RequestBuilder<crate::model::InspectContentRequest>);
 
@@ -139,7 +139,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::redact_image call.
+    /// The request builder for [DlpService::redact_image][super::super::client::DlpService::redact_image] calls.
     #[derive(Clone, Debug)]
     pub struct RedactImage(RequestBuilder<crate::model::RedactImageRequest>);
 
@@ -222,7 +222,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::deidentify_content call.
+    /// The request builder for [DlpService::deidentify_content][super::super::client::DlpService::deidentify_content] calls.
     #[derive(Clone, Debug)]
     pub struct DeidentifyContent(RequestBuilder<crate::model::DeidentifyContentRequest>);
 
@@ -314,7 +314,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::reidentify_content call.
+    /// The request builder for [DlpService::reidentify_content][super::super::client::DlpService::reidentify_content] calls.
     #[derive(Clone, Debug)]
     pub struct ReidentifyContent(RequestBuilder<crate::model::ReidentifyContentRequest>);
 
@@ -406,7 +406,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_info_types call.
+    /// The request builder for [DlpService::list_info_types][super::super::client::DlpService::list_info_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListInfoTypes(RequestBuilder<crate::model::ListInfoTypesRequest>);
 
@@ -466,7 +466,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::create_inspect_template call.
+    /// The request builder for [DlpService::create_inspect_template][super::super::client::DlpService::create_inspect_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInspectTemplate(RequestBuilder<crate::model::CreateInspectTemplateRequest>);
 
@@ -532,7 +532,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::update_inspect_template call.
+    /// The request builder for [DlpService::update_inspect_template][super::super::client::DlpService::update_inspect_template] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInspectTemplate(RequestBuilder<crate::model::UpdateInspectTemplateRequest>);
 
@@ -595,7 +595,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_inspect_template call.
+    /// The request builder for [DlpService::get_inspect_template][super::super::client::DlpService::get_inspect_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetInspectTemplate(RequestBuilder<crate::model::GetInspectTemplateRequest>);
 
@@ -640,7 +640,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_inspect_templates call.
+    /// The request builder for [DlpService::list_inspect_templates][super::super::client::DlpService::list_inspect_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListInspectTemplates(RequestBuilder<crate::model::ListInspectTemplatesRequest>);
 
@@ -724,7 +724,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_inspect_template call.
+    /// The request builder for [DlpService::delete_inspect_template][super::super::client::DlpService::delete_inspect_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInspectTemplate(RequestBuilder<crate::model::DeleteInspectTemplateRequest>);
 
@@ -769,7 +769,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::create_deidentify_template call.
+    /// The request builder for [DlpService::create_deidentify_template][super::super::client::DlpService::create_deidentify_template] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDeidentifyTemplate(
         RequestBuilder<crate::model::CreateDeidentifyTemplateRequest>,
@@ -839,7 +839,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::update_deidentify_template call.
+    /// The request builder for [DlpService::update_deidentify_template][super::super::client::DlpService::update_deidentify_template] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDeidentifyTemplate(
         RequestBuilder<crate::model::UpdateDeidentifyTemplateRequest>,
@@ -906,7 +906,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_deidentify_template call.
+    /// The request builder for [DlpService::get_deidentify_template][super::super::client::DlpService::get_deidentify_template] calls.
     #[derive(Clone, Debug)]
     pub struct GetDeidentifyTemplate(RequestBuilder<crate::model::GetDeidentifyTemplateRequest>);
 
@@ -951,7 +951,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_deidentify_templates call.
+    /// The request builder for [DlpService::list_deidentify_templates][super::super::client::DlpService::list_deidentify_templates] calls.
     #[derive(Clone, Debug)]
     pub struct ListDeidentifyTemplates(
         RequestBuilder<crate::model::ListDeidentifyTemplatesRequest>,
@@ -1039,7 +1039,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_deidentify_template call.
+    /// The request builder for [DlpService::delete_deidentify_template][super::super::client::DlpService::delete_deidentify_template] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDeidentifyTemplate(
         RequestBuilder<crate::model::DeleteDeidentifyTemplateRequest>,
@@ -1086,7 +1086,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::create_job_trigger call.
+    /// The request builder for [DlpService::create_job_trigger][super::super::client::DlpService::create_job_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct CreateJobTrigger(RequestBuilder<crate::model::CreateJobTriggerRequest>);
 
@@ -1152,7 +1152,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::update_job_trigger call.
+    /// The request builder for [DlpService::update_job_trigger][super::super::client::DlpService::update_job_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateJobTrigger(RequestBuilder<crate::model::UpdateJobTriggerRequest>);
 
@@ -1215,7 +1215,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::hybrid_inspect_job_trigger call.
+    /// The request builder for [DlpService::hybrid_inspect_job_trigger][super::super::client::DlpService::hybrid_inspect_job_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct HybridInspectJobTrigger(
         RequestBuilder<crate::model::HybridInspectJobTriggerRequest>,
@@ -1271,7 +1271,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_job_trigger call.
+    /// The request builder for [DlpService::get_job_trigger][super::super::client::DlpService::get_job_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct GetJobTrigger(RequestBuilder<crate::model::GetJobTriggerRequest>);
 
@@ -1313,7 +1313,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_job_triggers call.
+    /// The request builder for [DlpService::list_job_triggers][super::super::client::DlpService::list_job_triggers] calls.
     #[derive(Clone, Debug)]
     pub struct ListJobTriggers(RequestBuilder<crate::model::ListJobTriggersRequest>);
 
@@ -1406,7 +1406,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_job_trigger call.
+    /// The request builder for [DlpService::delete_job_trigger][super::super::client::DlpService::delete_job_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteJobTrigger(RequestBuilder<crate::model::DeleteJobTriggerRequest>);
 
@@ -1451,7 +1451,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::activate_job_trigger call.
+    /// The request builder for [DlpService::activate_job_trigger][super::super::client::DlpService::activate_job_trigger] calls.
     #[derive(Clone, Debug)]
     pub struct ActivateJobTrigger(RequestBuilder<crate::model::ActivateJobTriggerRequest>);
 
@@ -1496,7 +1496,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::create_discovery_config call.
+    /// The request builder for [DlpService::create_discovery_config][super::super::client::DlpService::create_discovery_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDiscoveryConfig(RequestBuilder<crate::model::CreateDiscoveryConfigRequest>);
 
@@ -1556,7 +1556,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::update_discovery_config call.
+    /// The request builder for [DlpService::update_discovery_config][super::super::client::DlpService::update_discovery_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDiscoveryConfig(RequestBuilder<crate::model::UpdateDiscoveryConfigRequest>);
 
@@ -1619,7 +1619,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_discovery_config call.
+    /// The request builder for [DlpService::get_discovery_config][super::super::client::DlpService::get_discovery_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetDiscoveryConfig(RequestBuilder<crate::model::GetDiscoveryConfigRequest>);
 
@@ -1664,7 +1664,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_discovery_configs call.
+    /// The request builder for [DlpService::list_discovery_configs][super::super::client::DlpService::list_discovery_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListDiscoveryConfigs(RequestBuilder<crate::model::ListDiscoveryConfigsRequest>);
 
@@ -1742,7 +1742,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_discovery_config call.
+    /// The request builder for [DlpService::delete_discovery_config][super::super::client::DlpService::delete_discovery_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDiscoveryConfig(RequestBuilder<crate::model::DeleteDiscoveryConfigRequest>);
 
@@ -1787,7 +1787,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::create_dlp_job call.
+    /// The request builder for [DlpService::create_dlp_job][super::super::client::DlpService::create_dlp_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDlpJob(RequestBuilder<crate::model::CreateDlpJobRequest>);
 
@@ -1850,7 +1850,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_dlp_jobs call.
+    /// The request builder for [DlpService::list_dlp_jobs][super::super::client::DlpService::list_dlp_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListDlpJobs(RequestBuilder<crate::model::ListDlpJobsRequest>);
 
@@ -1943,7 +1943,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_dlp_job call.
+    /// The request builder for [DlpService::get_dlp_job][super::super::client::DlpService::get_dlp_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetDlpJob(RequestBuilder<crate::model::GetDlpJobRequest>);
 
@@ -1985,7 +1985,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_dlp_job call.
+    /// The request builder for [DlpService::delete_dlp_job][super::super::client::DlpService::delete_dlp_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteDlpJob(RequestBuilder<crate::model::DeleteDlpJobRequest>);
 
@@ -2027,7 +2027,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::cancel_dlp_job call.
+    /// The request builder for [DlpService::cancel_dlp_job][super::super::client::DlpService::cancel_dlp_job] calls.
     #[derive(Clone, Debug)]
     pub struct CancelDlpJob(RequestBuilder<crate::model::CancelDlpJobRequest>);
 
@@ -2069,7 +2069,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::create_stored_info_type call.
+    /// The request builder for [DlpService::create_stored_info_type][super::super::client::DlpService::create_stored_info_type] calls.
     #[derive(Clone, Debug)]
     pub struct CreateStoredInfoType(RequestBuilder<crate::model::CreateStoredInfoTypeRequest>);
 
@@ -2135,7 +2135,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::update_stored_info_type call.
+    /// The request builder for [DlpService::update_stored_info_type][super::super::client::DlpService::update_stored_info_type] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateStoredInfoType(RequestBuilder<crate::model::UpdateStoredInfoTypeRequest>);
 
@@ -2198,7 +2198,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_stored_info_type call.
+    /// The request builder for [DlpService::get_stored_info_type][super::super::client::DlpService::get_stored_info_type] calls.
     #[derive(Clone, Debug)]
     pub struct GetStoredInfoType(RequestBuilder<crate::model::GetStoredInfoTypeRequest>);
 
@@ -2243,7 +2243,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_stored_info_types call.
+    /// The request builder for [DlpService::list_stored_info_types][super::super::client::DlpService::list_stored_info_types] calls.
     #[derive(Clone, Debug)]
     pub struct ListStoredInfoTypes(RequestBuilder<crate::model::ListStoredInfoTypesRequest>);
 
@@ -2327,7 +2327,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_stored_info_type call.
+    /// The request builder for [DlpService::delete_stored_info_type][super::super::client::DlpService::delete_stored_info_type] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteStoredInfoType(RequestBuilder<crate::model::DeleteStoredInfoTypeRequest>);
 
@@ -2372,7 +2372,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_project_data_profiles call.
+    /// The request builder for [DlpService::list_project_data_profiles][super::super::client::DlpService::list_project_data_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListProjectDataProfiles(
         RequestBuilder<crate::model::ListProjectDataProfilesRequest>,
@@ -2460,7 +2460,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_table_data_profiles call.
+    /// The request builder for [DlpService::list_table_data_profiles][super::super::client::DlpService::list_table_data_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListTableDataProfiles(RequestBuilder<crate::model::ListTableDataProfilesRequest>);
 
@@ -2544,7 +2544,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_column_data_profiles call.
+    /// The request builder for [DlpService::list_column_data_profiles][super::super::client::DlpService::list_column_data_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListColumnDataProfiles(RequestBuilder<crate::model::ListColumnDataProfilesRequest>);
 
@@ -2630,7 +2630,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_project_data_profile call.
+    /// The request builder for [DlpService::get_project_data_profile][super::super::client::DlpService::get_project_data_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetProjectDataProfile(RequestBuilder<crate::model::GetProjectDataProfileRequest>);
 
@@ -2675,7 +2675,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_file_store_data_profiles call.
+    /// The request builder for [DlpService::list_file_store_data_profiles][super::super::client::DlpService::list_file_store_data_profiles] calls.
     #[derive(Clone, Debug)]
     pub struct ListFileStoreDataProfiles(
         RequestBuilder<crate::model::ListFileStoreDataProfilesRequest>,
@@ -2763,7 +2763,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_file_store_data_profile call.
+    /// The request builder for [DlpService::get_file_store_data_profile][super::super::client::DlpService::get_file_store_data_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetFileStoreDataProfile(
         RequestBuilder<crate::model::GetFileStoreDataProfileRequest>,
@@ -2810,7 +2810,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_file_store_data_profile call.
+    /// The request builder for [DlpService::delete_file_store_data_profile][super::super::client::DlpService::delete_file_store_data_profile] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteFileStoreDataProfile(
         RequestBuilder<crate::model::DeleteFileStoreDataProfileRequest>,
@@ -2857,7 +2857,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_table_data_profile call.
+    /// The request builder for [DlpService::get_table_data_profile][super::super::client::DlpService::get_table_data_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetTableDataProfile(RequestBuilder<crate::model::GetTableDataProfileRequest>);
 
@@ -2902,7 +2902,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_column_data_profile call.
+    /// The request builder for [DlpService::get_column_data_profile][super::super::client::DlpService::get_column_data_profile] calls.
     #[derive(Clone, Debug)]
     pub struct GetColumnDataProfile(RequestBuilder<crate::model::GetColumnDataProfileRequest>);
 
@@ -2947,7 +2947,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_table_data_profile call.
+    /// The request builder for [DlpService::delete_table_data_profile][super::super::client::DlpService::delete_table_data_profile] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTableDataProfile(RequestBuilder<crate::model::DeleteTableDataProfileRequest>);
 
@@ -2992,7 +2992,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::hybrid_inspect_dlp_job call.
+    /// The request builder for [DlpService::hybrid_inspect_dlp_job][super::super::client::DlpService::hybrid_inspect_dlp_job] calls.
     #[derive(Clone, Debug)]
     pub struct HybridInspectDlpJob(RequestBuilder<crate::model::HybridInspectDlpJobRequest>);
 
@@ -3046,7 +3046,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::finish_dlp_job call.
+    /// The request builder for [DlpService::finish_dlp_job][super::super::client::DlpService::finish_dlp_job] calls.
     #[derive(Clone, Debug)]
     pub struct FinishDlpJob(RequestBuilder<crate::model::FinishDlpJobRequest>);
 
@@ -3088,7 +3088,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::create_connection call.
+    /// The request builder for [DlpService::create_connection][super::super::client::DlpService::create_connection] calls.
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -3142,7 +3142,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::get_connection call.
+    /// The request builder for [DlpService::get_connection][super::super::client::DlpService::get_connection] calls.
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -3184,7 +3184,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::list_connections call.
+    /// The request builder for [DlpService::list_connections][super::super::client::DlpService::list_connections] calls.
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -3259,7 +3259,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::search_connections call.
+    /// The request builder for [DlpService::search_connections][super::super::client::DlpService::search_connections] calls.
     #[derive(Clone, Debug)]
     pub struct SearchConnections(RequestBuilder<crate::model::SearchConnectionsRequest>);
 
@@ -3337,7 +3337,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::delete_connection call.
+    /// The request builder for [DlpService::delete_connection][super::super::client::DlpService::delete_connection] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -3382,7 +3382,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for a DlpService::update_connection call.
+    /// The request builder for [DlpService::update_connection][super::super::client::DlpService::update_connection] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 

--- a/src/generated/spanner/admin/database/v1/src/builder.rs
+++ b/src/generated/spanner/admin/database/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::list_databases call.
+    /// The request builder for [DatabaseAdmin::list_databases][super::super::client::DatabaseAdmin::list_databases] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatabases(RequestBuilder<crate::model::ListDatabasesRequest>);
 
@@ -136,7 +136,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::create_database call.
+    /// The request builder for [DatabaseAdmin::create_database][super::super::client::DatabaseAdmin::create_database] calls.
     #[derive(Clone, Debug)]
     pub struct CreateDatabase(RequestBuilder<crate::model::CreateDatabaseRequest>);
 
@@ -260,7 +260,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::get_database call.
+    /// The request builder for [DatabaseAdmin::get_database][super::super::client::DatabaseAdmin::get_database] calls.
     #[derive(Clone, Debug)]
     pub struct GetDatabase(RequestBuilder<crate::model::GetDatabaseRequest>);
 
@@ -302,7 +302,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::update_database call.
+    /// The request builder for [DatabaseAdmin::update_database][super::super::client::DatabaseAdmin::update_database] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDatabase(RequestBuilder<crate::model::UpdateDatabaseRequest>);
 
@@ -395,7 +395,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::update_database_ddl call.
+    /// The request builder for [DatabaseAdmin::update_database_ddl][super::super::client::DatabaseAdmin::update_database_ddl] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateDatabaseDdl(RequestBuilder<crate::model::UpdateDatabaseDdlRequest>);
 
@@ -500,7 +500,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::drop_database call.
+    /// The request builder for [DatabaseAdmin::drop_database][super::super::client::DatabaseAdmin::drop_database] calls.
     #[derive(Clone, Debug)]
     pub struct DropDatabase(RequestBuilder<crate::model::DropDatabaseRequest>);
 
@@ -542,7 +542,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::get_database_ddl call.
+    /// The request builder for [DatabaseAdmin::get_database_ddl][super::super::client::DatabaseAdmin::get_database_ddl] calls.
     #[derive(Clone, Debug)]
     pub struct GetDatabaseDdl(RequestBuilder<crate::model::GetDatabaseDdlRequest>);
 
@@ -584,7 +584,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::set_iam_policy call.
+    /// The request builder for [DatabaseAdmin::set_iam_policy][super::super::client::DatabaseAdmin::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -644,7 +644,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::get_iam_policy call.
+    /// The request builder for [DatabaseAdmin::get_iam_policy][super::super::client::DatabaseAdmin::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -695,7 +695,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::test_iam_permissions call.
+    /// The request builder for [DatabaseAdmin::test_iam_permissions][super::super::client::DatabaseAdmin::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -751,7 +751,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::create_backup call.
+    /// The request builder for [DatabaseAdmin::create_backup][super::super::client::DatabaseAdmin::create_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -857,7 +857,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::copy_backup call.
+    /// The request builder for [DatabaseAdmin::copy_backup][super::super::client::DatabaseAdmin::copy_backup] calls.
     #[derive(Clone, Debug)]
     pub struct CopyBackup(RequestBuilder<crate::model::CopyBackupRequest>);
 
@@ -968,7 +968,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::get_backup call.
+    /// The request builder for [DatabaseAdmin::get_backup][super::super::client::DatabaseAdmin::get_backup] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1010,7 +1010,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::update_backup call.
+    /// The request builder for [DatabaseAdmin::update_backup][super::super::client::DatabaseAdmin::update_backup] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -1064,7 +1064,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::delete_backup call.
+    /// The request builder for [DatabaseAdmin::delete_backup][super::super::client::DatabaseAdmin::delete_backup] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1106,7 +1106,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::list_backups call.
+    /// The request builder for [DatabaseAdmin::list_backups][super::super::client::DatabaseAdmin::list_backups] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1181,7 +1181,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::restore_database call.
+    /// The request builder for [DatabaseAdmin::restore_database][super::super::client::DatabaseAdmin::restore_database] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreDatabase(RequestBuilder<crate::model::RestoreDatabaseRequest>);
 
@@ -1288,7 +1288,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::list_database_operations call.
+    /// The request builder for [DatabaseAdmin::list_database_operations][super::super::client::DatabaseAdmin::list_database_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatabaseOperations(RequestBuilder<crate::model::ListDatabaseOperationsRequest>);
 
@@ -1368,7 +1368,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::list_backup_operations call.
+    /// The request builder for [DatabaseAdmin::list_backup_operations][super::super::client::DatabaseAdmin::list_backup_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupOperations(RequestBuilder<crate::model::ListBackupOperationsRequest>);
 
@@ -1446,7 +1446,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::list_database_roles call.
+    /// The request builder for [DatabaseAdmin::list_database_roles][super::super::client::DatabaseAdmin::list_database_roles] calls.
     #[derive(Clone, Debug)]
     pub struct ListDatabaseRoles(RequestBuilder<crate::model::ListDatabaseRolesRequest>);
 
@@ -1518,7 +1518,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::add_split_points call.
+    /// The request builder for [DatabaseAdmin::add_split_points][super::super::client::DatabaseAdmin::add_split_points] calls.
     #[derive(Clone, Debug)]
     pub struct AddSplitPoints(RequestBuilder<crate::model::AddSplitPointsRequest>);
 
@@ -1577,7 +1577,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::create_backup_schedule call.
+    /// The request builder for [DatabaseAdmin::create_backup_schedule][super::super::client::DatabaseAdmin::create_backup_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBackupSchedule(RequestBuilder<crate::model::CreateBackupScheduleRequest>);
 
@@ -1637,7 +1637,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::get_backup_schedule call.
+    /// The request builder for [DatabaseAdmin::get_backup_schedule][super::super::client::DatabaseAdmin::get_backup_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct GetBackupSchedule(RequestBuilder<crate::model::GetBackupScheduleRequest>);
 
@@ -1682,7 +1682,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::update_backup_schedule call.
+    /// The request builder for [DatabaseAdmin::update_backup_schedule][super::super::client::DatabaseAdmin::update_backup_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBackupSchedule(RequestBuilder<crate::model::UpdateBackupScheduleRequest>);
 
@@ -1739,7 +1739,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::delete_backup_schedule call.
+    /// The request builder for [DatabaseAdmin::delete_backup_schedule][super::super::client::DatabaseAdmin::delete_backup_schedule] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBackupSchedule(RequestBuilder<crate::model::DeleteBackupScheduleRequest>);
 
@@ -1784,7 +1784,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::list_backup_schedules call.
+    /// The request builder for [DatabaseAdmin::list_backup_schedules][super::super::client::DatabaseAdmin::list_backup_schedules] calls.
     #[derive(Clone, Debug)]
     pub struct ListBackupSchedules(RequestBuilder<crate::model::ListBackupSchedulesRequest>);
 
@@ -1856,7 +1856,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::list_operations call.
+    /// The request builder for [DatabaseAdmin::list_operations][super::super::client::DatabaseAdmin::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1934,7 +1934,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::get_operation call.
+    /// The request builder for [DatabaseAdmin::get_operation][super::super::client::DatabaseAdmin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1979,7 +1979,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::delete_operation call.
+    /// The request builder for [DatabaseAdmin::delete_operation][super::super::client::DatabaseAdmin::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2024,7 +2024,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for a DatabaseAdmin::cancel_operation call.
+    /// The request builder for [DatabaseAdmin::cancel_operation][super::super::client::DatabaseAdmin::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/spanner/admin/instance/v1/src/builder.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builder.rs
@@ -67,7 +67,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::list_instance_configs call.
+    /// The request builder for [InstanceAdmin::list_instance_configs][super::super::client::InstanceAdmin::list_instance_configs] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstanceConfigs(RequestBuilder<crate::model::ListInstanceConfigsRequest>);
 
@@ -139,7 +139,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::get_instance_config call.
+    /// The request builder for [InstanceAdmin::get_instance_config][super::super::client::InstanceAdmin::get_instance_config] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstanceConfig(RequestBuilder<crate::model::GetInstanceConfigRequest>);
 
@@ -184,7 +184,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::create_instance_config call.
+    /// The request builder for [InstanceAdmin::create_instance_config][super::super::client::InstanceAdmin::create_instance_config] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstanceConfig(RequestBuilder<crate::model::CreateInstanceConfigRequest>);
 
@@ -291,7 +291,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::update_instance_config call.
+    /// The request builder for [InstanceAdmin::update_instance_config][super::super::client::InstanceAdmin::update_instance_config] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstanceConfig(RequestBuilder<crate::model::UpdateInstanceConfigRequest>);
 
@@ -395,7 +395,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::delete_instance_config call.
+    /// The request builder for [InstanceAdmin::delete_instance_config][super::super::client::InstanceAdmin::delete_instance_config] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstanceConfig(RequestBuilder<crate::model::DeleteInstanceConfigRequest>);
 
@@ -452,7 +452,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::list_instance_config_operations call.
+    /// The request builder for [InstanceAdmin::list_instance_config_operations][super::super::client::InstanceAdmin::list_instance_config_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstanceConfigOperations(
         RequestBuilder<crate::model::ListInstanceConfigOperationsRequest>,
@@ -534,7 +534,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::list_instances call.
+    /// The request builder for [InstanceAdmin::list_instances][super::super::client::InstanceAdmin::list_instances] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -618,7 +618,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::list_instance_partitions call.
+    /// The request builder for [InstanceAdmin::list_instance_partitions][super::super::client::InstanceAdmin::list_instance_partitions] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstancePartitions(RequestBuilder<crate::model::ListInstancePartitionsRequest>);
 
@@ -701,7 +701,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::get_instance call.
+    /// The request builder for [InstanceAdmin::get_instance][super::super::client::InstanceAdmin::get_instance] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -752,7 +752,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::create_instance call.
+    /// The request builder for [InstanceAdmin::create_instance][super::super::client::InstanceAdmin::create_instance] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -848,7 +848,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::update_instance call.
+    /// The request builder for [InstanceAdmin::update_instance][super::super::client::InstanceAdmin::update_instance] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -941,7 +941,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::delete_instance call.
+    /// The request builder for [InstanceAdmin::delete_instance][super::super::client::InstanceAdmin::delete_instance] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -983,7 +983,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::set_iam_policy call.
+    /// The request builder for [InstanceAdmin::set_iam_policy][super::super::client::InstanceAdmin::set_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1043,7 +1043,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::get_iam_policy call.
+    /// The request builder for [InstanceAdmin::get_iam_policy][super::super::client::InstanceAdmin::get_iam_policy] calls.
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1094,7 +1094,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::test_iam_permissions call.
+    /// The request builder for [InstanceAdmin::test_iam_permissions][super::super::client::InstanceAdmin::test_iam_permissions] calls.
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1150,7 +1150,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::get_instance_partition call.
+    /// The request builder for [InstanceAdmin::get_instance_partition][super::super::client::InstanceAdmin::get_instance_partition] calls.
     #[derive(Clone, Debug)]
     pub struct GetInstancePartition(RequestBuilder<crate::model::GetInstancePartitionRequest>);
 
@@ -1195,7 +1195,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::create_instance_partition call.
+    /// The request builder for [InstanceAdmin::create_instance_partition][super::super::client::InstanceAdmin::create_instance_partition] calls.
     #[derive(Clone, Debug)]
     pub struct CreateInstancePartition(
         RequestBuilder<crate::model::CreateInstancePartitionRequest>,
@@ -1302,7 +1302,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::delete_instance_partition call.
+    /// The request builder for [InstanceAdmin::delete_instance_partition][super::super::client::InstanceAdmin::delete_instance_partition] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteInstancePartition(
         RequestBuilder<crate::model::DeleteInstancePartitionRequest>,
@@ -1355,7 +1355,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::update_instance_partition call.
+    /// The request builder for [InstanceAdmin::update_instance_partition][super::super::client::InstanceAdmin::update_instance_partition] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateInstancePartition(
         RequestBuilder<crate::model::UpdateInstancePartitionRequest>,
@@ -1459,7 +1459,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::list_instance_partition_operations call.
+    /// The request builder for [InstanceAdmin::list_instance_partition_operations][super::super::client::InstanceAdmin::list_instance_partition_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListInstancePartitionOperations(
         RequestBuilder<crate::model::ListInstancePartitionOperationsRequest>,
@@ -1550,7 +1550,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::move_instance call.
+    /// The request builder for [InstanceAdmin::move_instance][super::super::client::InstanceAdmin::move_instance] calls.
     #[derive(Clone, Debug)]
     pub struct MoveInstance(RequestBuilder<crate::model::MoveInstanceRequest>);
 
@@ -1639,7 +1639,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::list_operations call.
+    /// The request builder for [InstanceAdmin::list_operations][super::super::client::InstanceAdmin::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1717,7 +1717,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::get_operation call.
+    /// The request builder for [InstanceAdmin::get_operation][super::super::client::InstanceAdmin::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1762,7 +1762,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::delete_operation call.
+    /// The request builder for [InstanceAdmin::delete_operation][super::super::client::InstanceAdmin::delete_operation] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1807,7 +1807,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for a InstanceAdmin::cancel_operation call.
+    /// The request builder for [InstanceAdmin::cancel_operation][super::super::client::InstanceAdmin::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/storagetransfer/v1/src/builder.rs
+++ b/src/generated/storagetransfer/v1/src/builder.rs
@@ -69,7 +69,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::get_google_service_account call.
+    /// The request builder for [StorageTransferService::get_google_service_account][super::super::client::StorageTransferService::get_google_service_account] calls.
     #[derive(Clone, Debug)]
     pub struct GetGoogleServiceAccount(
         RequestBuilder<crate::model::GetGoogleServiceAccountRequest>,
@@ -118,7 +118,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::create_transfer_job call.
+    /// The request builder for [StorageTransferService::create_transfer_job][super::super::client::StorageTransferService::create_transfer_job] calls.
     #[derive(Clone, Debug)]
     pub struct CreateTransferJob(RequestBuilder<crate::model::CreateTransferJobRequest>);
 
@@ -168,7 +168,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::update_transfer_job call.
+    /// The request builder for [StorageTransferService::update_transfer_job][super::super::client::StorageTransferService::update_transfer_job] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateTransferJob(RequestBuilder<crate::model::UpdateTransferJobRequest>);
 
@@ -239,7 +239,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::get_transfer_job call.
+    /// The request builder for [StorageTransferService::get_transfer_job][super::super::client::StorageTransferService::get_transfer_job] calls.
     #[derive(Clone, Debug)]
     pub struct GetTransferJob(RequestBuilder<crate::model::GetTransferJobRequest>);
 
@@ -289,7 +289,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::list_transfer_jobs call.
+    /// The request builder for [StorageTransferService::list_transfer_jobs][super::super::client::StorageTransferService::list_transfer_jobs] calls.
     #[derive(Clone, Debug)]
     pub struct ListTransferJobs(RequestBuilder<crate::model::ListTransferJobsRequest>);
 
@@ -363,7 +363,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::pause_transfer_operation call.
+    /// The request builder for [StorageTransferService::pause_transfer_operation][super::super::client::StorageTransferService::pause_transfer_operation] calls.
     #[derive(Clone, Debug)]
     pub struct PauseTransferOperation(RequestBuilder<crate::model::PauseTransferOperationRequest>);
 
@@ -410,7 +410,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::resume_transfer_operation call.
+    /// The request builder for [StorageTransferService::resume_transfer_operation][super::super::client::StorageTransferService::resume_transfer_operation] calls.
     #[derive(Clone, Debug)]
     pub struct ResumeTransferOperation(
         RequestBuilder<crate::model::ResumeTransferOperationRequest>,
@@ -459,7 +459,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::run_transfer_job call.
+    /// The request builder for [StorageTransferService::run_transfer_job][super::super::client::StorageTransferService::run_transfer_job] calls.
     #[derive(Clone, Debug)]
     pub struct RunTransferJob(RequestBuilder<crate::model::RunTransferJobRequest>);
 
@@ -544,7 +544,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::delete_transfer_job call.
+    /// The request builder for [StorageTransferService::delete_transfer_job][super::super::client::StorageTransferService::delete_transfer_job] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteTransferJob(RequestBuilder<crate::model::DeleteTransferJobRequest>);
 
@@ -597,7 +597,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::create_agent_pool call.
+    /// The request builder for [StorageTransferService::create_agent_pool][super::super::client::StorageTransferService::create_agent_pool] calls.
     #[derive(Clone, Debug)]
     pub struct CreateAgentPool(RequestBuilder<crate::model::CreateAgentPoolRequest>);
 
@@ -656,7 +656,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::update_agent_pool call.
+    /// The request builder for [StorageTransferService::update_agent_pool][super::super::client::StorageTransferService::update_agent_pool] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateAgentPool(RequestBuilder<crate::model::UpdateAgentPoolRequest>);
 
@@ -712,7 +712,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::get_agent_pool call.
+    /// The request builder for [StorageTransferService::get_agent_pool][super::super::client::StorageTransferService::get_agent_pool] calls.
     #[derive(Clone, Debug)]
     pub struct GetAgentPool(RequestBuilder<crate::model::GetAgentPoolRequest>);
 
@@ -756,7 +756,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::list_agent_pools call.
+    /// The request builder for [StorageTransferService::list_agent_pools][super::super::client::StorageTransferService::list_agent_pools] calls.
     #[derive(Clone, Debug)]
     pub struct ListAgentPools(RequestBuilder<crate::model::ListAgentPoolsRequest>);
 
@@ -833,7 +833,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::delete_agent_pool call.
+    /// The request builder for [StorageTransferService::delete_agent_pool][super::super::client::StorageTransferService::delete_agent_pool] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteAgentPool(RequestBuilder<crate::model::DeleteAgentPoolRequest>);
 
@@ -877,7 +877,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::list_operations call.
+    /// The request builder for [StorageTransferService::list_operations][super::super::client::StorageTransferService::list_operations] calls.
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -957,7 +957,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::get_operation call.
+    /// The request builder for [StorageTransferService::get_operation][super::super::client::StorageTransferService::get_operation] calls.
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1004,7 +1004,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for a StorageTransferService::cancel_operation call.
+    /// The request builder for [StorageTransferService::cancel_operation][super::super::client::StorageTransferService::cancel_operation] calls.
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 


### PR DESCRIPTION
Currently these things are unlinked: https://docs.rs/google-cloud-kms-v1/latest/google_cloud_kms_v1/builders/autokey/index.html

While we're here, avoid "a" vs. "an" weirdness.