### PR TITLE
feat(generator/dart): add error utility methods to rpc.Status

### DIFF
--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -78,3 +78,6 @@ jobs:
       - name: "test package:google_cloud_gax"
         run: dart test
         working-directory: generator/dart/packages/google_cloud_gax
+      - name: "test package:google_cloud_rpc"
+        run: dart test
+        working-directory: generator/dart/generated/google_cloud_rpc

--- a/generator/dart/examples/bin/language_api.dart
+++ b/generator/dart/examples/bin/language_api.dart
@@ -20,12 +20,12 @@ library;
 import 'dart:io';
 
 import 'package:google_cloud_language_v2/language.dart';
-
+import 'package:google_cloud_rpc/rpc.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 
 void main(List<String> args) async {
   if (args.isEmpty) {
-    print('usage: dart example/language.dart <api-key>');
+    print('usage: dart bin/language_api.dart <api-key>');
     exit(1);
   }
 
@@ -38,18 +38,25 @@ void main(List<String> args) async {
     type: Document$Type.plainText,
   );
 
-  final result = await service.analyzeSentiment(
-    AnalyzeSentimentRequest(document: document),
-  );
+  try {
+    final result = await service.analyzeSentiment(
+      AnalyzeSentimentRequest(document: document),
+    );
 
-  print('result: ${result}');
-  print('documentSentiment: ${result.documentSentiment}');
+    print('result: ${result}');
+    print('documentSentiment: ${result.documentSentiment}');
 
-  for (final sentence in result.sentences!) {
-    print('');
-    print('sentence:');
-    print('  text: ${sentence.text}');
-    print('  sentiment: ${sentence.sentiment}');
+    for (final sentence in result.sentences!) {
+      print('');
+      print('sentence:');
+      print('  text: ${sentence.text}');
+      print('  sentiment: ${sentence.sentiment}');
+    }
+  } on Status catch (error) {
+    print('error: $error');
+    for (final detail in error.detailsAsMessages) {
+      print('  detail: $detail');
+    }
   }
 
   client.close();

--- a/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -81,7 +81,7 @@ class Any extends Message {
   ///   ...
   /// }
   /// ```
-  T unpackFrom<T, S>(T Function(S) decoder) {
+  T unpackFrom<T extends Message, S>(T Function(S) decoder) {
     final name = typeName;
 
     if (_customEncodedTypes.contains(name)) {

--- a/generator/dart/generated/google_cloud_rpc/.sidekick.toml
+++ b/generator/dart/generated/google_cloud_rpc/.sidekick.toml
@@ -18,3 +18,5 @@ service-config = 'google/rpc/rpc_publish.yaml'
 
 [codec]
 copyright-year = '2025'
+part-file = "src/rpc.p.dart"
+dev-dependencies = "test"

--- a/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
@@ -27,6 +27,8 @@ import 'package:google_cloud_gax/common.dart';
 import 'package:google_cloud_gax/src/json_helpers.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 
+part 'src/rpc.p.dart';
+
 /// Describes the cause of the error with structured details.
 ///
 /// Example of an error when contacting the "pubsub.googleapis.com" API when it

--- a/generator/dart/generated/google_cloud_rpc/lib/src/rpc.p.dart
+++ b/generator/dart/generated/google_cloud_rpc/lib/src/rpc.p.dart
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of '../rpc.dart';
+
+typedef _MessageDecoder = Message Function(Map<String, dynamic> json);
+
+// A map from message IDs to decoder functions.
+const Map<String, _MessageDecoder> _decoders = {
+  BadRequest.fullyQualifiedName: BadRequest.fromJson,
+  DebugInfo.fullyQualifiedName: DebugInfo.fromJson,
+  ErrorInfo.fullyQualifiedName: ErrorInfo.fromJson,
+  Help.fullyQualifiedName: Help.fromJson,
+  LocalizedMessage.fullyQualifiedName: LocalizedMessage.fromJson,
+  PreconditionFailure.fullyQualifiedName: PreconditionFailure.fromJson,
+  QuotaFailure.fullyQualifiedName: QuotaFailure.fromJson,
+  RequestInfo.fullyQualifiedName: RequestInfo.fromJson,
+  ResourceInfo.fullyQualifiedName: ResourceInfo.fromJson,
+  RetryInfo.fullyQualifiedName: RetryInfo.fromJson,
+};
+
+/// Extend [Status] to add custom handling for [Status.details].
+extension StatusExtension on Status {
+  /// A utility method to return any [ErrorInfo] instance from the [details]
+  /// list.
+  ///
+  /// All error responses are expected to include an [ErrorInfo] object.
+  ErrorInfo? get errorInfo {
+    if (details == null) return null;
+
+    for (final any in details!) {
+      if (any.typeName == ErrorInfo.fullyQualifiedName) {
+        return any.unpackFrom(ErrorInfo.fromJson);
+      }
+    }
+
+    return null;
+  }
+
+  /// A utility method to return any [LocalizedMessage] instance from the
+  /// [details] list.
+  LocalizedMessage? get localizedMessage {
+    if (details == null) return null;
+
+    for (final any in details!) {
+      if (any.typeName == LocalizedMessage.fullyQualifiedName) {
+        return any.unpackFrom(LocalizedMessage.fromJson);
+      }
+    }
+
+    return null;
+  }
+
+  /// Return the list of [details] with the list elements converted to [Message]
+  /// instances.
+  ///
+  /// If an element isn't a known error detail type then [Any] is returned for
+  /// that element.
+  ///
+  /// The known message error types are:
+  ///
+  /// - [BadRequest]
+  /// - [DebugInfo]
+  /// - [ErrorInfo]
+  /// - [Help]
+  /// - [LocalizedMessage]
+  /// - [PreconditionFailure]
+  /// - [QuotaFailure]
+  /// - [RequestInfo]
+  /// - [ResourceInfo]
+  /// - [RetryInfo]
+  ///
+  /// For more information see https://google.aip.dev/193 and
+  /// https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto.
+  List<Message> get detailsAsMessages {
+    return (details ?? []).map((any) {
+      final decoder = _decoders[any.typeName];
+      return decoder == null ? any : any.unpackFrom(decoder);
+    }).toList();
+  }
+}

--- a/generator/dart/generated/google_cloud_rpc/pubspec.yaml
+++ b/generator/dart/generated/google_cloud_rpc/pubspec.yaml
@@ -26,3 +26,6 @@ resolution: workspace
 dependencies:
   google_cloud_gax: any
   google_cloud_protobuf: any
+
+dev_dependencies:
+  test: any

--- a/generator/dart/generated/google_cloud_rpc/test/status_test.dart
+++ b/generator/dart/generated/google_cloud_rpc/test/status_test.dart
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_rpc/rpc.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final sampleStatus = Status(
+    code: 429,
+    message: "Zone 'us-east1-a': not enough resources",
+    details: [
+      Any.from(ErrorInfo(
+        reason: 'RESOURCE_AVAILABILITY',
+        domain: 'compute.googleapis.com',
+      )),
+      Any.from(
+        LocalizedMessage(
+          locale: 'en-US',
+          message: 'Lorem ipsum.',
+        ),
+      )
+    ],
+  );
+
+  test('detailsAsMessages', () {
+    expect(sampleStatus.detailsAsMessages, isNotEmpty);
+    expect(sampleStatus.detailsAsMessages, contains(isA<ErrorInfo>()));
+    expect(sampleStatus.detailsAsMessages, contains(isA<LocalizedMessage>()));
+  });
+
+  test('errorInfo', () {
+    expect(sampleStatus.errorInfo, isNotNull);
+    expect(sampleStatus.errorInfo!.reason, 'RESOURCE_AVAILABILITY');
+  });
+
+  test('localizedMessage', () {
+    expect(sampleStatus.localizedMessage, isNotNull);
+    expect(sampleStatus.localizedMessage!.locale, 'en-US');
+    expect(sampleStatus.localizedMessage!.message, isNotEmpty);
+  });
+}

--- a/generator/dart/tests/test/status_test.dart
+++ b/generator/dart/tests/test/status_test.dart
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Test that we can encode and decode common [Any] related types, like [Status]
+/// and [ErrorInfo].
+library;
+
+import 'dart:convert';
+
+import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_rpc/rpc.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Status.details helpers', () {
+    final status = Status.fromJson(jsonDecode(sampleStatus));
+    expect(status.code, 429);
+    expect(status.message, isNotEmpty);
+    expect(status.details, isNotEmpty);
+
+    final details = status.detailsAsMessages;
+    expect(details, isNotEmpty);
+    expect(details[0], isA<ErrorInfo>());
+    expect(details[1], isA<LocalizedMessage>());
+    expect(details[2], isA<Help>());
+
+    expect(status.errorInfo, isNotNull);
+    expect(status.errorInfo!.reason, 'RESOURCE_AVAILABILITY');
+    expect(status.errorInfo!.metadata, isNotEmpty);
+  });
+}
+
+const sampleStatus = r'''{
+  "code": 429,
+  "message": "The zone 'us-east1-a' does not have enough resources available to fulfill the request. Try a different zone, or try again later.",
+  "details": [
+    {
+      "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+      "reason": "RESOURCE_AVAILABILITY",
+      "domain": "compute.googleapis.com",
+      "metadata": {
+        "zone": "us-east1-a",
+        "vmType": "e2-medium",
+        "attachment": "local-ssd=3,nvidia-t4=2",
+        "zonesWithCapacity": "us-central1-f,us-central1-c"
+      }
+    },
+    {
+      "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
+      "locale": "en-US",
+      "message": "An <e2-medium> VM instance with <local-ssd=3,nvidia-t4=2> is currently unavailable in the <us-east1-a> zone. Consider trying your request in the <us-central1-f,us-central1-c> zone(s), which currently has/have capacity to accommodate your request. Alternatively, you can try your request again with a different VM hardware configuration or at a later time. For more information, see the troubleshooting documentation."
+    },
+    {
+      "@type": "type.googleapis.com/google.rpc.Help",
+      "links": [
+        {
+          "description": "Additional information on this error",
+          "url": "https://cloud.google.com/compute/docs/resource-error"
+        }
+      ]
+    }
+  ]
+}
+''';


### PR DESCRIPTION
Add error utility methods to `rpc.Status`:
- add a `Status.errorInfo` getter which retrieves the single expected ErrorInfo instance from Status.details
- add a `Status.localizedMessage` getter to get any `LocalizedMessage` from the details list
- add `Status.detailsAsMessages` which can autoconvert the ~10 known error types
- closes https://github.com/googleapis/google-cloud-rust/issues/1572

This should make it easier for users to unpack the `Any` messages from `Status.details`. Code completion will show the existing members for `Status` (code, message, details) as well as these three new extension methods.
