### PR TITLE
ci: constant build names

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -19,12 +19,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+env:
+  GHA_GO_VERSIONS: '{ "go:current": "1.23.8" }'
 jobs:
   generator-build:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['1.23.8']
+        go-version: ['go:current']
     defaults:
       run:
         working-directory: generator
@@ -42,7 +44,7 @@ jobs:
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ fromJson(env.GHA_GO_VERSIONS)[matrix.go-version] }}
           cache-dependency-path: |
             generator/go.sum
       - name: Display Go version


### PR DESCRIPTION
Matrix dimensions show up in the names of builds. The list of required builds is maintained by name. Changing the name to something static ("go:current") saves us some toil in maintaining the list of required builds.