### PR TITLE
fix(auth): rename get_headers to headers

### DIFF
--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -99,7 +99,7 @@ impl {{Codec.Name}} {
     ) -> Result<http::header::HeaderMap> {
         let mut headers = self
             .cred
-            .get_headers()
+            .headers()
             .await
             .map_err(Error::authentication)?;
         headers.push((

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -91,8 +91,8 @@ impl Credentials {
         self.inner.get_token().await
     }
 
-    pub async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
-        self.inner.get_headers().await
+    pub async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        self.inner.headers().await
     }
 
     pub async fn universe_domain(&self) -> Option<String> {
@@ -154,7 +154,7 @@ pub trait CredentialsTrait: std::fmt::Debug {
     /// sent with a request.
     ///
     /// The underlying implementation refreshes the token as needed.
-    fn get_headers(&self) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send;
+    fn headers(&self) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send;
 
     /// Retrieves the universe domain associated with the credentials, if any.
     fn universe_domain(&self) -> impl Future<Output = Option<String>> + Send;
@@ -180,7 +180,7 @@ pub(crate) mod dynamic {
         /// sent with a request.
         ///
         /// The underlying implementation refreshes the token as needed.
-        async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
+        async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
 
         /// Retrieves the universe domain associated with the credentials, if any.
         async fn universe_domain(&self) -> Option<String> {
@@ -197,8 +197,8 @@ pub(crate) mod dynamic {
         async fn get_token(&self) -> Result<crate::token::Token> {
             T::get_token(self).await
         }
-        async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
-            T::get_headers(self).await
+        async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+            T::headers(self).await
         }
         async fn universe_domain(&self) -> Option<String> {
             T::universe_domain(self).await
@@ -376,7 +376,7 @@ pub mod testing {
             })
         }
 
-        async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
             Ok(Vec::new())
         }
 
@@ -387,7 +387,7 @@ pub mod testing {
 
     /// A simple credentials implementation to use in tests.
     ///
-    /// Always return an error in `get_token()` and `get_headers()`.
+    /// Always return an error in `get_token()` and `headers()`.
     pub fn error_credentials(retryable: bool) -> Credentials {
         Credentials {
             inner: Arc::from(ErrorCredentials(retryable)),
@@ -403,7 +403,7 @@ pub mod testing {
             Err(super::CredentialsError::from_str(self.0, "test-only"))
         }
 
-        async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
             Err(super::CredentialsError::from_str(self.0, "test-only"))
         }
 
@@ -574,7 +574,7 @@ mod test {
         );
         let err = credentials.get_token().await.err().unwrap();
         assert_eq!(err.is_retryable(), retryable, "{err:?}");
-        let err = credentials.get_headers().await.err().unwrap();
+        let err = credentials.headers().await.err().unwrap();
         assert_eq!(err.is_retryable(), retryable, "{err:?}");
     }
 }

--- a/src/auth/src/credentials/api_key_credentials.rs
+++ b/src/auth/src/credentials/api_key_credentials.rs
@@ -117,7 +117,7 @@ where
         self.token_provider.get_token().await
     }
 
-    async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+    async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
         let token = self.get_token().await?;
         let mut value = HeaderValue::from_str(&token.token).map_err(errors::non_retryable)?;
         value.set_sensitive(true);
@@ -165,7 +165,7 @@ mod test {
                 metadata: None,
             }
         );
-        let headers: Vec<HV> = HV::from(creds.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(creds.headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -186,7 +186,7 @@ mod test {
         let creds = create_api_key_credentials("test-api-key", options)
             .await
             .unwrap();
-        let headers: Vec<HV> = HV::from(creds.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(creds.headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -213,7 +213,7 @@ mod test {
         let creds = create_api_key_credentials("test-api-key", options)
             .await
             .unwrap();
-        let headers: Vec<HV> = HV::from(creds.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(creds.headers().await.unwrap());
 
         assert_eq!(
             headers,

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -179,7 +179,7 @@ where
         self.token_provider.get_token().await
     }
 
-    async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+    async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
         let token = self.get_token().await?;
         let mut value = HeaderValue::from_str(&format!("{} {}", token.token_type, token.token))
             .map_err(errors::non_retryable)?;
@@ -366,7 +366,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_headers_success() {
+    async fn headers_success() {
         let token = Token {
             token: "test-token".to_string(),
             token_type: "Bearer".to_string(),
@@ -382,7 +382,7 @@ mod test {
             universe_domain: None,
             token_provider: mock,
         };
-        let headers: Vec<HV> = HV::from(mdsc.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(mdsc.headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -395,7 +395,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_headers_failure() {
+    async fn headers_failure() {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token()
             .times(1)
@@ -406,7 +406,7 @@ mod test {
             universe_domain: None,
             token_provider: mock,
         };
-        assert!(mdsc.get_headers().await.is_err());
+        assert!(mdsc.headers().await.is_err());
     }
 
     fn handle_token_factory(
@@ -509,7 +509,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_headers_success_with_quota_project() {
+    async fn headers_success_with_quota_project() {
         let scopes = vec!["scope1".to_string(), "scope2".to_string()];
         let response = MDSTokenResponse {
             access_token: "test-access-token".to_string(),
@@ -538,7 +538,7 @@ mod test {
             .with_quota_project_id("test-project")
             .build();
 
-        let headers: Vec<HV> = HV::from(mdsc.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(mdsc.headers().await.unwrap());
         assert_eq!(
             headers,
             vec![

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -394,8 +394,8 @@ where
         self.token_provider.get_token().await
     }
 
-    async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
-        //TODO(#1686) Refactor the common logic out of the individual get_headers methods.
+    async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        //TODO(#1686) Refactor the common logic out of the individual headers methods.
         let token = self.get_token().await?;
         let mut value = HeaderValue::from_str(&format!("{} {}", token.token_type, token.token))
             .map_err(errors::non_retryable)?;
@@ -483,7 +483,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_headers_success_without_quota_project() {
+    async fn headers_success_without_quota_project() {
         let token = Token {
             token: "test-token".to_string(),
             token_type: "Bearer".to_string(),
@@ -498,7 +498,7 @@ mod test {
             token_provider: mock,
             quota_project_id: None,
         };
-        let headers: Vec<HV> = HV::from(sac.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(sac.headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -511,7 +511,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_headers_success_with_quota_project() {
+    async fn headers_success_with_quota_project() {
         let token = Token {
             token: "test-token".to_string(),
             token_type: "Bearer".to_string(),
@@ -528,7 +528,7 @@ mod test {
             token_provider: mock,
             quota_project_id: Some(quota_project.to_string()),
         };
-        let headers: Vec<HV> = HV::from(sac.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(sac.headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -548,7 +548,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_headers_failure() {
+    async fn headers_failure() {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token()
             .times(1)
@@ -558,7 +558,7 @@ mod test {
             token_provider: mock,
             quota_project_id: None,
         };
-        assert!(sac.get_headers().await.is_err());
+        assert!(sac.headers().await.is_err());
     }
 
     fn get_mock_service_key() -> Value {

--- a/src/auth/src/credentials/user_credentials.rs
+++ b/src/auth/src/credentials/user_credentials.rs
@@ -133,7 +133,7 @@ where
         self.token_provider.get_token().await
     }
 
-    async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+    async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
         let token = self.get_token().await?;
         let mut value = HeaderValue::from_str(&format!("{} {}", token.token_type, token.token))
             .map_err(errors::non_retryable)?;
@@ -322,7 +322,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_headers_success() {
+    async fn headers_success() {
         let token = Token {
             token: "test-token".to_string(),
             token_type: "Bearer".to_string(),
@@ -337,7 +337,7 @@ mod test {
             token_provider: mock,
             quota_project_id: None,
         };
-        let headers: Vec<HV> = HV::from(uc.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(uc.headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -350,7 +350,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_headers_failure() {
+    async fn headers_failure() {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token()
             .times(1)
@@ -360,11 +360,11 @@ mod test {
             token_provider: mock,
             quota_project_id: None,
         };
-        assert!(uc.get_headers().await.is_err());
+        assert!(uc.headers().await.is_err());
     }
 
     #[tokio::test]
-    async fn get_headers_with_quota_project_success() {
+    async fn headers_with_quota_project_success() {
         let token = Token {
             token: "test-token".to_string(),
             token_type: "Bearer".to_string(),
@@ -379,7 +379,7 @@ mod test {
             token_provider: mock,
             quota_project_id: Some("test-project".to_string()),
         };
-        let headers: Vec<HV> = HV::from(uc.get_headers().await.unwrap());
+        let headers: Vec<HV> = HV::from(uc.headers().await.unwrap());
         assert_eq!(
             headers,
             vec![

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -146,7 +146,7 @@ mod test {
 
         impl CredentialsTrait for Credentials {
             async fn get_token(&self) -> Result<Token>;
-            async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
+            async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
             async fn universe_domain(&self) -> Option<String>;
         }
     }
@@ -162,12 +162,12 @@ mod test {
                 metadata: None,
             })
         });
-        mock.expect_get_headers().return_once(|| Ok(Vec::new()));
+        mock.expect_headers().return_once(|| Ok(Vec::new()));
         mock.expect_universe_domain().return_once(|| None);
 
         let creds = Credentials::from(mock);
         assert_eq!(creds.get_token().await?.token, "test-token");
-        assert!(creds.get_headers().await?.is_empty());
+        assert!(creds.headers().await?.is_empty());
         assert_eq!(creds.universe_domain().await, None);
 
         Ok(())
@@ -177,7 +177,7 @@ mod test {
     async fn testing_credentials() -> Result<()> {
         let creds = test_credentials();
         assert_eq!(creds.get_token().await?.token, "test-only-token");
-        assert!(creds.get_headers().await?.is_empty());
+        assert!(creds.headers().await?.is_empty());
         assert_eq!(creds.universe_domain().await, None);
         Ok(())
     }

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -93,11 +93,7 @@ impl Firestore {
         options: &gax::options::RequestOptions,
         request_params: &str,
     ) -> Result<http::header::HeaderMap> {
-        let mut headers = self
-            .cred
-            .get_headers()
-            .await
-            .map_err(Error::authentication)?;
+        let mut headers = self.cred.headers().await.map_err(Error::authentication)?;
         headers.push((
             http::header::HeaderName::from_static("x-goog-api-client"),
             http::header::HeaderValue::from_static(&info::X_GOOG_API_CLIENT_HEADER),

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -199,10 +199,7 @@ impl Client {
         api_client_header: &'static str,
         request_params: &str,
     ) -> Result<http::header::HeaderMap> {
-        let mut headers = credentials
-            .headers()
-            .await
-            .map_err(Error::authentication)?;
+        let mut headers = credentials.headers().await.map_err(Error::authentication)?;
         headers.push((
             http::header::HeaderName::from_static("x-goog-api-client"),
             http::header::HeaderValue::from_static(api_client_header),

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -200,7 +200,7 @@ impl Client {
         request_params: &str,
     ) -> Result<http::header::HeaderMap> {
         let mut headers = credentials
-            .get_headers()
+            .headers()
             .await
             .map_err(Error::authentication)?;
         headers.push((

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -129,7 +129,7 @@ impl ReqwestClient {
             .fold(builder, |b, t| b.timeout(t));
         let auth_headers = self
             .cred
-            .get_headers()
+            .headers()
             .await
             .map_err(Error::authentication)?;
         for header in auth_headers.into_iter() {

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -127,11 +127,7 @@ impl ReqwestClient {
         builder = Self::effective_timeout(options, remaining_time)
             .into_iter()
             .fold(builder, |b, t| b.timeout(t));
-        let auth_headers = self
-            .cred
-            .headers()
-            .await
-            .map_err(Error::authentication)?;
+        let auth_headers = self.cred.headers().await.map_err(Error::authentication)?;
         for header in auth_headers.into_iter() {
             builder = builder.header(header.0, header.1);
         }

--- a/src/gax-internal/tests/auth.rs
+++ b/src/gax-internal/tests/auth.rs
@@ -31,7 +31,7 @@ mod test {
 
         impl CredentialsTrait for Credentials {
             async fn get_token(&self) -> AuthResult<Token>;
-            async fn get_headers(&self) -> AuthResult<Vec<(HeaderName, HeaderValue)>>;
+            async fn headers(&self) -> AuthResult<Vec<(HeaderName, HeaderValue)>>;
             async fn universe_domain(&self) -> Option<String>;
         }
     }
@@ -44,7 +44,7 @@ mod test {
         // 1. we can test that multiple headers are included in the request
         // 2. it gives us extra confidence that our interfaces are called
         let mut mock = MockCredentials::new();
-        mock.expect_get_headers().return_once(|| {
+        mock.expect_headers().return_once(|| {
             Ok(vec![
                 (
                     HeaderName::from_static("auth-key-1"),
@@ -83,7 +83,7 @@ mod test {
         let (endpoint, _server) = echo_server::start().await?;
         let retry_count = 3;
         let mut mock = MockCredentials::new();
-        mock.expect_get_headers()
+        mock.expect_headers()
             .times(retry_count..)
             .returning(|| Err(CredentialsError::from_str(true, "mock retryable error")));
 
@@ -120,7 +120,7 @@ mod test {
     async fn auth_error_non_retryable() -> Result<()> {
         let (endpoint, _server) = echo_server::start().await?;
         let mut mock = MockCredentials::new();
-        mock.expect_get_headers().times(1).returning(|| {
+        mock.expect_headers().times(1).returning(|| {
             Err(CredentialsError::from_str(
                 false,
                 "mock non-retryable error",


### PR DESCRIPTION
Part of making the auth methods rusty 