### PR TITLE
feat(gax): new type to represent credential errors

### DIFF
--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -128,9 +128,8 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// # use google_cloud_gax::client_builder::examples;
     /// # use google_cloud_gax::Result;
     /// # tokio_test::block_on(async {
+    /// # use examples::credentials; // placeholder for google_cloud_auth::credentials
     /// use examples::Client; // Placeholder for examples
-    /// // Placeholder, normally use google_cloud_auth::credentials
-    /// use examples::credentials;
     /// let client = Client::builder()
     ///     .with_credentials(
     ///         credentials::mds::Builder::new()

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -128,8 +128,9 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// # use google_cloud_gax::client_builder::examples;
     /// # use google_cloud_gax::Result;
     /// # tokio_test::block_on(async {
-    /// # use examples::credentials; // placeholder for google_cloud_auth::credentials
     /// use examples::Client; // Placeholder for examples
+    /// // Placeholder, normally use google_cloud_auth::credentials
+    /// use examples::credentials;
     /// let client = Client::builder()
     ///     .with_credentials(
     ///         credentials::mds::Builder::new()

--- a/src/gax/src/error.rs
+++ b/src/gax/src/error.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 mod core_error;
-mod http_error;
-mod service_error;
 pub use core_error::*;
+mod credentials;
+pub use credentials::CredentialError;
+mod http_error;
 pub use http_error::*;
+mod service_error;
 pub use service_error::*;
 
 /// Errors and error details returned by Service RPCs.

--- a/src/gax/src/error/credentials.rs
+++ b/src/gax/src/error/credentials.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 ///
 /// The Google Cloud client libraries may experience problems creating
 /// credentials and/or using them. An example of problems creating credentials
-/// may be a badly formatted or missing files key files. An example of problems
-/// using credentials may be a temporary failure to retrieve or create
+/// may be a badly formatted or missing key file. An example of problems using
+/// credentials may be a temporary failure to retrieve or create
 /// [access tokens]. Note that the latter kind of errors may happen even after
 /// the credential files are successfully loaded and parsed.
 ///
