### PR TITLE
fix(auth): Leftover Credential to Credentials renaming

### DIFF
--- a/src/auth/.gcb/builds/service_account_test/main.tf
+++ b/src/auth/.gcb/builds/service_account_test/main.tf
@@ -47,7 +47,7 @@ resource "google_secret_manager_secret_version" "test-sa-creds-json-secret-versi
 # Note that this is not really a "secret", in that we are not trying to hide its
 # contents.
 #
-# In order to validate our credential types, we need a GCP resource we can set
+# In order to validate our credentials types, we need a GCP resource we can set
 # fine-grained ACL on. We have picked Secret Manager secrets for this purpose.
 #
 resource "google_secret_manager_secret" "test-sa-creds-secret" {

--- a/src/auth/integration-tests/README.md
+++ b/src/auth/integration-tests/README.md
@@ -101,7 +101,7 @@ For each principal we have:
 The steps in the test are:
 
 1. The principal running the build pulls the ADC JSON from SecretManager.
-1. We create a credential object from the ADC JSON.
+1. We create a credentials object from the ADC JSON.
 1. We create a SecretManager client using these credentials.
 1. We use this client to access the principal-specific secret.
 

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -156,7 +156,7 @@ pub trait CredentialsTrait: std::fmt::Debug {
     /// The underlying implementation refreshes the token as needed.
     fn get_headers(&self) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send;
 
-    /// Retrieves the universe domain associated with the credential, if any.
+    /// Retrieves the universe domain associated with the credentials, if any.
     fn get_universe_domain(&self) -> impl Future<Output = Option<String>> + Send;
 }
 

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -100,7 +100,7 @@ pub struct Builder {
 }
 
 impl Builder {
-    /// Sets the endpoint for this credential.
+    /// Sets the endpoint for this credentials.
     ///
     /// If not set, the credentials use `http://metadata.google.internal/`.
     pub fn endpoint<S: Into<String>>(mut self, endpoint: S) -> Self {
@@ -108,7 +108,7 @@ impl Builder {
         self
     }
 
-    /// Set the [quota project] for this credential.
+    /// Set the [quota project] for this credentials.
     ///
     /// In some services, you can use a service account in
     /// one project for authentication and authorization, and charge
@@ -121,7 +121,7 @@ impl Builder {
         self
     }
 
-    /// Sets the universe domain for this credential.
+    /// Sets the universe domain for this credentials.
     ///
     /// Client libraries use `universe_domain` to determine
     /// the API endpoints to use for making requests.
@@ -132,10 +132,10 @@ impl Builder {
         self
     }
 
-    /// Sets the [scopes] for this credential.
+    /// Sets the [scopes] for this credentials.
     ///
     /// Metadata server issues tokens based on the requested scopes.
-    /// If no scopes are specified, the credential defaults to all
+    /// If no scopes are specified, the credentials defaults to all
     /// scopes configured for the [default service account] on the instance.
     ///
     /// [default service account]: https://cloud.google.com/iam/docs/service-account-types#default

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -654,8 +654,8 @@ mod test {
             "universe_domain": "test-universe-domain"
         });
 
-        let credential = creds_from(json_value)?;
-        let token = credential.get_token().await?;
+        let credentials = creds_from(json_value)?;
+        let token = credentials.get_token().await?;
 
         let re = regex::Regex::new(SSJ_REGEX).unwrap();
         let captures = re.captures(&token.token).unwrap();
@@ -670,7 +670,7 @@ mod test {
         std::thread::sleep(Duration::from_secs(1));
 
         // Get the token again.
-        let token = credential.get_token().await?;
+        let token = credentials.get_token().await?;
         let captures = re.captures(&token.token).unwrap();
 
         let claims = b64_decode_to_json(captures["claims"].to_string());

--- a/src/auth/src/credentials/user_credentials.rs
+++ b/src/auth/src/credentials/user_credentials.rs
@@ -56,7 +56,7 @@ struct UserTokenProvider {
 
 impl std::fmt::Debug for UserTokenProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UserTokenCredential")
+        f.debug_struct("UserCredentials")
             .field("client_id", &self.client_id)
             .field("client_secret", &"[censored]")
             .field("refresh_token", &"[censored]")

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -106,7 +106,7 @@ mod test {
 
         let uc = create_access_token_credentials().await.unwrap();
         let fmt = format!("{:?}", uc);
-        assert!(fmt.contains("UserCredential"));
+        assert!(fmt.contains("UserCredentials"));
     }
 
     #[tokio::test]
@@ -137,14 +137,14 @@ mod test {
             .await
             .unwrap();
         let fmt = format!("{:?}", creds);
-        assert!(fmt.contains("ApiKeyCredential"), "{fmt:?}");
+        assert!(fmt.contains("ApiKeyCredentials"), "{fmt:?}");
     }
 
     mockall::mock! {
         #[derive(Debug)]
-        Credential {}
+        Credentials {}
 
-        impl CredentialsTrait for Credential {
+        impl CredentialsTrait for Credentials {
             async fn get_token(&self) -> Result<Token>;
             async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
             async fn get_universe_domain(&self) -> Option<String>;
@@ -153,7 +153,7 @@ mod test {
 
     #[tokio::test]
     async fn mocking() -> Result<()> {
-        let mut mock = MockCredential::new();
+        let mut mock = MockCredentials::new();
         mock.expect_get_token().return_once(|| {
             Ok(Token {
                 token: "test-token".to_string(),

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -121,7 +121,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     ///
     /// Most Google Cloud services require authentication, though some services
     /// allow for anonymous access, and some services provide emulators where
-    /// no authentication is required. More information about valid credential
+    /// no authentication is required. More information about valid credentials
     /// types can be found in the [google-cloud-auth] crate documentation.
     ///
     /// ```

--- a/src/gax/src/error/credentials.rs
+++ b/src/gax/src/error/credentials.rs
@@ -16,14 +16,14 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::sync::Arc;
 
-/// Represents an error creating or using a [Credential].
+/// Represents an error creating or using a [Credentials].
 ///
 /// The Google Cloud client libraries may experience problems creating
 /// credentials and/or using them. An example of problems creating credentials
 /// may be a badly formatted or missing key file. An example of problems using
 /// credentials may be a temporary failure to retrieve or create
 /// [access tokens]. Note that the latter kind of errors may happen even after
-/// the credential files are successfully loaded and parsed.
+/// the credentials files are successfully loaded and parsed.
 ///
 /// Applications rarely need to create instances of this error type. The
 /// exception might be when testing application code, where the application is
@@ -40,7 +40,7 @@ use std::sync::Arc;
 /// ```
 ///
 /// [access tokens]: https://cloud.google.com/docs/authentication/token-types
-/// [Credential]: https://docs.rs/google-cloud-auth/latest/google_cloud_auth/credentials/struct.Credential.html
+/// [Credentials]: https://docs.rs/google-cloud-auth/latest/google_cloud_auth/credentials/struct.Credential.html
 #[derive(Clone, Debug)]
 pub struct CredentialsError {
     /// A boolean value indicating whether the error is retryable.


### PR DESCRIPTION
This change is a part of an effort to Consistently use the term "Credentials" instead of "Credential".