### PR TITLE
feat(generator/dart): expand the list of dart keywords

### DIFF
--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -42,8 +42,50 @@ var usesCustomEncoding = map[string]string{
 	".google.protobuf.Timestamp": ".google.protobuf.Timestamp",
 }
 
+// Dart reserved words.
+//
+// This blocklist includes words that can never be used as an identifier as well
+// as a few that could be used depending on context. We can add additional
+// context keywords as we discover conflicts.
+//
+// See also https://dart.dev/language/keywords.
 var reservedNames = map[string]string{
+	"assert":   "",
+	"await":    "",
+	"break":    "",
+	"case":     "",
+	"catch":    "",
+	"class":    "",
+	"const":    "",
+	"continue": "",
+	"default":  "",
+	"do":       "",
+	"else":     "",
+	"enum":     "",
+	"extends":  "",
+	"false":    "",
+	"final":    "",
+	"finally":  "",
+	"for":      "",
 	"Function": "",
+	"if":       "",
+	"in":       "",
+	"is":       "",
+	"new":      "",
+	"null":     "",
+	"rethrow":  "",
+	"return":   "",
+	"super":    "",
+	"switch":   "",
+	"this":     "",
+	"throw":    "",
+	"true":     "",
+	"try":      "",
+	"var":      "",
+	"void":     "",
+	"while":    "",
+	"with":     "",
+	"yield":    "",
 }
 
 func messageName(m *api.Message) string {
@@ -67,7 +109,11 @@ func qualifiedName(m *api.Message) string {
 }
 
 func fieldName(field *api.Field) string {
-	return strcase.ToLowerCamel(field.Name)
+	name := strcase.ToLowerCamel(field.Name)
+	if _, hasConflict := reservedNames[name]; hasConflict {
+		name = name + "$"
+	}
+	return name
 }
 
 func enumName(e *api.Enum) string {
@@ -78,7 +124,11 @@ func enumName(e *api.Enum) string {
 }
 
 func enumValueName(e *api.EnumValue) string {
-	return strcase.ToLowerCamel(e.Name)
+	name := strcase.ToLowerCamel(e.Name)
+	if _, hasConflict := reservedNames[name]; hasConflict {
+		name = name + "$"
+	}
+	return name
 }
 
 func httpPathFmt(pathInfo *api.PathInfo) string {

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -108,6 +108,10 @@ func TestEnumValues(t *testing.T) {
 		Name: "NAME",
 		ID:   ".test.v1.SomeMessage.SomeEnum.NAME",
 	}
+	enumReservedName := &api.EnumValue{
+		Name: "in",
+		ID:   ".test.v1.SomeMessage.SomeEnum.in",
+	}
 	enumValueCompound := &api.EnumValue{
 		Name: "ENUM_VALUE",
 		ID:   ".test.v1.SomeMessage.SomeEnum.ENUM_VALUE",
@@ -115,7 +119,7 @@ func TestEnumValues(t *testing.T) {
 	someEnum := &api.Enum{
 		Name:    "SomeEnum",
 		ID:      ".test.v1.SomeMessage.SomeEnum",
-		Values:  []*api.EnumValue{enumValueSimple, enumValueCompound},
+		Values:  []*api.EnumValue{enumValueSimple, enumReservedName, enumValueCompound},
 		Package: "test.v1",
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{someEnum}, []*api.Service{})
@@ -128,6 +132,7 @@ func TestEnumValues(t *testing.T) {
 		wantName string
 	}{
 		{enumValueSimple, "name"},
+		{enumReservedName, "in$"},
 		{enumValueCompound, "enumValue"},
 	} {
 		if got := enumValueName(test.value); got != test.wantName {


### PR DESCRIPTION
- expand the list of dart keywords

This allows generation of `google/firestore/v1` (an enum there - StructuredQuery$FieldFilter$Operator - has an enum value named `in`).

