### PR TITLE
fix(auth): Rename CredentialError to CredentialsError

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -21,7 +21,7 @@ pub mod service_account;
 pub(crate) mod user_credentials;
 
 use crate::Result;
-use crate::errors::{self, CredentialError};
+use crate::errors::{self, CredentialsError};
 use http::header::{HeaderName, HeaderValue};
 use std::future::Future;
 use std::sync::Arc;
@@ -237,12 +237,12 @@ pub(crate) mod dynamic {
 ///
 /// ```
 /// # use google_cloud_auth::credentials::create_access_token_credentials;
-/// # use google_cloud_auth::errors::CredentialError;
+/// # use google_cloud_auth::errors::CredentialsError;
 /// # tokio_test::block_on(async {
 /// let mut creds = create_access_token_credentials().await?;
 /// let token = creds.get_token().await?;
 /// println!("Token: {}", token.token);
-/// # Ok::<(), CredentialError>(())
+/// # Ok::<(), CredentialsError>(())
 /// # });
 /// ```
 ///
@@ -285,7 +285,7 @@ enum AdcContents {
     FallbackToMds,
 }
 
-fn path_not_found(path: String) -> CredentialError {
+fn path_not_found(path: String) -> CredentialsError {
     errors::non_retryable_from_str(format!(
         "Failed to load Application Default Credentials (ADC) from {path}. Check that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable points to a valid file."
     ))
@@ -400,11 +400,11 @@ pub mod testing {
     #[async_trait::async_trait]
     impl CredentialsTrait for ErrorCredentials {
         async fn get_token(&self) -> Result<Token> {
-            Err(super::CredentialError::from_str(self.0, "test-only"))
+            Err(super::CredentialsError::from_str(self.0, "test-only"))
         }
 
         async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
-            Err(super::CredentialError::from_str(self.0, "test-only"))
+            Err(super::CredentialsError::from_str(self.0, "test-only"))
         }
 
         async fn get_universe_domain(&self) -> Option<String> {

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -35,12 +35,12 @@
 //! ```
 //! # use google_cloud_auth::credentials::mds::Builder;
 //! # use google_cloud_auth::credentials::Credentials;
-//! # use google_cloud_auth::errors::CredentialError;
+//! # use google_cloud_auth::errors::CredentialsError;
 //! # tokio_test::block_on(async {
 //! let credentials: Credentials = Builder::default().quota_project_id("my-quota-project").build();
 //! let token = credentials.get_token().await?;
 //! println!("Token: {}", token.token);
-//! # Ok::<(), CredentialError>(())
+//! # Ok::<(), CredentialsError>(())
 //! # });
 //! ```
 //!
@@ -52,7 +52,7 @@
 
 use crate::credentials::dynamic::CredentialsTrait;
 use crate::credentials::{Credentials, DEFAULT_UNIVERSE_DOMAIN, QUOTA_PROJECT_KEY, Result};
-use crate::errors::{self, CredentialError, is_retryable};
+use crate::errors::{self, CredentialsError, is_retryable};
 use crate::token::{Token, TokenProvider};
 use async_trait::async_trait;
 use bon::Builder;
@@ -278,15 +278,15 @@ impl TokenProvider for MDSAccessTokenProvider {
             let body = response
                 .text()
                 .await
-                .map_err(|e| CredentialError::new(is_retryable(status), e))?;
-            return Err(CredentialError::from_str(
+                .map_err(|e| CredentialsError::new(is_retryable(status), e))?;
+            return Err(CredentialsError::from_str(
                 is_retryable(status),
                 format!("Failed to fetch token. {body}"),
             ));
         }
         let response = response.json::<MDSTokenResponse>().await.map_err(|e| {
             let retryable = !e.is_decode();
-            CredentialError::new(retryable, e)
+            CredentialsError::new(retryable, e)
         })?;
         let token = Token {
             token: response.access_token,

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -48,7 +48,7 @@
 //! ```
 //! # use google_cloud_auth::credentials::service_account::Builder;
 //! # use google_cloud_auth::credentials::Credentials;
-//! # use google_cloud_auth::errors::CredentialError;
+//! # use google_cloud_auth::errors::CredentialsError;
 //! # tokio_test::block_on(async {
 //! let service_account_key = serde_json::json!({
 //! "client_email": "test-client-email",
@@ -60,7 +60,7 @@
 //! let credentials: Credentials = Builder::new(service_account_key).with_quota_project_id("my-quota-project").build()?;
 //! let token = credentials.get_token().await?;
 //! println!("Token: {}", token.token);
-//! # Ok::<(), CredentialError>(())
+//! # Ok::<(), CredentialsError>(())
 //! # });
 //! ```
 //!
@@ -74,7 +74,7 @@ mod jws;
 use crate::credentials::QUOTA_PROJECT_KEY;
 use crate::credentials::dynamic::CredentialsTrait;
 use crate::credentials::{Credentials, Result};
-use crate::errors::{self, CredentialError};
+use crate::errors::{self, CredentialsError};
 use crate::token::{Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use async_trait::async_trait;
@@ -229,7 +229,7 @@ impl Builder {
     ///
     /// # Errors
     ///
-    /// Returns a [CredentialError] if the `service_account_key`
+    /// Returns a [CredentialsError] if the `service_account_key`
     /// provided to [`Builder::new`] cannot be successfully deserialized into the
     /// expected format for a service account key. This typically happens if the
     /// JSON value is malformed or missing required fields. For more information,
@@ -377,7 +377,7 @@ impl ServiceAccountTokenProvider {
             .ok_or_else(|| errors::non_retryable_from_str("Unable to choose RSA_PKCS1_SHA256 signing scheme as it is not supported by current signer"))
     }
 
-    fn unexpected_private_key_error(private_key_format: Item) -> CredentialError {
+    fn unexpected_private_key_error(private_key_format: Item) -> CredentialsError {
         errors::non_retryable_from_str(format!(
             "expected key to be in form of PKCS8, found {:?}",
             private_key_format

--- a/src/auth/src/credentials/user_credentials.rs
+++ b/src/auth/src/credentials/user_credentials.rs
@@ -14,7 +14,7 @@
 
 use crate::credentials::dynamic::CredentialsTrait;
 use crate::credentials::{Credentials, QUOTA_PROJECT_KEY, Result};
-use crate::errors::{self, CredentialError, is_retryable};
+use crate::errors::{self, CredentialsError, is_retryable};
 use crate::token::{Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use http::header::{AUTHORIZATION, CONTENT_TYPE, HeaderName, HeaderValue};
@@ -90,15 +90,15 @@ impl TokenProvider for UserTokenProvider {
             let body = resp
                 .text()
                 .await
-                .map_err(|e| CredentialError::new(is_retryable(status), e))?;
-            return Err(CredentialError::from_str(
+                .map_err(|e| CredentialsError::new(is_retryable(status), e))?;
+            return Err(CredentialsError::from_str(
                 is_retryable(status),
                 format!("Failed to fetch token. {body}"),
             ));
         }
         let response = resp.json::<Oauth2RefreshResponse>().await.map_err(|e| {
             let retryable = !e.is_decode();
-            CredentialError::new(retryable, e)
+            CredentialsError::new(retryable, e)
         })?;
         let token = Token {
             token: response.access_token,

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -17,25 +17,25 @@
 use http::StatusCode;
 use std::error::Error;
 
-pub use gax::error::CredentialError;
+pub use gax::error::CredentialsError;
 
 /// A helper to create a retryable error.
-pub(crate) fn retryable<T: Error + Send + Sync + 'static>(source: T) -> CredentialError {
-    CredentialError::new(true, source)
+pub(crate) fn retryable<T: Error + Send + Sync + 'static>(source: T) -> CredentialsError {
+    CredentialsError::new(true, source)
 }
 
 #[allow(dead_code)]
-pub(crate) fn retryable_from_str<T: Into<String>>(message: T) -> CredentialError {
-    CredentialError::from_str(true, message)
+pub(crate) fn retryable_from_str<T: Into<String>>(message: T) -> CredentialsError {
+    CredentialsError::from_str(true, message)
 }
 
 /// A helper to create a non-retryable error.
-pub(crate) fn non_retryable<T: Error + Send + Sync + 'static>(source: T) -> CredentialError {
-    CredentialError::new(false, source)
+pub(crate) fn non_retryable<T: Error + Send + Sync + 'static>(source: T) -> CredentialsError {
+    CredentialsError::new(false, source)
 }
 
-pub(crate) fn non_retryable_from_str<T: Into<String>>(message: T) -> CredentialError {
-    CredentialError::from_str(false, message)
+pub(crate) fn non_retryable_from_str<T: Into<String>>(message: T) -> CredentialsError {
+    CredentialsError::from_str(false, message)
 }
 
 pub(crate) fn is_retryable(c: StatusCode) -> bool {

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -50,5 +50,5 @@ pub mod token;
 pub(crate) mod token_cache;
 
 /// A `Result` alias where the `Err` case is
-/// `google_cloud_auth::errors::CredentialError`.
-pub(crate) type Result<T> = std::result::Result<T, crate::errors::CredentialError>;
+/// `google_cloud_auth::errors::CredentialsError`.
+pub(crate) type Result<T> = std::result::Result<T, crate::errors::CredentialsError>;

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -19,11 +19,11 @@ use google_cloud_auth::credentials::{
     ApiKeyOptions, Credentials, CredentialsTrait, create_access_token_credentials,
     create_api_key_credentials,
 };
-use google_cloud_auth::errors::CredentialError;
+use google_cloud_auth::errors::CredentialsError;
 use google_cloud_auth::token::Token;
 use serde_json::json;
 
-type Result<T> = std::result::Result<T, CredentialError>;
+type Result<T> = std::result::Result<T, CredentialsError>;
 
 #[cfg(test)]
 mod test {

--- a/src/gax-internal/tests/auth.rs
+++ b/src/gax-internal/tests/auth.rs
@@ -15,14 +15,14 @@
 #[cfg(all(test, feature = "_internal_http_client"))]
 mod test {
     use auth::credentials::{Credentials, CredentialsTrait};
-    use auth::errors::CredentialError;
+    use auth::errors::CredentialsError;
     use auth::token::Token;
     use gax::options::*;
     use gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use http::header::{HeaderName, HeaderValue};
     use serde_json::json;
 
-    type AuthResult<T> = std::result::Result<T, CredentialError>;
+    type AuthResult<T> = std::result::Result<T, CredentialsError>;
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
     mockall::mock! {
@@ -85,7 +85,7 @@ mod test {
         let mut mock = MockCredentials::new();
         mock.expect_get_headers()
             .times(retry_count..)
-            .returning(|| Err(CredentialError::from_str(true, "mock retryable error")));
+            .returning(|| Err(CredentialsError::from_str(true, "mock retryable error")));
 
         let retry_policy = Aip194Strict.with_attempt_limit(retry_count as u32);
         let client = echo_server::builder(endpoint)
@@ -103,13 +103,13 @@ mod test {
         assert!(result.is_err());
 
         if let Err(e) = result {
-            if let Some(cred_err) = e.as_inner::<CredentialError>() {
+            if let Some(cred_err) = e.as_inner::<CredentialsError>() {
                 assert!(
                     cred_err.is_retryable(),
-                    "Expected a retryable CredentialError, but got non-retryable"
+                    "Expected a retryable CredentialsError, but got non-retryable"
                 );
             } else {
-                panic!("Expected a CredentialError, but got some other error: {e:?}");
+                panic!("Expected a CredentialsError, but got some other error: {e:?}");
             }
         }
 
@@ -122,7 +122,7 @@ mod test {
         let mut mock = MockCredentials::new();
         mock.expect_get_headers()
             .times(1)
-            .returning(|| Err(CredentialError::from_str(false, "mock non-retryable error")));
+            .returning(|| Err(CredentialsError::from_str(false, "mock non-retryable error")));
 
         let client = echo_server::builder(endpoint)
             .with_credentials(Credentials::from(mock))
@@ -139,13 +139,13 @@ mod test {
         assert!(result.is_err());
 
         if let Err(e) = result {
-            if let Some(cred_err) = e.as_inner::<CredentialError>() {
+            if let Some(cred_err) = e.as_inner::<CredentialsError>() {
                 assert!(
                     !cred_err.is_retryable(),
-                    "Expected a non-retryable CredentialError, but got retryable"
+                    "Expected a non-retryable CredentialsError, but got retryable"
                 );
             } else {
-                panic!("Expected a CredentialError, but got another error type: {e:?}");
+                panic!("Expected a CredentialsError, but got another error type: {e:?}");
             }
         }
 

--- a/src/gax-internal/tests/auth.rs
+++ b/src/gax-internal/tests/auth.rs
@@ -120,9 +120,12 @@ mod test {
     async fn auth_error_non_retryable() -> Result<()> {
         let (endpoint, _server) = echo_server::start().await?;
         let mut mock = MockCredentials::new();
-        mock.expect_get_headers()
-            .times(1)
-            .returning(|| Err(CredentialsError::from_str(false, "mock non-retryable error")));
+        mock.expect_get_headers().times(1).returning(|| {
+            Err(CredentialsError::from_str(
+                false,
+                "mock non-retryable error",
+            ))
+        });
 
         let client = echo_server::builder(endpoint)
             .with_credentials(Credentials::from(mock))

--- a/src/gax/src/error.rs
+++ b/src/gax/src/error.rs
@@ -15,7 +15,7 @@
 mod core_error;
 pub use core_error::*;
 mod credentials;
-pub use credentials::CredentialError;
+pub use credentials::CredentialsError;
 mod http_error;
 pub use http_error::*;
 mod service_error;

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -52,7 +52,7 @@
 //!
 //! [idempotent]: https://en.wikipedia.org/wiki/Idempotence
 
-use crate::error::{CredentialError, Error};
+use crate::error::{CredentialsError, Error};
 use crate::loop_state::LoopState;
 use std::sync::Arc;
 
@@ -248,7 +248,7 @@ impl RetryPolicy for Aip194Strict {
                 }
             }
             ErrorKind::Authentication => {
-                if let Some(cred_err) = error.as_inner::<CredentialError>() {
+                if let Some(cred_err) = error.as_inner::<CredentialsError>() {
                     if cred_err.is_retryable() {
                         LoopState::Continue(error)
                     } else {


### PR DESCRIPTION
This change is a part of an effort to Consistently use the term "Credentials" instead of "Credential".