### PR TITLE
impl(gax-credentials): retry loop in `grpc::Client`

### DIFF
--- a/src/gax-internal/tests/grpc_retry_loop.rs
+++ b/src/gax-internal/tests/grpc_retry_loop.rs
@@ -1,0 +1,142 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(all(test, feature = "_internal_grpc_client"))]
+mod test {
+    use auth::credentials::testing::test_credentials;
+    use gax::options::*;
+    use gax::retry_policy::{Aip194Strict, RetryPolicyExt};
+    use google_cloud_gax_internal::grpc;
+    use grpc_server::google::test::v1::EchoResponse;
+    use grpc_server::{builder, google, start_fixed_responses};
+
+    #[tokio::test]
+    async fn no_retry_immediate_success() -> anyhow::Result<()> {
+        let (endpoint, _server) = start_fixed_responses(vec![success()]).await?;
+
+        let client = builder(endpoint)
+            .with_credentials(test_credentials())
+            .build()
+            .await?;
+        let response = send_request(client, "no_retry_immediate_success").await;
+        assert!(response.is_ok(), "{response:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn no_retry_immediate_error() -> anyhow::Result<()> {
+        let (endpoint, _server) = start_fixed_responses(vec![transient()]).await?;
+
+        let client = builder(endpoint)
+            .with_credentials(test_credentials())
+            .build()
+            .await?;
+        let response = send_request(client, "no_retry_immediate_error").await;
+        assert!(response.is_err(), "{response:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retry_then_success() -> anyhow::Result<()> {
+        let (endpoint, _server) =
+            start_fixed_responses(vec![transient(), transient(), success()]).await?;
+
+        let client = builder(endpoint)
+            .with_credentials(test_credentials())
+            .with_retry_policy(Aip194Strict)
+            .with_backoff_policy(test_backoff())
+            .build()
+            .await?;
+        let response = send_request(client, "retry_then_success").await;
+        assert!(response.is_ok(), "{response:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retry_then_error() -> anyhow::Result<()> {
+        let (endpoint, _server) =
+            start_fixed_responses(vec![transient(), transient(), permanent()]).await?;
+
+        let client = builder(endpoint)
+            .with_credentials(test_credentials())
+            .with_retry_policy(Aip194Strict)
+            .with_backoff_policy(test_backoff())
+            .build()
+            .await?;
+        let response = send_request(client, "no_retry_immediate_error").await;
+        assert!(response.is_err(), "{response:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retry_policy_exhausted() -> anyhow::Result<()> {
+        let (endpoint, _server) =
+            start_fixed_responses((0..3).into_iter().map(|_| transient())).await?;
+
+        let client = builder(endpoint)
+            .with_credentials(test_credentials())
+            .with_retry_policy(Aip194Strict.with_attempt_limit(3))
+            .with_backoff_policy(test_backoff())
+            .build()
+            .await?;
+        let response = send_request(client, "no_retry_immediate_error").await;
+        assert!(response.is_err(), "{response:?}");
+        Ok(())
+    }
+
+    fn success() -> tonic::Result<tonic::Response<EchoResponse>> {
+        Ok(tonic::Response::new(EchoResponse {
+            message: "success!".into(),
+            metadata: std::collections::HashMap::default(),
+        }))
+    }
+
+    fn transient() -> tonic::Result<tonic::Response<EchoResponse>> {
+        Err(tonic::Status::unavailable("try-again"))
+    }
+
+    fn permanent() -> tonic::Result<tonic::Response<EchoResponse>> {
+        Err(tonic::Status::permission_denied("uh-oh"))
+    }
+
+    fn test_backoff() -> impl gax::backoff_policy::BackoffPolicy {
+        use std::time::Duration;
+        gax::exponential_backoff::ExponentialBackoffBuilder::new()
+            .with_initial_delay(Duration::from_micros(1))
+            .with_maximum_delay(Duration::from_micros(1))
+            .build()
+            .expect("a valid backoff policy")
+    }
+
+    pub async fn send_request(
+        client: grpc::Client,
+        msg: &str,
+    ) -> gax::Result<google::test::v1::EchoResponse> {
+        let request = google::test::v1::EchoRequest {
+            message: msg.into(),
+        };
+        let mut request_options = RequestOptions::default();
+        request_options.set_idempotency(true);
+        client
+            .execute(
+                tonic::GrpcMethod::new("google.test.v1.EchoServices", "Echo"),
+                http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Echo"),
+                request,
+                request_options,
+                "test-only-api-client/1.0",
+                "name=test-only",
+            )
+            .await
+    }
+}


### PR DESCRIPTION
Part of the work for #1612
