### PR TITLE
feat(gax): a wrapper for responses with metadata

### DIFF
--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -33,7 +33,7 @@
 /// An alias of [std::result::Result] where the error is always [Error][crate::error::Error].
 ///
 /// This is the result type used by all functions wrapping RPCs.
-pub type Result<T> = std::result::Result<T, error::Error>;
+pub type Result<T> = std::result::Result<T, crate::error::Error>;
 
 /// Implements helpers to create telemetry headers.
 #[cfg(feature = "unstable-sdk-client")]
@@ -45,6 +45,8 @@ pub mod error;
 
 /// Defines some types and traits to convert and use List RPCs as a Stream.
 pub mod paginator;
+
+pub mod response;
 
 pub mod backoff_policy;
 pub mod client_builder;

--- a/src/gax/src/response.rs
+++ b/src/gax/src/response.rs
@@ -218,7 +218,7 @@ impl<T> Response<T> {
 /// Component parts of a response.
 ///
 /// The response parts, other than the body, consist of just headers. We
-/// anticipate addition fields in the future.
+/// anticipate the addition of new fields over time.
 ///
 /// The headers are used to return gRPC metadata, as well as (unsurprisingly)
 /// HTTP headers.

--- a/src/gax/src/response.rs
+++ b/src/gax/src/response.rs
@@ -300,8 +300,7 @@ mod test {
             http::header::CONTENT_TYPE,
             http::HeaderValue::from_static("application/json"),
         );
-        let parts = Parts::new()
-            .set_headers(headers.clone());
+        let parts = Parts::new().set_headers(headers.clone());
 
         let response = Response::from_parts(parts, "abc123".to_string());
         assert_eq!(response.body().as_str(), "abc123");
@@ -321,8 +320,7 @@ mod test {
             http::header::CONTENT_TYPE,
             http::HeaderValue::from_static("application/json"),
         );
-        let parts = Parts::new()
-            .set_headers(headers.clone());
+        let parts = Parts::new().set_headers(headers.clone());
 
         assert_eq!(parts.headers, headers);
         assert_eq!(

--- a/src/gax/src/response.rs
+++ b/src/gax/src/response.rs
@@ -304,6 +304,7 @@ mod test {
 
         let response = Response::from_parts(parts, "abc123".to_string());
         assert_eq!(response.body().as_str(), "abc123");
+        assert_eq!(response.headers(), &headers);
 
         let (parts, body) = response.into_parts();
         assert_eq!(body.as_str(), "abc123");

--- a/src/gax/src/response.rs
+++ b/src/gax/src/response.rs
@@ -1,0 +1,383 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Response types.
+//!
+//! This module contains types related to Google Cloud service responses.
+//! Notably it contains the `Response` type itself. Typically you'll import
+//! this type.
+//!
+//! # Examples
+//!
+//! Inspecting the result of a request
+//!
+//! ```no_run
+//! # use google_cloud_gax::Result;
+//! # use google_cloud_gax::response::Response;
+//! // A type representing a Google Cloud service resource, for example, a
+//! // secret manager secret.
+//! struct Resource {
+//!   // ...
+//! }
+//!
+//! async fn make_google_service_rpc(project_id: &str) -> Result<Response<Resource>> {
+//!   // ...
+//! # panic!()
+//! }
+//!
+//! # tokio_test::block_on(async {
+//! let response = make_google_service_rpc("my-project").await?;
+//! if let Some(date) = response.headers().get("Date") {
+//!     // do something with the date
+//! }
+//! let resource = response.body();
+//! // do something with
+//! # Result::<()>::Ok(()) });
+//! ```
+//!
+//! Creating a response for mocks
+//!
+//! ```
+//! # use google_cloud_gax::Result;
+//! # use google_cloud_gax::response::Response;
+//! // A type representing a Google Cloud service resource, for example, a
+//! // secret manager secret.
+//! struct Resource {
+//!   // ...
+//! }
+//!
+//! fn make_mock_response(body: Resource) -> Result<Response<Resource>> {
+//!     Ok(Response::from(body))
+//! }
+//! ```
+
+/// Represents a Google Cloud service response.
+///
+/// A response from a Google Cloud service consists of a body (potentially the
+/// unit type), headers and maybe some extensions.
+///
+/// Typically you get a response as the result of making a request via some
+/// client in the Google Cloud client libraries for Rust. You may also create
+/// responses directly when mocking clients for your own tests.
+///
+/// # Examples
+/// Inspecting the result of a request
+///
+/// ```no_run
+/// # use google_cloud_gax::Result;
+/// # use google_cloud_gax::response::Response;
+/// // A type representing a Google Cloud service resource, for example, a
+/// // secret manager secret.
+/// struct Resource {
+///   // ...
+/// }
+///
+/// async fn make_google_service_rpc(project_id: &str) -> Result<Response<Resource>> {
+///   // ...
+/// # panic!()
+/// }
+///
+/// # tokio_test::block_on(async {
+/// let response = make_google_service_rpc("my-project").await?;
+/// if let Some(date) = response.headers().get("Date") {
+///     // do something with the date
+/// }
+/// let resource = response.body();
+/// // do something with
+/// # Result::<()>::Ok(()) });
+/// ```
+///
+/// Creating a response for mocks
+///
+/// ```
+/// # use google_cloud_gax::Result;
+/// # use google_cloud_gax::response::Response;
+/// // A type representing a Google Cloud service resource, for example, a
+/// // secret manager secret.
+/// struct Resource {
+///   // ...
+/// }
+///
+/// fn make_mock_response(body: Resource) -> Result<Response<Resource>> {
+///     Ok(Response::from(body))
+/// }
+/// ```
+///   
+#[derive(Clone, Debug)]
+pub struct Response<T> {
+    parts: Parts,
+    body: T,
+}
+
+impl<T> Response<T> {
+    /// Creates a response from the body.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Response;
+    /// #[derive(Clone, Default)]
+    /// pub struct Resource {
+    ///   // ...
+    /// }
+    ///
+    /// let body = Resource::default();
+    /// let response = Response::from(body);
+    /// ```
+    pub fn from(body: T) -> Self {
+        Self {
+            body,
+            parts: Parts::default(),
+        }
+    }
+
+    /// Creates a response from the given parts.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Response;
+    /// # use google_cloud_gax::response::Parts;
+    /// #[derive(Clone, Default)]
+    /// pub struct Resource {
+    ///   // ...
+    /// }
+    ///
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.insert(http::header::CONTENT_TYPE, http::HeaderValue::from_static("application/json"));
+    /// let body = Resource::default();
+    /// let response : Response<Resource> = Response::from_parts(
+    ///     Parts::new().set_headers(headers), body);
+    /// assert!(response.headers().get(http::header::CONTENT_TYPE).is_some());
+    /// ```
+    pub fn from_parts(parts: Parts, body: T) -> Self {
+        Self { parts, body }
+    }
+
+    /// Returns the headers associated with this response.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Response;
+    /// let response = Response::from(());
+    /// assert!(response.headers().is_empty());
+    /// ```
+    pub fn headers(&self) -> &http::HeaderMap<http::HeaderValue> {
+        &self.parts.headers
+    }
+
+    /// Returns the extensions associated with this response.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Response;
+    /// let response = Response::from(());
+    /// assert!(response.extensions().is_empty());
+    /// ```
+    pub fn extensions(&self) -> &http::Extensions {
+        &self.parts.extensions
+    }
+
+    /// Returns the extensions associated with this response.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Response;
+    /// let response = Response::from("test".to_string());
+    /// assert_eq!(response.body().as_str(), "test");
+    /// ```
+    pub fn body(&self) -> &T {
+        &self.body
+    }
+
+    /// Consumes the response returning the headers, extensions, and body.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Response;
+    /// let response = Response::from("test".to_string());
+    /// let (parts, body) = response.into_parts();
+    /// assert_eq!(body.as_str(), "test");
+    /// assert!(parts.headers.is_empty());
+    /// assert!(parts.extensions.is_empty());
+    /// ```
+    pub fn into_parts(self) -> (Parts, T) {
+        (self.parts, self.body)
+    }
+
+    /// Consumes the response returning only its body.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Response;
+    /// let response = Response::from("test".to_string());
+    /// let body = response.into_body();
+    /// assert_eq!(body.as_str(), "test");
+    /// ```
+    pub fn into_body(self) -> T {
+        self.body
+    }
+}
+
+/// Component parts of a response.
+///
+/// The response parts, other than the body, consist of the headers and
+/// extensions.
+///
+/// The headers are used to return gRPC metadata, as well as (unsurprisingly)
+/// HTTP headers. The extensions are used to return additional information about
+/// the response, maybe because the implementation uses a [tower] service.
+///
+/// # Example
+/// ```
+/// # use google_cloud_gax::response::Parts;
+/// let mut headers = http::HeaderMap::new();
+/// headers.insert(http::header::CONTENT_TYPE, http::HeaderValue::from_static("application/json"));
+/// let mut extensions = http::Extensions::new();
+/// extensions.insert(42_i32);
+/// let parts = Parts::new().set_headers(headers).set_extensions(extensions);
+///
+/// assert_eq!(
+///     parts.headers.get(http::header::CONTENT_TYPE),
+///     Some(&http::HeaderValue::from_static("application/json"))
+/// );
+/// assert_eq!(parts.extensions.get::<i32>(), Some(&42_i32));
+/// ```
+///  
+/// [tower]: https://github.com/tower-rs/tower
+#[derive(Clone, Debug, Default)]
+pub struct Parts {
+    /// The HTTP headers or the gRPC metadata converted to HTTP headers.
+    pub headers: http::HeaderMap<http::HeaderValue>,
+
+    /// Any data associated with extensions.
+    pub extensions: http::Extensions,
+}
+
+impl Parts {
+    /// Create a new instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Parts;
+    /// let parts = Parts::new();
+    /// assert!(parts.headers.is_empty());
+    /// assert!(parts.extensions.is_empty());
+    /// ```
+    pub fn new() -> Self {
+        Parts::default()
+    }
+
+    /// Set the headers.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Parts;
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.insert(
+    ///     http::header::CONTENT_TYPE,
+    ///     http::HeaderValue::from_static("application/json"),
+    /// );
+    /// let parts = Parts::new().set_headers(headers.clone());
+    /// assert_eq!(parts.headers, headers);
+    /// assert!(parts.extensions.is_empty());
+    /// ```
+    pub fn set_headers<V>(mut self, v: V) -> Self
+    where
+        V: Into<http::HeaderMap>,
+    {
+        self.headers = v.into();
+        self
+    }
+
+    /// Set the extensions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::response::Parts;
+    /// let mut extensions = http::Extensions::new();
+    /// extensions.insert(42_i32);
+    /// let parts = Parts::new().set_extensions(extensions);
+    /// assert_eq!(parts.extensions.get::<i32>(), Some(&42_i32));
+    /// assert!(parts.headers.is_empty());
+    /// ```
+    pub fn set_extensions<V>(mut self, v: V) -> Self
+    where
+        V: Into<http::Extensions>,
+    {
+        self.extensions = v.into();
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn response_from() {
+        let response = Response::from("abc123".to_string());
+        assert!(response.headers().is_empty());
+        assert!(response.extensions().is_empty());
+        assert_eq!(response.body().as_str(), "abc123");
+
+        let body = response.into_body();
+        assert_eq!(body.as_str(), "abc123");
+    }
+
+    #[test]
+    fn response_from_parts() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+        let mut extensions = http::Extensions::new();
+        extensions.insert(42_i32);
+        let parts = Parts::new()
+            .set_headers(headers.clone())
+            .set_extensions(extensions);
+
+        let response = Response::from_parts(parts, "abc123".to_string());
+        assert_eq!(response.body().as_str(), "abc123");
+
+        let (parts, body) = response.into_parts();
+        assert_eq!(body.as_str(), "abc123");
+        assert_eq!(parts.headers, headers);
+        assert_eq!(parts.extensions.get::<i32>(), Some(&42_i32));
+    }
+
+    #[test]
+    fn parts() {
+        let parts = Parts::new();
+        assert!(parts.headers.is_empty());
+        assert!(parts.extensions.is_empty());
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+        let mut extensions = http::Extensions::new();
+        extensions.insert(42_i32);
+        let parts = Parts::new()
+            .set_headers(headers.clone())
+            .set_extensions(extensions);
+
+        assert_eq!(parts.headers, headers);
+        assert_eq!(
+            parts.headers.get(http::header::CONTENT_TYPE),
+            Some(&http::HeaderValue::from_static("application/json"))
+        );
+        assert_eq!(parts.extensions.get::<i32>(), Some(&42_i32));
+    }
+}


### PR DESCRIPTION
Part of the work for #1510
