### PR TITLE
refactor(auth): move error helpers to module

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -22,7 +22,7 @@ mod service_account;
 pub(crate) mod user_credential;
 
 use crate::Result;
-use crate::errors::CredentialError;
+use crate::errors::{self, CredentialError};
 use http::header::{HeaderName, HeaderValue};
 use std::future::Future;
 use std::sync::Arc;
@@ -258,18 +258,17 @@ pub async fn create_access_token_credential() -> Result<Credential> {
         AdcContents::Contents(contents) => contents,
         AdcContents::FallbackToMds => return Ok(mds::new()),
     };
-    let js: serde_json::Value =
-        serde_json::from_str(&contents).map_err(CredentialError::non_retryable)?;
+    let js: serde_json::Value = serde_json::from_str(&contents).map_err(errors::non_retryable)?;
     let cred_type = js
         .get("type")
-        .ok_or_else(|| CredentialError::non_retryable_from_str("Failed to parse Application Default Credentials (ADC). No `type` field found."))?
+        .ok_or_else(|| errors::non_retryable_from_str("Failed to parse Application Default Credentials (ADC). No `type` field found."))?
         .as_str()
-        .ok_or_else(|| CredentialError::non_retryable_from_str("Failed to parse Application Default Credentials (ADC). `type` field is not a string.")
+        .ok_or_else(|| errors::non_retryable_from_str("Failed to parse Application Default Credentials (ADC). `type` field is not a string.")
         )?;
     match cred_type {
         "authorized_user" => user_credential::creds_from(js),
         "service_account" => service_account::creds_from(js),
-        _ => Err(CredentialError::non_retryable_from_str(format!(
+        _ => Err(errors::non_retryable_from_str(format!(
             "Unimplemented credential type: {cred_type}"
         ))),
     }
@@ -288,7 +287,7 @@ enum AdcContents {
 }
 
 fn path_not_found(path: String) -> CredentialError {
-    CredentialError::non_retryable_from_str(format!(
+    errors::non_retryable_from_str(format!(
         "Failed to load Application Default Credentials (ADC) from {path}. Check that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable points to a valid file."
     ))
 }
@@ -299,12 +298,12 @@ fn load_adc() -> Result<AdcContents> {
         Some(AdcPath::FromEnv(path)) => match std::fs::read_to_string(&path) {
             Ok(contents) => Ok(AdcContents::Contents(contents)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(path_not_found(path)),
-            Err(e) => Err(CredentialError::non_retryable(e)),
+            Err(e) => Err(errors::non_retryable(e)),
         },
         Some(AdcPath::WellKnown(path)) => match std::fs::read_to_string(path) {
             Ok(contents) => Ok(AdcContents::Contents(contents)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(AdcContents::FallbackToMds),
-            Err(e) => Err(CredentialError::non_retryable(e)),
+            Err(e) => Err(errors::non_retryable(e)),
         },
     }
 }

--- a/src/auth/src/credentials/api_key_credential.rs
+++ b/src/auth/src/credentials/api_key_credential.rs
@@ -14,7 +14,7 @@
 
 use crate::credentials::dynamic::CredentialTrait;
 use crate::credentials::{Credential, QUOTA_PROJECT_KEY, Result};
-use crate::errors::CredentialError;
+use crate::errors;
 use crate::token::{Token, TokenProvider};
 use http::header::{HeaderName, HeaderValue};
 use std::sync::Arc;
@@ -119,14 +119,13 @@ where
 
     async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
         let token = self.get_token().await?;
-        let mut value =
-            HeaderValue::from_str(&token.token).map_err(CredentialError::non_retryable)?;
+        let mut value = HeaderValue::from_str(&token.token).map_err(errors::non_retryable)?;
         value.set_sensitive(true);
         let mut headers = vec![(HeaderName::from_static(API_KEY_HEADER_KEY), value)];
         if let Some(project) = &self.quota_project_id {
             headers.push((
                 HeaderName::from_static(QUOTA_PROJECT_KEY),
-                HeaderValue::from_str(project).map_err(CredentialError::non_retryable)?,
+                HeaderValue::from_str(project).map_err(errors::non_retryable)?,
             ));
         }
         Ok(headers)

--- a/src/auth/src/credentials/service_account/jws.rs
+++ b/src/auth/src/credentials/service_account/jws.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::CredentialError;
 use crate::credentials::Result;
+use crate::errors;
 use serde::Serialize;
 use std::time::Duration;
 use time::OffsetDateTime;
@@ -47,21 +47,21 @@ pub struct JwsClaims {
 impl JwsClaims {
     pub fn encode(&self) -> Result<String> {
         if self.exp < self.iat {
-            return Err(CredentialError::non_retryable_from_str(format!(
+            return Err(errors::non_retryable_from_str(format!(
                 "expiration time {:?}, must be later than issued time {:?}",
                 self.exp, self.iat
             )));
         }
 
         if self.aud.is_some() && self.scope.is_some() {
-            return Err(CredentialError::non_retryable_from_str(format!(
+            return Err(errors::non_retryable_from_str(format!(
                 "Found {:?} for audience and {:?} for scope, however expecting only 1 of them to be set.",
                 self.aud, self.scope
             )));
         }
 
         use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine as _};
-        let json = serde_json::to_string(&self).map_err(CredentialError::non_retryable)?;
+        let json = serde_json::to_string(&self).map_err(errors::non_retryable)?;
         Ok(BASE64_URL_SAFE_NO_PAD.encode(json.as_bytes()))
     }
 }
@@ -78,7 +78,7 @@ pub struct JwsHeader<'a> {
 impl JwsHeader<'_> {
     pub fn encode(&self) -> Result<String> {
         use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine as _};
-        let json = serde_json::to_string(&self).map_err(CredentialError::non_retryable)?;
+        let json = serde_json::to_string(&self).map_err(errors::non_retryable)?;
         Ok(BASE64_URL_SAFE_NO_PAD.encode(json.as_bytes()))
     }
 }

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -74,25 +74,6 @@ impl CredentialError {
     pub fn is_retryable(&self) -> bool {
         self.is_retryable
     }
-
-    /// A helper to create a retryable error.
-    pub(crate) fn retryable<T: Error + Send + Sync + 'static>(source: T) -> Self {
-        CredentialError::new(true, source)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn retryable_from_str<T: Into<String>>(message: T) -> Self {
-        CredentialError::from_str(true, message)
-    }
-
-    /// A helper to create a non-retryable error.
-    pub(crate) fn non_retryable<T: Error + Send + Sync + 'static>(source: T) -> Self {
-        CredentialError::new(false, source)
-    }
-
-    pub(crate) fn non_retryable_from_str<T: Into<String>>(message: T) -> Self {
-        CredentialError::from_str(false, message)
-    }
 }
 
 impl std::error::Error for CredentialErrorImpl {
@@ -145,6 +126,25 @@ impl Display for CredentialError {
 #[derive(thiserror::Error, Debug)]
 pub enum InnerAuthError {
     // TODO(#389) - define error types here
+}
+
+/// A helper to create a retryable error.
+pub(crate) fn retryable<T: Error + Send + Sync + 'static>(source: T) -> CredentialError {
+    CredentialError::new(true, source)
+}
+
+#[allow(dead_code)]
+pub(crate) fn retryable_from_str<T: Into<String>>(message: T) -> CredentialError {
+    CredentialError::from_str(true, message)
+}
+
+/// A helper to create a non-retryable error.
+pub(crate) fn non_retryable<T: Error + Send + Sync + 'static>(source: T) -> CredentialError {
+    CredentialError::new(false, source)
+}
+
+pub(crate) fn non_retryable_from_str<T: Into<String>>(message: T) -> CredentialError {
+    CredentialError::from_str(false, message)
 }
 
 pub(crate) fn is_retryable(c: StatusCode) -> bool {

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -193,4 +193,33 @@ mod test {
         assert!(got.contains("test-only-err-123"), "{got}");
         assert!(got.contains(NON_RETRYABLE_MSG), "{got}");
     }
+
+    #[test]
+    fn helpers() {
+        let e = super::retryable_from_str("test-only-err-123");
+        assert!(e.is_retryable(), "{e}");
+        assert!(e.source().unwrap().source().is_none());
+        let got = format!("{e}");
+        assert!(got.contains("test-only-err-123"), "{got}");
+        assert!(got.contains(RETRYABLE_MSG), "{got}");
+
+        let input = "NaN".parse::<u32>().unwrap_err();
+        let e = super::retryable(input.clone());
+        assert!(e.is_retryable(), "{e}");
+        let got = format!("{e}");
+        assert!(got.contains(RETRYABLE_MSG), "{got}");
+        assert!(got.contains(&format!("{input}")), "{got}");
+
+        let e = super::non_retryable_from_str("test-only-err-123");
+        assert!(!e.is_retryable(), "{e}");
+        let got = format!("{e}");
+        assert!(got.contains("test-only-err-123"), "{got}");
+        assert!(got.contains(NON_RETRYABLE_MSG), "{got}");
+
+        let e = super::non_retryable(input.clone());
+        assert!(!e.is_retryable(), "{e}");
+        let got = format!("{e}");
+        assert!(got.contains(NON_RETRYABLE_MSG), "{got}");
+        assert!(got.contains(&format!("{input}")), "{got}");
+    }
 }

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -130,7 +130,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::errors::CredentialError;
+    use crate::errors;
     use crate::token::test::MockTokenProvider;
     use std::ops::{Add, Sub};
     use std::sync::{Arc, Mutex};
@@ -168,7 +168,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token()
             .times(1)
-            .returning(|| Err(CredentialError::non_retryable_from_str("fail")));
+            .returning(|| Err(errors::non_retryable_from_str("fail")));
 
         let cache = TokenCache::new(mock);
         assert!(cache.get_token().await.is_err());
@@ -241,7 +241,7 @@ mod test {
 
         mock.expect_get_token()
             .times(1)
-            .return_once(|| Err(CredentialError::non_retryable_from_str("fail")));
+            .return_once(|| Err(errors::non_retryable_from_str("fail")));
 
         // fetch an initial token
         let cache = TokenCache::new(mock);
@@ -560,7 +560,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn no_initial_token_thundering_herd_failure_shares_error() {
-        let err = Err(CredentialError::non_retryable_from_str("epic fail"));
+        let err = Err(errors::non_retryable_from_str("epic fail"));
 
         let tp = FakeTokenProvider::new(err);
 


### PR DESCRIPTION
This is part of the work to move the `CredentialError` type out of the
crate.

Part of the work for #1542
