### PR TITLE
chore: bump the golang version to 1.23.8

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['1.23.5']
+        go-version: ['1.23.8']
     defaults:
       run:
         working-directory: generator

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go 1.23
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.8
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -21,7 +21,7 @@ on:
     branches: [main]
 env:
   GHA_RUST_VERSIONS: '{ "rust:msrv": "1.85", "rust:current": "1.85.1" }'
-  GHA_GO_VERSIONS: '{ "go:current": "1.23.5" }'
+  GHA_GO_VERSIONS: '{ "go:current": "1.23.8" }'
 jobs:
   build:
     strategy:


### PR DESCRIPTION
- bump the golang version to `1.23.8`

(investigating the breakage from https://github.com/googleapis/google-cloud-rust/pull/1748)