### PR TITLE
fix(auth): Rename the public Credential Struct to Credentials

### DIFF
--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -48,7 +48,7 @@ mod info {
 #[derive(Clone)]
 pub struct {{Codec.Name}} {
     inner: tonic::client::Grpc<tonic::transport::Channel>,
-    cred: auth::credentials::Credential,
+    cred: auth::credentials::Credentials,
     retry_policy: Option<Arc<dyn gax::retry_policy::RetryPolicy>>,
     backoff_policy: Option<Arc<dyn gax::backoff_policy::BackoffPolicy>>,
     retry_throttler: gax::retry_throttler::SharedRetryThrottler,
@@ -83,7 +83,7 @@ impl {{Codec.Name}} {
         Ok(tonic::client::Grpc::new(conn))
     }
 
-    async fn make_credentials(config: &gaxi::options::ClientConfig) -> Result<auth::credentials::Credential> {
+    async fn make_credentials(config: &gaxi::options::ClientConfig) -> Result<auth::credentials::Credentials> {
         if let Some(c) = config.cred.clone() {
             return Ok(c);
         }

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -31,7 +31,7 @@ pub(crate) const DEFAULT_UNIVERSE_DOMAIN: &str = "googleapis.com";
 
 /// An implementation of [crate::credentials::CredentialsTrait].
 ///
-/// Represents a [Credential] used to obtain auth [Token][crate::token::Token]s
+/// Represents a [Credentials] used to obtain auth [Token][crate::token::Token]s
 /// and the corresponding request headers.
 ///
 /// In general, [Credentials][credentials-link] are "digital object that provide
@@ -63,7 +63,7 @@ pub(crate) const DEFAULT_UNIVERSE_DOMAIN: &str = "googleapis.com";
 /// [Google Compute Engine]: https://cloud.google.com/products/compute
 /// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
 #[derive(Clone, Debug)]
-pub struct Credential {
+pub struct Credentials {
     // We use an `Arc` to hold the inner implementation.
     //
     // Credentials may be shared across threads (`Send + Sync`), so an `Rc`
@@ -75,7 +75,7 @@ pub struct Credential {
     inner: Arc<dyn dynamic::CredentialsTrait>,
 }
 
-impl<T> std::convert::From<T> for Credential
+impl<T> std::convert::From<T> for Credentials
 where
     T: crate::credentials::CredentialsTrait + Send + Sync + 'static,
 {
@@ -86,7 +86,7 @@ where
     }
 }
 
-impl Credential {
+impl Credentials {
     pub async fn get_token(&self) -> Result<crate::token::Token> {
         self.inner.get_token().await
     }
@@ -100,7 +100,7 @@ impl Credential {
     }
 }
 
-/// Represents a [Credential] used to obtain auth
+/// Represents a [Credentials] used to obtain auth
 /// [Token][crate::token::Token]s and the corresponding request headers.
 ///
 /// In general, [Credentials][credentials-link] are "digital object that
@@ -150,7 +150,7 @@ pub trait CredentialsTrait: std::fmt::Debug {
     /// Asynchronously constructs the auth headers.
     ///
     /// Different auth tokens are sent via different headers. The
-    /// [Credential] constructs the headers (and header values) that should be
+    /// [Credentials] constructs the headers (and header values) that should be
     /// sent with a request.
     ///
     /// The underlying implementation refreshes the token as needed.
@@ -176,13 +176,13 @@ pub(crate) mod dynamic {
         /// Asynchronously constructs the auth headers.
         ///
         /// Different auth tokens are sent via different headers. The
-        /// [Credential] constructs the headers (and header values) that should be
+        /// [Credentials] constructs the headers (and header values) that should be
         /// sent with a request.
         ///
         /// The underlying implementation refreshes the token as needed.
         async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
 
-        /// Retrieves the universe domain associated with the credential, if any.
+        /// Retrieves the universe domain associated with the credentials, if any.
         async fn get_universe_domain(&self) -> Option<String> {
             Some("googleapis.com".to_string())
         }
@@ -252,7 +252,7 @@ pub(crate) mod dynamic {
 /// [gce-link]: https://cloud.google.com/products/compute
 /// [gcloud auth application-default]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default
 /// [gke-link]: https://cloud.google.com/kubernetes-engine
-pub async fn create_access_token_credential() -> Result<Credential> {
+pub async fn create_access_token_credential() -> Result<Credentials> {
     let contents = match load_adc()? {
         AdcContents::Contents(contents) => contents,
         AdcContents::FallbackToMds => return Ok(mds::new()),
@@ -268,7 +268,7 @@ pub async fn create_access_token_credential() -> Result<Credential> {
         "authorized_user" => user_credentials::creds_from(js),
         "service_account" => service_account::creds_from(js),
         _ => Err(errors::non_retryable_from_str(format!(
-            "Unimplemented credential type: {cred_type}"
+            "Unimplemented credentials type: {cred_type}"
         ))),
     }
 }
@@ -347,7 +347,7 @@ fn adc_well_known_path() -> Option<String> {
 /// may find it useful.
 pub mod testing {
     use crate::Result;
-    use crate::credentials::Credential;
+    use crate::credentials::Credentials;
     use crate::credentials::dynamic::CredentialsTrait;
     use crate::token::Token;
     use http::header::{HeaderName, HeaderValue};
@@ -356,17 +356,17 @@ pub mod testing {
     /// A simple credentials implementation to use in tests where authentication does not matter.
     ///
     /// Always returns a "Bearer" token, with "test-only-token" as the value.
-    pub fn test_credentials() -> Credential {
-        Credential {
-            inner: Arc::from(TestCredential {}),
+    pub fn test_credentials() -> Credentials {
+        Credentials {
+            inner: Arc::from(TestCredentials {}),
         }
     }
 
     #[derive(Debug)]
-    struct TestCredential;
+    struct TestCredentials;
 
     #[async_trait::async_trait]
-    impl CredentialsTrait for TestCredential {
+    impl CredentialsTrait for TestCredentials {
         async fn get_token(&self) -> Result<Token> {
             Ok(Token {
                 token: "test-only-token".to_string(),
@@ -388,8 +388,8 @@ pub mod testing {
     /// A simple credentials implementation to use in tests.
     ///
     /// Always return an error in `get_token()` and `get_headers()`.
-    pub fn error_credentials(retryable: bool) -> Credential {
-        Credential {
+    pub fn error_credentials(retryable: bool) -> Credentials {
+        Credentials {
             inner: Arc::from(ErrorCredentials(retryable)),
         }
     }

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -131,7 +131,7 @@ impl Credentials {
 /// # Notes
 ///
 /// Application developers who directly use the Auth SDK can use this trait,
-/// along with [crate::credentials::Credential::from()] to mock the credentials.
+/// along with [crate::credentials::Credentials::from()] to mock the credentials.
 /// Application developers who use the Google Cloud Rust SDK directly should not
 /// need this functionality.
 ///

--- a/src/auth/src/credentials/api_key_credentials.rs
+++ b/src/auth/src/credentials/api_key_credentials.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::credentials::dynamic::CredentialsTrait;
-use crate::credentials::{Credential, QUOTA_PROJECT_KEY, Result};
+use crate::credentials::{Credentials, QUOTA_PROJECT_KEY, Result};
 use crate::errors;
 use crate::token::{Token, TokenProvider};
 use http::header::{HeaderName, HeaderValue};
@@ -58,7 +58,7 @@ impl ApiKeyOptions {
 pub async fn create_api_key_credentials<T: Into<String>>(
     api_key: T,
     o: ApiKeyOptions,
-) -> Result<Credential> {
+) -> Result<Credentials> {
     let token_provider = ApiKeyTokenProvider {
         api_key: api_key.into(),
     };
@@ -67,7 +67,7 @@ pub async fn create_api_key_credentials<T: Into<String>>(
         .ok()
         .or(o.quota_project);
 
-    Ok(Credential {
+    Ok(Credentials {
         inner: Arc::new(ApiKeyCredentials {
             token_provider,
             quota_project_id,

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -34,11 +34,11 @@
 //!
 //! ```
 //! # use google_cloud_auth::credentials::mds::Builder;
-//! # use google_cloud_auth::credentials::Credential;
+//! # use google_cloud_auth::credentials::Credentials;
 //! # use google_cloud_auth::errors::CredentialError;
 //! # tokio_test::block_on(async {
-//! let credential: Credential = Builder::default().quota_project_id("my-quota-project").build();
-//! let token = credential.get_token().await?;
+//! let credentials: Credentials = Builder::default().quota_project_id("my-quota-project").build();
+//! let token = credentials.get_token().await?;
 //! println!("Token: {}", token.token);
 //! # Ok::<(), CredentialError>(())
 //! # });
@@ -51,7 +51,7 @@
 //! [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
 
 use crate::credentials::dynamic::CredentialsTrait;
-use crate::credentials::{Credential, DEFAULT_UNIVERSE_DOMAIN, QUOTA_PROJECT_KEY, Result};
+use crate::credentials::{Credentials, DEFAULT_UNIVERSE_DOMAIN, QUOTA_PROJECT_KEY, Result};
 use crate::errors::{self, CredentialError, is_retryable};
 use crate::token::{Token, TokenProvider};
 use async_trait::async_trait;
@@ -66,7 +66,7 @@ const METADATA_FLAVOR_VALUE: &str = "Google";
 const METADATA_FLAVOR: &str = "metadata-flavor";
 const METADATA_ROOT: &str = "http://metadata.google.internal/";
 
-pub(crate) fn new() -> Credential {
+pub(crate) fn new() -> Credentials {
     Builder::default().build()
 }
 
@@ -80,7 +80,7 @@ where
     token_provider: T,
 }
 
-/// Creates [Credential] instances backed by the [Metadata Service].
+/// Creates [Credentials] instances backed by the [Metadata Service].
 ///
 /// While the Google Cloud client libraries for Rust default to credentials
 /// backed by the metadata service, some applications may need to:
@@ -149,8 +149,8 @@ impl Builder {
         self
     }
 
-    /// Returns a [Credential] instance with the configured settings.
-    pub fn build(self) -> Credential {
+    /// Returns a [Credentials] instance with the configured settings.
+    pub fn build(self) -> Credentials {
         let endpoint = self.endpoint.clone().unwrap_or(METADATA_ROOT.to_string());
 
         let token_provider = MDSAccessTokenProvider::builder()
@@ -164,7 +164,7 @@ impl Builder {
             token_provider: cached_token_provider,
             universe_domain: self.universe_domain,
         };
-        Credential {
+        Credentials {
             inner: Arc::new(mdsc),
         }
     }

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -73,7 +73,7 @@ mod jws;
 
 use crate::credentials::QUOTA_PROJECT_KEY;
 use crate::credentials::dynamic::CredentialsTrait;
-use crate::credentials::{Credential, Result};
+use crate::credentials::{Credentials, Result};
 use crate::errors::{self, CredentialError};
 use crate::token::{Token, TokenProvider};
 use crate::token_cache::TokenCache;
@@ -89,7 +89,7 @@ use time::OffsetDateTime;
 
 const DEFAULT_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
 
-pub(crate) fn creds_from(js: Value) -> Result<Credential> {
+pub(crate) fn creds_from(js: Value) -> Result<Credentials> {
     Builder::new(js).build()
 }
 
@@ -115,7 +115,7 @@ impl ServiceAccountRestrictions {
     }
 }
 
-/// A builder for constructing service account [Credential] instances.
+/// A builder for constructing service account [Credentials] instances.
 ///
 /// # Example
 /// ```
@@ -155,11 +155,11 @@ impl Builder {
         }
     }
 
-    /// Sets the audience for this credential.
+    /// Sets the audience for this credentials.
     ///
     /// `aud` is a [JWT] claim specifying intended recipient(s) of the token,
     /// that is, a service(s).
-    /// Only one of audience or scopes can be specified for a credential.
+    /// Only one of audience or scopes can be specified for a credentials.
     /// Setting the audience will replace any previously configured scopes.
     /// The value should be `https://{SERVICE}/`, e.g., `https://pubsub.googleapis.com/`
     ///
@@ -176,10 +176,10 @@ impl Builder {
         self
     }
 
-    /// Sets the [scopes] for this credential.
+    /// Sets the [scopes] for this credentials.
     ///
     /// `scopes` is a [JWT] claim specifying requested permission(s) for the token.
-    /// Only one of audience or scopes can be specified for a credential.
+    /// Only one of audience or scopes can be specified for a credentials.
     /// Setting the scopes will replace any previously configured audience.
     ///
     /// `scopes` define the *permissions being requested* for this specific session
@@ -212,7 +212,7 @@ impl Builder {
         self
     }
 
-    /// Sets the [quota project] for this credential.
+    /// Sets the [quota project] for this credentials.
     ///
     /// In some services, you can use a service account in
     /// one project for authentication and authorization, and charge
@@ -225,7 +225,7 @@ impl Builder {
         self
     }
 
-    /// Returns a [Credential] instance with the configured settings.
+    /// Returns a [Credentials] instance with the configured settings.
     ///
     /// # Errors
     ///
@@ -237,7 +237,7 @@ impl Builder {
     /// relevant section in the [service account keys] guide.
     ///
     /// [creating service account keys]: https://cloud.google.com/iam/docs/keys-create-delete#creating
-    pub fn build(self) -> Result<Credential> {
+    pub fn build(self) -> Result<Credentials> {
         let service_account_key =
             serde_json::from_value::<ServiceAccountKey>(self.service_account_key)
                 .map_err(errors::non_retryable)?;
@@ -247,7 +247,7 @@ impl Builder {
         };
         let token_provider = TokenCache::new(token_provider);
 
-        Ok(Credential {
+        Ok(Credentials {
             inner: Arc::new(ServiceAccountCredential {
                 token_provider,
                 quota_project_id: self.quota_project_id,

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -47,7 +47,7 @@
 //!
 //! ```
 //! # use google_cloud_auth::credentials::service_account::Builder;
-//! # use google_cloud_auth::credentials::Credential;
+//! # use google_cloud_auth::credentials::Credentials;
 //! # use google_cloud_auth::errors::CredentialError;
 //! # tokio_test::block_on(async {
 //! let service_account_key = serde_json::json!({
@@ -57,8 +57,8 @@
 //! "project_id": "test-project-id",
 //! "universe_domain": "test-universe-domain",
 //! });
-//! let credential: Credential = Builder::new(service_account_key).with_quota_project_id("my-quota-project").build()?;
-//! let token = credential.get_token().await?;
+//! let credentials: Credentials = Builder::new(service_account_key).with_quota_project_id("my-quota-project").build()?;
+//! let token = credentials.get_token().await?;
 //! println!("Token: {}", token.token);
 //! # Ok::<(), CredentialError>(())
 //! # });

--- a/src/auth/src/credentials/user_credentials.rs
+++ b/src/auth/src/credentials/user_credentials.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::credentials::dynamic::CredentialsTrait;
-use crate::credentials::{Credential, QUOTA_PROJECT_KEY, Result};
+use crate::credentials::{Credentials, QUOTA_PROJECT_KEY, Result};
 use crate::errors::{self, CredentialError, is_retryable};
 use crate::token::{Token, TokenProvider};
 use crate::token_cache::TokenCache;
@@ -24,7 +24,7 @@ use std::time::Duration;
 
 const OAUTH2_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
 
-pub(crate) fn creds_from(js: serde_json::Value) -> Result<Credential> {
+pub(crate) fn creds_from(js: serde_json::Value) -> Result<Credentials> {
     let au = serde_json::from_value::<AuthorizedUser>(js).map_err(errors::non_retryable)?;
 
     let endpoint = au.token_uri.unwrap_or_else(|| OAUTH2_ENDPOINT.to_string());
@@ -38,7 +38,7 @@ pub(crate) fn creds_from(js: serde_json::Value) -> Result<Credential> {
 
     let cached_token_provider = TokenCache::new(token_provider);
 
-    Ok(Credential {
+    Ok(Credentials {
         inner: Arc::new(UserCredentials {
             token_provider: cached_token_provider,
             quota_project_id: au.quota_project_id,

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! This crate contains types and functions used to authenticate applications
 //! on Google Cloud.  The SDK clients consume an implementation of
-//! [credentials::Credential] and use these credentials to authenticate RPCs
+//! [credentials::Credentials] and use these credentials to authenticate RPCs
 //! issued by the application.
 //!
 //! [Authentication methods at Google] is a good introduction on the topic of

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -16,7 +16,7 @@ use google_cloud_auth::credentials::mds::Builder as MdsBuilder;
 use google_cloud_auth::credentials::service_account::Builder as ServiceAccountBuilder;
 use google_cloud_auth::credentials::testing::test_credentials;
 use google_cloud_auth::credentials::{
-    ApiKeyOptions, Credential, CredentialsTrait, create_access_token_credential,
+    ApiKeyOptions, Credentials, CredentialsTrait, create_access_token_credential,
     create_api_key_credentials,
 };
 use google_cloud_auth::errors::CredentialError;

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -165,7 +165,7 @@ mod test {
         mock.expect_get_headers().return_once(|| Ok(Vec::new()));
         mock.expect_get_universe_domain().return_once(|| None);
 
-        let creds = Credential::from(mock);
+        let creds = Credentials::from(mock);
         assert_eq!(creds.get_token().await?.token, "test-token");
         assert!(creds.get_headers().await?.is_empty());
         assert_eq!(creds.get_universe_domain().await, None);

--- a/src/auth/tests/crypto_provider.rs
+++ b/src/auth/tests/crypto_provider.rs
@@ -23,7 +23,7 @@ mod test {
     // TODO(#1442) : We should use auth's factory function specifically for
     // service account credentials when it is available, instead of using the
     // generic ADC factory function with delicately crafted json.
-    async fn test_service_account_credentials() -> Credential {
+    async fn test_service_account_credentials() -> Credentials {
         let contents = r#"{
             "type": "service_account",
             "project_id": "test-project-id",

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -40,7 +40,7 @@ mod info {
 #[derive(Clone)]
 pub struct Firestore {
     inner: tonic::client::Grpc<tonic::transport::Channel>,
-    cred: auth::credentials::Credential,
+    cred: auth::credentials::Credentials,
     retry_policy: Option<Arc<dyn gax::retry_policy::RetryPolicy>>,
     backoff_policy: Option<Arc<dyn gax::backoff_policy::BackoffPolicy>>,
     retry_throttler: gax::retry_throttler::SharedRetryThrottler,
@@ -79,7 +79,7 @@ impl Firestore {
 
     async fn make_credentials(
         config: &gaxi::options::ClientConfig,
-    ) -> Result<auth::credentials::Credential> {
+    ) -> Result<auth::credentials::Credentials> {
         if let Some(c) = config.cred.clone() {
             return Ok(c);
         }

--- a/src/gax-internal/echo-server/src/lib.rs
+++ b/src/gax-internal/echo-server/src/lib.rs
@@ -42,14 +42,14 @@ pub async fn start() -> Result<(String, JoinHandle<()>)> {
 
 pub fn builder(
     endpoint: impl Into<String>,
-) -> gax::client_builder::ClientBuilder<Factory, auth::credentials::Credential> {
+) -> gax::client_builder::ClientBuilder<Factory, auth::credentials::Credentials> {
     gax::client_builder::internal::new_builder(Factory(endpoint.into()))
 }
 
 pub struct Factory(String);
 impl gax::client_builder::internal::ClientFactory for Factory {
     type Client = gaxi::http::ReqwestClient;
-    type Credentials = auth::credentials::Credential;
+    type Credentials = auth::credentials::Credentials;
     async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
         Self::Client::new(config, &self.0).await
     }

--- a/src/gax-internal/grpc-server/src/lib.rs
+++ b/src/gax-internal/grpc-server/src/lib.rs
@@ -66,14 +66,14 @@ where
 
 pub fn builder(
     endpoint: impl Into<String>,
-) -> gax::client_builder::ClientBuilder<Factory, auth::credentials::Credential> {
+) -> gax::client_builder::ClientBuilder<Factory, auth::credentials::Credentials> {
     gax::client_builder::internal::new_builder(Factory(endpoint.into()))
 }
 
 pub struct Factory(String);
 impl gax::client_builder::internal::ClientFactory for Factory {
     type Client = gaxi::grpc::Client;
-    type Credentials = auth::credentials::Credential;
+    type Credentials = auth::credentials::Credentials;
     async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
         Self::Client::new(config, &self.0).await
     }

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -14,7 +14,7 @@
 
 //! Implements the common features of all gRPC-based client.
 
-use auth::credentials::Credential;
+use auth::credentials::Credentials;
 use gax::Result;
 use gax::backoff_policy::BackoffPolicy;
 use gax::error::Error;

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -33,7 +33,7 @@ pub type InnerClient = tonic::client::Grpc<tonic::transport::Channel>;
 #[derive(Clone, Debug)]
 pub struct Client {
     inner: InnerClient,
-    credentials: auth::credentials::Credential,
+    credentials: auth::credentials::Credentials,
     retry_policy: Option<Arc<dyn RetryPolicy>>,
     backoff_policy: Option<Arc<dyn BackoffPolicy>>,
     retry_throttler: SharedRetryThrottler,
@@ -185,7 +185,7 @@ impl Client {
 
     async fn make_credentials(
         config: &crate::options::ClientConfig,
-    ) -> Result<auth::credentials::Credential> {
+    ) -> Result<auth::credentials::Credentials> {
         if let Some(c) = config.cred.clone() {
             return Ok(c);
         }

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -146,7 +146,7 @@ impl Client {
     #[allow(clippy::too_many_arguments)]
     pub async fn request_attempt<Request, Response>(
         inner: &mut InnerClient,
-        credentials: &Credential,
+        credentials: &Credentials,
         method: tonic::GrpcMethod<'static>,
         path: http::uri::PathAndQuery,
         request: Request,
@@ -195,7 +195,7 @@ impl Client {
     }
 
     async fn make_headers(
-        credentials: &Credential,
+        credentials: &Credentials,
         api_client_header: &'static str,
         request_params: &str,
     ) -> Result<http::header::HeaderMap> {

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use auth::credentials::{Credential, create_access_token_credential};
+use auth::credentials::{Credentials, create_access_token_credential};
 use gax::Result;
 use gax::backoff_policy::BackoffPolicy;
 use gax::error::Error;
@@ -30,7 +30,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct ReqwestClient {
     inner: reqwest::Client,
-    cred: Credential,
+    cred: Credentials,
     endpoint: String,
     retry_policy: Option<Arc<dyn RetryPolicy>>,
     backoff_policy: Option<Arc<dyn BackoffPolicy>>,

--- a/src/gax-internal/src/options.rs
+++ b/src/gax-internal/src/options.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use auth::credentials::Credentials as Credentials;
+pub use auth::credentials::Credentials;
 
 // The client configuration for [crate::http::ReqwestClient] and [crate::grpc::Client].
 pub type ClientConfig = gax::client_builder::internal::ClientConfig<Credentials>;

--- a/src/gax-internal/src/options.rs
+++ b/src/gax-internal/src/options.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use auth::credentials::Credential as Credentials;
+pub use auth::credentials::Credentials as Credentials;
 
 // The client configuration for [crate::http::ReqwestClient] and [crate::grpc::Client].
 pub type ClientConfig = gax::client_builder::internal::ClientConfig<Credentials>;

--- a/src/gax-internal/tests/auth.rs
+++ b/src/gax-internal/tests/auth.rs
@@ -14,7 +14,7 @@
 
 #[cfg(all(test, feature = "_internal_http_client"))]
 mod test {
-    use auth::credentials::{Credential, CredentialsTrait};
+    use auth::credentials::{Credentials, CredentialsTrait};
     use auth::errors::CredentialError;
     use auth::token::Token;
     use gax::options::*;

--- a/src/gax-internal/tests/client_builder.rs
+++ b/src/gax-internal/tests/client_builder.rs
@@ -19,7 +19,7 @@ mod test {
 
     #[cfg(feature = "_internal_grpc_client")]
     mod grpc {
-        use auth::credentials::Credential;
+        use auth::credentials::Credentials;
         use google_cloud_gax_internal as gaxi;
 
         #[tokio::test]
@@ -48,7 +48,7 @@ mod test {
         }
         /// Make this visible for documentation purposes.
         pub type ClientBuilder =
-            gax::client_builder::ClientBuilder<fake_client::Factory, Credential>;
+            gax::client_builder::ClientBuilder<fake_client::Factory, Credentials>;
         // Note the pub(self), the types in this module are not accessible to
         // application developers.
         pub(self) mod fake_client {
@@ -56,7 +56,7 @@ mod test {
             pub struct Factory;
             impl gax::client_builder::internal::ClientFactory for Factory {
                 type Client = super::FakeClient;
-                type Credentials = super::Credential;
+                type Credentials = super::Credentials;
                 async fn build(
                     self,
                     config: gaxi::options::ClientConfig,
@@ -69,7 +69,7 @@ mod test {
 
     #[cfg(feature = "_internal_http_client")]
     mod http {
-        use auth::credentials::Credential;
+        use auth::credentials::Credentials;
         use google_cloud_gax_internal as gaxi;
 
         #[tokio::test]
@@ -98,7 +98,7 @@ mod test {
         }
         /// Make this visible for documentation purposes.
         pub type ClientBuilder =
-            gax::client_builder::ClientBuilder<fake_client::Factory, Credential>;
+            gax::client_builder::ClientBuilder<fake_client::Factory, Credentials>;
         // Note the pub(self), the types in this module are not accessible to
         // application developers.
         pub(self) mod fake_client {
@@ -106,7 +106,7 @@ mod test {
             pub struct Factory;
             impl gax::client_builder::internal::ClientFactory for Factory {
                 type Client = super::FakeClient;
-                type Credentials = super::Credential;
+                type Credentials = super::Credentials;
                 async fn build(
                     self,
                     config: gaxi::options::ClientConfig,

--- a/src/lro/tests/fake/library/client.rs
+++ b/src/lro/tests/fake/library/client.rs
@@ -45,7 +45,8 @@ impl Client {
     }
 }
 
-pub type ClientBuilder = gax::client_builder::ClientBuilder<Factory, auth::credentials::Credentials>;
+pub type ClientBuilder =
+    gax::client_builder::ClientBuilder<Factory, auth::credentials::Credentials>;
 pub struct Factory;
 impl gax::client_builder::internal::ClientFactory for Factory {
     type Client = Client;

--- a/src/lro/tests/fake/library/client.rs
+++ b/src/lro/tests/fake/library/client.rs
@@ -45,11 +45,11 @@ impl Client {
     }
 }
 
-pub type ClientBuilder = gax::client_builder::ClientBuilder<Factory, auth::credentials::Credential>;
+pub type ClientBuilder = gax::client_builder::ClientBuilder<Factory, auth::credentials::Credentials>;
 pub struct Factory;
 impl gax::client_builder::internal::ClientFactory for Factory {
     type Client = Client;
-    type Credentials = auth::credentials::Credential;
+    type Credentials = auth::credentials::Credentials;
     async fn build(self, config: gaxi::options::ClientConfig) -> Result<Self::Client> {
         Self::Client::new(config).await
     }


### PR DESCRIPTION
This change is a part of an effort to Consistently use the term "Credentials" instead of "Credential".