### PR TITLE
fix(auth): Rename CredentialTrait to CredentialsTrait and UserCredential to UserCredentials

### DIFF
--- a/src/auth/src/credentials/api_key_credential.rs
+++ b/src/auth/src/credentials/api_key_credential.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::dynamic::CredentialTrait;
+use crate::credentials::dynamic::CredentialsTrait;
 use crate::credentials::{Credential, QUOTA_PROJECT_KEY, Result};
 use crate::errors;
 use crate::token::{Token, TokenProvider};
@@ -109,7 +109,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialTrait for ApiKeyCredential<T>
+impl<T> CredentialsTrait for ApiKeyCredential<T>
 where
     T: TokenProvider,
 {

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -50,7 +50,7 @@
 //! [gke-link]: https://cloud.google.com/kubernetes-engine
 //! [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
 
-use crate::credentials::dynamic::CredentialTrait;
+use crate::credentials::dynamic::CredentialsTrait;
 use crate::credentials::{Credential, DEFAULT_UNIVERSE_DOMAIN, QUOTA_PROJECT_KEY, Result};
 use crate::errors::{self, CredentialError, is_retryable};
 use crate::token::{Token, TokenProvider};
@@ -171,7 +171,7 @@ impl Builder {
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialTrait for MDSCredential<T>
+impl<T> CredentialsTrait for MDSCredential<T>
 where
     T: TokenProvider,
 {

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -72,7 +72,7 @@
 mod jws;
 
 use crate::credentials::QUOTA_PROJECT_KEY;
-use crate::credentials::dynamic::CredentialTrait;
+use crate::credentials::dynamic::CredentialsTrait;
 use crate::credentials::{Credential, Result};
 use crate::errors::{self, CredentialError};
 use crate::token::{Token, TokenProvider};
@@ -386,7 +386,7 @@ impl ServiceAccountTokenProvider {
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialTrait for ServiceAccountCredential<T>
+impl<T> CredentialsTrait for ServiceAccountCredential<T>
 where
     T: TokenProvider,
 {

--- a/src/auth/src/credentials/user_credentials.rs
+++ b/src/auth/src/credentials/user_credentials.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::dynamic::CredentialTrait;
+use crate::credentials::dynamic::CredentialsTrait;
 use crate::credentials::{Credential, QUOTA_PROJECT_KEY, Result};
 use crate::errors::{self, CredentialError, is_retryable};
 use crate::token::{Token, TokenProvider};
@@ -39,7 +39,7 @@ pub(crate) fn creds_from(js: serde_json::Value) -> Result<Credential> {
     let cached_token_provider = TokenCache::new(token_provider);
 
     Ok(Credential {
-        inner: Arc::new(UserCredential {
+        inner: Arc::new(UserCredentials {
             token_provider: cached_token_provider,
             quota_project_id: au.quota_project_id,
         }),
@@ -112,11 +112,11 @@ impl TokenProvider for UserTokenProvider {
     }
 }
 
-/// Data model for a UserCredential
+/// Data model for a UserCredentials
 ///
 /// See: https://cloud.google.com/docs/authentication#user-accounts
 #[derive(Debug)]
-pub(crate) struct UserCredential<T>
+pub(crate) struct UserCredentials<T>
 where
     T: TokenProvider,
 {
@@ -125,7 +125,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialTrait for UserCredential<T>
+impl<T> CredentialsTrait for UserCredentials<T>
 where
     T: TokenProvider,
 {
@@ -299,7 +299,7 @@ mod test {
             .times(1)
             .return_once(|| Ok(expected_clone));
 
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider: mock,
             quota_project_id: None,
         };
@@ -314,7 +314,7 @@ mod test {
             .times(1)
             .return_once(|| Err(errors::non_retryable_from_str("fail")));
 
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider: mock,
             quota_project_id: None,
         };
@@ -333,7 +333,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token().times(1).return_once(|| Ok(token));
 
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider: mock,
             quota_project_id: None,
         };
@@ -356,7 +356,7 @@ mod test {
             .times(1)
             .return_once(|| Err(errors::non_retryable_from_str("fail")));
 
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider: mock,
             quota_project_id: None,
         };
@@ -375,7 +375,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token().times(1).return_once(|| Ok(token));
 
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider: mock,
             quota_project_id: Some("test-project".to_string()),
         };
@@ -523,7 +523,7 @@ mod test {
             refresh_token: "test-refresh-token".to_string(),
             endpoint: endpoint,
         };
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider,
             quota_project_id: None,
         };
@@ -603,7 +603,7 @@ mod test {
             refresh_token: "test-refresh-token".to_string(),
             endpoint: endpoint,
         };
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider,
             quota_project_id: None,
         };
@@ -631,7 +631,7 @@ mod test {
             refresh_token: "test-refresh-token".to_string(),
             endpoint: endpoint,
         };
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider,
             quota_project_id: None,
         };
@@ -658,7 +658,7 @@ mod test {
             refresh_token: "test-refresh-token".to_string(),
             endpoint: endpoint,
         };
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider,
             quota_project_id: None,
         };
@@ -685,7 +685,7 @@ mod test {
             refresh_token: "test-refresh-token".to_string(),
             endpoint: endpoint,
         };
-        let uc = UserCredential {
+        let uc = UserCredentials {
             token_provider,
             quota_project_id: None,
         };

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -16,7 +16,7 @@ use google_cloud_auth::credentials::mds::Builder as MdsBuilder;
 use google_cloud_auth::credentials::service_account::Builder as ServiceAccountBuilder;
 use google_cloud_auth::credentials::testing::test_credentials;
 use google_cloud_auth::credentials::{
-    ApiKeyOptions, Credential, CredentialTrait, create_access_token_credential,
+    ApiKeyOptions, Credential, CredentialsTrait, create_access_token_credential,
     create_api_key_credential,
 };
 use google_cloud_auth::errors::CredentialError;
@@ -144,7 +144,7 @@ mod test {
         #[derive(Debug)]
         Credential {}
 
-        impl CredentialTrait for Credential {
+        impl CredentialsTrait for Credential {
             async fn get_token(&self) -> Result<Token>;
             async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
             async fn get_universe_domain(&self) -> Option<String>;

--- a/src/gax-internal/tests/auth.rs
+++ b/src/gax-internal/tests/auth.rs
@@ -14,7 +14,7 @@
 
 #[cfg(all(test, feature = "_internal_http_client"))]
 mod test {
-    use auth::credentials::{Credential, CredentialTrait};
+    use auth::credentials::{Credential, CredentialsTrait};
     use auth::errors::CredentialError;
     use auth::token::Token;
     use gax::options::*;
@@ -29,7 +29,7 @@ mod test {
         #[derive(Debug)]
         Credential {}
 
-        impl CredentialTrait for Credential {
+        impl CredentialsTrait for Credential {
             async fn get_token(&self) -> AuthResult<Token>;
             async fn get_headers(&self) -> AuthResult<Vec<(HeaderName, HeaderValue)>>;
             async fn get_universe_domain(&self) -> Option<String>;


### PR DESCRIPTION
This change is a part of an effort to Consistently use the term "Credentials" instead of "Credential"