### PR TITLE
fix(auth): Rename get_token to token

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -87,8 +87,8 @@ where
 }
 
 impl Credentials {
-    pub async fn get_token(&self) -> Result<crate::token::Token> {
-        self.inner.get_token().await
+    pub async fn token(&self) -> Result<crate::token::Token> {
+        self.inner.token().await
     }
 
     pub async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
@@ -145,7 +145,7 @@ pub trait CredentialsTrait: std::fmt::Debug {
     ///
     /// Returns a [Token][crate::token::Token] for the current credentials.
     /// The underlying implementation refreshes the token as needed.
-    fn get_token(&self) -> impl Future<Output = Result<crate::token::Token>> + Send;
+    fn token(&self) -> impl Future<Output = Result<crate::token::Token>> + Send;
 
     /// Asynchronously constructs the auth headers.
     ///
@@ -171,7 +171,7 @@ pub(crate) mod dynamic {
         ///
         /// Returns a [Token][crate::token::Token] for the current credentials.
         /// The underlying implementation refreshes the token as needed.
-        async fn get_token(&self) -> Result<crate::token::Token>;
+        async fn token(&self) -> Result<crate::token::Token>;
 
         /// Asynchronously constructs the auth headers.
         ///
@@ -194,8 +194,8 @@ pub(crate) mod dynamic {
     where
         T: super::CredentialsTrait + Send + Sync,
     {
-        async fn get_token(&self) -> Result<crate::token::Token> {
-            T::get_token(self).await
+        async fn token(&self) -> Result<crate::token::Token> {
+            T::token(self).await
         }
         async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
             T::headers(self).await
@@ -240,7 +240,7 @@ pub(crate) mod dynamic {
 /// # use google_cloud_auth::errors::CredentialsError;
 /// # tokio_test::block_on(async {
 /// let mut creds = create_access_token_credentials().await?;
-/// let token = creds.get_token().await?;
+/// let token = creds.token().await?;
 /// println!("Token: {}", token.token);
 /// # Ok::<(), CredentialsError>(())
 /// # });
@@ -367,7 +367,7 @@ pub mod testing {
 
     #[async_trait::async_trait]
     impl CredentialsTrait for TestCredentials {
-        async fn get_token(&self) -> Result<Token> {
+        async fn token(&self) -> Result<Token> {
             Ok(Token {
                 token: "test-only-token".to_string(),
                 token_type: "Bearer".to_string(),
@@ -387,7 +387,7 @@ pub mod testing {
 
     /// A simple credentials implementation to use in tests.
     ///
-    /// Always return an error in `get_token()` and `headers()`.
+    /// Always return an error in `token()` and `headers()`.
     pub fn error_credentials(retryable: bool) -> Credentials {
         Credentials {
             inner: Arc::from(ErrorCredentials(retryable)),
@@ -399,7 +399,7 @@ pub mod testing {
 
     #[async_trait::async_trait]
     impl CredentialsTrait for ErrorCredentials {
-        async fn get_token(&self) -> Result<Token> {
+        async fn token(&self) -> Result<Token> {
             Err(super::CredentialsError::from_str(self.0, "test-only"))
         }
 
@@ -572,7 +572,7 @@ mod test {
             credentials.universe_domain().await.is_none(),
             "{credentials:?}"
         );
-        let err = credentials.get_token().await.err().unwrap();
+        let err = credentials.token().await.err().unwrap();
         assert_eq!(err.is_retryable(), retryable, "{err:?}");
         let err = credentials.headers().await.err().unwrap();
         assert_eq!(err.is_retryable(), retryable, "{err:?}");

--- a/src/auth/src/credentials/api_key_credentials.rs
+++ b/src/auth/src/credentials/api_key_credentials.rs
@@ -89,7 +89,7 @@ impl std::fmt::Debug for ApiKeyTokenProvider {
 
 #[async_trait::async_trait]
 impl TokenProvider for ApiKeyTokenProvider {
-    async fn get_token(&self) -> Result<Token> {
+    async fn token(&self) -> Result<Token> {
         Ok(Token {
             token: self.api_key.clone(),
             token_type: String::new(),
@@ -113,12 +113,12 @@ impl<T> CredentialsTrait for ApiKeyCredentials<T>
 where
     T: TokenProvider,
 {
-    async fn get_token(&self) -> Result<Token> {
-        self.token_provider.get_token().await
+    async fn token(&self) -> Result<Token> {
+        self.token_provider.token().await
     }
 
     async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
-        let token = self.get_token().await?;
+        let token = self.token().await?;
         let mut value = HeaderValue::from_str(&token.token).map_err(errors::non_retryable)?;
         value.set_sensitive(true);
         let mut headers = vec![(HeaderName::from_static(API_KEY_HEADER_KEY), value)];
@@ -155,7 +155,7 @@ mod test {
         let creds = create_api_key_credentials("test-api-key", ApiKeyOptions::default())
             .await
             .unwrap();
-        let token = creds.get_token().await.unwrap();
+        let token = creds.token().await.unwrap();
         assert_eq!(
             token,
             Token {

--- a/src/auth/src/token.rs
+++ b/src/auth/src/token.rs
@@ -52,7 +52,7 @@ pub struct Token {
 
 #[async_trait::async_trait]
 pub(crate) trait TokenProvider: std::fmt::Debug + Send + Sync {
-    async fn get_token(&self) -> Result<Token>;
+    async fn token(&self) -> Result<Token>;
 }
 
 #[cfg(test)]
@@ -65,7 +65,7 @@ pub(crate) mod test {
 
         #[async_trait::async_trait]
         impl TokenProvider for TokenProvider {
-            async fn get_token(&self) -> Result<Token>;
+            async fn token(&self) -> Result<Token>;
         }
     }
 }

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -46,7 +46,7 @@ impl TokenCache {
 
 #[async_trait::async_trait]
 impl TokenProvider for TokenCache {
-    async fn get_token(&self) -> Result<Token> {
+    async fn token(&self) -> Result<Token> {
         let mut rx = self.rx_token.clone();
         let token_result = rx.borrow_and_update().clone();
 
@@ -87,7 +87,7 @@ where
     T: TokenProvider + Send + Sync + 'static,
 {
     loop {
-        let token_result = token_provider.get_token().await;
+        let token_result = token_provider.token().await;
 
         let _ = tx_token.send(Some(token_result.clone()));
 
@@ -149,33 +149,33 @@ mod test {
         let expected_clone = expected.clone();
 
         let mut mock = MockTokenProvider::new();
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(expected_clone));
 
         let cache = TokenCache::new(mock);
-        let actual = cache.get_token().await.unwrap();
+        let actual = cache.token().await.unwrap();
         assert_eq!(actual, expected);
 
         // Verify that we use the cached token instead of making a new request
         // to the mock token provider.
-        let actual = cache.get_token().await.unwrap();
+        let actual = cache.token().await.unwrap();
         assert_eq!(actual, expected);
     }
 
     #[tokio::test]
     async fn initial_token_failure() {
         let mut mock = MockTokenProvider::new();
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .returning(|| Err(errors::non_retryable_from_str("fail")));
 
         let cache = TokenCache::new(mock);
-        assert!(cache.get_token().await.is_err());
+        assert!(cache.token().await.is_err());
 
         // Verify that a new request is made to the mock token provider when we
         // don't have a valid token.
-        assert!(cache.get_token().await.is_err());
+        assert!(cache.token().await.is_err());
     }
 
     #[tokio::test(start_paused = true)]
@@ -199,26 +199,26 @@ mod test {
         let refresh_clone = refresh.clone();
 
         let mut mock = MockTokenProvider::new();
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(initial_clone));
 
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(refresh_clone));
 
         // fetch an initial token
         let cache = TokenCache::new(mock);
-        let actual = cache.get_token().await.unwrap();
+        let actual = cache.token().await.unwrap();
         assert_eq!(actual, initial);
 
         // wait long enough for the token to be expired
-        // get_token should be waiting until the new token is available
+        // token should be waiting until the new token is available
         let sleep = TOKEN_VALID_DURATION.add(Duration::from_secs(100));
         tokio::time::advance(sleep).await;
 
         // make sure this is the new token
-        let actual = cache.get_token().await.unwrap();
+        let actual = cache.token().await.unwrap();
         assert_eq!(actual, refresh);
     }
 
@@ -235,17 +235,17 @@ mod test {
         let initial_clone = initial.clone();
 
         let mut mock = MockTokenProvider::new();
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(initial_clone));
 
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Err(errors::non_retryable_from_str("fail")));
 
         // fetch an initial token
         let cache = TokenCache::new(mock);
-        let actual = cache.get_token().await.unwrap();
+        let actual = cache.token().await.unwrap();
         assert_eq!(actual, initial);
 
         // wait long enough for the token to be expired
@@ -253,7 +253,7 @@ mod test {
         tokio::time::advance(sleep).await;
 
         // make sure we return the error, not the expired token
-        assert!(cache.get_token().await.is_err());
+        assert!(cache.token().await.is_err());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
@@ -269,20 +269,18 @@ mod test {
         let token_clone = token.clone();
 
         let mut mock = MockTokenProvider::new();
-        mock.expect_get_token()
-            .times(1)
-            .return_once(|| Ok(token_clone));
+        mock.expect_token().times(1).return_once(|| Ok(token_clone));
 
         // fetch an initial token
         let cache = TokenCache::new(mock);
-        let actual = cache.get_token().await.unwrap();
+        let actual = cache.token().await.unwrap();
         assert_eq!(actual, token);
 
         // Spawn N tasks, all asking for a token at once.
         let tasks = (0..1000)
             .map(|_| {
                 let cache_clone = cache.clone();
-                tokio::spawn(async move { cache_clone.get_token().await })
+                tokio::spawn(async move { cache_clone.token().await })
             })
             .collect::<Vec<_>>();
 
@@ -315,11 +313,11 @@ mod test {
         let token2_clone = token2.clone();
 
         let mut mock = MockTokenProvider::new();
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(token1_clone));
 
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(token2_clone));
 
@@ -370,15 +368,15 @@ mod test {
         let token3_clone = token3.clone();
 
         let mut mock = MockTokenProvider::new();
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(token1_clone));
 
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(token2_clone));
 
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(token3_clone));
 
@@ -444,15 +442,15 @@ mod test {
         let token2_clone = token2.clone();
 
         let mut mock = MockTokenProvider::new();
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(token1_clone));
 
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(token1_clone2));
 
-        mock.expect_get_token()
+        mock.expect_token()
             .times(1)
             .return_once(|| Ok(token2_clone));
 
@@ -513,7 +511,7 @@ mod test {
 
     #[async_trait::async_trait]
     impl TokenProvider for FakeTokenProvider {
-        async fn get_token(&self) -> Result<Token> {
+        async fn token(&self) -> Result<Token> {
             // We give enough time for the a thundering herd to pile up waiting for a change notification from watch channel
             sleep(Duration::from_millis(50)).await;
 
@@ -542,7 +540,7 @@ mod test {
         let tasks = (0..100)
             .map(|_| {
                 let cache_clone = cache.clone();
-                tokio::spawn(async move { cache_clone.get_token().await })
+                tokio::spawn(async move { cache_clone.token().await })
             })
             .collect::<Vec<_>>();
 
@@ -570,7 +568,7 @@ mod test {
         let tasks = (0..100)
             .map(|_| {
                 let cache_clone = cache.clone();
-                tokio::spawn(async move { cache_clone.get_token().await })
+                tokio::spawn(async move { cache_clone.token().await })
             })
             .collect::<Vec<_>>();
 

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -145,7 +145,7 @@ mod test {
         Credentials {}
 
         impl CredentialsTrait for Credentials {
-            async fn get_token(&self) -> Result<Token>;
+            async fn token(&self) -> Result<Token>;
             async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
             async fn universe_domain(&self) -> Option<String>;
         }
@@ -154,7 +154,7 @@ mod test {
     #[tokio::test]
     async fn mocking() -> Result<()> {
         let mut mock = MockCredentials::new();
-        mock.expect_get_token().return_once(|| {
+        mock.expect_token().return_once(|| {
             Ok(Token {
                 token: "test-token".to_string(),
                 token_type: "Bearer".to_string(),
@@ -166,7 +166,7 @@ mod test {
         mock.expect_universe_domain().return_once(|| None);
 
         let creds = Credentials::from(mock);
-        assert_eq!(creds.get_token().await?.token, "test-token");
+        assert_eq!(creds.token().await?.token, "test-token");
         assert!(creds.headers().await?.is_empty());
         assert_eq!(creds.universe_domain().await, None);
 
@@ -176,7 +176,7 @@ mod test {
     #[tokio::test]
     async fn testing_credentials() -> Result<()> {
         let creds = test_credentials();
-        assert_eq!(creds.get_token().await?.token, "test-only-token");
+        assert_eq!(creds.token().await?.token, "test-only-token");
         assert!(creds.headers().await?.is_empty());
         assert_eq!(creds.universe_domain().await, None);
         Ok(())

--- a/src/auth/tests/crypto_provider.rs
+++ b/src/auth/tests/crypto_provider.rs
@@ -85,7 +85,7 @@ mod test {
         // Try to use the service account credentials. This calls into the
         // custom crypto provider.
         let creds = test_service_account_credentials().await;
-        let e = creds.get_token().await.err().unwrap();
+        let e = creds.token().await.err().unwrap();
         assert!(e.to_string().contains(CUSTOM_ERROR), "{e}");
     }
 }

--- a/src/gax-internal/tests/auth.rs
+++ b/src/gax-internal/tests/auth.rs
@@ -30,7 +30,7 @@ mod test {
         Credentials {}
 
         impl CredentialsTrait for Credentials {
-            async fn get_token(&self) -> AuthResult<Token>;
+            async fn token(&self) -> AuthResult<Token>;
             async fn headers(&self) -> AuthResult<Vec<(HeaderName, HeaderValue)>>;
             async fn universe_domain(&self) -> Option<String>;
         }


### PR DESCRIPTION
Part of making the auth methods rusty