@@ -66,8 +66,8 @@ impl CredentialError {
     ///
     /// This function is only intended for use in the client libraries
     /// implementation. Application may use this in mocks, though we do not
-    /// recommend that your write tests for specific error cases. Most tests
-    /// should use the generic type [Error][crate::error::Error] type.
+    /// recommend that you write tests for specific error cases. Most tests
+    /// should use the generic [Error][crate::error::Error] type.
     ///
     /// # Example
     /// ```
@@ -92,8 +92,8 @@ impl CredentialError {
     ///
     /// This function is only intended for use in the client libraries
     /// implementation. Application may use this in mocks, though we do not
-    /// recommend that your write tests for specific error cases. Most tests
-    /// should use the generic type [Error][crate::error::Error] type.
+    /// recommend that you write tests for specific error cases. Most tests
+    /// should use the generic [Error][crate::error::Error] type.
     ///
     /// # Example
     /// ```

--- a/src/gax/src/error/credentials.rs
+++ b/src/gax/src/error/credentials.rs
@@ -1,0 +1,177 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter, Result};
+use std::sync::Arc;
+
+/// Represents an error creating or using a [Credential](crate::credentials::Credential).
+///
+/// This error type indicates issues encountered while trying to create or use a
+/// `Credential`.
+#[derive(Clone, Debug)]
+pub struct CredentialError {
+    /// A boolean value indicating whether the error is retryable.
+    ///
+    /// If `true`, the operation that resulted in this error might succeed upon
+    /// retry.
+    is_retryable: bool,
+
+    /// The underlying source of the error.
+    ///
+    /// This provides more specific information about the cause of the failure.
+    source: CredentialErrorImpl,
+}
+
+#[derive(Clone, Debug)]
+enum CredentialErrorImpl {
+    SimpleMessage(String),
+    Source(Arc<dyn Error + Send + Sync>),
+}
+
+impl CredentialError {
+    /// Creates a new `CredentialError`.
+    ///
+    /// This function is only intended for use in the client libraries
+    /// implementation. Application may use this in mocks, though we do not
+    /// recommend that your write tests for specific error cases. Most tests
+    /// should use the generic type [Error][crate::error::Error] type.
+    ///
+    /// # Arguments
+    /// * `is_retryable` - A boolean indicating whether the error is retryable.
+    /// * `source` - The underlying error that caused the auth failure.
+    pub fn new<T: Error + Send + Sync + 'static>(is_retryable: bool, source: T) -> Self {
+        CredentialError {
+            is_retryable,
+            source: CredentialErrorImpl::Source(Arc::new(source)),
+        }
+    }
+
+    /// Creates a new `CredentialError`.
+    ///
+    /// This function is only intended for use in the client libraries
+    /// implementation. Application may use this in mocks, though we do not
+    /// recommend that your write tests for specific error cases. Most tests
+    /// should use the generic type [Error][crate::error::Error] type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::error::CredentialError;
+    /// // A mock may use something like this:
+    /// let error = CredentialError::from_str(
+    ///     true, "simulated retryable error while trying to create credentials");
+    /// Err(error)
+    /// ```
+    ///
+    /// # Arguments
+    /// * `is_retryable` - A boolean indicating whether the error is retryable.
+    /// * `message` - The underlying error that caused the auth failure.
+    pub fn from_str<T: Into<String>>(is_retryable: bool, message: T) -> Self {
+        CredentialError::new(
+            is_retryable,
+            CredentialErrorImpl::SimpleMessage(message.into()),
+        )
+    }
+
+    /// Returns `true` if the error is retryable; otherwise returns `false`.
+    pub fn is_retryable(&self) -> bool {
+        self.is_retryable
+    }
+}
+
+impl std::error::Error for CredentialErrorImpl {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self {
+            CredentialErrorImpl::SimpleMessage(_) => None,
+            CredentialErrorImpl::Source(source) => Some(source),
+        }
+    }
+}
+
+impl Display for CredentialErrorImpl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match &self {
+            CredentialErrorImpl::SimpleMessage(message) => write!(f, "{}", message),
+            CredentialErrorImpl::Source(source) => write!(f, "{}", source),
+        }
+    }
+}
+
+impl std::error::Error for CredentialError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.source()
+    }
+}
+
+const RETRYABLE_MSG: &str = "but future attempts may succeed";
+const NON_RETRYABLE_MSG: &str = "and future attempts will not succeed";
+
+impl Display for CredentialError {
+    /// Formats the error message to include retryability and source.
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let msg = if self.is_retryable {
+            RETRYABLE_MSG
+        } else {
+            NON_RETRYABLE_MSG
+        };
+        write!(
+            f,
+            "cannot create access token, {}, source:{}",
+            msg, self.source
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use test_case::test_case;
+    use std::collections::HashMap;
+
+    #[test_case(true)]
+    #[test_case(false)]
+    fn new(retryable: bool) {
+        let source = crate::error::HttpError::new(
+            404,
+            HashMap::new(),
+            Some(bytes::Bytes::from_static("test-only".as_bytes())),
+        );
+        let got = CredentialError::new(retryable, source);
+        assert_eq!(got.is_retryable(), retryable, "{got}");
+        assert!(got.source().is_some(), "{got}");
+        assert!(format!("{got}").contains("test-only"), "{got}");
+    }
+
+    #[test_case(true)]
+    #[test_case(false)]
+    fn from_str(retryable: bool) {
+        let got = CredentialError::from_str(retryable, "test-only");
+        assert_eq!(got.is_retryable(), retryable, "{got}");
+        assert!(got.source().is_some(), "{got}");
+        assert!(format!("{got}").contains("test-only"), "{got}");
+    }
+
+    #[test]
+    fn fmt() {
+        let e = CredentialError::from_str(true, "test-only-err-123");
+        let got = format!("{e}");
+        assert!(got.contains("test-only-err-123"), "{got}");
+        assert!(got.contains(RETRYABLE_MSG), "{got}");
+
+        let e = CredentialError::from_str(false, "test-only-err-123");
+        let got = format!("{e}");
+        assert!(got.contains("test-only-err-123"), "{got}");
+        assert!(got.contains(NON_RETRYABLE_MSG), "{got}");
+    }
+}

--- a/src/gax/src/error/credentials.rs
+++ b/src/gax/src/error/credentials.rs
@@ -16,10 +16,31 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::sync::Arc;
 
-/// Represents an error creating or using a [Credential](crate::credentials::Credential).
+/// Represents an error creating or using a [Credential].
 ///
-/// This error type indicates issues encountered while trying to create or use a
-/// `Credential`.
+/// The Google Cloud client libraries may experience problems creating
+/// credentials and/or using them. An example of problems creating credentials
+/// may be a badly formatted or missing files key files. An example of problems
+/// using credentials may be a temporary failure to retrieve or create
+/// [access tokens]. Note that the latter kind of errors may happen even after
+/// the credential files are successfully loaded and parsed.
+///
+/// Applications rarely need to create instances of this error type. The
+/// exception might be when testing application code, where the application is
+/// mocking a client library behavior. Such tests are extremely rare, most
+/// applications should only work with the [Error][crate::error::Error] type.
+///
+/// # Example
+/// ```
+/// # use google_cloud_gax::error::CredentialError;
+/// let err = CredentialError::from_str(
+///     true, "simulated retryable error while trying to create credentials");
+/// assert!(err.is_retryable());
+/// assert!(format!("{err}").contains("simulated retryable error"));
+/// ```
+///
+/// [access tokens]: https://cloud.google.com/docs/authentication/token-types
+/// [Credential]: https://docs.rs/google-cloud-auth/latest/google_cloud_auth/credentials/struct.Credential.html
 #[derive(Clone, Debug)]
 pub struct CredentialError {
     /// A boolean value indicating whether the error is retryable.
@@ -48,6 +69,15 @@ impl CredentialError {
     /// recommend that your write tests for specific error cases. Most tests
     /// should use the generic type [Error][crate::error::Error] type.
     ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::error::CredentialError;
+    /// # use google_cloud_gax::error::Error;
+    /// let err = CredentialError::new(
+    ///     false, Error::other("simulated non-retryable error while trying to create credentials"));
+    /// assert!(!err.is_retryable());
+    /// assert!(format!("{err}").contains("simulated non-retryable error"));
+    /// ```
     /// # Arguments
     /// * `is_retryable` - A boolean indicating whether the error is retryable.
     /// * `source` - The underlying error that caused the auth failure.
@@ -68,10 +98,10 @@ impl CredentialError {
     /// # Example
     /// ```
     /// # use google_cloud_gax::error::CredentialError;
-    /// // A mock may use something like this:
-    /// let error = CredentialError::from_str(
+    /// let err = CredentialError::from_str(
     ///     true, "simulated retryable error while trying to create credentials");
-    /// Err(error)
+    /// assert!(err.is_retryable());
+    /// assert!(format!("{err}").contains("simulated retryable error"));
     /// ```
     ///
     /// # Arguments
@@ -136,8 +166,8 @@ impl Display for CredentialError {
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_case::test_case;
     use std::collections::HashMap;
+    use test_case::test_case;
 
     #[test_case(true)]
     #[test_case(false)]

--- a/src/gax/src/error/credentials.rs
+++ b/src/gax/src/error/credentials.rs
@@ -204,4 +204,12 @@ mod test {
         assert!(got.contains("test-only-err-123"), "{got}");
         assert!(got.contains(NON_RETRYABLE_MSG), "{got}");
     }
+
+    #[test]
+    fn source() {
+        let got = CredentialErrorImpl::SimpleMessage("test-only".into());
+        assert!(got.source().is_none(), "{got}");
+        let got = CredentialErrorImpl::Source(Arc::new(crate::error::Error::other("test-only")));
+        assert!(got.source().is_some(), "{got}");
+    }
 }


### PR DESCRIPTION
`CredentialError` represents problems trying to create the
authentication credentials. Some of these errors are recoverable, e.g.,
trying to fetch access tokens from the metadata server. Other errors are
not, e.g., malformed credential files.

Part of the work for #1542
