### PR TITLE
chore: have the typos-cli config apply to all languages

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -26,7 +26,7 @@ extend-glob = ["*.mustache"]
 [type.mustache.extend-words]
 ser = "ser"
 
-[type.rust.extend-words]
+[default.extend-words]
 # This is correct, https://en.wikipedia.org/wiki/Comune
 comune = "comune"
 # A common spelling, but typos-cli prefers implementers
@@ -198,7 +198,7 @@ combintation = "combintation"
 
 # These are not good ideas for "extend-words" because they will catch too many
 # true positives
-[type.rust]
+[default]
 extend-ignore-re = [
   # This is intentional, `typ` is the name of a field in OAuth2 claims:
   "\"typ\"",


### PR DESCRIPTION
- have the typos-cli config apply to all languages

This adjusts the config in `.typos.toml` so that it's not rust specific; related to https://github.com/googleapis/google-cloud-rust/pull/1731.
