### PR TITLE
fix(auth): Rename ServiceAccountCredential and MDSCredential

### DIFF
--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -71,7 +71,7 @@ pub(crate) fn new() -> Credentials {
 }
 
 #[derive(Debug)]
-struct MDSCredential<T>
+struct MDSCredentials<T>
 where
     T: TokenProvider,
 {
@@ -159,7 +159,7 @@ impl Builder {
             .build();
         let cached_token_provider = crate::token_cache::TokenCache::new(token_provider);
 
-        let mdsc = MDSCredential {
+        let mdsc = MDSCredentials {
             quota_project_id: self.quota_project_id,
             token_provider: cached_token_provider,
             universe_domain: self.universe_domain,
@@ -171,7 +171,7 @@ impl Builder {
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialsTrait for MDSCredential<T>
+impl<T> CredentialsTrait for MDSCredentials<T>
 where
     T: TokenProvider,
 {
@@ -341,7 +341,7 @@ mod test {
             .times(1)
             .return_once(|| Ok(expected_clone));
 
-        let mdsc = MDSCredential {
+        let mdsc = MDSCredentials {
             quota_project_id: None,
             universe_domain: None,
             token_provider: mock,
@@ -357,7 +357,7 @@ mod test {
             .times(1)
             .return_once(|| Err(errors::non_retryable_from_str("fail")));
 
-        let mdsc = MDSCredential {
+        let mdsc = MDSCredentials {
             quota_project_id: None,
             universe_domain: None,
             token_provider: mock,
@@ -377,7 +377,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token().times(1).return_once(|| Ok(token));
 
-        let mdsc = MDSCredential {
+        let mdsc = MDSCredentials {
             quota_project_id: None,
             universe_domain: None,
             token_provider: mock,
@@ -401,7 +401,7 @@ mod test {
             .times(1)
             .return_once(|| Err(errors::non_retryable_from_str("fail")));
 
-        let mdsc = MDSCredential {
+        let mdsc = MDSCredentials {
             quota_project_id: None,
             universe_domain: None,
             token_provider: mock,

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -248,7 +248,7 @@ impl Builder {
         let token_provider = TokenCache::new(token_provider);
 
         Ok(Credentials {
-            inner: Arc::new(ServiceAccountCredential {
+            inner: Arc::new(ServiceAccountCredentials {
                 token_provider,
                 quota_project_id: self.quota_project_id,
             }),
@@ -288,7 +288,7 @@ impl std::fmt::Debug for ServiceAccountKey {
 }
 
 #[derive(Debug)]
-struct ServiceAccountCredential<T>
+struct ServiceAccountCredentials<T>
 where
     T: TokenProvider,
 {
@@ -386,7 +386,7 @@ impl ServiceAccountTokenProvider {
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialsTrait for ServiceAccountCredential<T>
+impl<T> CredentialsTrait for ServiceAccountCredentials<T>
 where
     T: TokenProvider,
 {
@@ -460,7 +460,7 @@ mod test {
             .times(1)
             .return_once(|| Ok(expected_clone));
 
-        let sac = ServiceAccountCredential {
+        let sac = ServiceAccountCredentials {
             token_provider: mock,
             quota_project_id: None,
         };
@@ -475,7 +475,7 @@ mod test {
             .times(1)
             .return_once(|| Err(errors::non_retryable_from_str("fail")));
 
-        let sac = ServiceAccountCredential {
+        let sac = ServiceAccountCredentials {
             token_provider: mock,
             quota_project_id: None,
         };
@@ -494,7 +494,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token().times(1).return_once(|| Ok(token));
 
-        let sac = ServiceAccountCredential {
+        let sac = ServiceAccountCredentials {
             token_provider: mock,
             quota_project_id: None,
         };
@@ -524,7 +524,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token().times(1).return_once(|| Ok(token));
 
-        let sac = ServiceAccountCredential {
+        let sac = ServiceAccountCredentials {
             token_provider: mock,
             quota_project_id: Some(quota_project.to_string()),
         };
@@ -554,7 +554,7 @@ mod test {
             .times(1)
             .return_once(|| Err(errors::non_retryable_from_str("fail")));
 
-        let sac = ServiceAccountCredential {
+        let sac = ServiceAccountCredentials {
             token_provider: mock,
             quota_project_id: None,
         };

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -41,7 +41,7 @@ mod test {
 
         let mds = create_access_token_credentials().await.unwrap();
         let fmt = format!("{:?}", mds);
-        assert!(fmt.contains("MDSCredential"));
+        assert!(fmt.contains("MDSCredentials"));
     }
 
     #[tokio::test]
@@ -128,7 +128,7 @@ mod test {
 
         let sac = create_access_token_credentials().await.unwrap();
         let fmt = format!("{:?}", sac);
-        assert!(fmt.contains("ServiceAccountCredential"));
+        assert!(fmt.contains("ServiceAccountCredentials"));
     }
 
     #[tokio::test]
@@ -191,7 +191,7 @@ mod test {
             .universe_domain(test_universe_domain)
             .build();
         let fmt = format!("{:?}", mdcs);
-        assert!(fmt.contains("MDSCredential"));
+        assert!(fmt.contains("MDSCredentials"));
         assert!(fmt.contains(test_quota_project));
         assert!(fmt.contains(test_universe_domain));
         Ok(())
@@ -211,7 +211,7 @@ mod test {
             .with_quota_project_id(test_quota_project)
             .build()?;
         let fmt = format!("{:?}", service_account);
-        assert!(fmt.contains("ServiceAccountCredential"));
+        assert!(fmt.contains("ServiceAccountCredentials"));
         assert!(fmt.contains(test_quota_project));
         Ok(())
     }

--- a/src/auth/tests/crypto_provider.rs
+++ b/src/auth/tests/crypto_provider.rs
@@ -40,7 +40,7 @@ mod test {
 
         let creds = create_access_token_credentials().await.unwrap();
         let fmt = format!("{:?}", creds);
-        assert!(fmt.contains("ServiceAccountCredential"));
+        assert!(fmt.contains("ServiceAccountCredentials"));
 
         creds
     }


### PR DESCRIPTION
This change is a part of an effort to Consistently use the term "Credentials" instead of "Credential".