### PR TITLE
docs: fix broken links

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -15,7 +15,7 @@
 # A requirements file to install Python-based development tools. Using a file
 # makes these dependencies visible to robots like dependabot and renovatebot.
 
-mdformat==0.7.19
+mdformat==0.7.18
 mdformat-gfm==0.4.1
 mdformat-frontmatter==2.0.8
 mdformat-footnote==0.1.1

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -301,5 +301,6 @@ git ls-files -z -- '*.tf' ':!:**/testdata/**' | xargs -0 terraform fmt
 [golang-install]: https://go.dev/doc/install
 [google cloud cli]: https://cloud.google.com/cli
 [install terraform]: https://developer.hashicorp.com/terraform/install
+[mdbook]: https://rust-lang.github.io/mdBook/
 [secret manager]: https://cloud.google.com/secret-manager/
 [workflows]: https://cloud.google.com/workflows/

--- a/guide/src/setting_up_rust_on_cloud_shell.md
+++ b/guide/src/setting_up_rust_on_cloud_shell.md
@@ -82,4 +82,5 @@ Cloud Shell is a great environment to run small examples and tests.
 
 [cloud shell]: https://cloud.google.com/shell
 [rustup]: https://rust-lang.github.io/rustup/
+[secret manager]: https://cloud.google.com/secret-manager/docs/overview
 [tokio]: https://crates.io/crates/tokio

--- a/guide/src/setting_up_your_development_environment.md
+++ b/guide/src/setting_up_your_development_environment.md
@@ -51,8 +51,8 @@ To install the gcloud CLI, see [Installing the gcloud CLI](https://cloud.google.
 
 ## Install the Cloud Client Libraries for Rust in a New Project
 
-The [Cloud Client Libraries for Rust] is the idiomatic way for Rust developers
-to integrate with Google Cloud services, such as Secret Manager and Workflows.
+The Cloud Client Libraries for Rust is the idiomatic way for Rust developers to
+integrate with Google Cloud services, such as Secret Manager and Workflows.
 
 For example, to use the package for an individual API, such as the
 Secret Manager API, do the following:
@@ -131,4 +131,5 @@ Note: The source of the Cloud Client Libraries for Rust is
 [google cloud cli]: https://cloud.google.com/sdk/
 [rust]: https://www.rust-lang.org/
 [rust-getting-started]: https://www.rust-lang.org/learn/get-started
+[secret manager]: https://cloud.google.com/secret-manager/docs/overview
 [tokio]: https://crates.io/crates/tokio


### PR DESCRIPTION
We have some broken links in the documentation.

My local `mdformat` is version `0.7.18` which will escape `[` and `]` that aren't proper links. This alerted me to the missing links.

`mdformat` `v0.7.19` (which we currently use in our CI) stopped escaping `[` and `]` that weren't proper links.

![image](https://github.com/user-attachments/assets/ed9c4652-3603-4ca0-8788-d84cc2f5da19)

I think we should revert our version of `mdformat` until there is a compelling reason to take another update, because it is good to flag broken links.