### PR TITLE
feat(gax-internal): convert `tonic::Status` errors

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -16,6 +16,8 @@
 
 use gax::Result;
 use gax::error::Error;
+mod from_status;
+use from_status::to_gax_error;
 
 #[doc(hidden)]
 pub type InnerClient = tonic::client::Grpc<tonic::transport::Channel>;
@@ -62,7 +64,7 @@ impl Client {
         let response: tonic::Response<Response> = inner
             .unary(request, path, codec)
             .await
-            .map_err(Error::rpc)?;
+            .map_err(to_gax_error)?;
         let response = response.into_inner();
         Ok(response)
     }

--- a/src/gax-internal/src/grpc/from_status.rs
+++ b/src/gax-internal/src/grpc/from_status.rs
@@ -65,6 +65,6 @@ mod test {
         let got = svc.status().clone();
         assert_eq!(got.code, rpc::Code::InvalidArgument as i32);
         assert_eq!(&got.message, "test-only");
-        assert_eq!(got.status, Some(String::from(rpc::Code::from(got.code))));
+        assert_eq!(got.status.as_deref(), Some("INVALID_ARGUMENT"));
     }
 }

--- a/src/gax-internal/src/grpc/from_status.rs
+++ b/src/gax-internal/src/grpc/from_status.rs
@@ -16,7 +16,7 @@ use gax::error::rpc;
 
 fn to_gax_status(status: tonic::Status) -> rpc::Status {
     let code = rpc::Code::from(status.code() as i32);
-    // TODO(#...) - also convert the details
+    // TODO(#1699) - also convert the details
     rpc::Status::default()
         .set_code(code as i32)
         .set_message(status.message())
@@ -49,7 +49,6 @@ mod test {
     #[test_case(tonic::Code::Unavailable, rpc::Code::Unavailable)]
     #[test_case(tonic::Code::DataLoss, rpc::Code::DataLoss)]
     #[test_case(tonic::Code::Unauthenticated, rpc::Code::Unauthenticated)]
-
     fn check_code(input: tonic::Code, want: rpc::Code) {
         let got = to_gax_status(tonic::Status::new(input, "test-only"));
         assert_eq!(got.code, want as i32);

--- a/src/gax-internal/src/grpc/from_status.rs
+++ b/src/gax-internal/src/grpc/from_status.rs
@@ -1,0 +1,71 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use gax::error::rpc;
+
+fn to_gax_status(status: tonic::Status) -> rpc::Status {
+    let code = rpc::Code::from(status.code() as i32);
+    // TODO(#...) - also convert the details
+    rpc::Status::default()
+        .set_code(code as i32)
+        .set_message(status.message())
+        .set_status(String::from(code))
+}
+
+pub fn to_gax_error(status: tonic::Status) -> gax::error::Error {
+    gax::error::Error::rpc(gax::error::ServiceError::from(to_gax_status(status)))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case(tonic::Code::Ok, rpc::Code::Ok)]
+    #[test_case(tonic::Code::Cancelled, rpc::Code::Canceled)]
+    #[test_case(tonic::Code::Unknown, rpc::Code::Unknown)]
+    #[test_case(tonic::Code::InvalidArgument, rpc::Code::InvalidArgument)]
+    #[test_case(tonic::Code::DeadlineExceeded, rpc::Code::DeadlineExceeded)]
+    #[test_case(tonic::Code::NotFound, rpc::Code::NotFound)]
+    #[test_case(tonic::Code::AlreadyExists, rpc::Code::AlreadyExists)]
+    #[test_case(tonic::Code::PermissionDenied, rpc::Code::PermissionDenied)]
+    #[test_case(tonic::Code::ResourceExhausted, rpc::Code::ResourceExhausted)]
+    #[test_case(tonic::Code::FailedPrecondition, rpc::Code::FailedPrecondition)]
+    #[test_case(tonic::Code::Aborted, rpc::Code::Aborted)]
+    #[test_case(tonic::Code::OutOfRange, rpc::Code::OutOfRange)]
+    #[test_case(tonic::Code::Unimplemented, rpc::Code::Unimplemented)]
+    #[test_case(tonic::Code::Internal, rpc::Code::Internal)]
+    #[test_case(tonic::Code::Unavailable, rpc::Code::Unavailable)]
+    #[test_case(tonic::Code::DataLoss, rpc::Code::DataLoss)]
+    #[test_case(tonic::Code::Unauthenticated, rpc::Code::Unauthenticated)]
+
+    fn check_code(input: tonic::Code, want: rpc::Code) {
+        let got = to_gax_status(tonic::Status::new(input, "test-only"));
+        assert_eq!(got.code, want as i32);
+        assert_eq!(&got.message, "test-only");
+        assert_eq!(got.status, Some(String::from(rpc::Code::from(got.code))))
+    }
+
+    #[test]
+    fn gax_error() {
+        let status = tonic::Status::invalid_argument("test-only");
+        let got = to_gax_error(status);
+        assert_eq!(got.kind(), gax::error::ErrorKind::Rpc);
+        let svc = got.as_inner::<gax::error::ServiceError>().unwrap();
+        let got = svc.status().clone();
+        assert_eq!(got.code, rpc::Code::InvalidArgument as i32);
+        assert_eq!(&got.message, "test-only");
+        assert_eq!(got.status, Some(String::from(rpc::Code::from(got.code))));
+    }
+}

--- a/src/gax-internal/tests/grpc_simple_request.rs
+++ b/src/gax-internal/tests/grpc_simple_request.rs
@@ -94,7 +94,10 @@ mod test {
         let svc = err.as_inner::<gax::error::ServiceError>().unwrap();
         let status = svc.status().clone();
         assert_eq!(status.code, gax::error::rpc::Code::InvalidArgument as i32);
-        assert_eq!(status.status, Some(String::from(gax::error::rpc::Code::from(status.code))));
+        assert_eq!(
+            status.status,
+            Some(String::from(gax::error::rpc::Code::from(status.code)))
+        );
         Ok(())
     }
 

--- a/src/gax-internal/tests/grpc_simple_request.rs
+++ b/src/gax-internal/tests/grpc_simple_request.rs
@@ -94,10 +94,7 @@ mod test {
         let svc = err.as_inner::<gax::error::ServiceError>().unwrap();
         let status = svc.status().clone();
         assert_eq!(status.code, gax::error::rpc::Code::InvalidArgument as i32);
-        assert_eq!(
-            status.status,
-            Some(String::from(gax::error::rpc::Code::from(status.code)))
-        );
+        assert_eq!(status.status.as_deref(), Some("INVALID_ARGUMENT"));
         Ok(())
     }
 

--- a/src/gax-internal/tests/grpc_simple_request.rs
+++ b/src/gax-internal/tests/grpc_simple_request.rs
@@ -91,6 +91,10 @@ mod test {
         let response = send_request(client, "").await;
         let err = response.err().unwrap();
         assert_eq!(err.kind(), gax::error::ErrorKind::Rpc, "{err:?}");
+        let svc = err.as_inner::<gax::error::ServiceError>().unwrap();
+        let status = svc.status().clone();
+        assert_eq!(status.code, gax::error::rpc::Code::InvalidArgument as i32);
+        assert_eq!(status.status, Some(String::from(gax::error::rpc::Code::from(status.code))));
         Ok(())
     }
 

--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -84,7 +84,7 @@ impl Status {
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Code {
     /// Not an error; returned on success.
@@ -330,7 +330,7 @@ impl Serialize for Code {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_i32(self.clone() as i32)
+        serializer.serialize_i32(*self as i32)
     }
 }
 


### PR DESCRIPTION
Tonic returns `tonic::Status` as errors, we want to treat these as a
`gax::error::ServiceError`. In this PR we just handle the code error
message. This makes the retry loop reusable for gRPC. The additional
details will happen in future PRs.

Part of the work for #1699 