### PR TITLE
chore: validate the committed clients

### DIFF
--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.7.3
+          sdk: 3.7.2
 
       # Run pub get.
       - run: dart pub get
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.7.3
+          sdk: 3.7.2
 
       # Run pub get.
       - run: dart pub get

--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -41,6 +41,12 @@ jobs:
         uses: actions/setup-go@v5
       - name: Install Dart
         uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.7.3
+
+      # Run pub get.
+      - run: dart pub get
+        working-directory: generator/dart
 
       # Regenerate and check the existing clients. If there is any difference
       # between the generated code and the committed code that is an error; all
@@ -64,6 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.7.3
 
       # Run pub get.
       - run: dart pub get

--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -41,6 +41,17 @@ jobs:
         uses: actions/setup-go@v5
       - name: Install Dart
         uses: dart-lang/setup-dart@v1
+
+      # Regenerate and check the existing clients. If there is any difference
+      # between the generated code and the committed code that is an error; all
+      # the inputs should be pinned, including the generator version and the
+      # googleapis SHA.
+      - name: Regenerate existing clients
+        working-directory: generator
+        run: go run ./cmd/sidekick refreshall -project-root dart
+      - run: git diff --exit-code
+
+      # Regenerate and check our goldens.
       - name: Generate a Dart secretmanager / protobuf client
         run: go test -run TestDart github.com/googleapis/google-cloud-rust/generator/internal/sidekick
         working-directory: generator


### PR DESCRIPTION
- validate that the code we generate is the same as the code being committed (the source googleapis SHAs are the same, all the affected clients have been generated, ...)
