### PR TITLE
test(http): effective timeout used in loop

### DIFF
--- a/src/gax-internal/tests/retry_loop.rs
+++ b/src/gax-internal/tests/retry_loop.rs
@@ -377,11 +377,12 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn retry_loop_retry_transient_then_permanent() -> Result<()> {
-        // We create a server that will return two transient errors and then succeed.
+        // We create a server that will return a transient error, then a
+        // permanent error.
         let (endpoint, _server) = start(vec![transient(), permanent()]).await?;
 
-        // Create a matching policy provider. It returns a policy that expects two
-        // errors.
+        // Create a matching policy provider. It returns a policy that expects
+        // two errors.
         let mut seq = mockall::Sequence::new();
         let mut retry_policy = MockRetryPolicy::new();
         retry_policy

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -41,7 +41,7 @@ pin-project = { version = "1" }
 rand        = "0.9"
 serde       = "1"
 serde_json  = "1"
-tokio       = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio       = { version = "1", features = ["macros", "time", "rt-multi-thread"] }
 # Local crates
 rpc = { version = "0.2", path = "../generated/rpc/types", package = "google-cloud-rpc" }
 wkt = { version = "0.3", path = "../wkt", package = "google-cloud-wkt" }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -41,7 +41,7 @@ pin-project = { version = "1" }
 rand        = "0.9"
 serde       = "1"
 serde_json  = "1"
-tokio       = { version = "1", features = ["macros", "time", "rt-multi-thread"] }
+tokio       = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 # Local crates
 rpc = { version = "0.2", path = "../generated/rpc/types", package = "google-cloud-rpc" }
 wkt = { version = "0.3", path = "../wkt", package = "google-cloud-wkt" }

--- a/src/gax/src/retry_loop_internal.rs
+++ b/src/gax/src/retry_loop_internal.rs
@@ -39,7 +39,7 @@ where
     F: AsyncFn(Option<std::time::Duration>) -> Result<Response> + Send,
     S: AsyncFn(std::time::Duration) -> () + Send,
 {
-    let loop_start = std::time::Instant::now();
+    let loop_start = tokio::time::Instant::now().into_std();
     let mut attempt_count = 0;
     loop {
         let remaining_time = retry_policy.remaining_time(loop_start, attempt_count);

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -412,7 +412,7 @@ where
 
     fn error_if_expired(&self, loop_start: std::time::Instant) -> Option<Error> {
         let deadline = loop_start + self.maximum_duration;
-        let now = std::time::Instant::now();
+        let now = tokio::time::Instant::now().into_std();
         if now < deadline {
             None
         } else {
@@ -439,7 +439,7 @@ where
             LoopState::Permanent(e) => LoopState::Permanent(e),
             LoopState::Exhausted(e) => LoopState::Exhausted(e),
             LoopState::Continue(e) => {
-                if std::time::Instant::now() >= start + self.maximum_duration {
+                if tokio::time::Instant::now().into_std() >= start + self.maximum_duration {
                     LoopState::Exhausted(e)
                 } else {
                     LoopState::Continue(e)
@@ -460,7 +460,7 @@ where
         attempt_count: u32,
     ) -> Option<std::time::Duration> {
         let deadline = loop_start + self.maximum_duration;
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now().into_std());
         if let Some(inner) = self.inner.remaining_time(loop_start, attempt_count) {
             return Some(std::cmp::min(remaining, inner));
         }


### PR DESCRIPTION
Motivated by #1612  (I will want a test like this for gRPC timeouts, so write the HTTP one first)

We have tests for the effective timeout fn, but no tests that verify we call it with the right parameters in the `ReqwestClient`. This code:

https://github.com/googleapis/google-cloud-rust/blob/aaf619e1dadbd6b78ce8c61e41d86a0735ecf113/src/gax-internal/src/http.rs#L127-L129

So add a test that verifies the effective timeout.

While we are here, put some stricter bounds on the other timeout tests.

In order to make this work, we use `tokio::time::Instant::now().into_std()` internally. This lets us control the timing in our tests. Note that `tokio`'s wrapper is as thin as possible. https://docs.rs/tokio/1.42.2/src/tokio/time/instant.rs.html#33-36