### PR TITLE
ci: no more `govulncheck`

### DIFF
--- a/generator/all_test.go
+++ b/generator/all_test.go
@@ -69,10 +69,6 @@ func TestGoModTidy(t *testing.T) {
 	rungo(t, "mod", "tidy", "-diff")
 }
 
-func TestGovulncheck(t *testing.T) {
-	rungo(t, "run", "golang.org/x/vuln/cmd/govulncheck@v1.1.3", "./...")
-}
-
 func rungo(t *testing.T, args ...string) {
 	t.Helper()
 


### PR DESCRIPTION
We use `go` locally, with no permissions. We are not really susceptible to vulnerabilities.

So remove the vulnerability check, which can break the CI without a PR.