### PR TITLE
doc: fix `cargo doc` for HTTP libs

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -126,7 +126,10 @@ jobs:
       - run: cargo doc --workspace
         env:
           RUSTDOCFLAGS: "-D warnings"
-      - run: cargo doc --package google-cloud-gax
+      - run: cargo doc --package google-cloud-kms-v1
+        # Our docs get built if our dependents run `cargo doc`. We want to be
+        # reasonably sure that their command will not error because of us. We do
+        # this by running `cargo doc` on one of our libraries.
         env:
           RUSTDOCFLAGS: "-D warnings"
       - run: mdbook build guide

--- a/src/gax-internal/src/options.rs
+++ b/src/gax-internal/src/options.rs
@@ -14,6 +14,7 @@
 
 pub use auth::credentials::Credential as Credentials;
 
+#[allow(rustdoc::broken_intra_doc_links)]
 /// The client configuration for [crate::http::ReqwestClient] and [crate::grpc::Client].
 pub type ClientConfig = gax::client_builder::internal::ClientConfig<Credentials>;
 


### PR DESCRIPTION
I cannot explain why `cargo doc` goes into modules annotated with `#[doc(hidden)]`. But it does. So fix the docs within.

In our CI test by building the docs for a random library. Currently, this enables the HTTP features, but not the gRPC features in `gaxi`. Good enough for now.