### PR TITLE
fix(auth): Replace api_key_credential with api_key_credentials

### DIFF
--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use auth::credentials::{ApiKeyOptions, create_access_token_credential, create_api_key_credential};
+use auth::credentials::{ApiKeyOptions, create_access_token_credential, create_api_key_credentials};
 use gax::error::Error;
 use language::client::LanguageService;
 use language::model::Document;
@@ -98,7 +98,7 @@ pub async fn api_key() -> Result<()> {
     let api_key = std::str::from_utf8(&api_key).unwrap();
 
     // Create credentials using the API key.
-    let creds = create_api_key_credential(api_key, ApiKeyOptions::default())
+    let creds = create_api_key_credentials(api_key, ApiKeyOptions::default())
         .await
         .map_err(Error::authentication)?;
 

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use auth::credentials::{ApiKeyOptions, create_access_token_credential, create_api_key_credentials};
+use auth::credentials::{
+    ApiKeyOptions, create_access_token_credential, create_api_key_credentials,
+};
 use gax::error::Error;
 use language::client::LanguageService;
 use language::model::Document;

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod api_key_credential;
+mod api_key_credentials;
 // Export API Key factory function and options
-pub use api_key_credential::ApiKeyOptions;
-pub use api_key_credential::create_api_key_credential;
+pub use api_key_credentials::{ApiKeyOptions, create_api_key_credentials};
 
 pub mod mds;
 pub mod service_account;

--- a/src/auth/src/credentials/api_key_credentials.rs
+++ b/src/auth/src/credentials/api_key_credentials.rs
@@ -55,7 +55,7 @@ impl ApiKeyOptions {
 ///
 /// [API key]: https://cloud.google.com/docs/authentication/api-keys-use
 /// [principal]: https://cloud.google.com/docs/authentication#principal
-pub async fn create_api_key_credential<T: Into<String>>(
+pub async fn create_api_key_credentials<T: Into<String>>(
     api_key: T,
     o: ApiKeyOptions,
 ) -> Result<Credential> {
@@ -149,10 +149,10 @@ mod test {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn create_api_key_credential_basic() {
+    async fn create_api_key_credentials_basic() {
         let _e = ScopedEnv::remove("GOOGLE_CLOUD_QUOTA_PROJECT");
 
-        let creds = create_api_key_credential("test-api-key", ApiKeyOptions::default())
+        let creds = create_api_key_credentials("test-api-key", ApiKeyOptions::default())
             .await
             .unwrap();
         let token = creds.get_token().await.unwrap();
@@ -179,11 +179,11 @@ mod test {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn create_api_key_credential_with_options() {
+    async fn create_api_key_credentials_with_options() {
         let _e = ScopedEnv::remove("GOOGLE_CLOUD_QUOTA_PROJECT");
 
         let options = ApiKeyOptions::default().set_quota_project("qp-option");
-        let creds = create_api_key_credential("test-api-key", options)
+        let creds = create_api_key_credentials("test-api-key", options)
             .await
             .unwrap();
         let headers: Vec<HV> = HV::from(creds.get_headers().await.unwrap());
@@ -207,10 +207,10 @@ mod test {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn create_api_key_credential_with_env() {
+    async fn create_api_key_credentials_with_env() {
         let _e = ScopedEnv::set("GOOGLE_CLOUD_QUOTA_PROJECT", "qp-env");
         let options = ApiKeyOptions::default().set_quota_project("qp-option");
-        let creds = create_api_key_credential("test-api-key", options)
+        let creds = create_api_key_credentials("test-api-key", options)
             .await
             .unwrap();
         let headers: Vec<HV> = HV::from(creds.get_headers().await.unwrap());

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -17,7 +17,7 @@ use google_cloud_auth::credentials::service_account::Builder as ServiceAccountBu
 use google_cloud_auth::credentials::testing::test_credentials;
 use google_cloud_auth::credentials::{
     ApiKeyOptions, Credential, CredentialsTrait, create_access_token_credential,
-    create_api_key_credential,
+    create_api_key_credentials,
 };
 use google_cloud_auth::errors::CredentialError;
 use google_cloud_auth::token::Token;
@@ -132,8 +132,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn create_api_key_credential_success() {
-        let creds = create_api_key_credential("test-api-key", ApiKeyOptions::default())
+    async fn create_api_key_credentials_success() {
+        let creds = create_api_key_credentials("test-api-key", ApiKeyOptions::default())
             .await
             .unwrap();
         let fmt = format!("{:?}", creds);


### PR DESCRIPTION
This change is a part of an effort to Consistently use the term "Credentials" instead of "Credential"