### PR TITLE
fix(auth): Rename create_access_token_credential to create_access_token_credentials

### DIFF
--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -87,7 +87,7 @@ impl {{Codec.Name}} {
         if let Some(c) = config.cred.clone() {
             return Ok(c);
         }
-        auth::credentials::create_access_token_credential()
+        auth::credentials::create_access_token_credentials()
                 .await
                 .map_err(Error::authentication)
     }

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use auth::credentials::{
-    ApiKeyOptions, create_access_token_credential, create_api_key_credentials,
+    ApiKeyOptions, create_access_token_credentials, create_api_key_credentials,
 };
 use gax::error::Error;
 use language::client::LanguageService;
@@ -51,7 +51,7 @@ pub async fn service_account() -> Result<()> {
 
     // Create credentials for the principal under test.
     let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", path.to_str().unwrap());
-    let creds = create_access_token_credential()
+    let creds = create_access_token_credentials()
         .await
         .map_err(Error::authentication)?;
 

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -236,10 +236,10 @@ pub(crate) mod dynamic {
 /// Example usage:
 ///
 /// ```
-/// # use google_cloud_auth::credentials::create_access_token_credential;
+/// # use google_cloud_auth::credentials::create_access_token_credentials;
 /// # use google_cloud_auth::errors::CredentialError;
 /// # tokio_test::block_on(async {
-/// let mut creds = create_access_token_credential().await?;
+/// let mut creds = create_access_token_credentials().await?;
 /// let token = creds.get_token().await?;
 /// println!("Token: {}", token.token);
 /// # Ok::<(), CredentialError>(())
@@ -252,7 +252,7 @@ pub(crate) mod dynamic {
 /// [gce-link]: https://cloud.google.com/products/compute
 /// [gcloud auth application-default]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default
 /// [gke-link]: https://cloud.google.com/kubernetes-engine
-pub async fn create_access_token_credential() -> Result<Credentials> {
+pub async fn create_access_token_credentials() -> Result<Credentials> {
     let contents = match load_adc()? {
         AdcContents::Contents(contents) => contents,
         AdcContents::FallbackToMds => return Ok(mds::new()),

--- a/src/auth/tests/crypto_provider.rs
+++ b/src/auth/tests/crypto_provider.rs
@@ -38,7 +38,7 @@ mod test {
         std::fs::write(&path, contents).expect("Unable to write to temporary file.");
         let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", path.to_str().unwrap());
 
-        let creds = create_access_token_credential().await.unwrap();
+        let creds = create_access_token_credentials().await.unwrap();
         let fmt = format!("{:?}", creds);
         assert!(fmt.contains("ServiceAccountCredential"));
 

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -83,7 +83,7 @@ impl Firestore {
         if let Some(c) = config.cred.clone() {
             return Ok(c);
         }
-        auth::credentials::create_access_token_credential()
+        auth::credentials::create_access_token_credentials()
             .await
             .map_err(Error::authentication)
     }

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -189,7 +189,7 @@ impl Client {
         if let Some(c) = config.cred.clone() {
             return Ok(c);
         }
-        auth::credentials::create_access_token_credential()
+        auth::credentials::create_access_token_credentials()
             .await
             .map_err(Error::authentication)
     }

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use auth::credentials::{Credentials, create_access_token_credential};
+use auth::credentials::{Credentials, create_access_token_credentials};
 use gax::Result;
 use gax::backoff_policy::BackoffPolicy;
 use gax::error::Error;
@@ -45,7 +45,7 @@ impl ReqwestClient {
         let cred = if let Some(c) = config.cred.clone() {
             c
         } else {
-            create_access_token_credential()
+            create_access_token_credentials()
                 .await
                 .map_err(Error::authentication)?
         };


### PR DESCRIPTION
This change is a part of an effort to Consistently use the term "Credentials" instead of "Credential".