### PR TITLE
Prototype(auth): Introduce builder for adc

### DIFF
--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -51,7 +51,9 @@
 //! [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
 
 use crate::credentials::dynamic::CredentialsTrait;
-use crate::credentials::{Credentials, DEFAULT_UNIVERSE_DOMAIN, Result};
+use crate::credentials::{
+    AccessTokenCredentialOptions, Credentials, DEFAULT_UNIVERSE_DOMAIN, Result,
+};
 use crate::errors::{self, CredentialsError, is_retryable};
 use crate::headers_util::build_bearer_headers;
 use crate::token::{Token, TokenProvider};
@@ -101,6 +103,15 @@ pub struct Builder {
 }
 
 impl Builder {
+    pub(crate) fn with_access_token_options(
+        mut self,
+        options: AccessTokenCredentialOptions,
+    ) -> Self {
+        self.scopes = options.scopes;
+        self.quota_project_id = options.quota_project_id;
+        self
+    }
+
     /// Sets the endpoint for this credentials.
     ///
     /// If not set, the credentials use `http://metadata.google.internal/`.

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -87,6 +87,8 @@ use serde_json::Value;
 use std::sync::Arc;
 use time::OffsetDateTime;
 
+use super::AccessTokenCredentialOptions;
+
 const DEFAULT_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
 
 pub(crate) fn creds_from(js: Value) -> Result<Credentials> {
@@ -153,6 +155,18 @@ impl Builder {
             ),
             quota_project_id: None,
         }
+    }
+
+    pub(crate) fn with_access_token_options(
+        mut self,
+        options: AccessTokenCredentialOptions,
+    ) -> Self {
+        if let Some(scopes) = options.scopes {
+            self.restrictions = ServiceAccountRestrictions::Scopes(scopes);
+        }
+
+        self.quota_project_id = options.quota_project_id;
+        self
     }
 
     /// Sets the audience for this credentials.

--- a/src/auth/src/credentials/user_account.rs
+++ b/src/auth/src/credentials/user_account.rs
@@ -78,6 +78,8 @@ use serde_json::Value;
 use std::sync::Arc;
 use std::time::Duration;
 
+use super::AccessTokenCredentialOptions;
+
 const OAUTH2_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
 
 pub(crate) fn creds_from(js: Value) -> Result<Credentials> {
@@ -115,6 +117,15 @@ impl Builder {
             quota_project_id: None,
             token_uri: None,
         }
+    }
+
+    pub(crate) fn with_access_token_options(
+        mut self,
+        options: AccessTokenCredentialOptions,
+    ) -> Self {
+        self.scopes = options.scopes;
+        self.quota_project_id = options.quota_project_id;
+        self
     }
 
     /// Sets the URI for the token endpoint used to fetch access tokens.


### PR DESCRIPTION
Replacing `create_access_token_credentials()` function with a builder. Benefit is it allows user to add on more things like quota, scopes and more options like retry policy, backoff policy etc.

(A downside in introducing retry policy related options here is that SA creds do not do network calls, so these options are a no-op, but should be ok)